### PR TITLE
Streaming version of o3-mini

### DIFF
--- a/.changeset/gold-pillows-fix.md
+++ b/.changeset/gold-pillows-fix.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Streaming version of o3-mini

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -27,8 +27,7 @@ export class OpenAiNativeHandler implements ApiHandler, SingleCompletionHandler 
 		switch (modelId) {
 			case "o1":
 			case "o1-preview":
-			case "o1-mini":
-			case "o3-mini": {
+			case "o1-mini": {
 				// o1-preview and o1-mini don't support streaming, non-1 temp, or system prompt
 				// o1 doesnt support streaming or non-1 temp but does support a developer prompt
 				const response = await this.client.chat.completions.create({
@@ -46,6 +45,34 @@ export class OpenAiNativeHandler implements ApiHandler, SingleCompletionHandler 
 					type: "usage",
 					inputTokens: response.usage?.prompt_tokens || 0,
 					outputTokens: response.usage?.completion_tokens || 0,
+				}
+				break
+			}
+			case "o3-mini": {
+				const stream = await this.client.chat.completions.create({
+					model: this.getModel().id,
+					messages: [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
+					stream: true,
+					stream_options: { include_usage: true },
+				})
+
+				for await (const chunk of stream) {
+					const delta = chunk.choices[0]?.delta
+					if (delta?.content) {
+						yield {
+							type: "text",
+							text: delta.content,
+						}
+					}
+
+					// contains a null value except for the last chunk which contains the token usage statistics for the entire request
+					if (chunk.usage) {
+						yield {
+							type: "usage",
+							inputTokens: chunk.usage.prompt_tokens || 0,
+							outputTokens: chunk.usage.completion_tokens || 0,
+						}
+					}
 				}
 				break
 			}


### PR DESCRIPTION
o3-mini can stream
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds streaming support for `o3-mini` in `createMessage()` in `openai-native.ts`.
> 
>   - **Behavior**:
>     - Adds streaming support for `o3-mini` in `createMessage()` in `openai-native.ts`.
>     - Streams responses with `type: "text"` and `type: "usage"` for `o3-mini`.
>   - **Misc**:
>     - Removes `o3-mini` from non-streaming case in `createMessage()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7d28ff516c9700925b428b610e4b0c382a0090fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->