### PR TITLE
Extend deepseek-r1 support

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -19,6 +19,7 @@ interface OpenRouterApiStreamUsageChunk extends ApiStreamUsageChunk {
 }
 
 import { SingleCompletionHandler } from ".."
+import { convertToR1Format } from "../transform/r1-format"
 
 export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 	private options: ApiHandlerOptions
@@ -41,7 +42,7 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 		messages: Anthropic.Messages.MessageParam[],
 	): AsyncGenerator<ApiStreamChunk> {
 		// Convert Anthropic messages to OpenAI format
-		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
 			...convertToOpenAiMessages(messages),
 		]
@@ -117,6 +118,9 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 			case "deepseek/deepseek-r1":
 				// Recommended temperature for DeepSeek reasoning models
 				temperature = 0.6
+				// DeepSeek highly recommends using user instead of system role
+				openAiMessages[0].role = "user"
+				openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}
 
 		// https://openrouter.ai/docs/transforms

--- a/src/api/transform/__tests__/r1-format.test.ts
+++ b/src/api/transform/__tests__/r1-format.test.ts
@@ -1,0 +1,180 @@
+import { convertToR1Format } from "../r1-format"
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+
+describe("convertToR1Format", () => {
+	it("should convert basic text messages", () => {
+		const input: Anthropic.Messages.MessageParam[] = [
+			{ role: "user", content: "Hello" },
+			{ role: "assistant", content: "Hi there" },
+		]
+
+		const expected: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{ role: "user", content: "Hello" },
+			{ role: "assistant", content: "Hi there" },
+		]
+
+		expect(convertToR1Format(input)).toEqual(expected)
+	})
+
+	it("should merge consecutive messages with same role", () => {
+		const input: Anthropic.Messages.MessageParam[] = [
+			{ role: "user", content: "Hello" },
+			{ role: "user", content: "How are you?" },
+			{ role: "assistant", content: "Hi!" },
+			{ role: "assistant", content: "I'm doing well" },
+		]
+
+		const expected: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{ role: "user", content: "Hello\nHow are you?" },
+			{ role: "assistant", content: "Hi!\nI'm doing well" },
+		]
+
+		expect(convertToR1Format(input)).toEqual(expected)
+	})
+
+	it("should handle image content", () => {
+		const input: Anthropic.Messages.MessageParam[] = [
+			{
+				role: "user",
+				content: [
+					{
+						type: "image",
+						source: {
+							type: "base64",
+							media_type: "image/jpeg",
+							data: "base64data",
+						},
+					},
+				],
+			},
+		]
+
+		const expected: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{
+				role: "user",
+				content: [
+					{
+						type: "image_url",
+						image_url: {
+							url: "data:image/jpeg;base64,base64data",
+						},
+					},
+				],
+			},
+		]
+
+		expect(convertToR1Format(input)).toEqual(expected)
+	})
+
+	it("should handle mixed text and image content", () => {
+		const input: Anthropic.Messages.MessageParam[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "Check this image:" },
+					{
+						type: "image",
+						source: {
+							type: "base64",
+							media_type: "image/jpeg",
+							data: "base64data",
+						},
+					},
+				],
+			},
+		]
+
+		const expected: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "Check this image:" },
+					{
+						type: "image_url",
+						image_url: {
+							url: "data:image/jpeg;base64,base64data",
+						},
+					},
+				],
+			},
+		]
+
+		expect(convertToR1Format(input)).toEqual(expected)
+	})
+
+	it("should merge mixed content messages with same role", () => {
+		const input: Anthropic.Messages.MessageParam[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "First image:" },
+					{
+						type: "image",
+						source: {
+							type: "base64",
+							media_type: "image/jpeg",
+							data: "image1",
+						},
+					},
+				],
+			},
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "Second image:" },
+					{
+						type: "image",
+						source: {
+							type: "base64",
+							media_type: "image/png",
+							data: "image2",
+						},
+					},
+				],
+			},
+		]
+
+		const expected: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "First image:" },
+					{
+						type: "image_url",
+						image_url: {
+							url: "data:image/jpeg;base64,image1",
+						},
+					},
+					{ type: "text", text: "Second image:" },
+					{
+						type: "image_url",
+						image_url: {
+							url: "data:image/png;base64,image2",
+						},
+					},
+				],
+			},
+		]
+
+		expect(convertToR1Format(input)).toEqual(expected)
+	})
+
+	it("should handle empty messages array", () => {
+		expect(convertToR1Format([])).toEqual([])
+	})
+
+	it("should handle messages with empty content", () => {
+		const input: Anthropic.Messages.MessageParam[] = [
+			{ role: "user", content: "" },
+			{ role: "assistant", content: "" },
+		]
+
+		const expected: OpenAI.Chat.ChatCompletionMessageParam[] = [
+			{ role: "user", content: "" },
+			{ role: "assistant", content: "" },
+		]
+
+		expect(convertToR1Format(input)).toEqual(expected)
+	})
+})

