### PR TITLE
style: clean up chat row and api provider double scroll

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -567,10 +567,12 @@ export const ChatRowContent = ({
 								style={{
 									display: "flex",
 									justifyContent: "space-between",
-									alignItems: "center",
+									alignItems: "flex-start",
 									gap: "10px",
 								}}>
-								<span style={{ display: "block", flexGrow: 1 }}>{highlightMentions(message.text)}</span>
+								<span style={{ display: "block", flexGrow: 1, padding: "4px" }}>
+									{highlightMentions(message.text)}
+								</span>
 								<VSCodeButton
 									appearance="icon"
 									style={{

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -119,6 +119,11 @@ https://github.com/microsoft/vscode-webview-ui-toolkit/tree/main/src/dropdown#wi
 	margin-bottom: 2px;
 }
 
+/* Fix dropdown double scrollbar overflow */
+#api-provider > div > ul {
+	overflow: unset;
+}
+
 /* Fix scrollbar in dropdown */
 
 vscode-dropdown::part(listbox) {


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description
Fix chat row alignment and dropdown scrollbar issues.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
Manually tested in the webview.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->
The chat row alignment was not ideal, especially for longer messages. This change aligns items to `flex-start` for better readability.

<img width="626" alt="image" src="https://github.com/user-attachments/assets/03a85a22-ce8f-4d53-93cc-ae64ab35655c" />


Also, fixed a double scrollbar issue in dropdowns in the settings view.

**BEFORE:**
<img width="159" alt="image" src="https://github.com/user-attachments/assets/b2485813-dd8b-48b7-9e88-c5c095b4a299" />

**AFTER:**
<img width="146" alt="image" src="https://github.com/user-attachments/assets/b2b88023-1bc8-4d94-a98a-830ea4cfa41a" />

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->
N/A

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->