### PR TITLE
Add diff strategy to system prompt preview

### DIFF
--- a/.changeset/poor-adults-fetch.md
+++ b/.changeset/poor-adults-fetch.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix bug where apply_diff wasn't showing up in system prompt preview

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -10,6 +10,7 @@ import { downloadTask } from "../../integrations/misc/export-markdown"
 import { openFile, openImage } from "../../integrations/misc/open-file"
 import { selectImages } from "../../integrations/misc/process-images"
 import { getTheme } from "../../integrations/theme/getTheme"
+import { getDiffStrategy } from "../diff/DiffStrategy"
 import WorkspaceTracker from "../../integrations/workspace/WorkspaceTracker"
 import { McpHub } from "../../services/mcp/McpHub"
 import { ApiConfiguration, ApiProvider, ModelInfo } from "../../shared/api"
@@ -962,7 +963,16 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								preferredLanguage,
 								browserViewportSize,
 								mcpEnabled,
+								fuzzyMatchThreshold,
+								experimentalDiffStrategy,
 							} = await this.getState()
+
+							// Create diffStrategy based on current model and settings
+							const diffStrategy = getDiffStrategy(
+								apiConfiguration.apiModelId || apiConfiguration.openRouterModelId || "",
+								fuzzyMatchThreshold,
+								experimentalDiffStrategy,
+							)
 							const cwd =
 								vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) || ""
 
@@ -979,7 +989,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 								cwd,
 								apiConfiguration.openRouterModelInfo?.supportsComputerUse ?? false,
 								mcpEnabled ? this.mcpHub : undefined,
-								undefined,
+								diffStrategy,
 								browserViewportSize ?? "900x600",
 								mode,
 								{


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a diff strategy to the system prompt preview in `ClineProvider` and updates tests to verify this behavior.
> 
>   - **Behavior**:
>     - Adds `diffStrategy` to `getSystemPrompt` in `ClineProvider.ts` to include diff strategy in system prompt preview.
>     - Uses `getDiffStrategy` to create `diffStrategy` based on model and settings.
>   - **Tests**:
>     - Mocks `getDiffStrategy` in `ClineProvider.test.ts` to return a mock diff strategy.
>     - Adds test to verify `diffStrategy` is passed to `SYSTEM_PROMPT` in `ClineProvider.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 77fa8b1b3187f6bdbab25e121d653a4a30aab478. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->