### PR TITLE
Post PRs to a thread instead

### DIFF
--- a/.github/workflows/discord-pr-notify.yml
+++ b/.github/workflows/discord-pr-notify.yml
@@ -11,11 +11,10 @@ jobs:
     if: github.head_ref != 'changeset-release/main'
     steps:
       - name: Send Discord Notification
-        uses: Ilshidur/action-discord@master
-        with:
-          args: |
-            🚀 **New PR:** ${{ github.event.pull_request.title }}
-            🔗 <${{ github.event.pull_request.html_url }}>
-            👤 **Author:** ${{ github.event.pull_request.user.login }}
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+        run: |
+          curl -X POST ${{ secrets.DISCORD_WEBHOOK }} \
+          -H "Content-Type: application/json" \
+          -d '{
+            "content": "🚀 **New PR:** ${{ github.event.pull_request.title }}\n🔗 <${{ github.event.pull_request.html_url }}>\n👤 **Author:** ${{ github.event.pull_request.user.login }}",
+            "thread_name": "${{ github.event.pull_request.title }} by ${{ github.event.pull_request.user.login }}"
+          }'


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces Discord notification action with `curl` to create a new thread for each PR in `discord-pr-notify.yml`.
> 
>   - **Behavior**:
>     - Replaces `Ilshidur/action-discord` with `curl` in `discord-pr-notify.yml` to send Discord notifications.
>     - Adds `thread_name` to the Discord message payload to create a new thread for each PR notification.
>   - **Misc**:
>     - Removes `env` section for `DISCORD_WEBHOOK` in `discord-pr-notify.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bf799d72dbc75941cdf50b1d736fc5cbf43379c2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->