### PR TITLE
Move MCP creation checkbox to MCP view

### DIFF
--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -1,5 +1,6 @@
 import {
 	VSCodeButton,
+	VSCodeCheckbox,
 	VSCodeLink,
 	VSCodePanels,
 	VSCodePanelTab,
@@ -18,7 +19,13 @@ type McpViewProps = {
 }
 
 const McpView = ({ onDone }: McpViewProps) => {
-	const { mcpServers: servers, alwaysAllowMcp, mcpEnabled } = useExtensionState()
+	const {
+		mcpServers: servers,
+		alwaysAllowMcp,
+		mcpEnabled,
+		enableMcpServerCreation,
+		setEnableMcpServerCreation,
+	} = useExtensionState()
 
 	return (
 		<div
@@ -67,6 +74,27 @@ const McpView = ({ onDone }: McpViewProps) => {
 
 				{mcpEnabled && (
 					<>
+						<div style={{ marginBottom: 15 }}>
+							<VSCodeCheckbox
+								checked={enableMcpServerCreation}
+								onChange={(e: any) => {
+									setEnableMcpServerCreation(e.target.checked)
+									vscode.postMessage({ type: "enableMcpServerCreation", bool: e.target.checked })
+								}}>
+								<span style={{ fontWeight: "500" }}>Enable MCP Server Creation</span>
+							</VSCodeCheckbox>
+							<p
+								style={{
+									fontSize: "12px",
+									marginTop: "5px",
+									color: "var(--vscode-descriptionForeground)",
+								}}>
+								When enabled, Roo can help you create new MCP servers via commands like "add a new tool
+								to...". If you don't need to create MCP servers you can disable this to reduce Roo's
+								token usage.
+							</p>
+						</div>
+
 						{/* Server List */}
 						{servers.length > 0 && (
 							<div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -61,8 +61,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setExperimentEnabled,
 		alwaysAllowModeSwitch,
 		setAlwaysAllowModeSwitch,
-		enableMcpServerCreation,
-		setEnableMcpServerCreation,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -110,7 +108,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 			})
 
 			vscode.postMessage({ type: "alwaysAllowModeSwitch", bool: alwaysAllowModeSwitch })
-			vscode.postMessage({ type: "enableMcpServerCreation", bool: enableMcpServerCreation })
 			onDone()
 		}
 	}
@@ -357,17 +354,6 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 						<p style={{ fontSize: "12px", marginTop: "5px", color: "var(--vscode-descriptionForeground)" }}>
 							Enable auto-approval of individual MCP tools in the MCP Servers view (requires both this
 							setting and the tool's individual "Always allow" checkbox)
-						</p>
-					</div>
-
-					<div style={{ marginBottom: 5 }}>
-						<VSCodeCheckbox
-							checked={enableMcpServerCreation}
-							onChange={(e: any) => setEnableMcpServerCreation(e.target.checked)}>
-							<span style={{ fontWeight: "500" }}>Enable MCP Server Creation</span>
-						</VSCodeCheckbox>
-						<p style={{ fontSize: "12px", marginTop: "5px", color: "var(--vscode-descriptionForeground)" }}>
-							When enabled, Roo can help you create new MCP servers via commands like "add a new tool to...". If you don't need to create MCP servers you can disable this to reduce Roo's token usage.
 						</p>
 					</div>
 


### PR DESCRIPTION
Follow-up to #696 to move the checkbox to the MCP view
<img width="436" alt="Screenshot 2025-01-31 at 11 42 31 PM" src="https://github.com/user-attachments/assets/91aded24-9520-49f3-9df9-e9a341b889d7" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move "Enable MCP Server Creation" checkbox from `SettingsView.tsx` to `McpView.tsx` for better context placement.
> 
>   - **UI Changes**:
>     - Move "Enable MCP Server Creation" checkbox from `SettingsView.tsx` to `McpView.tsx`.
>     - Add explanatory text for the checkbox in `McpView.tsx`.
>   - **State Management**:
>     - Use `enableMcpServerCreation` and `setEnableMcpServerCreation` in `McpView.tsx`.
>     - Remove `enableMcpServerCreation` related code from `SettingsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5abf5e3aa6f345679c1acad084c2f81ba58e75d7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->