### PR TITLE
Do not exclude whole project dir when listing in case where project i…

### DIFF
--- a/src/services/glob/list-files.ts
+++ b/src/services/glob/list-files.ts
@@ -34,7 +34,7 @@ export async function listFiles(dirPath: string, recursive: boolean, limit: numb
 		"pkg",
 		"Pods",
 		".*", // '!**/.*' excludes hidden directories, while '!**/.*/**' excludes only their contents. This way we are at least aware of the existence of hidden directories.
-	].map((dir) => `**/${dir}/**`)
+	].map((dir) => `${dirPath}/**/${dir}/**`)
 
 	const options = {
 		cwd: dirPath,


### PR DESCRIPTION
…s places inside excluded dir (like /tmp or ~/tmp)

While doing some testing reasoning I noticed that model gets confused by information that working directory is empty, yet file inside is open. I found that this was caused by putting my test project in /tmp.
Current logic tries to exclude “noise” files inside project, but the glob used does not take into consideration working directory. In case project was inside excluded directory name it would always exclude everything.
This simple PR fix that by appending working dir to exclusion glob to limit it to names inside project directory.

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Create new project inside one of excluded directories like `/tmp` and confirm api request Current Working Directory Files section to contain correct listing.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes exclusion pattern in `listFiles()` to prevent entire project directories from being excluded when located inside ignored directories.
> 
>   - **Bug Fix**:
>     - Fixes issue in `listFiles()` in `list-files.ts` where projects inside excluded directories (e.g., `/tmp`) were entirely excluded.
>     - Updates exclusion pattern to be relative to `dirPath`, ensuring only specific subdirectories are ignored.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 048863e03991a3b49429a77827da2f96b32889f9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->