### PR TITLE
Allow the user to switch between and configure the two implemented edit strategies

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -108,14 +108,22 @@ export class Cline {
 	) {
 		this.providerRef = new WeakRef(provider)
 		this.api = buildApiHandler(apiConfiguration)
+		this.customInstructions = customInstructions
+		this.diffEnabled = enableDiff ?? false
 		this.terminalManager = new TerminalManager()
 		this.urlContentFetcher = new UrlContentFetcher(provider.context)
 		this.browserSession = new BrowserSession(provider.context)
 		this.diffViewProvider = new DiffViewProvider(cwd)
-		this.customInstructions = customInstructions
-		this.diffEnabled = enableDiff ?? false
+
 		if (this.diffEnabled && this.api.getModel().id) {
-			this.diffStrategy = getDiffStrategy(this.api.getModel().id, fuzzyMatchThreshold ?? 1.0)
+
+			this.diffStrategy = getDiffStrategy(this.api.getModel().id, fuzzyMatchThreshold ?? 1.0, 'search-replace')
+
+			provider.getState().then(({ diffStrategy: selectedStrategy }) => {
+				if (selectedStrategy && this.diffEnabled && this.api.getModel().id) {
+					this.diffStrategy = getDiffStrategy(this.api.getModel().id, fuzzyMatchThreshold ?? 1.0, selectedStrategy)
+				}
+			})
 		}
 		if (historyItem) {
 			this.taskId = historyItem.id

--- a/src/core/diff/DiffStrategy.ts
+++ b/src/core/diff/DiffStrategy.ts
@@ -6,9 +6,12 @@ import { SearchReplaceDiffStrategy } from './strategies/search-replace'
  * @param model The name of the model being used (e.g., 'gpt-4', 'claude-3-opus')
  * @returns The appropriate diff strategy for the model
  */
-export function getDiffStrategy(model: string, fuzzyMatchThreshold?: number): DiffStrategy {
+export function getDiffStrategy(model: string, fuzzyMatchThreshold?: number, strategy: 'unified' | 'search-replace' = 'search-replace'): DiffStrategy {
     // For now, return SearchReplaceDiffStrategy for all models
     // This architecture allows for future optimizations based on model capabilities
+    if (strategy === 'unified') {
+        return new UnifiedDiffStrategy(1 - (fuzzyMatchThreshold ?? 1.0))
+    }
     return new SearchReplaceDiffStrategy(fuzzyMatchThreshold ?? 1.0)
 }
 

--- a/src/core/diff/strategies/unified.ts
+++ b/src/core/diff/strategies/unified.ts
@@ -2,13 +2,32 @@ import { applyPatch } from "diff"
 import { DiffStrategy, DiffResult } from "../types"
 
 export class UnifiedDiffStrategy implements DiffStrategy {
+    private fuzzFactor: number
+    constructor(fuzzFactor?: number) {
+        this.fuzzFactor = fuzzFactor ?? 0
+    }
+
     getToolDescription(cwd: string): string {
         return `## apply_diff
-Description: Apply a unified diff to a file at the specified path. This tool is useful when you need to make specific modifications to a file based on a set of changes provided in unified diff format (diff -U3).
+Description: Apply a unified diff to a file at the specified path. This tool is useful when you need to make specific modifications to a file based on a set of changes provided in unified diff format, write out the changes similar to a unified diff like \`diff -U2\` would produce.
 
 Parameters:
 - path: (required) The path of the file to apply the diff to (relative to the current working directory ${cwd})
 - diff: (required) The diff content in unified format to apply to the file.
+
+Use --- and +++ to mark file paths. Include line numbers in @@ lines with format @@ -start,count +start,count @@ to locate changes.
+
+Match indentation with surrounding code. Include surrounding lines like what \`diff -U2\` would produce.
+
+Mark changes with - for removed lines and + for added lines.
+
+Replace complete functions, methods, loops, etc using \`-\` to remove the old code and \`+\` to add the new code.
+
+For moving code:
+1. First hunk removes code from original location
+2. Second hunk adds code to new location
+
+Use one hunk per logical change. Double check line numbers match the file.
 
 Format Requirements:
 
@@ -19,7 +38,7 @@ Format Requirements:
     \`\`\`
     - Must include both lines exactly as shown
     - Use actual file paths
-    - NO timestamps after paths
+    - Timestamps are not to be included
 
 2. Hunks:
     \`\`\`
@@ -81,24 +100,6 @@ Diff to modify the file:
  export { calculateTotal };
 \`\`\`
 
-Common Pitfalls:
-1. Missing or incorrect header lines
-2. Incorrect line numbers in @@ lines
-3. Wrong indentation in changed lines
-4. Incomplete context (missing lines that need changing)
-5. Not marking all modified lines with - and +
-
-Best Practices:
-1. Replace entire code blocks:
-    - Remove complete old version with - lines
-    - Add complete new version with + lines
-    - Include correct line numbers
-2. Moving code requires two hunks:
-    - First hunk: Remove from old location
-    - Second hunk: Add to new location
-3. One hunk per logical change
-4. Verify line numbers match the line numbers you have in the file
-
 Usage:
 <apply_diff>
 <path>File path here</path>
@@ -110,13 +111,16 @@ Your diff here
 
     applyDiff(originalContent: string, diffContent: string): DiffResult {
         try {
-            const result = applyPatch(originalContent, diffContent)
+            const result = applyPatch(originalContent, diffContent, {
+                fuzzFactor: this.fuzzFactor
+            })
             if (result === false) {
                 return {
                     success: false,
                     error: "Failed to apply unified diff - patch rejected",
                     details: {
-                        searchContent: diffContent
+                        searchContent: diffContent,
+                        fuzzFactor: this.fuzzFactor
                     }
                 }
             }
@@ -129,7 +133,8 @@ Your diff here
                 success: false,
                 error: `Error applying unified diff: ${error.message}`,
                 details: {
-                    searchContent: diffContent
+                    searchContent: diffContent,
+                    fuzzFactor: this.fuzzFactor
                 }
             }
         }

--- a/src/core/diff/types.ts
+++ b/src/core/diff/types.ts
@@ -10,6 +10,7 @@ export type DiffResult =
       matchedRange?: { start: number; end: number };
       searchContent?: string;
       bestMatch?: string;
+      fuzzFactor?: number;
     }};
 
 export interface DiffStrategy {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -82,6 +82,7 @@ type GlobalStateKey =
 	| "writeDelayMs"
 	| "terminalOutputLineLimit"
 	| "mcpEnabled"
+	| "diffStrategy"
 export const GlobalFileNames = {
 	apiConversationHistory: "api_conversation_history.json",
 	uiMessages: "ui_messages.json",
@@ -686,6 +687,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						await this.updateGlobalState("terminalOutputLineLimit", message.value)
 						await this.postStateToWebview()
 						break
+					case "diffStrategy":
+						await this.updateGlobalState("diffStrategy", message.text as 'unified' | 'search-replace')
+						await this.postStateToWebview()
+						break
 					case "deleteMessage": {
 						const answer = await vscode.window.showInformationMessage(
 							"Are you sure you want to delete this message and all subsequent messages?",
@@ -1181,6 +1186,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			terminalOutputLineLimit,
 			fuzzyMatchThreshold,
 			mcpEnabled,
+			diffStrategy,
 		} = await this.getState()
 		
 		const allowedCommands = vscode.workspace
@@ -1213,6 +1219,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			terminalOutputLineLimit: terminalOutputLineLimit ?? 500,
 			fuzzyMatchThreshold: fuzzyMatchThreshold ?? 1.0,
 			mcpEnabled: mcpEnabled ?? true,
+			diffStrategy: diffStrategy ?? 'search-replace'
 		}
 	}
 
@@ -1318,6 +1325,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			screenshotQuality,
 			terminalOutputLineLimit,
 			mcpEnabled,
+			diffStrategy,
 		] = await Promise.all([
 			this.getGlobalState("apiProvider") as Promise<ApiProvider | undefined>,
 			this.getGlobalState("apiModelId") as Promise<string | undefined>,
@@ -1368,6 +1376,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("screenshotQuality") as Promise<number | undefined>,
 			this.getGlobalState("terminalOutputLineLimit") as Promise<number | undefined>,
 			this.getGlobalState("mcpEnabled") as Promise<boolean | undefined>,
+			this.getGlobalState("diffStrategy") as Promise<'unified' | 'search-replace' | undefined>,
 		])
 
 		let apiProvider: ApiProvider
@@ -1462,6 +1471,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				return langMap[vscodeLang.split('-')[0]] ?? 'English';
 			})(),
 			mcpEnabled: mcpEnabled ?? true,
+			diffStrategy: diffStrategy ?? 'search-replace'
 		}
 	}
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -65,6 +65,7 @@ export interface ExtensionState {
 	writeDelayMs: number
 	terminalOutputLineLimit?: number
 	mcpEnabled: boolean
+	diffStrategy?: 'unified' | 'search-replace'
 }
 
 export interface ClineMessage {

--- a/src/shared/HistoryItem.ts
+++ b/src/shared/HistoryItem.ts
@@ -7,4 +7,6 @@ export type HistoryItem = {
 	cacheWrites?: number
 	cacheReads?: number
 	totalCost: number
+	diffStrategy?: 'unified' | 'search-replace'
+	fuzzyMatchThreshold?: number
 }

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -51,6 +51,7 @@ export interface WebviewMessage {
 		| "deleteMessage"
 		| "terminalOutputLineLimit"
 		| "mcpEnabled"
+		| "diffStrategy"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -324,13 +324,13 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 									<span style={{ fontWeight: "500", minWidth: '100px' }}>Match Precision</span>
 									<input
 										type="range"
-										min="0"
+										min="80"
 										max="100"
 										step="1"
 										value={Math.round((fuzzyMatchThreshold ?? 1) * 100)}
 										onChange={(e) => {
 											const value = parseInt(e.target.value)
-											setFuzzyMatchThreshold(Math.max(0.8, value / 100))
+											setFuzzyMatchThreshold(value / 100)
 										}}
 										style={{
 											flexGrow: 1,

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -46,6 +46,8 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setTerminalOutputLineLimit: (value: number) => void
 	mcpEnabled: boolean
 	setMcpEnabled: (value: boolean) => void
+	diffStrategy?: 'unified' | 'search-replace'
+	setDiffStrategy: (value: 'unified' | 'search-replace') => void
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -67,6 +69,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		screenshotQuality: 75,
 		terminalOutputLineLimit: 500,
 		mcpEnabled: true,
+		diffStrategy: 'search-replace'
 	})
 	const [didHydrateState, setDidHydrateState] = useState(false)
 	const [showWelcome, setShowWelcome] = useState(false)
@@ -200,6 +203,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setScreenshotQuality: (value) => setState((prevState) => ({ ...prevState, screenshotQuality: value })),
 		setTerminalOutputLineLimit: (value) => setState((prevState) => ({ ...prevState, terminalOutputLineLimit: value })),
 		setMcpEnabled: (value) => setState((prevState) => ({ ...prevState, mcpEnabled: value })),
+		setDiffStrategy: (value) => setState((prevState) => ({ ...prevState, diffStrategy: value }))
 	}
 
 	return <ExtensionStateContext.Provider value={contextValue}>{children}</ExtensionStateContext.Provider>


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->
## Description
Allow the user to switch between the two implemented edit strategies, unified diff and search/replace and also allowing the user to change the fuzziness of the selected strategy.
Improved the prompt used by the unified diff strategy to encourage the model to produce better diffs, the improved prompt is based on the previous prompt but restructuring it to use positive instructions, these changes are inspired on Aider's unified diff prompts.

## Type of change
<!-- Please ignore options that are not relevant -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes -->
I have used Roo Cline with both strategies selected on real-life projects while it still makes mistakes it allows me to switch to another strategy if the model gets stuck with the previous one. I recommend further testing specifically in the accuracy of the new unified diff prompt.
## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply -->
- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
Unified Diff:
![Screenshot_20250105_174003](https://github.com/user-attachments/assets/e9f4e29f-9c72-4485-8ed9-e8a738d7b7fa)
Search/Replace:
![search_replace](https://github.com/user-attachments/assets/0b0caeb1-c38f-420a-a6e5-9133023ece24)
Editing using diffs disabled:
![Screenshot_20250105_174951](https://github.com/user-attachments/assets/92e567a2-3a84-46d4-ac64-720cc231f322)



## Related Issues
<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers
<!-- @mention specific team members or individuals who should review this PR -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR adds functionality to switch between 'unified' and 'search-replace' edit strategies with adjustable fuzziness, updating both backend logic and UI components.
> 
>   - **Behavior**:
>     - Adds ability to switch between 'unified' and 'search-replace' edit strategies in `Cline.ts`.
>     - Allows adjusting fuzziness for each strategy in `UnifiedDiffStrategy` and `SearchReplaceDiffStrategy`.
>   - **UI Changes**:
>     - Updates `SettingsView.tsx` to include dropdown for selecting diff strategy and sliders for fuzziness.
>     - Sends selected strategy and fuzziness to backend via `WebviewMessage`.
>   - **Backend Changes**:
>     - Modifies `getDiffStrategy()` in `DiffStrategy.ts` to accept strategy type and fuzziness.
>     - Updates `ClineProvider.ts` to handle new settings and persist them in global state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for cad274db8209d888620fe2aca80b662b83a39178. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->