### PR TITLE
Support the Ark provider when used through OpenAI compatible

### DIFF
--- a/.changeset/spicy-pugs-guess.md
+++ b/.changeset/spicy-pugs-guess.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Support Volcano Ark platform through OpenAI compatible

--- a/src/api/transform/__tests__/simple-format.test.ts
+++ b/src/api/transform/__tests__/simple-format.test.ts
@@ -1,0 +1,138 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+import { convertToSimpleContent, convertToSimpleMessages } from "../simple-format"
+
+describe("simple-format", () => {
+	describe("convertToSimpleContent", () => {
+		it("returns string content as-is", () => {
+			const content = "Hello world"
+			expect(convertToSimpleContent(content)).toBe("Hello world")
+		})
+
+		it("extracts text from text blocks", () => {
+			const content = [
+				{ type: "text", text: "Hello" },
+				{ type: "text", text: "world" },
+			] as Anthropic.Messages.TextBlockParam[]
+			expect(convertToSimpleContent(content)).toBe("Hello\nworld")
+		})
+
+		it("converts image blocks to descriptive text", () => {
+			const content = [
+				{ type: "text", text: "Here's an image:" },
+				{
+					type: "image",
+					source: {
+						type: "base64",
+						media_type: "image/png",
+						data: "base64data",
+					},
+				},
+			] as Array<Anthropic.Messages.TextBlockParam | Anthropic.Messages.ImageBlockParam>
+			expect(convertToSimpleContent(content)).toBe("Here's an image:\n[Image: image/png]")
+		})
+
+		it("converts tool use blocks to descriptive text", () => {
+			const content = [
+				{ type: "text", text: "Using a tool:" },
+				{
+					type: "tool_use",
+					id: "tool-1",
+					name: "read_file",
+					input: { path: "test.txt" },
+				},
+			] as Array<Anthropic.Messages.TextBlockParam | Anthropic.Messages.ToolUseBlockParam>
+			expect(convertToSimpleContent(content)).toBe("Using a tool:\n[Tool Use: read_file]")
+		})
+
+		it("handles string tool result content", () => {
+			const content = [
+				{ type: "text", text: "Tool result:" },
+				{
+					type: "tool_result",
+					tool_use_id: "tool-1",
+					content: "Result text",
+				},
+			] as Array<Anthropic.Messages.TextBlockParam | Anthropic.Messages.ToolResultBlockParam>
+			expect(convertToSimpleContent(content)).toBe("Tool result:\nResult text")
+		})
+
+		it("handles array tool result content with text and images", () => {
+			const content = [
+				{
+					type: "tool_result",
+					tool_use_id: "tool-1",
+					content: [
+						{ type: "text", text: "Result 1" },
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: "image/jpeg",
+								data: "base64data",
+							},
+						},
+						{ type: "text", text: "Result 2" },
+					],
+				},
+			] as Anthropic.Messages.ToolResultBlockParam[]
+			expect(convertToSimpleContent(content)).toBe("Result 1\n[Image: image/jpeg]\nResult 2")
+		})
+
+		it("filters out empty strings", () => {
+			const content = [
+				{ type: "text", text: "Hello" },
+				{ type: "text", text: "" },
+				{ type: "text", text: "world" },
+			] as Anthropic.Messages.TextBlockParam[]
+			expect(convertToSimpleContent(content)).toBe("Hello\nworld")
+		})
+	})
+
+	describe("convertToSimpleMessages", () => {
+		it("converts messages with string content", () => {
+			const messages = [
+				{ role: "user", content: "Hello" },
+				{ role: "assistant", content: "Hi there" },
+			] as Anthropic.Messages.MessageParam[]
+			expect(convertToSimpleMessages(messages)).toEqual([
+				{ role: "user", content: "Hello" },
+				{ role: "assistant", content: "Hi there" },
+			])
+		})
+
+		it("converts messages with complex content", () => {
+			const messages = [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Look at this:" },
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								media_type: "image/png",
+								data: "base64data",
+							},
+						},
+					],
+				},
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "I see the image" },
+						{
+							type: "tool_use",
+							id: "tool-1",
+							name: "analyze_image",
+							input: { data: "base64data" },
+						},
+					],
+				},
+			] as Anthropic.Messages.MessageParam[]
+			expect(convertToSimpleMessages(messages)).toEqual([
+				{ role: "user", content: "Look at this:\n[Image: image/png]" },
+				{ role: "assistant", content: "I see the image\n[Tool Use: analyze_image]" },
+			])
+		})
+	})
+})

--- a/src/api/transform/simple-format.ts
+++ b/src/api/transform/simple-format.ts
@@ -1,0 +1,67 @@
+import { Anthropic } from "@anthropic-ai/sdk"
+
+/**
+ * Convert complex content blocks to simple string content
+ */
+export function convertToSimpleContent(
+	content:
+		| string
+		| Array<
+				| Anthropic.Messages.TextBlockParam
+				| Anthropic.Messages.ImageBlockParam
+				| Anthropic.Messages.ToolUseBlockParam
+				| Anthropic.Messages.ToolResultBlockParam
+		  >,
+): string {
+	if (typeof content === "string") {
+		return content
+	}
+
+	// Extract text from content blocks
+	return content
+		.map((block) => {
+			if (block.type === "text") {
+				return block.text
+			}
+			if (block.type === "image") {
+				return `[Image: ${block.source.media_type}]`
+			}
+			if (block.type === "tool_use") {
+				return `[Tool Use: ${block.name}]`
+			}
+			if (block.type === "tool_result") {
+				if (typeof block.content === "string") {
+					return block.content
+				}
+				if (Array.isArray(block.content)) {
+					return block.content
+						.map((part) => {
+							if (part.type === "text") {
+								return part.text
+							}
+							if (part.type === "image") {
+								return `[Image: ${part.source.media_type}]`
+							}
+							return ""
+						})
+						.join("\n")
+				}
+				return ""
+			}
+			return ""
+		})
+		.filter(Boolean)
+		.join("\n")
+}
+
+/**
+ * Convert Anthropic messages to simple format with string content
+ */
+export function convertToSimpleMessages(
+	messages: Anthropic.Messages.MessageParam[],
+): Array<{ role: "user" | "assistant"; content: string }> {
+	return messages.map((message) => ({
+		role: message.role,
+		content: convertToSimpleContent(message.content),
+	}))
+}


### PR DESCRIPTION
https://github.com/RooVetGit/Roo-Code/issues/770 https://github.com/RooVetGit/Roo-Code/discussions/839
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for Ark provider in OpenAI handler with new message conversion format and tests.
> 
>   - **Behavior**:
>     - Support for Ark provider added in `OpenAiHandler` in `openai.ts` by checking for `.volces.com` in `modelUrl` and using `convertToSimpleMessages()`.
>     - Introduces `convertToSimpleMessages()` and `convertToSimpleContent()` in `simple-format.ts` to handle message conversion for Ark.
>   - **Tests**:
>     - Adds tests for `convertToSimpleContent()` and `convertToSimpleMessages()` in `simple-format.test.ts` to verify conversion logic for various content types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2ddf54de5d21b48b105ae0d3115006e241690529. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->