### PR TITLE
fix: avoid deleting configs if the currentApiConfigName is the same

### DIFF
--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -58,7 +58,9 @@ const ApiConfigManager = ({
 		if (editState === "new") {
 			onUpsertConfig(trimmedValue)
 		} else if (editState === "rename" && currentApiConfigName) {
-			onRenameConfig(currentApiConfigName, trimmedValue)
+			if (currentApiConfigName !== trimmedValue) {
+				onRenameConfig(currentApiConfigName, trimmedValue)
+			}
 		}
 
 		setEditState(null)


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description
Fixes an issue where configs were being deleted even when the config name was not changed. This change ensures that configs are only deleted when their names are actually modified.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
Manually tested by building the extension and editing the config without making any changes to the config name. Verified that configs are not deleted in this scenario.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->
This fix addresses a bug introduced in a previous change that incorrectly deleted configs even when no changes were made to their names.

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `ApiConfigManager.tsx` to prevent config deletion when `currentApiConfigName` is unchanged.
> 
>   - **Behavior**:
>     - Fixes bug in `ApiConfigManager.tsx` where configs were deleted even if `currentApiConfigName` was unchanged.
>     - `onRenameConfig` is now only called if `currentApiConfigName` differs from `trimmedValue`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8ad904a13cdbf49ed5071703b9c850e58874fd00. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->