### PR TITLE
feat: add explicit Azure OpenAI flag 

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -18,7 +18,7 @@ export class OpenAiHandler implements ApiHandler, SingleCompletionHandler {
 		this.options = options
 		// Azure API shape slightly differs from the core API shape: https://github.com/openai/openai-node?tab=readme-ov-file#microsoft-azure-openai
 		const urlHost = new URL(this.options.openAiBaseUrl ?? "").host
-		if (urlHost === "azure.com" || urlHost.endsWith(".azure.com")) {
+		if (urlHost === "azure.com" || urlHost.endsWith(".azure.com") || options.openAiUseAzure) {
 			this.client = new AzureOpenAI({
 				baseURL: this.options.openAiBaseUrl,
 				apiKey: this.options.openAiApiKey,

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -78,6 +78,7 @@ type GlobalStateKey =
 	| "openAiBaseUrl"
 	| "openAiModelId"
 	| "openAiCustomModelInfo"
+	| "openAiUseAzure"
 	| "ollamaModelId"
 	| "ollamaBaseUrl"
 	| "lmStudioModelId"
@@ -1210,6 +1211,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openAiApiKey,
 			openAiModelId,
 			openAiCustomModelInfo,
+			openAiUseAzure,
 			ollamaModelId,
 			ollamaBaseUrl,
 			lmStudioModelId,
@@ -1244,6 +1246,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		await this.storeSecret("openAiApiKey", openAiApiKey)
 		await this.updateGlobalState("openAiModelId", openAiModelId)
 		await this.updateGlobalState("openAiCustomModelInfo", openAiCustomModelInfo)
+		await this.updateGlobalState("openAiUseAzure", openAiUseAzure)
 		await this.updateGlobalState("ollamaModelId", ollamaModelId)
 		await this.updateGlobalState("ollamaBaseUrl", ollamaBaseUrl)
 		await this.updateGlobalState("lmStudioModelId", lmStudioModelId)
@@ -1861,6 +1864,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openAiApiKey,
 			openAiModelId,
 			openAiCustomModelInfo,
+			openAiUseAzure,
 			ollamaModelId,
 			ollamaBaseUrl,
 			lmStudioModelId,
@@ -1925,6 +1929,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getSecret("openAiApiKey") as Promise<string | undefined>,
 			this.getGlobalState("openAiModelId") as Promise<string | undefined>,
 			this.getGlobalState("openAiCustomModelInfo") as Promise<ModelInfo | undefined>,
+			this.getGlobalState("openAiUseAzure") as Promise<boolean | undefined>,
 			this.getGlobalState("ollamaModelId") as Promise<string | undefined>,
 			this.getGlobalState("ollamaBaseUrl") as Promise<string | undefined>,
 			this.getGlobalState("lmStudioModelId") as Promise<string | undefined>,
@@ -2006,6 +2011,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				openAiApiKey,
 				openAiModelId,
 				openAiCustomModelInfo,
+				openAiUseAzure,
 				ollamaModelId,
 				ollamaBaseUrl,
 				lmStudioModelId,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -39,6 +39,7 @@ export interface ApiHandlerOptions {
 	openAiApiKey?: string
 	openAiModelId?: string
 	openAiCustomModelInfo?: ModelInfo
+	openAiUseAzure?: boolean
 	ollamaModelId?: string
 	ollamaBaseUrl?: string
 	lmStudioModelId?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -537,6 +537,15 @@ const ApiOptions = ({ apiErrorMessage, modelIdErrorMessage }: ApiOptionsProps) =
 						</Checkbox>
 					</div>
 					<Checkbox
+						checked={apiConfiguration?.openAiUseAzure ?? false}
+						onChange={(checked: boolean) => {
+							handleInputChange("openAiUseAzure")({
+								target: { value: checked },
+							})
+						}}>
+						Use Azure
+					</Checkbox>
+					<Checkbox
 						checked={azureApiVersionSelected}
 						onChange={(checked: boolean) => {
 							setAzureApiVersionSelected(checked)


### PR DESCRIPTION
- Add openAiUseAzure flag to force Azure OpenAI client initialization
- Add "Use Azure" checkbox in API settings UI

fix #430 

<img width="545" alt="image" src="https://github.com/user-attachments/assets/623f6305-5106-4aa4-8c1e-64429aaa05b0" />


This change improves Azure OpenAI configuration flexibility by allowing users to explicitly opt-in to Azure client, regardless of the base URL pattern.

<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `openAiUseAzure` flag and UI checkbox to explicitly use Azure OpenAI, enhancing configuration flexibility.
> 
>   - **Behavior**:
>     - Add `openAiUseAzure` flag in `openai.ts` to force Azure OpenAI client initialization.
>     - Add "Use Azure" checkbox in `ApiOptions.tsx` to toggle `openAiUseAzure`.
>   - **State Management**:
>     - Update `ClineProvider.ts` to handle `openAiUseAzure` in global state.
>   - **UI**:
>     - Add "Use Azure" checkbox in API settings UI in `ApiOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f745f080f48caeca9eddbdd8debc94c235c9f76c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->