### PR TITLE
Fix multiple terminals created

### DIFF
--- a/.changeset/friendly-bottles-kneel.md
+++ b/.changeset/friendly-bottles-kneel.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix issue where the terminal management system was creating unnecessary new terminals (thanks @evan-fannin!)


### PR DESCRIPTION
Pull in https://github.com/cline/cline/pull/1294
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes unnecessary terminal creation in `TerminalManager.ts` by reusing available terminals with matching `cwd`.
> 
>   - **Behavior**:
>     - Fixes issue in `getOrCreateTerminal()` in `TerminalManager.ts` where unnecessary new terminals were created.
>     - Now checks for a matching terminal with the same `cwd` and reuses it if available.
>     - If no matching terminal, finds any non-busy terminal and navigates to the desired `cwd`.
>     - Only creates a new terminal if all existing ones are busy.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 68712ea0f6bffdaef353914e41587dc3c438fa99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->