### PR TITLE
Add o3-mini-high and o3-mini-low

### DIFF
--- a/.changeset/kind-balloons-grin.md
+++ b/.changeset/kind-balloons-grin.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add o3-mini-high and o3-mini-low

--- a/src/api/providers/__tests__/openai-native.test.ts
+++ b/src/api/providers/__tests__/openai-native.test.ts
@@ -300,7 +300,7 @@ describe("OpenAiNativeHandler", () => {
 			expect(mockCreate).toHaveBeenCalledWith({
 				model: "o3-mini",
 				messages: [{ role: "user", content: "Test prompt" }],
-				temperature: 0,
+				reasoning_effort: "medium",
 			})
 		})
 

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -48,12 +48,15 @@ export class OpenAiNativeHandler implements ApiHandler, SingleCompletionHandler 
 				}
 				break
 			}
-			case "o3-mini": {
+			case "o3-mini":
+			case "o3-mini-low":
+			case "o3-mini-high": {
 				const stream = await this.client.chat.completions.create({
-					model: this.getModel().id,
+					model: "o3-mini",
 					messages: [{ role: "developer", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 					stream: true,
 					stream_options: { include_usage: true },
+					reasoning_effort: this.getModel().info.reasoningEffort,
 				})
 
 				for await (const chunk of stream) {
@@ -130,6 +133,16 @@ export class OpenAiNativeHandler implements ApiHandler, SingleCompletionHandler 
 					requestOptions = {
 						model: modelId,
 						messages: [{ role: "user", content: prompt }],
+					}
+					break
+				case "o3-mini":
+				case "o3-mini-low":
+				case "o3-mini-high":
+					// o3 doesn't support non-1 temp
+					requestOptions = {
+						model: "o3-mini",
+						messages: [{ role: "user", content: prompt }],
+						reasoning_effort: this.getModel().info.reasoningEffort,
 					}
 					break
 				default:

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -80,6 +80,7 @@ export interface ModelInfo {
 	cacheWritesPrice?: number
 	cacheReadsPrice?: number
 	description?: string
+	reasoningEffort?: "low" | "medium" | "high"
 }
 
 // Anthropic
@@ -517,6 +518,25 @@ export const openAiNativeModels = {
 		supportsPromptCache: false,
 		inputPrice: 1.1,
 		outputPrice: 4.4,
+		reasoningEffort: "medium",
+	},
+	"o3-mini-high": {
+		maxTokens: 100_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1.1,
+		outputPrice: 4.4,
+		reasoningEffort: "high",
+	},
+	"o3-mini-low": {
+		maxTokens: 100_000,
+		contextWindow: 200_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1.1,
+		outputPrice: 4.4,
+		reasoningEffort: "low",
 	},
 	o1: {
 		maxTokens: 100_000,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `o3-mini-high` and `o3-mini-low` models to OpenAI Native handler with specific reasoning efforts.
> 
>   - **Models**:
>     - Add `o3-mini-high` and `o3-mini-low` to `openAiNativeModels` in `api.ts` with reasoning efforts "high" and "low" respectively.
>   - **Handlers**:
>     - Update `OpenAiNativeHandler` in `openai-native.ts` to handle `o3-mini-high` and `o3-mini-low` in `createMessage()` and `completePrompt()`.
>   - **Tests**:
>     - Modify `openai-native.test.ts` to test `o3-mini` with `reasoning_effort: "medium"`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d047c8beae31525e86db373cbd7fe536a7a66481. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->