--- a/src/api/transform/r1-format.ts
+++ b/src/api/transform/r1-format.ts
@@ -1,0 +1,98 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+
+type ContentPartText = OpenAI.Chat.ChatCompletionContentPartText
+type ContentPartImage = OpenAI.Chat.ChatCompletionContentPartImage
+type UserMessage = OpenAI.Chat.ChatCompletionUserMessageParam
+type AssistantMessage = OpenAI.Chat.ChatCompletionAssistantMessageParam
+type Message = OpenAI.Chat.ChatCompletionMessageParam
+type AnthropicMessage = Anthropic.Messages.MessageParam
+
+/**
+ * Converts Anthropic messages to OpenAI format while merging consecutive messages with the same role.
+ * This is required for DeepSeek Reasoner which does not support successive messages with the same role.
+ *
+ * @param messages Array of Anthropic messages
+ * @returns Array of OpenAI messages where consecutive messages with the same role are combined
+ */
+export function convertToR1Format(messages: AnthropicMessage[]): Message[] {
+	return messages.reduce<Message[]>((merged, message) => {
+		const lastMessage = merged[merged.length - 1]
+		let messageContent: string | (ContentPartText | ContentPartImage)[] = ""
+		let hasImages = false
+
+		// Convert content to appropriate format
+		if (Array.isArray(message.content)) {
+			const textParts: string[] = []
+			const imageParts: ContentPartImage[] = []
+
+			message.content.forEach((part) => {
+				if (part.type === "text") {
+					textParts.push(part.text)
+				}
+				if (part.type === "image") {
+					hasImages = true
+					imageParts.push({
+						type: "image_url",
+						image_url: { url: `data:${part.source.media_type};base64,${part.source.data}` },
+					})
+				}
+			})
+
+			if (hasImages) {
+				const parts: (ContentPartText | ContentPartImage)[] = []
+				if (textParts.length > 0) {
+					parts.push({ type: "text", text: textParts.join("\n") })
+				}
+				parts.push(...imageParts)
+				messageContent = parts
+			} else {
+				messageContent = textParts.join("\n")
+			}
+		} else {
+			messageContent = message.content
+		}
+
+		// If last message has same role, merge the content
+		if (lastMessage?.role === message.role) {
+			if (typeof lastMessage.content === "string" && typeof messageContent === "string") {
+				lastMessage.content += `\n${messageContent}`
+			}
+			// If either has image content, convert both to array format
+			else {
+				const lastContent = Array.isArray(lastMessage.content)
+					? lastMessage.content
+					: [{ type: "text" as const, text: lastMessage.content || "" }]
+
+				const newContent = Array.isArray(messageContent)
+					? messageContent
+					: [{ type: "text" as const, text: messageContent }]
+
+				if (message.role === "assistant") {
+					const mergedContent = [...lastContent, ...newContent] as AssistantMessage["content"]
+					lastMessage.content = mergedContent
+				} else {
+					const mergedContent = [...lastContent, ...newContent] as UserMessage["content"]
+					lastMessage.content = mergedContent
+				}
+			}
+		} else {
+			// Add as new message with the correct type based on role
+			if (message.role === "assistant") {
+				const newMessage: AssistantMessage = {
+					role: "assistant",
+					content: messageContent as AssistantMessage["content"],
+				}
+				merged.push(newMessage)
+			} else {
+				const newMessage: UserMessage = {
+					role: "user",
+					content: messageContent as UserMessage["content"],
+				}
+				merged.push(newMessage)
+			}
+		}
+
+		return merged
+	}, [])
+}

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2391,6 +2391,10 @@ export class Cline {
 			let reasoningMessage = ""
 			try {
 				for await (const chunk of stream) {
+					if (!chunk) {
+						// Sometimes chunk is undefined, no idea that can cause it, but this workaround seems to fix it
+						continue
+					}
 					switch (chunk.type) {
 						case "reasoning":
 							reasoningMessage += chunk.text


### PR DESCRIPTION
This PR extends reasoning preview support for deepseek api.
It no longer use system message (model is not designed to use it)
It will merge any consecutive messages of the same role (deepseek api rejects requests that do not use altering user/assistant pattern). This was also extended to models loaded through openrouter - I assume they know that it might confuse model.
While testing I discovered that while using deepseek api sometimes chunk in cline.ts was unknown - I wasn't able to trace source of it, stack trace was directly from nodejs microtask. Added workaround to just ignore such chunks so code won't crash, this should have no negative impact, but it would be great if anyone could explain source of it.

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested deepseek-r1 model using openrouter and deepseek api (this took few days as they seem to have big outage since Saturday and almost all request return only `:keep-alive`)
tested few other models to make sure there is no regression for other models.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extend deepseek-r1 support by merging consecutive messages and handling undefined chunks.
> 
>   - **Behavior**:
>     - Extend support for `deepseek-r1` model in `openai.ts` and `openrouter.ts` by merging consecutive messages of the same role using `convertToR1Format()`.
>     - Remove system message usage for `deepseek-reasoner` in `openai.ts`.
>     - Add workaround in `Cline.ts` to ignore undefined chunks during streaming.
>   - **Functions**:
>     - Add `convertToR1Format()` in `r1-format.ts` to merge consecutive messages of the same role.
>   - **Misc**:
>     - Adjust message handling in `openai.ts` and `openrouter.ts` to accommodate `deepseek-r1` model requirements.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cb23be634661882b154739a47f9d9137ba228fd7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->