### PR TITLE
Add per-server MCP network timeout configuration

### DIFF
--- a/.changeset/flat-items-buy.md
+++ b/.changeset/flat-items-buy.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add per-server MCP network timeout configuration

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1177,6 +1177,16 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						}
 						await this.postStateToWebview()
 						break
+					case "updateMcpTimeout":
+						if (message.serverName && typeof message.timeout === "number") {
+							try {
+								await this.mcpHub?.updateServerTimeout(message.serverName, message.timeout)
+							} catch (error) {
+								console.error(`Failed to update timeout for ${message.serverName}:`, error)
+								vscode.window.showErrorMessage(`Failed to update server timeout`)
+							}
+						}
+						break
 					case "updateCustomMode":
 						if (message.modeConfig) {
 							await this.customModesManager.updateCustomMode(message.modeConfig.slug, message.modeConfig)

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -51,6 +51,7 @@ export interface WebviewMessage {
 		| "restartMcpServer"
 		| "toggleToolAlwaysAllow"
 		| "toggleMcpServer"
+		| "updateMcpTimeout"
 		| "fuzzyMatchThreshold"
 		| "preferredLanguage"
 		| "writeDelayMs"
@@ -99,6 +100,7 @@ export interface WebviewMessage {
 	query?: string
 	slug?: string
 	modeConfig?: ModeConfig
+	timeout?: number
 }
 
 export type ClineAskResponse = "yesButtonClicked" | "noButtonClicked" | "messageResponse"

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -7,6 +7,7 @@ export type McpServer = {
 	resources?: McpResource[]
 	resourceTemplates?: McpResourceTemplate[]
 	disabled?: boolean
+	timeout?: number
 }
 
 export type McpTool = {


### PR DESCRIPTION
People have been requesting longer MCP timeouts to allow for asynchronous use cases. This PR adds a per-server configurable network timeout that's stored in the JSON config. Seem reasonable?

![Screenshot 2025-01-26 at 4 36 57 PM](https://github.com/user-attachments/assets/5e50a75e-af6e-407a-8823-edca11bea02f)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add per-server configurable network timeout for MCP servers, with UI support and validation.
> 
>   - **Behavior**:
>     - Adds per-server configurable network timeout in `McpHub.ts` and `ClineProvider.ts`.
>     - Timeout is stored in JSON config and can be updated via the UI in `McpView.tsx`.
>     - Default timeout is 60 seconds, configurable between 1 and 3600 seconds.
>   - **Schema**:
>     - Updates `StdioConfigSchema` in `McpHub.ts` to include `timeout` with validation.
>   - **UI**:
>     - Adds timeout selection dropdown in `McpView.tsx` for each server.
>   - **Tests**:
>     - Adds tests for timeout configuration in `McpHub.test.ts`.
>     - Validates timeout values and ensures correct application in tool calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 57518e10b3e4797745d8225900ef06cbe9483164. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->