### PR TITLE
Update EditorUtils

### DIFF
--- a/src/core/__tests__/EditorUtils.test.ts
+++ b/src/core/__tests__/EditorUtils.test.ts
@@ -1,20 +1,35 @@
 import * as vscode from "vscode"
 import { EditorUtils } from "../EditorUtils"
 
-// Mock VSCode API
-jest.mock("vscode", () => ({
-	Range: jest.fn().mockImplementation((startLine, startChar, endLine, endChar) => ({
-		start: { line: startLine, character: startChar },
-		end: { line: endLine, character: endChar },
-	})),
-	Position: jest.fn().mockImplementation((line, character) => ({
-		line,
-		character,
-	})),
-	workspace: {
-		getWorkspaceFolder: jest.fn(),
-	},
-}))
+// Use simple classes to simulate VSCode's Range and Position behavior.
+jest.mock("vscode", () => {
+	class MockPosition {
+		constructor(
+			public line: number,
+			public character: number,
+		) {}
+	}
+	class MockRange {
+		start: MockPosition
+		end: MockPosition
+		constructor(start: MockPosition, end: MockPosition) {
+			this.start = start
+			this.end = end
+		}
+	}
+
+	return {
+		Range: MockRange,
+		Position: MockPosition,
+		workspace: {
+			getWorkspaceFolder: jest.fn(),
+		},
+		window: { activeTextEditor: undefined },
+		languages: {
+			getDiagnostics: jest.fn(() => []),
+		},
+	}
+})
 
 describe("EditorUtils", () => {
 	let mockDocument: any
@@ -30,7 +45,7 @@ describe("EditorUtils", () => {
 
 	describe("getEffectiveRange", () => {
 		it("should return selected text when available", () => {
-			const mockRange = new vscode.Range(0, 0, 0, 10)
+			const mockRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 10))
 			mockDocument.getText.mockReturnValue("selected text")
 
 			const result = EditorUtils.getEffectiveRange(mockDocument, mockRange)
@@ -42,13 +57,65 @@ describe("EditorUtils", () => {
 		})
 
 		it("should return null for empty line", () => {
-			const mockRange = new vscode.Range(0, 0, 0, 10)
+			const mockRange = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 10))
 			mockDocument.getText.mockReturnValue("")
 			mockDocument.lineAt.mockReturnValue({ text: "", lineNumber: 0 })
 
 			const result = EditorUtils.getEffectiveRange(mockDocument, mockRange)
 
 			expect(result).toBeNull()
+		})
+
+		it("should expand empty selection to full lines", () => {
+			// Simulate a caret (empty selection) on line 2 at character 5.
+			const initialRange = new vscode.Range(new vscode.Position(2, 5), new vscode.Position(2, 5))
+			// Return non-empty text for any line with text (lines 1, 2, and 3).
+			mockDocument.lineAt.mockImplementation((line: number) => {
+				return { text: `Line ${line} text`, lineNumber: line }
+			})
+			mockDocument.getText.mockImplementation((range: any) => {
+				// If the range is exactly the empty initial selection, return an empty string.
+				if (
+					range.start.line === initialRange.start.line &&
+					range.start.character === initialRange.start.character &&
+					range.end.line === initialRange.end.line &&
+					range.end.character === initialRange.end.character
+				) {
+					return ""
+				}
+				return "expanded text"
+			})
+
+			const result = EditorUtils.getEffectiveRange(mockDocument, initialRange)
+
+			expect(result).not.toBeNull()
+			// Expected effective range: from the beginning of line 1 to the end of line 3.
+			expect(result?.range.start).toEqual({ line: 1, character: 0 })
+			expect(result?.range.end).toEqual({ line: 3, character: 11 })
+			expect(result?.text).toBe("expanded text")
+		})
+	})
+
+	describe("hasIntersectingRange", () => {
+		it("should return false for ranges that only touch boundaries", () => {
+			// Range1: [0, 0) - [0, 10) and Range2: [0, 10) - [0, 20)
+			const range1 = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 10))
+			const range2 = new vscode.Range(new vscode.Position(0, 10), new vscode.Position(0, 20))
+			expect(EditorUtils.hasIntersectingRange(range1, range2)).toBe(false)
+		})
+
+		it("should return true for overlapping ranges", () => {
+			// Range1: [0, 0) - [0, 15) and Range2: [0, 10) - [0, 20)
+			const range1 = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 15))
+			const range2 = new vscode.Range(new vscode.Position(0, 10), new vscode.Position(0, 20))
+			expect(EditorUtils.hasIntersectingRange(range1, range2)).toBe(true)
+		})
+
+		it("should return false for non-overlapping ranges", () => {
+			// Range1: [0, 0) - [0, 10) and Range2: [1, 0) - [1, 5)
+			const range1 = new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 10))
+			const range2 = new vscode.Range(new vscode.Position(1, 0), new vscode.Position(1, 5))
+			expect(EditorUtils.hasIntersectingRange(range1, range2)).toBe(false)
 		})
 	})
 


### PR DESCRIPTION
- Updated the EditorUtils to expand an empty selection to cover full lines by using the entire previous and next lines.
- Revised the range intersection logic to follow VS Code's half-open interval semantics so that touching boundaries do not count as intersecting.
- Enhanced the test mocks by replacing jest.fn‑based implementations of vscode.Range and vscode.Position with class-based versions.
- Ensured that the improved mocks enable accurate deep equality comparisons in tests without altering the core functionality.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `EditorUtils` to expand empty selections to full lines and refine range intersection logic, with enhanced test mocks.
> 
>   - **Behavior**:
>     - `getEffectiveRange` in `EditorUtils.ts` now expands empty selections to include full lines, using the previous and next lines.
>     - `hasIntersectingRange` in `EditorUtils.ts` updated to use half-open interval semantics, ensuring touching boundaries do not intersect.
>   - **Testing**:
>     - Replaced `jest.fn` mocks with class-based mocks for `vscode.Range` and `vscode.Position` in `EditorUtils.test.ts`.
>     - Added tests for expanded selection behavior and range intersection logic in `EditorUtils.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e8a5e280b3c31e26fff2c7aef788395be8109be8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->