### PR TITLE
Better UX for adding new API config profiles

### DIFF
--- a/.changeset/dirty-coins-exist.md
+++ b/.changeset/dirty-coins-exist.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Improve the user experience for adding a new configuration profile

--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -49,6 +49,18 @@ const ApiConfigManager = ({
 		return null
 	}
 
+	const resetCreateState = () => {
+		setIsCreating(false)
+		setNewProfileName("")
+		setError(null)
+	}
+
+	const resetRenameState = () => {
+		setIsRenaming(false)
+		setInputValue("")
+		setError(null)
+	}
+
 	// Focus input when entering rename mode
 	useEffect(() => {
 		if (isRenaming) {
@@ -67,17 +79,13 @@ const ApiConfigManager = ({
 
 	// Reset state when current profile changes
 	useEffect(() => {
-		setIsRenaming(false)
-		setIsCreating(false)
-		setInputValue("")
-		setNewProfileName("")
-		setError(null)
+		resetCreateState()
+		resetRenameState()
 	}, [currentApiConfigName])
 
 	const handleAdd = () => {
+		resetCreateState()
 		setIsCreating(true)
-		setNewProfileName("")
-		setError(null)
 	}
 
 	const handleStartRename = () => {
@@ -87,9 +95,7 @@ const ApiConfigManager = ({
 	}
 
 	const handleCancel = () => {
-		setIsRenaming(false)
-		setInputValue("")
-		setError(null)
+		resetRenameState()
 	}
 
 	const handleSave = () => {
@@ -103,17 +109,13 @@ const ApiConfigManager = ({
 
 		if (isRenaming && currentApiConfigName) {
 			if (currentApiConfigName === trimmedValue) {
-				setIsRenaming(false)
-				setInputValue("")
-				setError(null)
+				resetRenameState()
 				return
 			}
 			onRenameConfig(currentApiConfigName, trimmedValue)
 		}
 
-		setIsRenaming(false)
-		setInputValue("")
-		setError(null)
+		resetRenameState()
 	}
 
 	const handleNewProfileSave = () => {
@@ -126,9 +128,7 @@ const ApiConfigManager = ({
 		}
 
 		onUpsertConfig(trimmedValue)
-		setIsCreating(false)
-		setNewProfileName("")
-		setError(null)
+		resetCreateState()
 	}
 
 	const handleDelete = () => {
@@ -293,9 +293,7 @@ const ApiConfigManager = ({
 							setNewProfileName("")
 							setError(null)
 						} else {
-							setIsCreating(false)
-							setNewProfileName("")
-							setError(null)
+							resetCreateState()
 						}
 					}}
 					aria-labelledby="new-profile-title">
@@ -303,14 +301,7 @@ const ApiConfigManager = ({
 						<h2 id="new-profile-title" className="text-lg font-semibold mb-4">
 							New Configuration Profile
 						</h2>
-						<button
-							className="absolute right-4 top-4"
-							aria-label="Close dialog"
-							onClick={() => {
-								setIsCreating(false)
-								setNewProfileName("")
-								setError(null)
-							}}>
+						<button className="absolute right-4 top-4" aria-label="Close dialog" onClick={resetCreateState}>
 							<span className="codicon codicon-close" />
 						</button>
 						<VSCodeTextField
@@ -328,9 +319,7 @@ const ApiConfigManager = ({
 								if (event.key === "Enter" && newProfileName.trim()) {
 									handleNewProfileSave()
 								} else if (event.key === "Escape") {
-									setIsCreating(false)
-									setNewProfileName("")
-									setError(null)
+									resetCreateState()
 								}
 							}}
 						/>
@@ -340,13 +329,7 @@ const ApiConfigManager = ({
 							</p>
 						)}
 						<div className="flex justify-end gap-2 mt-4">
-							<VSCodeButton
-								appearance="secondary"
-								onClick={() => {
-									setIsCreating(false)
-									setNewProfileName("")
-									setError(null)
-								}}>
+							<VSCodeButton appearance="secondary" onClick={resetCreateState}>
 								Cancel
 							</VSCodeButton>
 							<VSCodeButton

--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -1,5 +1,5 @@
 import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
-import { memo, useEffect, useReducer, useRef } from "react"
+import { memo, useEffect, useRef, useState } from "react"
 import { ApiConfigMeta } from "../../../../src/shared/ExtensionMessage"
 import { Dropdown } from "vscrui"
 import type { DropdownOption } from "vscrui"
@@ -14,86 +14,6 @@ interface ApiConfigManagerProps {
 	onUpsertConfig: (configName: string) => void
 }
 
-type State = {
-	isRenaming: boolean
-	isCreating: boolean
-	inputValue: string
-	newProfileName: string
-	error: string | null
-}
-
-type Action =
-	| { type: "START_RENAME"; payload: string }
-	| { type: "CANCEL_EDIT" }
-	| { type: "SET_INPUT"; payload: string }
-	| { type: "SET_NEW_NAME"; payload: string }
-	| { type: "START_CREATE" }
-	| { type: "CANCEL_CREATE" }
-	| { type: "SET_ERROR"; payload: string | null }
-	| { type: "RESET_STATE" }
-
-const initialState: State = {
-	isRenaming: false,
-	isCreating: false,
-	inputValue: "",
-	newProfileName: "",
-	error: null,
-}
-
-const reducer = (state: State, action: Action): State => {
-	switch (action.type) {
-		case "START_RENAME":
-			return {
-				...state,
-				isRenaming: true,
-				inputValue: action.payload,
-				error: null,
-			}
-		case "CANCEL_EDIT":
-			return {
-				...state,
-				isRenaming: false,
-				inputValue: "",
-				error: null,
-			}
-		case "SET_INPUT":
-			return {
-				...state,
-				inputValue: action.payload,
-				error: null,
-			}
-		case "SET_NEW_NAME":
-			return {
-				...state,
-				newProfileName: action.payload,
-				error: null,
-			}
-		case "START_CREATE":
-			return {
-				...state,
-				isCreating: true,
-				newProfileName: "",
-				error: null,
-			}
-		case "CANCEL_CREATE":
-			return {
-				...state,
-				isCreating: false,
-				newProfileName: "",
-				error: null,
-			}
-		case "SET_ERROR":
-			return {
-				...state,
-				error: action.payload,
-			}
-		case "RESET_STATE":
-			return initialState
-		default:
-			return state
-	}
-}
-
 const ApiConfigManager = ({
 	currentApiConfigName = "",
 	listApiConfigMeta = [],
@@ -102,7 +22,11 @@ const ApiConfigManager = ({
 	onRenameConfig,
 	onUpsertConfig,
 }: ApiConfigManagerProps) => {
-	const [state, dispatch] = useReducer(reducer, initialState)
+	const [isRenaming, setIsRenaming] = useState(false)
+	const [isCreating, setIsCreating] = useState(false)
+	const [inputValue, setInputValue] = useState("")
+	const [newProfileName, setNewProfileName] = useState("")
+	const [error, setError] = useState<string | null>(null)
 	const inputRef = useRef<any>(null)
 	const newProfileInputRef = useRef<any>(null)
 
@@ -127,68 +51,84 @@ const ApiConfigManager = ({
 
 	// Focus input when entering rename mode
 	useEffect(() => {
-		if (state.isRenaming) {
+		if (isRenaming) {
 			const timeoutId = setTimeout(() => inputRef.current?.focus(), 0)
 			return () => clearTimeout(timeoutId)
 		}
-	}, [state.isRenaming])
+	}, [isRenaming])
 
 	// Focus input when opening new dialog
 	useEffect(() => {
-		if (state.isCreating) {
+		if (isCreating) {
 			const timeoutId = setTimeout(() => newProfileInputRef.current?.focus(), 0)
 			return () => clearTimeout(timeoutId)
 		}
-	}, [state.isCreating])
+	}, [isCreating])
 
 	// Reset state when current profile changes
 	useEffect(() => {
-		dispatch({ type: "RESET_STATE" })
+		setIsRenaming(false)
+		setIsCreating(false)
+		setInputValue("")
+		setNewProfileName("")
+		setError(null)
 	}, [currentApiConfigName])
 
 	const handleAdd = () => {
-		dispatch({ type: "START_CREATE" })
+		setIsCreating(true)
+		setNewProfileName("")
+		setError(null)
 	}
 
 	const handleStartRename = () => {
-		dispatch({ type: "START_RENAME", payload: currentApiConfigName || "" })
+		setIsRenaming(true)
+		setInputValue(currentApiConfigName || "")
+		setError(null)
 	}
 
 	const handleCancel = () => {
-		dispatch({ type: "CANCEL_EDIT" })
+		setIsRenaming(false)
+		setInputValue("")
+		setError(null)
 	}
 
 	const handleSave = () => {
-		const trimmedValue = state.inputValue.trim()
+		const trimmedValue = inputValue.trim()
 		const error = validateName(trimmedValue, false)
 
 		if (error) {
-			dispatch({ type: "SET_ERROR", payload: error })
+			setError(error)
 			return
 		}
 
-		if (state.isRenaming && currentApiConfigName) {
+		if (isRenaming && currentApiConfigName) {
 			if (currentApiConfigName === trimmedValue) {
-				dispatch({ type: "CANCEL_EDIT" })
+				setIsRenaming(false)
+				setInputValue("")
+				setError(null)
 				return
 			}
 			onRenameConfig(currentApiConfigName, trimmedValue)
 		}
 
-		dispatch({ type: "CANCEL_EDIT" })
+		setIsRenaming(false)
+		setInputValue("")
+		setError(null)
 	}
 
 	const handleNewProfileSave = () => {
-		const trimmedValue = state.newProfileName.trim()
+		const trimmedValue = newProfileName.trim()
 		const error = validateName(trimmedValue, true)
 
 		if (error) {
-			dispatch({ type: "SET_ERROR", payload: error })
+			setError(error)
 			return
 		}
 
 		onUpsertConfig(trimmedValue)
-		dispatch({ type: "CANCEL_CREATE" })
+		setIsCreating(false)
+		setNewProfileName("")
+		setError(null)
 	}
 
 	const handleDelete = () => {
@@ -212,23 +152,24 @@ const ApiConfigManager = ({
 					<span style={{ fontWeight: "500" }}>Configuration Profile</span>
 				</label>
 
-				{state.isRenaming ? (
+				{isRenaming ? (
 					<div
 						data-testid="rename-form"
 						style={{ display: "flex", gap: "4px", alignItems: "center", flexDirection: "column" }}>
 						<div style={{ display: "flex", gap: "4px", alignItems: "center", width: "100%" }}>
 							<VSCodeTextField
 								ref={inputRef}
-								value={state.inputValue}
+								value={inputValue}
 								onInput={(e: unknown) => {
 									const target = e as { target: { value: string } }
-									dispatch({ type: "SET_INPUT", payload: target.target.value })
+									setInputValue(target.target.value)
+									setError(null)
 								}}
 								placeholder="Enter new name"
 								style={{ flexGrow: 1 }}
 								onKeyDown={(e: unknown) => {
 									const event = e as { key: string }
-									if (event.key === "Enter" && state.inputValue.trim()) {
+									if (event.key === "Enter" && inputValue.trim()) {
 										handleSave()
 									} else if (event.key === "Escape") {
 										handleCancel()
@@ -237,7 +178,7 @@ const ApiConfigManager = ({
 							/>
 							<VSCodeButton
 								appearance="icon"
-								disabled={!state.inputValue.trim()}
+								disabled={!inputValue.trim()}
 								onClick={handleSave}
 								title="Save"
 								style={{
@@ -263,9 +204,9 @@ const ApiConfigManager = ({
 								<span className="codicon codicon-close" />
 							</VSCodeButton>
 						</div>
-						{state.error && (
+						{error && (
 							<p className="text-red-500 text-sm mt-2" data-testid="error-message">
-								{state.error}
+								{error}
 							</p>
 						)}
 					</div>
@@ -345,8 +286,18 @@ const ApiConfigManager = ({
 				)}
 
 				<Dialog
-					open={state.isCreating}
-					onOpenChange={(open: boolean) => dispatch({ type: open ? "START_CREATE" : "CANCEL_CREATE" })}
+					open={isCreating}
+					onOpenChange={(open: boolean) => {
+						if (open) {
+							setIsCreating(true)
+							setNewProfileName("")
+							setError(null)
+						} else {
+							setIsCreating(false)
+							setNewProfileName("")
+							setError(null)
+						}
+					}}
 					aria-labelledby="new-profile-title">
 					<DialogContent className="p-4 max-w-sm">
 						<h2 id="new-profile-title" className="text-lg font-semibold mb-4">
@@ -355,39 +306,52 @@ const ApiConfigManager = ({
 						<button
 							className="absolute right-4 top-4"
 							aria-label="Close dialog"
-							onClick={() => dispatch({ type: "CANCEL_CREATE" })}>
+							onClick={() => {
+								setIsCreating(false)
+								setNewProfileName("")
+								setError(null)
+							}}>
 							<span className="codicon codicon-close" />
 						</button>
 						<VSCodeTextField
 							ref={newProfileInputRef}
-							value={state.newProfileName}
+							value={newProfileName}
 							onInput={(e: unknown) => {
 								const target = e as { target: { value: string } }
-								dispatch({ type: "SET_NEW_NAME", payload: target.target.value })
+								setNewProfileName(target.target.value)
+								setError(null)
 							}}
 							placeholder="Enter profile name"
 							style={{ width: "100%" }}
 							onKeyDown={(e: unknown) => {
 								const event = e as { key: string }
-								if (event.key === "Enter" && state.newProfileName.trim()) {
+								if (event.key === "Enter" && newProfileName.trim()) {
 									handleNewProfileSave()
 								} else if (event.key === "Escape") {
-									dispatch({ type: "CANCEL_CREATE" })
+									setIsCreating(false)
+									setNewProfileName("")
+									setError(null)
 								}
 							}}
 						/>
-						{state.error && (
+						{error && (
 							<p className="text-red-500 text-sm mt-2" data-testid="error-message">
-								{state.error}
+								{error}
 							</p>
 						)}
 						<div className="flex justify-end gap-2 mt-4">
-							<VSCodeButton appearance="secondary" onClick={() => dispatch({ type: "CANCEL_CREATE" })}>
+							<VSCodeButton
+								appearance="secondary"
+								onClick={() => {
+									setIsCreating(false)
+									setNewProfileName("")
+									setError(null)
+								}}>
 								Cancel
 							</VSCodeButton>
 							<VSCodeButton
 								appearance="primary"
-								disabled={!state.newProfileName.trim()}
+								disabled={!newProfileName.trim()}
 								onClick={handleNewProfileSave}>
 								Create Profile
 							</VSCodeButton>

--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -1,8 +1,9 @@
 import { VSCodeButton, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
-import { memo, useEffect, useRef, useState } from "react"
+import { memo, useEffect, useReducer, useRef } from "react"
 import { ApiConfigMeta } from "../../../../src/shared/ExtensionMessage"
 import { Dropdown } from "vscrui"
 import type { DropdownOption } from "vscrui"
+import { Dialog, DialogContent } from "../ui/dialog"
 
 interface ApiConfigManagerProps {
 	currentApiConfigName?: string
@@ -13,6 +14,86 @@ interface ApiConfigManagerProps {
 	onUpsertConfig: (configName: string) => void
 }
 
+type State = {
+	isRenaming: boolean
+	isCreating: boolean
+	inputValue: string
+	newProfileName: string
+	error: string | null
+}
+
+type Action =
+	| { type: "START_RENAME"; payload: string }
+	| { type: "CANCEL_EDIT" }
+	| { type: "SET_INPUT"; payload: string }
+	| { type: "SET_NEW_NAME"; payload: string }
+	| { type: "START_CREATE" }
+	| { type: "CANCEL_CREATE" }
+	| { type: "SET_ERROR"; payload: string | null }
+	| { type: "RESET_STATE" }
+
+const initialState: State = {
+	isRenaming: false,
+	isCreating: false,
+	inputValue: "",
+	newProfileName: "",
+	error: null,
+}
+
+const reducer = (state: State, action: Action): State => {
+	switch (action.type) {
+		case "START_RENAME":
+			return {
+				...state,
+				isRenaming: true,
+				inputValue: action.payload,
+				error: null,
+			}
+		case "CANCEL_EDIT":
+			return {
+				...state,
+				isRenaming: false,
+				inputValue: "",
+				error: null,
+			}
+		case "SET_INPUT":
+			return {
+				...state,
+				inputValue: action.payload,
+				error: null,
+			}
+		case "SET_NEW_NAME":
+			return {
+				...state,
+				newProfileName: action.payload,
+				error: null,
+			}
+		case "START_CREATE":
+			return {
+				...state,
+				isCreating: true,
+				newProfileName: "",
+				error: null,
+			}
+		case "CANCEL_CREATE":
+			return {
+				...state,
+				isCreating: false,
+				newProfileName: "",
+				error: null,
+			}
+		case "SET_ERROR":
+			return {
+				...state,
+				error: action.payload,
+			}
+		case "RESET_STATE":
+			return initialState
+		default:
+			return state
+	}
+}
+
 const ApiConfigManager = ({
 	currentApiConfigName = "",
 	listApiConfigMeta = [],
@@ -21,55 +102,93 @@ const ApiConfigManager = ({
 	onRenameConfig,
 	onUpsertConfig,
 }: ApiConfigManagerProps) => {
-	const [editState, setEditState] = useState<"new" | "rename" | null>(null)
-	const [inputValue, setInputValue] = useState("")
-	const inputRef = useRef<HTMLInputElement>()
+	const [state, dispatch] = useReducer(reducer, initialState)
+	const inputRef = useRef<any>(null)
+	const newProfileInputRef = useRef<any>(null)
 
-	// Focus input when entering edit mode
-	useEffect(() => {
-		if (editState) {
-			setTimeout(() => inputRef.current?.focus(), 0)
+	const validateName = (name: string, isNewProfile: boolean): string | null => {
+		const trimmed = name.trim()
+		if (!trimmed) return "Name cannot be empty"
+
+		const nameExists = listApiConfigMeta?.some((config) => config.name.toLowerCase() === trimmed.toLowerCase())
+
+		// For new profiles, any existing name is invalid
+		if (isNewProfile && nameExists) {
+			return "A profile with this name already exists"
 		}
-	}, [editState])
 
-	// Reset edit state when current profile changes
+		// For rename, only block if trying to rename to a different existing profile
+		if (!isNewProfile && nameExists && trimmed.toLowerCase() !== currentApiConfigName?.toLowerCase()) {
+			return "A profile with this name already exists"
+		}
+
+		return null
+	}
+
+	// Focus input when entering rename mode
 	useEffect(() => {
-		setEditState(null)
-		setInputValue("")
+		if (state.isRenaming) {
+			const timeoutId = setTimeout(() => inputRef.current?.focus(), 0)
+			return () => clearTimeout(timeoutId)
+		}
+	}, [state.isRenaming])
+
+	// Focus input when opening new dialog
+	useEffect(() => {
+		if (state.isCreating) {
+			const timeoutId = setTimeout(() => newProfileInputRef.current?.focus(), 0)
+			return () => clearTimeout(timeoutId)
+		}
+	}, [state.isCreating])
+
+	// Reset state when current profile changes
+	useEffect(() => {
+		dispatch({ type: "RESET_STATE" })
 	}, [currentApiConfigName])
 
 	const handleAdd = () => {
-		const newConfigName = currentApiConfigName + " (copy)"
-		onUpsertConfig(newConfigName)
+		dispatch({ type: "START_CREATE" })
 	}
 
 	const handleStartRename = () => {
-		setEditState("rename")
-		setInputValue(currentApiConfigName || "")
+		dispatch({ type: "START_RENAME", payload: currentApiConfigName || "" })
 	}
 
 	const handleCancel = () => {
-		setEditState(null)
-		setInputValue("")
+		dispatch({ type: "CANCEL_EDIT" })
 	}
 
 	const handleSave = () => {
-		const trimmedValue = inputValue.trim()
-		if (!trimmedValue) return
+		const trimmedValue = state.inputValue.trim()
+		const error = validateName(trimmedValue, false)
 
-		if (editState === "new") {
-			onUpsertConfig(trimmedValue)
-		} else if (editState === "rename" && currentApiConfigName) {
+		if (error) {
+			dispatch({ type: "SET_ERROR", payload: error })
+			return
+		}
+
+		if (state.isRenaming && currentApiConfigName) {
 			if (currentApiConfigName === trimmedValue) {
-				setEditState(null)
-				setInputValue("")
+				dispatch({ type: "CANCEL_EDIT" })
 				return
 			}
 			onRenameConfig(currentApiConfigName, trimmedValue)
 		}
 
-		setEditState(null)
-		setInputValue("")
+		dispatch({ type: "CANCEL_EDIT" })
+	}
+
+	const handleNewProfileSave = () => {
+		const trimmedValue = state.newProfileName.trim()
+		const error = validateName(trimmedValue, true)
+
+		if (error) {
+			dispatch({ type: "SET_ERROR", payload: error })
+			return
+		}
+
+		onUpsertConfig(trimmedValue)
+		dispatch({ type: "CANCEL_CREATE" })
 	}
 
 	const handleDelete = () => {
@@ -93,49 +212,62 @@ const ApiConfigManager = ({
 					<span style={{ fontWeight: "500" }}>Configuration Profile</span>
 				</label>
 
-				{editState ? (
-					<div style={{ display: "flex", gap: "4px", alignItems: "center" }}>
-						<VSCodeTextField
-							ref={inputRef as any}
-							value={inputValue}
-							onInput={(e: any) => setInputValue(e.target.value)}
-							placeholder={editState === "new" ? "Enter profile name" : "Enter new name"}
-							style={{ flexGrow: 1 }}
-							onKeyDown={(e: any) => {
-								if (e.key === "Enter" && inputValue.trim()) {
-									handleSave()
-								} else if (e.key === "Escape") {
-									handleCancel()
-								}
-							}}
-						/>
-						<VSCodeButton
-							appearance="icon"
-							disabled={!inputValue.trim()}
-							onClick={handleSave}
-							title="Save"
-							style={{
-								padding: 0,
-								margin: 0,
-								height: "28px",
-								width: "28px",
-								minWidth: "28px",
-							}}>
-							<span className="codicon codicon-check" />
-						</VSCodeButton>
-						<VSCodeButton
-							appearance="icon"
-							onClick={handleCancel}
-							title="Cancel"
-							style={{
-								padding: 0,
-								margin: 0,
-								height: "28px",
-								width: "28px",
-								minWidth: "28px",
-							}}>
-							<span className="codicon codicon-close" />
-						</VSCodeButton>
+				{state.isRenaming ? (
+					<div
+						data-testid="rename-form"
+						style={{ display: "flex", gap: "4px", alignItems: "center", flexDirection: "column" }}>
+						<div style={{ display: "flex", gap: "4px", alignItems: "center", width: "100%" }}>
+							<VSCodeTextField
+								ref={inputRef}
+								value={state.inputValue}
+								onInput={(e: unknown) => {
+									const target = e as { target: { value: string } }
+									dispatch({ type: "SET_INPUT", payload: target.target.value })
+								}}
+								placeholder="Enter new name"
+								style={{ flexGrow: 1 }}
+								onKeyDown={(e: unknown) => {
+									const event = e as { key: string }
+									if (event.key === "Enter" && state.inputValue.trim()) {
+										handleSave()
+									} else if (event.key === "Escape") {
+										handleCancel()
+									}
+								}}
+							/>
+							<VSCodeButton
+								appearance="icon"
+								disabled={!state.inputValue.trim()}
+								onClick={handleSave}
+								title="Save"
+								style={{
+									padding: 0,
+									margin: 0,
+									height: "28px",
+									width: "28px",
+									minWidth: "28px",
+								}}>
+								<span className="codicon codicon-check" />
+							</VSCodeButton>
+							<VSCodeButton
+								appearance="icon"
+								onClick={handleCancel}
+								title="Cancel"
+								style={{
+									padding: 0,
+									margin: 0,
+									height: "28px",
+									width: "28px",
+									minWidth: "28px",
+								}}>
+								<span className="codicon codicon-close" />
+							</VSCodeButton>
+						</div>
+						{state.error && (
+							<p className="text-red-500 text-sm mt-2" data-testid="error-message">
+								{state.error}
+							</p>
+						)}
 					</div>
 				) : (
 					<>
@@ -211,6 +343,57 @@ const ApiConfigManager = ({
 						</p>
 					</>
 				)}
+
+				<Dialog
+					open={state.isCreating}
+					onOpenChange={(open: boolean) => dispatch({ type: open ? "START_CREATE" : "CANCEL_CREATE" })}
+					aria-labelledby="new-profile-title">
+					<DialogContent className="p-4 max-w-sm">
+						<h2 id="new-profile-title" className="text-lg font-semibold mb-4">
+							New Configuration Profile
+						</h2>
+						<button
+							className="absolute right-4 top-4"
+							aria-label="Close dialog"
+							onClick={() => dispatch({ type: "CANCEL_CREATE" })}>
+							<span className="codicon codicon-close" />
+						</button>
+						<VSCodeTextField
+							ref={newProfileInputRef}
+							value={state.newProfileName}
+							onInput={(e: unknown) => {
+								const target = e as { target: { value: string } }
+								dispatch({ type: "SET_NEW_NAME", payload: target.target.value })
+							}}
+							placeholder="Enter profile name"
+							style={{ width: "100%" }}
+							onKeyDown={(e: unknown) => {
+								const event = e as { key: string }
+								if (event.key === "Enter" && state.newProfileName.trim()) {
+									handleNewProfileSave()
+								} else if (event.key === "Escape") {
+									dispatch({ type: "CANCEL_CREATE" })
+								}
+							}}
+						/>
+						{state.error && (
+							<p className="text-red-500 text-sm mt-2" data-testid="error-message">
+								{state.error}
+							</p>
+						)}
+						<div className="flex justify-end gap-2 mt-4">
+							<VSCodeButton appearance="secondary" onClick={() => dispatch({ type: "CANCEL_CREATE" })}>
+								Cancel
+							</VSCodeButton>
+							<VSCodeButton
+								appearance="primary"
+								disabled={!state.newProfileName.trim()}
+								onClick={handleNewProfileSave}>
+								Create Profile
+							</VSCodeButton>
+						</div>
+					</DialogContent>
+				</Dialog>
 			</div>
 		</div>
 	)


### PR DESCRIPTION
This seemed like a more obvious way to add a configuration profile than the current approach where we just clone an existing one. Thoughts? Am I using shadcn right?

![Screenshot 2025-02-07 at 4 25 48 PM](https://github.com/user-attachments/assets/887a995f-6b29-44f3-bc98-cf36044685ba)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves UX for adding and renaming API config profiles with a new dialog and enhanced validation.
> 
>   - **Behavior**:
>     - Introduces a dialog for creating new API configuration profiles in `ApiConfigManager.tsx`.
>     - Validates profile names to prevent duplicates and empty names.
>     - Updates renaming logic to handle existing names and empty inputs.
>   - **UI Components**:
>     - Adds `Dialog` and `DialogContent` components for new profile creation.
>     - Refactors input handling for renaming and creating profiles.
>   - **Tests**:
>     - Updates `ApiConfigManager.test.tsx` to test new dialog behavior and validation logic.
>     - Adds tests for keyboard interactions in both new profile creation and renaming modes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 69d58720db8c46b8838c781a97db47e19708a589. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->