### PR TITLE
Display reasoning for supported openrouter models

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -110,12 +110,20 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 				maxTokens = 8_192
 				break
 		}
+
+		let temperature = 0
+		switch (this.getModel().id) {
+			case "deepseek/deepseek-r1":
+				// Recommended temperature for DeepSeek reasoning models
+				temperature = 0.6
+		}
+
 		// https://openrouter.ai/docs/transforms
 		let fullResponseText = ""
 		const stream = await this.client.chat.completions.create({
 			model: this.getModel().id,
 			max_tokens: maxTokens,
-			temperature: 0,
+			temperature: temperature,
 			messages: openAiMessages,
 			stream: true,
 			// This way, the transforms field will only be included in the parameters when openRouterUseMiddleOutTransform is true.

--- a/src/api/transform/stream.ts
+++ b/src/api/transform/stream.ts
@@ -1,8 +1,13 @@
 export type ApiStream = AsyncGenerator<ApiStreamChunk>
-export type ApiStreamChunk = ApiStreamTextChunk | ApiStreamUsageChunk
+export type ApiStreamChunk = ApiStreamTextChunk | ApiStreamUsageChunk | ApiStreamReasoningChunk
 
 export interface ApiStreamTextChunk {
 	type: "text"
+	text: string
+}
+
+export interface ApiStreamReasoningChunk {
+	type: "reasoning"
 	text: string
 }
 

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2219,7 +2219,7 @@ export class Cline {
 		}
 
 		/*
-		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present. 
+		Seeing out of bounds is fine, it means that the next too call is being built up and ready to add to assistantMessageContent to present.
 		When you see the UI inactive during this, it means that a tool is breaking without presenting any UI. For example the write_to_file tool was breaking when relpath was undefined, and for invalid relpath it never presented UI.
 		*/
 		this.presentAssistantMessageLocked = false // this needs to be placed here, if not then calling this.presentAssistantMessage below would fail (sometimes) since it's locked
@@ -2391,9 +2391,14 @@ export class Cline {
 
 			const stream = this.attemptApiRequest(previousApiReqIndex) // yields only if the first chunk is successful, otherwise will allow the user to retry the request (most likely due to rate limit error, which gets thrown on the first chunk)
 			let assistantMessage = ""
+			let reasoningMessage = ""
 			try {
 				for await (const chunk of stream) {
 					switch (chunk.type) {
+						case "reasoning":
+							reasoningMessage += chunk.text
+							await this.say("reasoning", reasoningMessage, undefined, true)
+							break
 						case "usage":
 							inputTokens += chunk.inputTokens
 							outputTokens += chunk.outputTokens

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -121,6 +121,7 @@ export interface ClineMessage {
 	text?: string
 	images?: string[]
 	partial?: boolean
+	reasoning?: string
 }
 
 export type ClineAsk =
@@ -142,6 +143,7 @@ export type ClineSay =
 	| "api_req_started"
 	| "api_req_finished"
 	| "text"
+	| "reasoning"
 	| "completion_result"
 	| "user_feedback"
 	| "user_feedback_diff"

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -15,6 +15,7 @@ import { vscode } from "../../utils/vscode"
 import CodeAccordian, { removeLeadingNonAlphanumeric } from "../common/CodeAccordian"
 import CodeBlock, { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 import MarkdownBlock from "../common/MarkdownBlock"
+import ReasoningBlock from "./ReasoningBlock"
 import Thumbnails from "../common/Thumbnails"
 import McpResourceRow from "../mcp/McpResourceRow"
 import McpToolRow from "../mcp/McpToolRow"
@@ -79,6 +80,14 @@ export const ChatRowContent = ({
 	isStreaming,
 }: ChatRowContentProps) => {
 	const { mcpServers } = useExtensionState()
+	const [reasoningCollapsed, setReasoningCollapsed] = useState(false)
+
+	// Auto-collapse reasoning when new messages arrive
+	useEffect(() => {
+		if (!isLast && message.say === "reasoning") {
+			setReasoningCollapsed(true)
+		}
+	}, [isLast, message.say])
 	const [cost, apiReqCancelReason, apiReqStreamingFailedMessage] = useMemo(() => {
 		if (message.text != null && message.say === "api_req_started") {
 			const info: ClineApiReqInfo = JSON.parse(message.text)
@@ -472,6 +481,14 @@ export const ChatRowContent = ({
 	switch (message.type) {
 		case "say":
 			switch (message.say) {
+				case "reasoning":
+					return (
+						<ReasoningBlock
+							content={message.text || ""}
+							isCollapsed={reasoningCollapsed}
+							onToggleCollapse={() => setReasoningCollapsed(!reasoningCollapsed)}
+						/>
+					)
 				case "api_req_started":
 					return (
 						<>

--- a/webview-ui/src/components/chat/ReasoningBlock.tsx
+++ b/webview-ui/src/components/chat/ReasoningBlock.tsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useRef } from "react"
+import { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
+import MarkdownBlock from "../common/MarkdownBlock"
+
+interface ReasoningBlockProps {
+	content: string
+	isCollapsed?: boolean
+	onToggleCollapse?: () => void
+	autoHeight?: boolean
+}
+
+const ReasoningBlock: React.FC<ReasoningBlockProps> = ({
+	content,
+	isCollapsed = false,
+	onToggleCollapse,
+	autoHeight = false,
+}) => {
+	const contentRef = useRef<HTMLDivElement>(null)
+
+	// Scroll to bottom when content updates
+	useEffect(() => {
+		if (contentRef.current && !isCollapsed) {
+			contentRef.current.scrollTop = contentRef.current.scrollHeight
+		}
+	}, [content, isCollapsed])
+
+	return (
+		<div
+			style={{
+				backgroundColor: CODE_BLOCK_BG_COLOR,
+				border: "1px solid var(--vscode-editorGroup-border)",
+				borderRadius: "3px",
+				overflow: "hidden",
+			}}>
+			<div
+				onClick={onToggleCollapse}
+				style={{
+					padding: "8px 12px",
+					cursor: "pointer",
+					userSelect: "none",
+					display: "flex",
+					alignItems: "center",
+					justifyContent: "space-between",
+					borderBottom: isCollapsed ? "none" : "1px solid var(--vscode-editorGroup-border)",
+				}}>
+				<span style={{ fontWeight: "bold" }}>Reasoning</span>
+				<span className={`codicon codicon-chevron-${isCollapsed ? "right" : "down"}`}></span>
+			</div>
+			{!isCollapsed && (
+				<div
+					ref={contentRef}
+					style={{
+						padding: "8px 12px",
+						maxHeight: autoHeight ? "none" : "160px",
+						overflowY: "auto",
+					}}>
+					<div
+						style={{
+							fontSize: "13px",
+							opacity: 0.9,
+						}}>
+						<MarkdownBlock markdown={content} />
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default ReasoningBlock


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description
Introduced way to display model reasoning for compatible models. For now only openrouter is implemented.
It displays current reasoning, and hides it when content response is available.
Block is limited in height and auto scrolls.
Because reasoning might take long time, it provides better user feedback and allows better insights into model pitfalls.

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

1. configure openrouter provider
2. Select deepseek-r1 model
3. ask any question.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
![image](https://github.com/user-attachments/assets/e82483f7-bce1-4762-a382-50847e65dc1c)

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds reasoning display for OpenRouter models, including backend handling and UI components for reasoning data.
> 
>   - **Behavior**:
>     - Adds `include_reasoning` parameter to `OpenRouterChatCompletionParams` in `openrouter.ts` to include reasoning in responses.
>     - Updates `createMessage()` in `openrouter.ts` to yield reasoning chunks.
>     - Implements reasoning display in `Cline.ts` by handling reasoning chunks in `attemptApiRequest()`.
>   - **UI**:
>     - Adds `ReasoningBlock` component in `ReasoningBlock.tsx` to display reasoning with auto-scroll and collapse functionality.
>     - Updates `ChatRow.tsx` to include `ReasoningBlock` for reasoning messages.
>   - **Types**:
>     - Adds `ApiStreamReasoningChunk` to `stream.ts` for handling reasoning data.
>     - Updates `ClineMessage` in `ExtensionMessage.ts` to include `reasoning` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c6607065b9fa5264d14ce1d802e1897b5b475901. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->