### PR TITLE
Revert "chore: update eslint config and quiet lint output"

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,56 +1,24 @@
 {
 	"root": true,
-	"extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
 	"parser": "@typescript-eslint/parser",
 	"parserOptions": {
-		"ecmaVersion": 2021,
-		"sourceType": "module",
-		"project": "./tsconfig.json"
+		"ecmaVersion": 6,
+		"sourceType": "module"
 	},
 	"plugins": ["@typescript-eslint"],
 	"rules": {
-		"@typescript-eslint/naming-convention": ["warn"],
-		"@typescript-eslint/no-explicit-any": "off",
-		"@typescript-eslint/no-unused-vars": [
+		"@typescript-eslint/naming-convention": [
 			"warn",
 			{
-				"argsIgnorePattern": "^_",
-				"varsIgnorePattern": "^_",
-				"caughtErrorsIgnorePattern": "^_"
+				"selector": "import",
+				"format": ["camelCase", "PascalCase"]
 			}
 		],
-		"@typescript-eslint/explicit-function-return-type": [
-			"warn",
-			{
-				"allowExpressions": true,
-				"allowTypedFunctionExpressions": true
-			}
-		],
-		"@typescript-eslint/explicit-member-accessibility": [
-			"warn",
-			{
-				"accessibility": "explicit"
-			}
-		],
-		"@typescript-eslint/no-non-null-assertion": "warn",
+		"@typescript-eslint/semi": "off",
+		"eqeqeq": "warn",
 		"no-throw-literal": "warn",
-		"semi": ["off", "always"],
-		"quotes": ["warn", "double", { "avoidEscape": true }],
-		"@typescript-eslint/ban-types": "off",
-		"@typescript-eslint/no-var-requires": "warn",
-		"no-extra-semi": "warn",
-		"prefer-const": "warn",
-		"no-mixed-spaces-and-tabs": "warn",
-		"no-case-declarations": "warn",
-		"no-useless-escape": "warn",
-		"require-yield": "warn",
-		"no-empty": "warn",
-		"no-control-regex": "warn",
-		"@typescript-eslint/ban-ts-comment": "warn"
+		"semi": "off",
+		"react-hooks/exhaustive-deps": "off"
 	},
-	"env": {
-		"node": true,
-		"es2021": true
-	},
-	"ignorePatterns": ["dist/**", "out/**", "webview-ui/**", "**/*.js"]
+	"ignorePatterns": ["out", "dist", "**/*.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -214,7 +214,7 @@
 		"compile": "npm run check-types && npm run lint && node esbuild.js",
 		"compile-tests": "tsc -p . --outDir out",
 		"install:all": "npm install && cd webview-ui && npm install",
-		"lint": "eslint src --ext ts --quiet && npm run lint --prefix webview-ui",
+		"lint": "eslint src --ext ts && npm run lint --prefix webview-ui",
 		"package": "npm run build:webview && npm run check-types && npm run lint && node esbuild.js --production",
 		"pretest": "npm run compile-tests && npm run compile && npm run lint",
 		"start:webview": "cd webview-ui && npm run start",

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -8,7 +8,7 @@
 		"build": "tsc && vite build",
 		"preview": "vite preview",
 		"test": "jest",
-		"lint": "eslint src --ext ts,tsx --quiet"
+		"lint": "eslint src --ext ts,tsx"
 	},
 	"dependencies": {
 		"@vscode/webview-ui-toolkit": "^1.4.0",


### PR DESCRIPTION
I'm nervous about the lint rules confusing the agent, so reverting for now. Let's discuss more!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts ESLint configuration and lint script changes to previous state due to concerns about agent confusion.
> 
>   - **Revert Changes**:
>     - Reverts ESLint configuration in `.eslintrc.json` to previous state, removing extended rules and plugins.
>     - Reverts `lint` script in `package.json` and `webview-ui/package.json` to remove `--quiet` flag.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 810bbb449f2dd0e93730d56de9126a4373471226. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->