### PR TITLE
Feature/add context to environment

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3043,7 +3043,11 @@ export class Cline {
 
 		// Add context tokens information
 		const { contextTokens } = getApiMetrics(this.clineMessages)
-		details += `\n\n# Current Context Size (Tokens)\n${contextTokens ? contextTokens.toLocaleString() : "(Not available)"}`
+		const modelInfo = this.api.getModel().info
+		const contextWindow = modelInfo.contextWindow
+		const contextPercentage =
+			contextTokens && contextWindow ? Math.round((contextTokens / contextWindow) * 100) : undefined
+		details += `\n\n# Current Context Size (Tokens)\n${contextTokens ? `${contextTokens.toLocaleString()} (${contextPercentage}%)` : "(Not available)"}`
 
 		// Add current mode and any mode-specific warnings
 		const { mode, customModes } = (await this.providerRef.deref()?.getState()) ?? {}

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3041,6 +3041,10 @@ export class Cline {
 		const timeZoneOffsetStr = `${timeZoneOffset >= 0 ? "+" : ""}${timeZoneOffset}:00`
 		details += `\n\n# Current Time\n${formatter.format(now)} (${timeZone}, UTC${timeZoneOffsetStr})`
 
+		// Add context tokens information
+		const { contextTokens } = getApiMetrics(this.clineMessages)
+		details += `\n\n# Current Context Size (Tokens)\n${contextTokens ? contextTokens.toLocaleString() : "(Not available)"}`
+
 		// Add current mode and any mode-specific warnings
 		const { mode, customModes } = (await this.providerRef.deref()?.getState()) ?? {}
 		const currentMode = mode ?? defaultModeSlug

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -7,6 +7,7 @@ import { vscode } from "../../utils/vscode"
 import Thumbnails from "../common/Thumbnails"
 import { mentionRegexGlobal } from "../../../../src/shared/context-mentions"
 import { formatLargeNumber } from "../../utils/format"
+import { normalizeApiConfiguration } from "../settings/ApiOptions"
 
 interface TaskHeaderProps {
 	task: ClineMessage
@@ -32,11 +33,14 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	onClose,
 }) => {
 	const { apiConfiguration } = useExtensionState()
+	const { selectedModelInfo } = useMemo(() => normalizeApiConfiguration(apiConfiguration), [apiConfiguration])
 	const [isTaskExpanded, setIsTaskExpanded] = useState(true)
 	const [isTextExpanded, setIsTextExpanded] = useState(false)
 	const [showSeeMore, setShowSeeMore] = useState(false)
 	const textContainerRef = useRef<HTMLDivElement>(null)
 	const textRef = useRef<HTMLDivElement>(null)
+	const contextWindow = selectedModelInfo?.contextWindow || 1
+	const contextPercentage = Math.round((contextTokens / contextWindow) * 100)
 
 	/*
 	When dealing with event listeners in React components that depend on state variables, we face a challenge. We want our listener to always use the most up-to-date version of a callback function that relies on current state, but we don't want to constantly add and remove event listeners as that function updates. This scenario often arises with resize listeners or other window events. Simply adding the listener in a useEffect with an empty dependency array risks using stale state, while including the callback in the dependencies can lead to unnecessary re-registrations of the listener. There are react hook libraries that provide a elegant solution to this problem by utilizing the useRef hook to maintain a reference to the latest callback function without triggering re-renders or effect re-runs. This approach ensures that our event listener always has access to the most current state while minimizing performance overhead and potential memory leaks from multiple listener registrations. 
@@ -277,7 +281,9 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 							<div style={{ display: "flex", alignItems: "center", gap: "4px", flexWrap: "wrap" }}>
 								<span style={{ fontWeight: "bold" }}>Context:</span>
 								<span style={{ display: "flex", alignItems: "center", gap: "3px" }}>
-									{contextTokens ? formatLargeNumber(contextTokens) : '-'}
+									{contextTokens
+										? `${formatLargeNumber(contextTokens)} (${contextPercentage}%)`
+										: "-"}
 								</span>
 							</div>
 


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

## Type of change
Adds the current conversation's context token count to the environment details section by:
- Using existing getApiMetrics() to retrieve contextTokens from the last API request
- Adding a new "Context Tokens" section between "Current Time" and "Current Mode"
- Formatting the token count with toLocaleString() for better readability
- Showing "(Not available)" when no context tokens are present

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
Manually through debugging mode, using and switching different models.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] My code follows the patterns of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->
![image](https://github.com/user-attachments/assets/cfaf7997-3a24-4a44-8ed4-89e40aab345d)


## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds context token count display to environment details and task header, with formatting and handling for unavailable data.
> 
>   - **Behavior**:
>     - Adds context token count to environment details in `Cline.ts` using `getApiMetrics()`.
>     - Displays context token count in `TaskHeader.tsx` with percentage of context window.
>     - Shows "(Not available)" if context tokens are absent.
>   - **UI**:
>     - Inserts "Context Tokens" section between "Current Time" and "Current Mode" in `Cline.ts`.
>     - Formats token count with `toLocaleString()` for readability.
>   - **Misc**:
>     - Uses `normalizeApiConfiguration` in `TaskHeader.tsx` to get model info.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ea6dc7c16e0c6becd60da82abc9a746ab3c32aa9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->