### PR TITLE
Fix button to open custom modes settings

### DIFF
--- a/.changeset/happy-camels-rhyme.md
+++ b/.changeset/happy-camels-rhyme.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix button to open custom modes settings

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -655,6 +655,13 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						}
 						break
 					}
+					case "openCustomModesSettings": {
+						const customModesFilePath = await this.customModesManager.getCustomModesFilePath()
+						if (customModesFilePath) {
+							openFile(customModesFilePath)
+						}
+						break
+					}
 					case "restartMcpServer": {
 						try {
 							await this.mcpHub?.restartConnection(message.text!)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -77,6 +77,7 @@ export interface WebviewMessage {
 		| "updateCustomMode"
 		| "deleteCustomMode"
 		| "setopenAiCustomModelInfo"
+		| "openCustomModesSettings"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -434,8 +434,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 								title="Edit modes configuration"
 								onClick={() => {
 									vscode.postMessage({
-										type: "openFile",
-										text: "settings/cline_custom_modes.json",
+										type: "openCustomModesSettings",
 									})
 								}}>
 								<span className="codicon codicon-json"></span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes button in `PromptsView.tsx` to open custom modes settings by updating message type handling.
> 
>   - **Behavior**:
>     - Fix button in `PromptsView.tsx` to correctly open custom modes settings by changing message type from `openFile` to `openCustomModesSettings`.
>   - **Webview Message Handling**:
>     - Add `openCustomModesSettings` case in `ClineProvider.ts` to handle opening the custom modes file.
>     - Update `WebviewMessage` type in `WebviewMessage.ts` to include `openCustomModesSettings`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2b059c6d15711a27a2bdc258b57444fe1d329a41. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->