### PR TITLE
Fix bug where always allow wasn't showing up for MCP tools

### DIFF
--- a/.changeset/new-keys-relax.md
+++ b/.changeset/new-keys-relax.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix bug where always allow wasn't showing up for MCP tools

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -78,7 +78,7 @@ export const ChatRowContent = ({
 	isLast,
 	isStreaming,
 }: ChatRowContentProps) => {
-	const { mcpServers } = useExtensionState()
+	const { mcpServers, alwaysAllowMcp } = useExtensionState()
 	const [cost, apiReqCancelReason, apiReqStreamingFailedMessage] = useMemo(() => {
 		if (message.text != null && message.say === "api_req_started") {
 			const info: ClineApiReqInfo = JSON.parse(message.text)
@@ -871,6 +871,7 @@ export const ChatRowContent = ({
 														)?.alwaysAllow || false,
 												}}
 												serverName={useMcpServer.serverName}
+												alwaysAllowMcp={alwaysAllowMcp}
 											/>
 										</div>
 										{useMcpServer.arguments && useMcpServer.arguments !== "{}" && (


### PR DESCRIPTION
Before:
![Screenshot 2025-01-25 at 11 50 15 PM](https://github.com/user-attachments/assets/d9049056-f007-4e32-b8df-8d5e5b9be417)

After:
<img width="568" alt="Screenshot 2025-01-25 at 11 48 37 PM" src="https://github.com/user-attachments/assets/ba93c4ca-3cc3-4286-99a3-1a97388f9a8e" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `ChatRow.tsx` to display 'always allow' option for MCP tools by adding `alwaysAllowMcp` to `McpToolRow`.
> 
>   - **Behavior**:
>     - Fixes bug where 'always allow' option was not showing for MCP tools in `ChatRow.tsx`.
>     - Adds `alwaysAllowMcp` to `McpToolRow` component to ensure visibility.
>   - **Misc**:
>     - Adds a changeset file `new-keys-relax.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d052bebed69afbfd235f82b87c26579b9dac66cd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->