### PR TITLE
Throw FileRestrictionErrors sooner

### DIFF
--- a/.changeset/late-moose-watch.md
+++ b/.changeset/late-moose-watch.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Throw errors sooner when a mode tries to write a restricted file

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1144,25 +1144,22 @@ export class Cline {
 					await this.browserSession.closeBrowser()
 				}
 
-				// Only validate complete tool uses
-				if (!block.partial) {
-					const { mode } = (await this.providerRef.deref()?.getState()) ?? {}
-					const { customModes } = (await this.providerRef.deref()?.getState()) ?? {}
-					try {
-						validateToolUse(
-							block.name as ToolName,
-							mode ?? defaultModeSlug,
-							customModes ?? [],
-							{
-								apply_diff: this.diffEnabled,
-							},
-							block.params,
-						)
-					} catch (error) {
-						this.consecutiveMistakeCount++
-						pushToolResult(formatResponse.toolError(error.message))
-						break
-					}
+				// Validate tool use before execution
+				const { mode, customModes } = (await this.providerRef.deref()?.getState()) ?? {}
+				try {
+					validateToolUse(
+						block.name as ToolName,
+						mode ?? defaultModeSlug,
+						customModes ?? [],
+						{
+							apply_diff: this.diffEnabled,
+						},
+						block.params,
+					)
+				} catch (error) {
+					this.consecutiveMistakeCount++
+					pushToolResult(formatResponse.toolError(error.message))
+					break
 				}
 
 				switch (block.name) {

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -196,11 +196,13 @@ export function isToolAllowedForMode(
 		// For the edit group, check file regex if specified
 		if (groupName === "edit" && options.fileRegex) {
 			const filePath = toolParams?.path
-			// Only validate regex if a path is provided
-			if (filePath && !doesFileMatchRegex(filePath, options.fileRegex)) {
+			if (
+				filePath &&
+				(toolParams.diff || toolParams.content) &&
+				!doesFileMatchRegex(filePath, options.fileRegex)
+			) {
 				throw new FileRestrictionError(mode.name, options.fileRegex, options.description, filePath)
 			}
-			return true
 		}
 
 		return true


### PR DESCRIPTION
Previous behavior I added in #523 had an annoying side effect of not erroring out on writes to invalid file types until the user attempted to save the file. This is because I didn't want to validate the file path suffix while it was still streaming in, but I think this is a better approach - to wait until the content shows up and assume we have the full path then.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Validate file restrictions before tool execution to throw errors sooner, with updates in `Cline.ts`, `modes.ts`, and `modes.test.ts`.
> 
>   - **Behavior**:
>     - Validate file restrictions before tool execution in `Cline.ts`, ensuring errors are thrown sooner.
>     - Update `isToolAllowedForMode()` in `modes.ts` to check file path and content/diff before allowing tool execution.
>   - **Tests**:
>     - Update tests in `modes.test.ts` to include content/diff in `isToolAllowedForMode()` calls, ensuring early error detection.
>     - Add tests for partial streaming cases and custom mode descriptions in `modes.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5d2047778503628310cf80bb6bd4423e0f2f0dcf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->