### PR TITLE
Add support for perplexity/sonar-reasoning

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -114,11 +114,21 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 		}
 
 		let temperature = 0
-		if (this.getModel().id === "deepseek/deepseek-r1" || this.getModel().id.startsWith("deepseek/deepseek-r1:")) {
+		let topP: number | undefined = undefined
+
+		// Handle models based on deepseek-r1
+		if (
+			this.getModel().id === "deepseek/deepseek-r1" ||
+			this.getModel().id.startsWith("deepseek/deepseek-r1:") ||
+			this.getModel().id === "perplexity/sonar-reasoning"
+		) {
 			// Recommended temperature for DeepSeek reasoning models
 			temperature = 0.6
-			// DeepSeek highly recommends using user instead of system role
+			// DeepSeek highly recommends using user instead of system
+			// role
 			openAiMessages = convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
+			// Some provider support topP and 0.95 is value that Deepseek used in their benchmarks
+			topP = 0.95
 		}
 
 		// https://openrouter.ai/docs/transforms
@@ -127,6 +137,7 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 			model: this.getModel().id,
 			max_tokens: maxTokens,
 			temperature: temperature,
+			top_p: topP,
 			messages: openAiMessages,
 			stream: true,
 			include_reasoning: true,


### PR DESCRIPTION
Adds support for `perplexity/sonar-reasoning` model from openrouter, It's based on deepseek-r1 so it is threaded in the same way. I noticed that some providers allow setting `top_p`, I set it to value used in deepseek benchmarks.

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->
