### PR TITLE
fix: Move sliders to newline in settings to avoid horizontal scroll.

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -139,6 +139,20 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		}
 	}
 
+	const sliderLabelStyle = {
+		minWidth: "45px",
+		textAlign: "right" as const,
+		lineHeight: "20px",
+		paddingBottom: "2px",
+	}
+
+	const sliderStyle = {
+		flexGrow: 1,
+		maxWidth: "80%",
+		accentColor: "var(--vscode-button-background)",
+		height: "2px",
+	}
+
 	return (
 		<div
 			style={{
@@ -480,22 +494,22 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 					</div>
 
 					<div style={{ marginBottom: 15 }}>
-						<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
-							<span style={{ fontWeight: "500", minWidth: "100px" }}>Screenshot quality</span>
-							<input
-								type="range"
-								min="1"
-								max="100"
-								step="1"
-								value={screenshotQuality ?? 75}
-								onChange={(e) => setScreenshotQuality(parseInt(e.target.value))}
-								style={{
-									flexGrow: 1,
-									accentColor: "var(--vscode-button-background)",
-									height: "2px",
-								}}
-							/>
-							<span style={{ minWidth: "35px", textAlign: "left" }}>{screenshotQuality ?? 75}%</span>
+						<div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+							<span style={{ fontWeight: "500" }}>Screenshot quality</span>
+							<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+								<input
+									type="range"
+									min="1"
+									max="100"
+									step="1"
+									value={screenshotQuality ?? 75}
+									onChange={(e) => setScreenshotQuality(parseInt(e.target.value))}
+									style={{
+										...sliderStyle,
+									}}
+								/>
+								<span style={{ ...sliderLabelStyle }}>{screenshotQuality ?? 75}%</span>
+							</div>
 						</div>
 						<p
 							style={{
@@ -558,24 +572,20 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 				<div style={{ marginBottom: 40 }}>
 					<h3 style={{ color: "var(--vscode-foreground)", margin: "0 0 15px 0" }}>Advanced Settings</h3>
 					<div style={{ marginBottom: 15 }}>
-						<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
-							<span style={{ fontWeight: "500", minWidth: "150px" }}>Terminal output limit</span>
-							<input
-								type="range"
-								min="100"
-								max="5000"
-								step="100"
-								value={terminalOutputLineLimit ?? 500}
-								onChange={(e) => setTerminalOutputLineLimit(parseInt(e.target.value))}
-								style={{
-									flexGrow: 1,
-									accentColor: "var(--vscode-button-background)",
-									height: "2px",
-								}}
-							/>
-							<span style={{ minWidth: "45px", textAlign: "left" }}>
-								{terminalOutputLineLimit ?? 500}
-							</span>
+						<div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
+							<span style={{ fontWeight: "500" }}>Terminal output limit</span>
+							<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+								<input
+									type="range"
+									min="100"
+									max="5000"
+									step="100"
+									value={terminalOutputLineLimit ?? 500}
+									onChange={(e) => setTerminalOutputLineLimit(parseInt(e.target.value))}
+									style={{ ...sliderStyle }}
+								/>
+								<span style={{ ...sliderLabelStyle }}>{terminalOutputLineLimit ?? 500}</span>
+							</div>
 						</div>
 						<p style={{ fontSize: "12px", marginTop: "5px", color: "var(--vscode-descriptionForeground)" }}>
 							Maximum number of lines to include in terminal output when executing commands. When exceeded
@@ -613,26 +623,27 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 									enabled={experiments[EXPERIMENT_IDS.DIFF_STRATEGY] ?? false}
 									onChange={(enabled) => setExperimentEnabled(EXPERIMENT_IDS.DIFF_STRATEGY, enabled)}
 								/>
-								<div style={{ display: "flex", alignItems: "center", gap: "5px", marginTop: "15px" }}>
-									<span style={{ fontWeight: "500", minWidth: "100px" }}>Match precision</span>
-									<input
-										type="range"
-										min="0.8"
-										max="1"
-										step="0.005"
-										value={fuzzyMatchThreshold ?? 1.0}
-										onChange={(e) => {
-											setFuzzyMatchThreshold(parseFloat(e.target.value))
-										}}
-										style={{
-											flexGrow: 1,
-											accentColor: "var(--vscode-button-background)",
-											height: "2px",
-										}}
-									/>
-									<span style={{ minWidth: "35px", textAlign: "left" }}>
-										{Math.round((fuzzyMatchThreshold || 1) * 100)}%
-									</span>
+								<div
+									style={{ display: "flex", flexDirection: "column", gap: "5px", marginTop: "15px" }}>
+									<span style={{ fontWeight: "500" }}>Match precision</span>
+									<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+										<input
+											type="range"
+											min="0.8"
+											max="1"
+											step="0.005"
+											value={fuzzyMatchThreshold ?? 1.0}
+											onChange={(e) => {
+												setFuzzyMatchThreshold(parseFloat(e.target.value))
+											}}
+											style={{
+												...sliderStyle,
+											}}
+										/>
+										<span style={{ ...sliderLabelStyle }}>
+											{Math.round((fuzzyMatchThreshold || 1) * 100)}%
+										</span>
+									</div>
 								</div>
 								<p
 									style={{


### PR DESCRIPTION
## Description
Move sliders to newline in settings to avoid horizontal scroll at around normal window size.
## Type of change
UI
<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
webviewui tests ran successfully

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->
![image](https://github.com/user-attachments/assets/4ca4f623-cc07-4b26-b1cc-0d64b29984fd)
![image](https://github.com/user-attachments/assets/33bbc7b8-920c-46a6-aa02-aad2cdd84504)

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move sliders to a new line in `SettingsView.tsx` to prevent horizontal scrolling, affecting 'Screenshot quality', 'Terminal output limit', and 'Match precision'.
> 
>   - **UI Changes**:
>     - Move sliders to a new line in `SettingsView.tsx` to prevent horizontal scrolling.
>     - Affects sliders for 'Screenshot quality', 'Terminal output limit', and 'Match precision'.
>   - **Styles**:
>     - Extract `sliderStyle` and `sliderLabelStyle` for consistent styling of sliders and labels.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a07f94fa193279a105c793deed74c45cef28c0ec. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->