### PR TITLE
Bug/provider info updates

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -143,6 +143,8 @@ export class Cline {
 					const newConfig = await provider.getState()
 					if (newConfig?.apiConfiguration) {
 						this.api = buildApiHandler(newConfig.apiConfiguration)
+						// Force provider to update webview state
+						await provider.postStateToWebview()
 					}
 				}
 			}),

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1525,6 +1525,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		if (this.cline) {
 			this.cline.api = buildApiHandler(apiConfiguration)
 		}
+
+		// Force a state refresh after updating configuration
+		await this.postStateToWebview()
 	}
 
 	async updateCustomInstructions(instructions?: string) {
@@ -1986,8 +1989,12 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	}
 
 	async postStateToWebview() {
-		const state = await this.getStateToPostToWebview()
-		this.postMessageToWebview({ type: "state", state })
+		try {
+			const state = await this.getStateToPostToWebview()
+			await this.postMessageToWebview({ type: "state", state })
+		} catch (error) {
+			console.error("Error posting state to webview:", error)
+		}
 	}
 
 	async getStateToPostToWebview() {


### PR DESCRIPTION
## Description
Scenario:
When switching between configuration profiles, the API provider information would sometimes remain stuck on the previous profile's settings and wouldn't properly reflect the saved configuration. This was particularly noticeable when:
- Switching between different provider profiles
- Only the last saved profile would update correctly
- Provider settings would occasionally get stuck in an inconsistent state

Fix:
- Added proper state refresh in `ClineProvider.updateApiConfiguration()` by ensuring `postStateToWebview()` is called after updating the API configuration
- Added error handling in `postStateToWebview()` to catch and log any state update errors
- Removed incorrect attempt to override API provider from model ID in state updates

The core issue was that state updates weren't being consistently propagated to the webview after API configuration changes. The fix ensures that whenever the API configuration is updated (either through profile switches or direct changes), the full state is properly refreshed in the webview.

To test this fix:
1. Create multiple configuration profiles with different providers
2. Switch between profiles and verify the provider settings update correctly
3. Verify changes persist after reloading the window

This should resolve the inconsistent behavior when switching between configuration profiles.

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Have tested it myself multiple times having 5 different profiles and switching between them.

## Checklist:

- [ X] My code follows the patterns of this project
- [ X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation  - N/A

## Additional context

N/A

Screenshot:
<img width="283" alt="image" src="https://github.com/user-attachments/assets/0afb2850-d2cb-4950-b935-52f5955de150" />


## Related Issues

N/A

## Reviewers

@mrubens 
