### PR TITLE
Add .clineignore support

### DIFF
--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -4,8 +4,19 @@ import pdf from "pdf-parse/lib/pdf-parse"
 import mammoth from "mammoth"
 import fs from "fs/promises"
 import { isBinaryFile } from "isbinaryfile"
+import { loadIgnorePatterns } from "../../utils/cline-ignore"
 
 export async function extractTextFromFile(filePath: string): Promise<string> {
+	// Convert file path to relative path
+	const cwd = path.dirname(filePath)
+	const relativePath = path.relative(cwd, filePath)
+
+	// Load and check .clineignore patterns
+	const { shouldIgnore } = await loadIgnorePatterns(cwd)
+	if (shouldIgnore(relativePath)) {
+		throw new Error(`File is ignored by .clineignore: ${filePath}`)
+	}
+
 	try {
 		await fs.access(filePath)
 	} catch (error) {

--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -2,6 +2,7 @@ import { globby, Options } from "globby"
 import os from "os"
 import * as path from "path"
 import { arePathsEqual } from "../../utils/path"
+import { loadIgnorePatterns } from "../../utils/cline-ignore"
 
 export async function listFiles(dirPath: string, recursive: boolean, limit: number): Promise<[string[], boolean]> {
 	const absolutePath = path.resolve(dirPath)
@@ -16,6 +17,8 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 	if (isHomeDir) {
 		return [[homeDir], false]
 	}
+
+	const { patterns } = await loadIgnorePatterns(absolutePath)
 
 	const dirsToIgnore = [
 		"node_modules",
@@ -34,6 +37,7 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 		"pkg",
 		"Pods",
 		".*", // '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
+		...patterns,
 	].map((dir) => `**/${dir}/**`)
 
 	const options = {

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -3,6 +3,7 @@ import * as childProcess from "child_process"
 import * as path from "path"
 import * as fs from "fs"
 import * as readline from "readline"
+import { loadClineIgnoreFile, loadIgnorePatterns } from "../../utils/cline-ignore"
 
 /*
 This file provides functionality to perform regex searches on files using ripgrep.
@@ -178,8 +179,9 @@ export async function regexSearchFiles(
 	if (currentResult) {
 		results.push(currentResult as SearchResult)
 	}
-
-	return formatResults(results, cwd)
+	const { shouldIgnore } = await loadIgnorePatterns(cwd)
+	const filteredResults = results.filter((result) => !shouldIgnore(result.file.replace(`${cwd}/`, "")))
+	return formatResults(filteredResults, cwd)
 }
 
 function formatResults(results: SearchResult[], cwd: string): string {

--- a/src/utils/__tests__/cline-ignore.test.ts
+++ b/src/utils/__tests__/cline-ignore.test.ts
@@ -1,0 +1,73 @@
+import { shouldIgnorePath } from "../cline-ignore"
+
+describe("shouldIgnorePath", () => {
+	test("exact match pattern", () => {
+		const ignoreContent = "test.txt"
+		expect(shouldIgnorePath("test.txt", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath("other.txt", ignoreContent)).toBe(false)
+	})
+
+	test("wildcard pattern", () => {
+		const ignoreContent = "*.txt"
+		expect(shouldIgnorePath("test.txt", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath("test.js", ignoreContent)).toBe(false)
+	})
+
+	test("directory pattern", () => {
+		const ignoreContent = "node_modules/"
+		expect(shouldIgnorePath("node_modules/package.json", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath("src/node_modules.ts", ignoreContent)).toBe(false)
+	})
+
+	test("comments and empty lines", () => {
+		const ignoreContent = `
+      # This is a comment
+      test.txt
+
+      # This is also ignored
+      *.js
+    `
+		expect(shouldIgnorePath("test.txt", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath("app.js", ignoreContent)).toBe(true)
+	})
+
+	test("negation pattern", () => {
+		const ignoreContent = `
+      *.txt
+      !important.txt
+      docs/
+      !docs/README.txt
+    `
+		// Matches *.txt but excluded by !important.txt
+		expect(shouldIgnorePath("test.txt", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath("important.txt", ignoreContent)).toBe(false)
+
+		// Matches docs/ but excluded by !docs/README.txt
+		expect(shouldIgnorePath("docs/test.txt", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath("docs/README.txt", ignoreContent)).toBe(false)
+	})
+
+	test("complex negation pattern combinations", () => {
+		const ignoreContent = `
+      # Ignore all .log files
+      *.log
+      # But not debug.log
+      !debug.log
+      # However, ignore debug.log in tmp/
+      tmp/debug.log
+    `
+		expect(shouldIgnorePath("error.log", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath("debug.log", ignoreContent)).toBe(false)
+		expect(shouldIgnorePath("tmp/debug.log", ignoreContent)).toBe(true)
+	})
+
+	test("negation pattern with reversed order", () => {
+		const ignoreContent = `
+			!.env.example
+			.env*
+		`
+		// .env.example should be ignored because .env* comes after !.env.example
+		expect(shouldIgnorePath(".env.example", ignoreContent)).toBe(true)
+		expect(shouldIgnorePath(".env.local", ignoreContent)).toBe(true)
+	})
+})

--- a/src/utils/cline-ignore.ts
+++ b/src/utils/cline-ignore.ts
@@ -1,0 +1,87 @@
+import { fileExistsAtPath } from "./fs"
+import * as path from "path"
+import * as fs from "fs/promises"
+
+/**
+ * Loads the contents of .clineignore file and returns cache and evaluation function.
+ * @param cwd Current working directory
+ * @returns Object containing patterns and evaluation function
+ */
+function parseIgnorePatterns(clineIgnoreFile: string): string[] {
+	return clineIgnoreFile
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line && !line.startsWith("#"))
+}
+
+export async function loadIgnorePatterns(cwd: string): Promise<{
+	patterns: string[]
+	shouldIgnore: (path: string) => boolean
+}> {
+	const ignoreContent = await loadClineIgnoreFile(cwd)
+	const patterns = parseIgnorePatterns(ignoreContent)
+	return {
+		patterns,
+		shouldIgnore: (path: string) => shouldIgnorePath(path, ignoreContent),
+	}
+}
+
+/**
+ * Filters multiple file paths in batch.
+ * @param paths Array of paths to filter
+ * @param ignoreContent Contents of .clineignore file
+ * @returns Array of filtered paths
+ */
+export function filterIgnoredPaths(paths: string[], ignoreContent: string): string[] {
+	return paths.filter((path) => !shouldIgnorePath(path, ignoreContent))
+}
+
+export async function loadClineIgnoreFile(cwd: string): Promise<string> {
+	const filePath = path.join(cwd, ".clineignore")
+	try {
+		const fileExists = await fileExistsAtPath(filePath)
+		if (!fileExists) {
+			return ""
+		}
+		return fs.readFile(filePath, "utf-8")
+	} catch (error) {
+		return ""
+	}
+}
+
+function convertGlobToRegExp(pattern: string): string {
+	// Handle directory pattern
+	if (pattern.endsWith("/")) {
+		pattern = pattern + "**"
+	}
+
+	return (
+		pattern
+			// Escape special characters
+			.replace(/[.+^${}()|[\]\\]/g, "\\$&")
+			// Convert wildcard * to regex pattern
+			.replace(/\*/g, ".*")
+	)
+}
+
+export function shouldIgnorePath(filePath: string, clineIgnoreFile: string): boolean {
+	const patterns = parseIgnorePatterns(clineIgnoreFile)
+	let isIgnored = false
+
+	// Evaluate patterns in order
+	for (const pattern of patterns) {
+		const isNegation = pattern.startsWith("!")
+		const actualPattern = isNegation ? pattern.slice(1) : pattern
+
+		// Convert pattern to regex
+		const regexPattern = convertGlobToRegExp(actualPattern)
+		const regex = new RegExp(`^${regexPattern}$`)
+
+		// Check if pattern matches
+		if (regex.test(filePath)) {
+			isIgnored = !isNegation
+		}
+	}
+
+	return isIgnored
+}


### PR DESCRIPTION
## Overview
This PR introduces support for .clineignore files, allowing users to specify which files should be ignored during Cline operations.

## Changes
- Implemented .clineignore file parsing and pattern matching
- Added support for glob patterns and negation patterns
- Integrated ignore patterns with existing file processing systems
- Added comprehensive test coverage for ignore pattern functionality

## Implementation Details
- Added new utility functions for handling ignore patterns
- Integrated with extract-text, list-files, and ripgrep services
- Support for various pattern types:
  - Exact matches
  - Wildcards
  - Directory patterns
  - Negation patterns

## Testing
Added comprehensive test suite covering:
- Basic pattern matching
- Wildcard patterns
- Directory patterns
- Negation patterns
- Complex pattern combinations

## Impact
This change improves user control over which files are processed by Cline, making the tool more efficient and customizable.

## Scenarios
[Task] What is written in the .env file? |
:-: | 
<img src="https://github.com/user-attachments/assets/13063482-11ef-4e0e-997d-ce9fd23895d1" width=180/> |
 
[Task] Search for the string SAMPLE_API_KEY and list the files. |
:-: | 
<img src="https://github.com/user-attachments/assets/5006f4ae-958b-4acd-9e27-fd14221353bb" width=180/> |
 
.clineignore files are not listed in the Current Working Directory |
:-: | 
<img src="https://github.com/user-attachments/assets/b818f074-20a5-4a69-afaa-3ad205dc84fc" width=180/> |