### PR TITLE
refactor: move API config management to context

### DIFF
--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -8,7 +8,7 @@ interface ApiConfigManagerProps {
 	onSelectConfig: (configName: string) => void
 	onDeleteConfig: (configName: string) => void
 	onRenameConfig: (oldName: string, newName: string) => void
-	onUpsertConfig: (configName: string) => void
+	onDuplicateConfig: (configName: string) => void
 }
 
 const ApiConfigManager = ({
@@ -17,7 +17,7 @@ const ApiConfigManager = ({
 	onSelectConfig,
 	onDeleteConfig,
 	onRenameConfig,
-	onUpsertConfig,
+	onDuplicateConfig,
 }: ApiConfigManagerProps) => {
 	const [editState, setEditState] = useState<"new" | "rename" | null>(null)
 	const [inputValue, setInputValue] = useState("")
@@ -36,9 +36,9 @@ const ApiConfigManager = ({
 		setInputValue("")
 	}, [currentApiConfigName])
 
-	const handleAdd = () => {
+	const handleDuplicate = () => {
 		const newConfigName = currentApiConfigName + " (copy)"
-		onUpsertConfig(newConfigName)
+		onDuplicateConfig(newConfigName)
 	}
 
 	const handleStartRename = () => {
@@ -56,7 +56,7 @@ const ApiConfigManager = ({
 		if (!trimmedValue) return
 
 		if (editState === "new") {
-			onUpsertConfig(trimmedValue)
+			onDuplicateConfig(trimmedValue)
 		} else if (editState === "rename" && currentApiConfigName) {
 			if (currentApiConfigName !== trimmedValue) {
 				onRenameConfig(currentApiConfigName, trimmedValue)
@@ -159,7 +159,7 @@ const ApiConfigManager = ({
 							</select>
 							<VSCodeButton
 								appearance="icon"
-								onClick={handleAdd}
+								onClick={handleDuplicate}
 								title="Add profile"
 								style={{
 									padding: 0,

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -53,6 +53,8 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		listApiConfigMeta,
 		experimentalDiffStrategy,
 		setExperimentalDiffStrategy,
+		renameApiConfiguration,
+		duplicateApiConfig,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -172,18 +174,10 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 								})
 							}}
 							onRenameConfig={(oldName: string, newName: string) => {
-								vscode.postMessage({
-									type: "renameApiConfiguration",
-									values: { oldName, newName },
-									apiConfiguration,
-								})
+								renameApiConfiguration(oldName, newName)
 							}}
-							onUpsertConfig={(configName: string) => {
-								vscode.postMessage({
-									type: "upsertApiConfiguration",
-									text: configName,
-									apiConfiguration,
-								})
+							onDuplicateConfig={(configName: string) => {
+								duplicateApiConfig(configName)
 							}}
 						/>
 						<ApiOptions apiErrorMessage={apiErrorMessage} modelIdErrorMessage={modelIdErrorMessage} />

--- a/webview-ui/src/components/settings/__tests__/ApiConfigManager.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiConfigManager.test.tsx
@@ -23,15 +23,18 @@ describe("ApiConfigManager", () => {
 	const mockOnSelectConfig = jest.fn()
 	const mockOnDeleteConfig = jest.fn()
 	const mockOnRenameConfig = jest.fn()
-	const mockOnUpsertConfig = jest.fn()
+	const mockOnDuplicateConfig = jest.fn()
 
 	const defaultProps = {
 		currentApiConfigName: "Default Config",
-		listApiConfigMeta: [{ name: "Default Config" }, { name: "Another Config" }],
+		listApiConfigMeta: [
+			{ name: "Default Config", id: "default" },
+			{ name: "Another Config", id: "another" },
+		],
 		onSelectConfig: mockOnSelectConfig,
 		onDeleteConfig: mockOnDeleteConfig,
 		onRenameConfig: mockOnRenameConfig,
-		onUpsertConfig: mockOnUpsertConfig,
+		onDuplicateConfig: mockOnDuplicateConfig,
 	}
 
 	beforeEach(() => {
@@ -45,9 +48,9 @@ describe("ApiConfigManager", () => {
 		const addButton = screen.getByTitle("Add profile")
 		fireEvent.click(addButton)
 
-		// Verify that onUpsertConfig was called with the correct name
-		expect(mockOnUpsertConfig).toHaveBeenCalledTimes(1)
-		expect(mockOnUpsertConfig).toHaveBeenCalledWith("Default Config (copy)")
+		// Verify that onDuplicateConfig was called with the correct name
+		expect(mockOnDuplicateConfig).toHaveBeenCalledTimes(1)
+		expect(mockOnDuplicateConfig).toHaveBeenCalledWith("Default Config (copy)")
 	})
 
 	it("creates copy with correct name when current config has spaces", () => {
@@ -56,7 +59,7 @@ describe("ApiConfigManager", () => {
 		const addButton = screen.getByTitle("Add profile")
 		fireEvent.click(addButton)
 
-		expect(mockOnUpsertConfig).toHaveBeenCalledWith("My Test Config (copy)")
+		expect(mockOnDuplicateConfig).toHaveBeenCalledWith("My Test Config (copy)")
 	})
 
 	it("handles empty current config name gracefully", () => {
@@ -65,7 +68,7 @@ describe("ApiConfigManager", () => {
 		const addButton = screen.getByTitle("Add profile")
 		fireEvent.click(addButton)
 
-		expect(mockOnUpsertConfig).toHaveBeenCalledWith(" (copy)")
+		expect(mockOnDuplicateConfig).toHaveBeenCalledWith(" (copy)")
 	})
 
 	it("allows renaming the current config", () => {
@@ -106,7 +109,7 @@ describe("ApiConfigManager", () => {
 	})
 
 	it("disables delete button when only one config exists", () => {
-		render(<ApiConfigManager {...defaultProps} listApiConfigMeta={[{ name: "Default Config" }]} />)
+		render(<ApiConfigManager {...defaultProps} listApiConfigMeta={[{ name: "Default Config", id: "default" }]} />)
 
 		const deleteButton = screen.getByTitle("Cannot delete the only profile")
 		expect(deleteButton).toHaveAttribute("disabled")


### PR DESCRIPTION
- Rename onUpsertConfig to onDuplicateConfig to better reflect its purpose
- Move API configuration state management logic into ExtensionStateContext
- Add renameApiConfiguration and duplicateApiConfig context methods

<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor API configuration management by moving logic to `ExtensionStateContext` and renaming functions for clarity.
> 
>   - **Behavior**:
>     - Renames `onUpsertConfig` to `onDuplicateConfig` in `ApiConfigManager.tsx` and `SettingsView.tsx`.
>     - Moves API configuration state management to `ExtensionStateContext`.
>     - Adds `renameApiConfiguration` and `duplicateApiConfig` methods to `ExtensionStateContext`.
>   - **Context**:
>     - Updates `ExtensionStateContext.tsx` to include new methods for API config management.
>     - Integrates new methods in `SettingsView.tsx` for handling API config renaming and duplication.
>   - **UI**:
>     - Modifies `ApiConfigManager.tsx` to use new `onDuplicateConfig` method for duplicating configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Cline&utm_source=github&utm_medium=referral)<sup> for bf06b2b70bb0e0e531aeeff29592fc5bb7351720. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->