### PR TITLE
feat(code-actions): add "Fix Code in Current Task" action

### DIFF
--- a/src/core/CodeActionProvider.ts
+++ b/src/core/CodeActionProvider.ts
@@ -1,15 +1,18 @@
 import * as vscode from "vscode"
 import * as path from "path"
+import { ClineProvider } from "./webview/ClineProvider"
 
 export const ACTION_NAMES = {
 	EXPLAIN: "Roo Code: Explain Code",
 	FIX: "Roo Code: Fix Code",
+	FIX_IN_CURRENT_TASK: "Roo Code: Fix Code in Current Task",
 	IMPROVE: "Roo Code: Improve Code",
 } as const
 
 const COMMAND_IDS = {
 	EXPLAIN: "roo-cline.explainCode",
 	FIX: "roo-cline.fixCode",
+	FIX_IN_CURRENT_TASK: "roo-cline.fixCodeInCurrentTask",
 	IMPROVE: "roo-cline.improveCode",
 } as const
 
@@ -159,6 +162,13 @@ export class CodeActionProvider implements vscode.CodeActionProvider {
 							effectiveRange.text,
 							diagnosticMessages,
 						]),
+
+						this.createAction(
+							ACTION_NAMES.FIX_IN_CURRENT_TASK,
+							vscode.CodeActionKind.QuickFix,
+							COMMAND_IDS.FIX_IN_CURRENT_TASK,
+							[filePath, effectiveRange.text, diagnosticMessages],
+						),
 					)
 				}
 			}

--- a/src/core/__tests__/CodeActionProvider.test.ts
+++ b/src/core/__tests__/CodeActionProvider.test.ts
@@ -125,7 +125,7 @@ describe("CodeActionProvider", () => {
 
 			const actions = provider.provideCodeActions(mockDocument, mockRange, mockContext)
 
-			expect(actions).toHaveLength(3)
+			expect(actions).toHaveLength(4)
 			expect((actions as any).some((a: any) => a.title === "Roo Code: Fix Code")).toBe(true)
 		})
 

