### PR TITLE
Slash commands for switching modes

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -52,7 +52,7 @@ import { parseMentions } from "./mentions"
 import { AssistantMessageContent, parseAssistantMessage, ToolParamName, ToolUseName } from "./assistant-message"
 import { formatResponse } from "./prompts/responses"
 import { SYSTEM_PROMPT } from "./prompts/system"
-import { modes, defaultModeSlug, getModeBySlug } from "../shared/modes"
+import { modes, defaultModeSlug, getModeBySlug, parseSlashCommand } from "../shared/modes"
 import { truncateHalfConversation } from "./sliding-window"
 import { ClineProvider, GlobalFileNames } from "./webview/ClineProvider"
 import { detectCodeOmission } from "../integrations/editor/detect-omission"
@@ -77,6 +77,29 @@ export class Cline {
 	private terminalManager: TerminalManager
 	private urlContentFetcher: UrlContentFetcher
 	private browserSession: BrowserSession
+
+	/**
+	 * Processes a message for slash commands and handles mode switching if needed.
+	 * @param message The message to process
+	 * @returns The processed message with slash command removed if one was present
+	 */
+	private async handleSlashCommand(message: string): Promise<string> {
+		if (!message) return message
+
+		const { customModes } = (await this.providerRef.deref()?.getState()) ?? {}
+		const slashCommand = parseSlashCommand(message, customModes)
+
+		if (slashCommand) {
+			// Switch mode before processing the remaining message
+			const provider = this.providerRef.deref()
+			if (provider) {
+				await provider.handleModeSwitch(slashCommand.modeSlug)
+				return slashCommand.remainingMessage
+			}
+		}
+
+		return message
+	}
 	private didEditFile: boolean = false
 	customInstructions?: string
 	diffStrategy?: DiffStrategy
@@ -355,6 +378,11 @@ export class Cline {
 	}
 
 	async handleWebviewAskResponse(askResponse: ClineAskResponse, text?: string, images?: string[]) {
+		// Process slash command if present
+		if (text) {
+			text = await this.handleSlashCommand(text)
+		}
+
 		this.askResponse = askResponse
 		this.askResponseText = text
 		this.askResponseImages = images
@@ -436,6 +464,22 @@ export class Cline {
 		this.clineMessages = []
 		this.apiConversationHistory = []
 		await this.providerRef.deref()?.postStateToWebview()
+
+		// Check for slash command if task is provided
+		if (task) {
+			const { customModes } = (await this.providerRef.deref()?.getState()) ?? {}
+			const slashCommand = parseSlashCommand(task, customModes)
+
+			if (slashCommand) {
+				// Switch mode before processing the remaining message
+				const provider = this.providerRef.deref()
+				if (provider) {
+					await provider.handleModeSwitch(slashCommand.modeSlug)
+					// Update task to be just the remaining message
+					task = slashCommand.remainingMessage
+				}
+			}
+		}
 
 		await this.say("text", task, images)
 

--- a/src/shared/__tests__/modes.test.ts
+++ b/src/shared/__tests__/modes.test.ts
@@ -1,4 +1,4 @@
-import { isToolAllowedForMode, FileRestrictionError, ModeConfig } from "../modes"
+import { isToolAllowedForMode, FileRestrictionError, ModeConfig, parseSlashCommand } from "../modes"
 
 describe("isToolAllowedForMode", () => {
 	const customModes: ModeConfig[] = [
@@ -330,5 +330,67 @@ describe("FileRestrictionError", () => {
 			"This mode (Markdown Editor) can only edit files matching pattern: \\.md$ (Markdown files only). Got: test.js",
 		)
 		expect(error.name).toBe("FileRestrictionError")
+	})
+})
+
+describe("parseSlashCommand", () => {
+	const customModes: ModeConfig[] = [
+		{
+			slug: "custom-mode",
+			name: "Custom Mode",
+			roleDefinition: "Custom role",
+			groups: ["read"],
+		},
+	]
+
+	it("returns null for non-slash messages", () => {
+		expect(parseSlashCommand("hello world")).toBeNull()
+		expect(parseSlashCommand("code help me")).toBeNull()
+	})
+
+	it("returns null for incomplete commands", () => {
+		expect(parseSlashCommand("/")).toBeNull()
+		expect(parseSlashCommand("/code")).toBeNull()
+		expect(parseSlashCommand("/code ")).toBeNull()
+	})
+
+	it("returns null for invalid mode slugs", () => {
+		expect(parseSlashCommand("/invalid help me")).toBeNull()
+		expect(parseSlashCommand("/nonexistent do something")).toBeNull()
+	})
+
+	it("successfully parses valid commands", () => {
+		expect(parseSlashCommand("/code help me write tests")).toEqual({
+			modeSlug: "code",
+			remainingMessage: "help me write tests",
+		})
+
+		expect(parseSlashCommand("/ask what is typescript?")).toEqual({
+			modeSlug: "ask",
+			remainingMessage: "what is typescript?",
+		})
+
+		expect(parseSlashCommand("/architect plan this feature")).toEqual({
+			modeSlug: "architect",
+			remainingMessage: "plan this feature",
+		})
+	})
+
+	it("preserves whitespace in remaining message", () => {
+		expect(parseSlashCommand("/code   help   me   write   tests  ")).toEqual({
+			modeSlug: "code",
+			remainingMessage: "help me write tests",
+		})
+	})
+
+	it("handles custom modes", () => {
+		expect(parseSlashCommand("/custom-mode do something", customModes)).toEqual({
+			modeSlug: "custom-mode",
+			remainingMessage: "do something",
+		})
+	})
+
+	it("returns null for invalid custom mode slugs", () => {
+		expect(parseSlashCommand("/invalid-custom do something", customModes)).toBeNull()
 	})
 })

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -257,3 +257,36 @@ export function getCustomInstructions(modeSlug: string, customModes?: ModeConfig
 	}
 	return mode.customInstructions ?? ""
 }
+
+// Slash command parsing types and functions
+export type SlashCommandResult = {
+	modeSlug: string
+	remainingMessage: string
+} | null
+
+export function parseSlashCommand(message: string, customModes?: ModeConfig[]): SlashCommandResult {
+	// Check if message starts with a slash
+	if (!message.startsWith("/")) {
+		return null
+	}
+
+	// Extract command (everything between / and first space)
+	const parts = message.trim().split(/\s+/)
+	if (parts.length < 2) {
+		return null // Need both command and message
+	}
+
+	const command = parts[0].substring(1) // Remove leading slash
+	const remainingMessage = parts.slice(1).join(" ")
+
+	// Validate command is a valid mode slug
+	const mode = getModeBySlug(command, customModes)
+	if (!mode) {
+		return null
+	}
+
+	return {
+		modeSlug: command,
+		remainingMessage,
+	}
+}


### PR DESCRIPTION
This makes it so you can start a message with `/ask`, `/code`, `/custom-slug`, etc to switch into that mode before executing the rest of the message.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add slash command parsing to switch modes in `Cline.ts`, with `parseSlashCommand` function and tests in `modes.test.ts`.
> 
>   - **Behavior**:
>     - Add slash command parsing in `Cline.ts` to switch modes before processing messages.
>     - Supports commands like `/ask`, `/code`, `/custom-slug` to change modes.
>   - **Functions**:
>     - Add `parseSlashCommand` in `modes.ts` to extract mode and remaining message from input.
>   - **Tests**:
>     - Add tests for `parseSlashCommand` in `modes.test.ts` to validate command parsing and mode switching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 97128bc144dad2c3203b3d0c23d561454593d8f2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->