### PR TITLE
Make o3-mini work in glama

### DIFF
--- a/src/api/providers/glama.ts
+++ b/src/api/providers/glama.ts
@@ -72,28 +72,30 @@ export class GlamaHandler implements ApiHandler, SingleCompletionHandler {
 			maxTokens = 8_192
 		}
 
+		const requestOptions: OpenAI.Chat.ChatCompletionCreateParams = {
+			model: this.getModel().id,
+			max_tokens: maxTokens,
+			messages: openAiMessages,
+			stream: true,
+		}
+
+		if (this.supportsTemperature()) {
+			requestOptions.temperature = 0
+		}
+
 		const { data: completion, response } = await this.client.chat.completions
-			.create(
-				{
-					model: this.getModel().id,
-					max_tokens: maxTokens,
-					temperature: 0,
-					messages: openAiMessages,
-					stream: true,
+			.create(requestOptions, {
+				headers: {
+					"X-Glama-Metadata": JSON.stringify({
+						labels: [
+							{
+								key: "app",
+								value: "vscode.rooveterinaryinc.roo-cline",
+							},
+						],
+					}),
 				},
-				{
-					headers: {
-						"X-Glama-Metadata": JSON.stringify({
-							labels: [
-								{
-									key: "app",
-									value: "vscode.rooveterinaryinc.roo-cline",
-								},
-							],
-						}),
-					},
-				},
-			)
+			})
 			.withResponse()
 
 		const completionRequestId = response.headers.get("x-completion-request-id")
@@ -148,6 +150,10 @@ export class GlamaHandler implements ApiHandler, SingleCompletionHandler {
 		}
 	}
 
+	private supportsTemperature(): boolean {
+		return this.getModel().id !== "openai/o3-mini"
+	}
+
 	getModel(): { id: string; info: ModelInfo } {
 		const modelId = this.options.glamaModelId
 		const modelInfo = this.options.glamaModelInfo
@@ -164,7 +170,10 @@ export class GlamaHandler implements ApiHandler, SingleCompletionHandler {
 			const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
 				model: this.getModel().id,
 				messages: [{ role: "user", content: prompt }],
-				temperature: 0,
+			}
+
+			if (this.supportsTemperature()) {
+				requestOptions.temperature = 0
 			}
 
 			if (this.getModel().id.startsWith("anthropic/")) {

--- a/src/api/providers/glama.ts
+++ b/src/api/providers/glama.ts
@@ -151,7 +151,7 @@ export class GlamaHandler implements ApiHandler, SingleCompletionHandler {
 	}
 
 	private supportsTemperature(): boolean {
-		return this.getModel().id !== "openai/o3-mini"
+		return !this.getModel().id.startsWith("openai/o3-mini")
 	}
 
 	getModel(): { id: string; info: ModelInfo } {


### PR DESCRIPTION
Make o3-mini work with glama
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds conditional temperature support in `GlamaHandler` for `o3-mini` model compatibility in `glama.ts`.
> 
>   - **Behavior**:
>     - Introduces `supportsTemperature()` in `GlamaHandler` to check if the model supports temperature settings.
>     - Adjusts `createMessage` and `completePrompt` methods to conditionally set `temperature` based on `supportsTemperature()`.
>   - **Functions**:
>     - Adds `supportsTemperature()` to return false for models starting with `openai/o3-mini`.
>   - **Misc**:
>     - Refactors request options creation in `createMessage` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0cd1642612c3e116644bbb4effbcab3b7479e2cf. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->