--- a/src/core/__tests__/CodeActionProvider.test.ts
+++ b/src/core/__tests__/CodeActionProvider.test.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode"
-import { CodeActionProvider } from "../CodeActionProvider"
+import { CodeActionProvider, ACTION_NAMES } from "../CodeActionProvider"
 
 // Mock VSCode API
 jest.mock("vscode", () => ({
@@ -109,9 +109,11 @@ describe("CodeActionProvider", () => {
 		it("should provide explain and improve actions by default", () => {
 			const actions = provider.provideCodeActions(mockDocument, mockRange, mockContext)
 
-			expect(actions).toHaveLength(2)
-			expect((actions as any)[0].title).toBe("Roo Code: Explain Code")
-			expect((actions as any)[1].title).toBe("Roo Code: Improve Code")
+			expect(actions).toHaveLength(4)
+			expect((actions as any)[0].title).toBe(`${ACTION_NAMES.EXPLAIN} in New Task`)
+			expect((actions as any)[1].title).toBe(`${ACTION_NAMES.EXPLAIN} in Current Task`)
+			expect((actions as any)[2].title).toBe(`${ACTION_NAMES.IMPROVE} in New Task`)
+			expect((actions as any)[3].title).toBe(`${ACTION_NAMES.IMPROVE} in Current Task`)
 		})
 
 		it("should provide fix action when diagnostics exist", () => {
@@ -125,8 +127,9 @@ describe("CodeActionProvider", () => {
 
 			const actions = provider.provideCodeActions(mockDocument, mockRange, mockContext)
 
-			expect(actions).toHaveLength(4)
-			expect((actions as any).some((a: any) => a.title === "Roo Code: Fix Code")).toBe(true)
+			expect(actions).toHaveLength(6)
+			expect((actions as any).some((a: any) => a.title === `${ACTION_NAMES.FIX} in New Task`)).toBe(true)
+			expect((actions as any).some((a: any) => a.title === `${ACTION_NAMES.FIX} in Current Task`)).toBe(true)
 		})
 
 		it("should handle errors gracefully", () => {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -234,7 +234,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 		const prompt = supportPrompt.create(promptType, params, customSupportPrompts)
 
-		if (visibleProvider.cline && ["roo-cline.fixCodeInCurrentTask"].indexOf(command) !== -1) {
+		if (visibleProvider.cline && command.endsWith("InCurrentTask")) {
 			await visibleProvider.postMessageToWebview({
 				type: "invoke",
 				invoke: "sendMessage",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -188,10 +188,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		return findLast(Array.from(this.activeInstances), (instance) => instance.view?.visible === true)
 	}
 
-	public static async handleCodeAction(
-		promptType: keyof typeof ACTION_NAMES,
-		params: Record<string, string | any[]>,
-	): Promise<void> {
+	public static async getInstance(): Promise<ClineProvider | undefined> {
 		let visibleProvider = ClineProvider.getVisibleInstance()
 
 		// If no visible provider, try to show the sidebar view
@@ -207,9 +204,45 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			return
 		}
 
+		return visibleProvider
+	}
+
+	public static async isActiveTask(): Promise<boolean> {
+		const visibleProvider = await ClineProvider.getInstance()
+		if (!visibleProvider) {
+			return false
+		}
+
+		if (visibleProvider.cline) {
+			return true
+		}
+
+		return false
+	}
+
+	public static async handleCodeAction(
+		command: string,
+		promptType: keyof typeof ACTION_NAMES,
+		params: Record<string, string | any[]>,
+	): Promise<void> {
+		const visibleProvider = await ClineProvider.getInstance()
+		if (!visibleProvider) {
+			return
+		}
+
 		const { customSupportPrompts } = await visibleProvider.getState()
 
 		const prompt = supportPrompt.create(promptType, params, customSupportPrompts)
+
+		if (visibleProvider.cline && ["roo-cline.fixCodeInCurrentTask"].indexOf(command) !== -1) {
+			await visibleProvider.postMessageToWebview({
+				type: "invoke",
+				invoke: "sendMessage",
+				text: prompt,
+			})
+
+			return
+		}
 
 		await visibleProvider.initClineWithTask(prompt)
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -171,6 +171,7 @@ export function activate(context: vscode.ExtensionContext) {
 		context: vscode.ExtensionContext,
 		command: string,
 		promptType: keyof typeof ACTION_NAMES,
+		inNewTask: boolean,
 		inputPrompt?: string,
 		inputPlaceholder?: string,
 	) => {
@@ -200,8 +201,23 @@ export function activate(context: vscode.ExtensionContext) {
 		)
 	}
 
+	// Helper function to register both versions of a code action
+	const registerCodeActionPair = (
+		context: vscode.ExtensionContext,
+		baseCommand: string,
+		promptType: keyof typeof ACTION_NAMES,
+		inputPrompt?: string,
+		inputPlaceholder?: string,
+	) => {
+		// Register new task version
+		registerCodeAction(context, baseCommand, promptType, true, inputPrompt, inputPlaceholder)
+
+		// Register current task version
+		registerCodeAction(context, `${baseCommand}InCurrentTask`, promptType, false, inputPrompt, inputPlaceholder)
+	}
+
 	// Register code action commands
-	registerCodeAction(
+	registerCodeActionPair(
 		context,
 		"roo-cline.explainCode",
 		"EXPLAIN",
@@ -209,7 +225,7 @@ export function activate(context: vscode.ExtensionContext) {
 		"E.g. How does the error handling work?",
 	)
 
-	registerCodeAction(
+	registerCodeActionPair(
 		context,
 		"roo-cline.fixCode",
 		"FIX",
@@ -217,15 +233,7 @@ export function activate(context: vscode.ExtensionContext) {
 		"E.g. Maintain backward compatibility",
 	)
 
-	registerCodeAction(
-		context,
-		"roo-cline.fixCodeInCurrentTask",
-		"FIX", // keep this for use the same prompt with FIX command
-		"What would you like Roo to fix?",
-		"E.g. Maintain backward compatibility",
-	)
-
-	registerCodeAction(
+	registerCodeActionPair(
 		context,
 		"roo-cline.improveCode",
 		"IMPROVE",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -194,7 +194,7 @@ export function activate(context: vscode.ExtensionContext) {
 						...(userInput ? { userInput } : {}),
 					}
 
-					await ClineProvider.handleCodeAction(promptType, params)
+					await ClineProvider.handleCodeAction(command, promptType, params)
 				},
 			),
 		)
@@ -213,6 +213,14 @@ export function activate(context: vscode.ExtensionContext) {
 		context,
 		"roo-cline.fixCode",
 		"FIX",
+		"What would you like Roo to fix?",
+		"E.g. Maintain backward compatibility",
+	)
+
+	registerCodeAction(
+		context,
+		"roo-cline.fixCodeInCurrentTask",
+		"FIX", // keep this for use the same prompt with FIX command
 		"What would you like Roo to fix?",
 		"E.g. Maintain backward compatibility",
 	)


### PR DESCRIPTION
Adds ability to fix code within the context of an active task instead of starting a new one. This allows for more efficient workflow when already working with Roo.

Add new FIX_IN_CURRENT_TASK code action and command Enhance ClineProvider to support context-aware code fixing Update tests to verify new action functionality

<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `FIX_IN_CURRENT_TASK` action to handle code fixes within active tasks, updating `CodeActionProvider`, `ClineProvider`, and `extension` files, with tests in `CodeActionProvider.test.ts`.
> 
>   - **Behavior**:
>     - Add `FIX_IN_CURRENT_TASK` action and command in `CodeActionProvider.ts`.
>     - Update `ClineProvider.ts` to handle `FIX_IN_CURRENT_TASK` command, checking for active tasks and sending messages to the webview.
>     - Register `FIX_IN_CURRENT_TASK` command in `extension.ts` with prompt for user input.
>   - **Tests**:
>     - Update `CodeActionProvider.test.ts` to verify `FIX_IN_CURRENT_TASK` action, increasing expected actions count from 3 to 4.
>   - **Misc**:
>     - Add `FIX_IN_CURRENT_TASK` to `ACTION_NAMES` and `COMMAND_IDS` in `CodeActionProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 85c49d8eff6641dee1d68a7e113399135a8eb7f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->