### PR TITLE
Validate vsix in publish GHA

### DIFF
--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -42,10 +42,10 @@ jobs:
 
           npm run vsix
           package=$(unzip -l bin/roo-cline-${current_package_version}.vsix)
-          echo $package
-          echo $package | grep -q "dist/extension.js" || exit 1
-          echo $package | grep -q "extension/webview-ui/build/assets/index.js" || exit 1
-          echo $package | grep -q "extension/node_modules/@vscode/codicons/dist/codicon.ttf" || exit 1
+          echo "$package"
+          echo "$package" | grep -q "dist/extension.js" || exit 1
+          echo "$package" | grep -q "extension/webview-ui/build/assets/index.js" || exit 1
+          echo "$package" | grep -q "extension/node_modules/@vscode/codicons/dist/codicon.ttf" || exit 1
 
           npm run publish:marketplace
           echo "Successfully published version $current_package_version to VS Code Marketplace"

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -39,6 +39,13 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
         run: |
           current_package_version=$(node -p "require('./package.json').version")
+
+          npm run vsix
+          package=$(unzip -l bin/roo-cline-${current_package_version}.vsix)
+          echo $package
+          echo $package | grep -q "dist/extension.js" || exit 1
+          echo $package | grep -q "extension/webview-ui/build/assets/index.js" || exit 1
+          echo $package | grep -q "extension/node_modules/@vscode/codicons/dist/codicon.ttf" || exit 1
+
           npm run publish:marketplace
           echo "Successfully published version $current_package_version to VS Code Marketplace"
-

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,6 @@
 # Default
+.github/**
+.husky/**
 .vscode/**
 .vscode-test/**
 out/**


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

#799 broke the `marketplace:publish` npm script because `npm run build:webview` got removed from the `package` script. This change lightly validates the `vsix` file we produce before publishing.

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add validation for `vsix` file contents in `marketplace-publish.yml` and update `.vscodeignore` to exclude additional directories.
> 
>   - **Validation**:
>     - Adds validation in `marketplace-publish.yml` to check `vsix` file for `dist/extension.js`, `extension/webview-ui/build/assets/index.js`, and `extension/node_modules/@vscode/codicons/dist/codicon.ttf` before publishing.
>   - **Ignore Files**:
>     - Updates `.vscodeignore` to exclude `.github/**` and `.husky/**` directories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 36dd8c9ce41db0077e30c0faa8881d654b4482fe. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->