### PR TITLE
Run discord GHA against pull_request_target

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    if: github.head_ref != 'changeset-release/main'
     steps:
       - name: Send Discord Notification
         uses: Ilshidur/action-discord@master

--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -2,7 +2,7 @@ name: Discord PR Notifier
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 jobs:


### PR DESCRIPTION
Hopefully this will give it access to the secrets it needs
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change GitHub Actions trigger to `pull_request_target` in `discord-pr-notify.yml` to access secrets.
> 
>   - **Workflow Trigger**:
>     - Change trigger from `pull_request` to `pull_request_target` in `.github/workflows/discord-pr-notify.yml` to access secrets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e37692c2418e0352217fa2639d01dde754a866bc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->