### PR TITLE
Set jekyll baseurl

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,6 +3,7 @@ description: Documentation for the Roo Code project
 remote_theme: just-the-docs/just-the-docs
 
 url: https://docs.roocode.com
+baseurl: /docs
 
 aux_links:
   "Roo Code on GitHub":


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `baseurl: /docs` to `docs/_config.yml` for Jekyll site configuration.
> 
>   - **Configuration**:
>     - Add `baseurl: /docs` to `docs/_config.yml` to set the base path for the Jekyll site.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4393269486be19f0607b17a9cd94b64f9f17ee7c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->