### PR TITLE
handle other deepseek-r1 variants on openrouter

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -114,13 +114,11 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 		}
 
 		let temperature = 0
-		switch (this.getModel().id) {
-			case "deepseek/deepseek-r1":
-				// Recommended temperature for DeepSeek reasoning models
-				temperature = 0.6
-				// DeepSeek highly recommends using user instead of system role
-				openAiMessages[0].role = "user"
-				openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
+		if (this.getModel().id === "deepseek/deepseek-r1" || this.getModel().id.startsWith("deepseek/deepseek-r1:")) {
+			// Recommended temperature for DeepSeek reasoning models
+			temperature = 0.6
+			// DeepSeek highly recommends using user instead of system role
+			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 		}
 
 		// https://openrouter.ai/docs/transforms


### PR DESCRIPTION
This trivial change adds support for other r1 variants in openrouter (currently `:nitro` and `:free` but it looks like we might have other ones in near future)

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extend support for `deepseek-r1` variants in `OpenRouterHandler` by checking model ID prefix.
> 
>   - **Behavior**:
>     - Extend support for `deepseek-r1` variants in `OpenRouterHandler` in `openrouter.ts` by checking if model ID starts with `deepseek/deepseek-r1:`.
>     - Applies recommended temperature of 0.6 and converts messages to R1 format for these models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9710fd111055741590b408cb53ef0ff38a75d3be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->