### PR TITLE
Safer profile path check

### DIFF
--- a/.changeset/heavy-feet-judge.md
+++ b/.changeset/heavy-feet-judge.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Safer shell profile path check

--- a/src/utils/__tests__/shell.test.ts
+++ b/src/utils/__tests__/shell.test.ts
@@ -97,6 +97,12 @@ describe("Shell Detection Tests", () => {
 			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
 		})
 
+		it("handles undefined profile gracefully", () => {
+			// Mock a case where defaultProfileName exists but the profile doesn't
+			mockVsCodeConfig("windows", "NonexistentProfile", {})
+			expect(getShell()).toBe("C:\\Windows\\System32\\cmd.exe")
+		})
+
 		it("respects userInfo() if no VS Code config is available", () => {
 			vscode.workspace.getConfiguration = () => ({ get: () => undefined }) as any
 			;(userInfo as any) = () => ({ shell: "C:\\Custom\\PowerShell.exe" })

--- a/src/utils/shell.ts
+++ b/src/utils/shell.ts
@@ -105,7 +105,7 @@ function getWindowsShellFromVSCode(): string | null {
 	}
 
 	// If there's a specific path, return that immediately
-	if (profile.path) {
+	if (profile?.path) {
 		return profile.path
 	}
 


### PR DESCRIPTION
Got a complaint from someone after upgrading to the latest version 

>Cannot read properties of undefined (reading 'path')
>This is a special error message for the latest version.

I'm asking them to try out a vsix with this change to confirm, but seems like more correct code in general.
