### PR TITLE
Jest fixes for webview-ui

### DIFF
--- a/webview-ui/jest.config.cjs
+++ b/webview-ui/jest.config.cjs
@@ -1,0 +1,22 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+	preset: "ts-jest",
+	testEnvironment: "jsdom",
+	injectGlobals: true,
+	moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
+	transform: { "^.+\\.(ts|tsx)$": ["ts-jest", { tsconfig: { jsx: "react-jsx" } }] },
+	testMatch: ["<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}", "<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"],
+	setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts", "@testing-library/jest-dom/extend-expect"],
+	moduleNameMapper: {
+		"\\.(css|less|scss|sass)$": "identity-obj-proxy",
+		"^vscrui$": "<rootDir>/src/__mocks__/vscrui.ts",
+		"^@vscode/webview-ui-toolkit/react$": "<rootDir>/src/__mocks__/@vscode/webview-ui-toolkit/react.ts",
+		"^@/(.*)$": "<rootDir>/src/$1",
+	},
+	reporters: [["jest-simple-dot-reporter", {}]],
+	transformIgnorePatterns: [
+		"/node_modules/(?!(rehype-highlight|react-remark|unist-util-visit|unist-util-find-after|vfile|unified|bail|is-plain-obj|trough|vfile-message|unist-util-stringify-position|mdast-util-from-markdown|mdast-util-to-string|micromark|decode-named-character-reference|character-entities|markdown-table|zwitch|longest-streak|escape-string-regexp|unist-util-is|hast-util-to-text|@vscode/webview-ui-toolkit|@microsoft/fast-react-wrapper|@microsoft/fast-element|@microsoft/fast-foundation|@microsoft/fast-web-utilities|exenv-es6|vscrui)/)",
+	],
+	roots: ["<rootDir>/src"],
+	moduleDirectories: ["node_modules", "src"],
+}

--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -69,44 +69,5 @@
 		"ts-jest": "^27.1.5",
 		"typescript": "^4.9.5",
 		"vite": "6.0.11"
-	},
-	"jest": {
-		"testEnvironment": "jsdom",
-		"setupFilesAfterEnv": [
-			"@testing-library/jest-dom/extend-expect"
-		],
-		"preset": "ts-jest",
-		"reporters": [
-			[
-				"jest-simple-dot-reporter",
-				{}
-			]
-		],
-		"moduleNameMapper": {
-			"\\.(css|less|scss|sass)$": "identity-obj-proxy",
-			"^vscrui$": "<rootDir>/src/__mocks__/vscrui.ts",
-			"^@vscode/webview-ui-toolkit/react$": "<rootDir>/src/__mocks__/@vscode/webview-ui-toolkit/react.ts"
-		},
-		"transformIgnorePatterns": [
-			"/node_modules/(?!(rehype-highlight|react-remark|unist-util-visit|unist-util-find-after|vfile|unified|bail|is-plain-obj|trough|vfile-message|unist-util-stringify-position|mdast-util-from-markdown|mdast-util-to-string|micromark|decode-named-character-reference|character-entities|markdown-table|zwitch|longest-streak|escape-string-regexp|unist-util-is|hast-util-to-text|@vscode/webview-ui-toolkit|@microsoft/fast-react-wrapper|@microsoft/fast-element|@microsoft/fast-foundation|@microsoft/fast-web-utilities|exenv-es6|vscrui)/)"
-		],
-		"transform": {
-			"^.+\\.(ts|tsx)$": [
-				"ts-jest",
-				{
-					"tsconfig": {
-						"jsx": "react-jsx"
-					}
-				}
-			]
-		},
-		"moduleDirectories": [
-			"node_modules",
-			"src"
-		],
-		"testMatch": [
-			"<rootDir>/src/**/__tests__/**/*.{js,jsx,ts,tsx}",
-			"<rootDir>/src/**/*.{spec,test}.{js,jsx,ts,tsx}"
-		]
 	}
 }

--- a/webview-ui/src/components/chat/__tests__/ChatTextArea.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatTextArea.test.tsx
@@ -1,5 +1,4 @@
 import { render, fireEvent, screen } from "@testing-library/react"
-import "@testing-library/jest-dom"
 import ChatTextArea from "../ChatTextArea"
 import { useExtensionState } from "../../../context/ExtensionStateContext"
 import { vscode } from "../../../utils/vscode"

--- a/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
+++ b/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
-import "@testing-library/jest-dom"
 import PromptsView from "../PromptsView"
 import { ExtensionStateContext } from "../../../context/ExtensionStateContext"
 import { vscode } from "../../../utils/vscode"

--- a/webview-ui/src/components/settings/__tests__/ApiConfigManager.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiConfigManager.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, fireEvent } from "@testing-library/react"
-import "@testing-library/jest-dom"
 import ApiConfigManager from "../ApiConfigManager"
 
 // Mock VSCode components


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

- Remove unnecessary imports of `@testing-library/jest-dom` - the jest setup does this automatically.
- Move `jest` config into it's own file.
- Add a `moduleNameMapper` entry that allows us to import modules using aliases without breaking tests, for example:
```typescript
import { Button } from "@/components/ui"
```

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor Jest setup by moving configuration to `jest.config.cjs` and removing redundant imports in test files.
> 
>   - **Configuration**:
>     - Move `jest` configuration from `package.json` to `jest.config.cjs`.
>     - Add `moduleNameMapper` in `jest.config.cjs` to support module aliasing.
>   - **Imports**:
>     - Remove unnecessary `@testing-library/jest-dom` imports from `ChatTextArea.test.tsx`, `PromptsView.test.tsx`, and `ApiConfigManager.test.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4948e527793b13b6c1b5e3fecba9f9a737bc5f94. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->