### PR TITLE
Fix bug with role definition overrides for built-in modes

### DIFF
--- a/.changeset/purple-grapes-destroy.md
+++ b/.changeset/purple-grapes-destroy.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix bug with role definition overrides for built-in modes

--- a/src/core/prompts/__tests__/system.test.ts
+++ b/src/core/prompts/__tests__/system.test.ts
@@ -350,6 +350,56 @@ describe("SYSTEM_PROMPT", () => {
 		expect(customInstructionsIndex).toBeGreaterThan(userInstructionsHeader)
 	})
 
+	it("should use promptComponent roleDefinition when available", async () => {
+		const customPrompts = {
+			[defaultModeSlug]: {
+				roleDefinition: "Custom prompt role definition",
+				customInstructions: "Custom prompt instructions",
+			},
+		}
+
+		const prompt = await SYSTEM_PROMPT(
+			mockContext,
+			"/test/path",
+			false,
+			undefined,
+			undefined,
+			undefined,
+			defaultModeSlug,
+			customPrompts,
+			undefined,
+		)
+
+		// Role definition from promptComponent should be at the top
+		expect(prompt.indexOf("Custom prompt role definition")).toBeLessThan(prompt.indexOf("TOOL USE"))
+		// Should not contain the default mode's role definition
+		expect(prompt).not.toContain(modes[0].roleDefinition)
+	})
+
+	it("should fallback to modeConfig roleDefinition when promptComponent has no roleDefinition", async () => {
+		const customPrompts = {
+			[defaultModeSlug]: {
+				customInstructions: "Custom prompt instructions",
+				// No roleDefinition provided
+			},
+		}
+
+		const prompt = await SYSTEM_PROMPT(
+			mockContext,
+			"/test/path",
+			false,
+			undefined,
+			undefined,
+			undefined,
+			defaultModeSlug,
+			customPrompts,
+			undefined,
+		)
+
+		// Should use the default mode's role definition
+		expect(prompt.indexOf(modes[0].roleDefinition)).toBeLessThan(prompt.indexOf("TOOL USE"))
+	})
+
 	afterAll(() => {
 		jest.restoreAllMocks()
 	})

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -54,7 +54,7 @@ async function generatePrompt(
 
 	// Get the full mode config to ensure we have the role definition
 	const modeConfig = getModeBySlug(mode, customModeConfigs) || modes.find((m) => m.slug === mode) || modes[0]
-	const roleDefinition = modeConfig.roleDefinition
+	const roleDefinition = promptComponent?.roleDefinition || modeConfig.roleDefinition
 
 	const basePrompt = `${roleDefinition}
 


### PR DESCRIPTION
https://github.com/RooVetGit/Roo-Code/issues/483
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes role definition override bug in `generatePrompt` by prioritizing `promptComponent` roleDefinition and adds relevant tests.
> 
>   - **Behavior**:
>     - Fixes bug in `generatePrompt` in `system.ts` to prioritize `promptComponent` roleDefinition over `modeConfig` roleDefinition.
>     - Adds fallback to `modeConfig` roleDefinition if `promptComponent` roleDefinition is unavailable.
>   - **Tests**:
>     - Adds test `should use promptComponent roleDefinition when available` in `system.test.ts`.
>     - Adds test `should fallback to modeConfig roleDefinition when promptComponent has no roleDefinition` in `system.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8e48b734a5e260158be3e45a1cb5b2ee4dc3dc8b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->