### PR TITLE
Make list of modes multi-line on the prompts page

### DIFF
--- a/.changeset/breezy-badgers-refuse.md
+++ b/.changeset/breezy-badgers-refuse.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Visual cleanup to the list of modes on the prompts tab

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -472,13 +472,11 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 					<div
 						style={{
 							display: "flex",
-							gap: "16px",
+							gap: "8px",
 							alignItems: "center",
 							marginBottom: "12px",
-							overflowX: "auto",
-							flexWrap: "nowrap",
-							paddingBottom: "4px",
-							paddingRight: "20px",
+							flexWrap: "wrap",
+							padding: "4px 0",
 						}}>
 						{modes.map((modeConfig) => {
 							const isActive = mode === modeConfig.slug
@@ -859,13 +857,11 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 					<div
 						style={{
 							display: "flex",
-							gap: "16px",
+							gap: "8px",
 							alignItems: "center",
 							marginBottom: "12px",
-							overflowX: "auto",
-							flexWrap: "nowrap",
-							paddingBottom: "4px",
-							paddingRight: "20px",
+							flexWrap: "wrap",
+							padding: "4px 0",
 						}}>
 						{Object.keys(supportPrompt.default).map((type) => (
 							<button


### PR DESCRIPTION
Need to rethink the design of this whole page, but IMO this is better for now.

Before:
![Screenshot 2025-02-02 at 2 30 57 AM](https://github.com/user-attachments/assets/8db93d5d-b8e4-44ba-89a7-73019d67dec5)

After:
<img width="508" alt="Screenshot 2025-02-02 at 2 33 30 AM" src="https://github.com/user-attachments/assets/c82900c8-52c4-4fba-844b-0d338e2ad828" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make the list of modes multi-line in `PromptsView.tsx` by adjusting flexbox properties for better readability.
> 
>   - **UI Changes**:
>     - In `PromptsView.tsx`, change `gap` from `16px` to `8px` and `flexWrap` from `nowrap` to `wrap` for mode and support prompt lists.
>     - Remove `overflowX: auto`, `paddingBottom`, and `paddingRight` from mode and support prompt lists.
>     - Add `padding: "4px 0"` to mode and support prompt lists for better spacing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a01d923f2f82ebe8f3a8aa9eae28bef3d389f7cb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->