### PR TITLE
Do a more complete mode switch from switch_mode command

### DIFF
--- a/.changeset/stupid-parrots-grin.md
+++ b/.changeset/stupid-parrots-grin.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix bug where the saved API provider for a mode wasn't being selected after a mode switch command

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2065,11 +2065,10 @@ export class Cline {
 									break
 								}
 
-								// Switch the mode
+								// Switch the mode using shared handler
 								const provider = this.providerRef.deref()
 								if (provider) {
-									await provider.updateGlobalState("mode", mode_slug)
-									await provider.postStateToWebview()
+									await provider.handleModeSwitch(mode_slug)
 								}
 								pushToolResult(
 									`Successfully switched from ${getModeBySlug(currentMode)?.name ?? currentMode} mode to ${

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -781,38 +781,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						await this.postStateToWebview()
 						break
 					case "mode":
-						const newMode = message.text as Mode
-						await this.updateGlobalState("mode", newMode)
-
-						// Load the saved API config for the new mode if it exists
-						const savedConfigId = await this.configManager.getModeConfigId(newMode)
-						const listApiConfig = await this.configManager.listConfig()
-
-						// Update listApiConfigMeta first to ensure UI has latest data
-						await this.updateGlobalState("listApiConfigMeta", listApiConfig)
-
-						// If this mode has a saved config, use it
-						if (savedConfigId) {
-							const config = listApiConfig?.find((c) => c.id === savedConfigId)
-							if (config?.name) {
-								const apiConfig = await this.configManager.loadConfig(config.name)
-								await Promise.all([
-									this.updateGlobalState("currentApiConfigName", config.name),
-									this.updateApiConfiguration(apiConfig),
-								])
-							}
-						} else {
-							// If no saved config for this mode, save current config as default
-							const currentApiConfigName = await this.getGlobalState("currentApiConfigName")
-							if (currentApiConfigName) {
-								const config = listApiConfig?.find((c) => c.name === currentApiConfigName)
-								if (config?.id) {
-									await this.configManager.setModeConfig(newMode, config.id)
-								}
-							}
-						}
-
-						await this.postStateToWebview()
+						await this.handleModeSwitch(message.text as Mode)
 						break
 					case "updateSupportPrompt":
 						try {
@@ -1239,6 +1208,44 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			null,
 			this.disposables,
 		)
+	}
+
+	/**
+	 * Handle switching to a new mode, including updating the associated API configuration
+	 * @param newMode The mode to switch to
+	 */
+	public async handleModeSwitch(newMode: Mode) {
+		await this.updateGlobalState("mode", newMode)
+
+		// Load the saved API config for the new mode if it exists
+		const savedConfigId = await this.configManager.getModeConfigId(newMode)
+		const listApiConfig = await this.configManager.listConfig()
+
+		// Update listApiConfigMeta first to ensure UI has latest data
+		await this.updateGlobalState("listApiConfigMeta", listApiConfig)
+
+		// If this mode has a saved config, use it
+		if (savedConfigId) {
+			const config = listApiConfig?.find((c) => c.id === savedConfigId)
+			if (config?.name) {
+				const apiConfig = await this.configManager.loadConfig(config.name)
+				await Promise.all([
+					this.updateGlobalState("currentApiConfigName", config.name),
+					this.updateApiConfiguration(apiConfig),
+				])
+			}
+		} else {
+			// If no saved config for this mode, save current config as default
+			const currentApiConfigName = await this.getGlobalState("currentApiConfigName")
+			if (currentApiConfigName) {
+				const config = listApiConfig?.find((c) => c.name === currentApiConfigName)
+				if (config?.id) {
+					await this.configManager.setModeConfig(newMode, config.id)
+				}
+			}
+		}
+
+		await this.postStateToWebview()
 	}
 
 	private async updateApiConfiguration(apiConfiguration: ApiConfiguration) {


### PR DESCRIPTION
From Discord: "found a bug. When I approved the mode change it doesnt change the model like it does when i manually switch"
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix mode switch bug by centralizing logic in `handleModeSwitch()` in `ClineProvider`, ensuring correct API provider updates.
> 
>   - **Behavior**:
>     - Fix bug where API provider wasn't updated after mode switch in `Cline.ts` and `ClineProvider.ts`.
>     - Introduce `handleModeSwitch()` in `ClineProvider` to centralize mode switching logic.
>   - **Tests**:
>     - Add tests for `handleModeSwitch()` in `ClineProvider.test.ts` to verify correct API config loading and saving.
>   - **Misc**:
>     - Update `Cline.ts` to use `handleModeSwitch()` for mode changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8c929ba16aca0a671aa01bc2d8719004f7bb25c9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->