### PR TITLE
feat: user prompt in code action

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,11 +201,29 @@ export function activate(context: vscode.ExtensionContext) {
 	}
 
 	// Register code action commands
-	registerCodeAction(context, "roo-cline.explainCode", "EXPLAIN")
+	registerCodeAction(
+		context,
+		"roo-cline.explainCode",
+		"EXPLAIN",
+		"What would you like Roo to explain?",
+		"E.g. How does the error handling work?",
+	)
 
-	registerCodeAction(context, "roo-cline.fixCode", "FIX")
+	registerCodeAction(
+		context,
+		"roo-cline.fixCode",
+		"FIX",
+		"What would you like Roo to fix?",
+		"E.g. Maintain backward compatibility",
+	)
 
-	registerCodeAction(context, "roo-cline.improveCode", "IMPROVE")
+	registerCodeAction(
+		context,
+		"roo-cline.improveCode",
+		"IMPROVE",
+		"What would you like Roo to improve?",
+		"E.g. Focus on performance optimization",
+	)
 
 	return createClineAPI(outputChannel, sidebarProvider)
 }


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description
User prompt for code action 
## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds user prompts for code actions in `extension.ts` to enhance user interaction for `EXPLAIN`, `FIX`, and `IMPROVE` actions.
> 
>   - **New Feature**:
>     - Adds user prompts to `registerCodeAction` in `extension.ts` for code actions `EXPLAIN`, `FIX`, and `IMPROVE`.
>     - Prompts include specific questions and examples, e.g., "What would you like Roo to explain?" with placeholder "E.g. How does the error handling work?".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a7ae6c46d1e5369591b81f949fe186955390969b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->