### PR TITLE
Don't clobber existing user.name and user.email git config values

### DIFF
--- a/src/services/checkpoints/CheckpointService.ts
+++ b/src/services/checkpoints/CheckpointService.ts
@@ -284,8 +284,17 @@ export class CheckpointService {
 			log(`[initRepo] Initialized new Git repository at ${baseDir}`)
 		}
 
-		await git.addConfig("user.name", "Roo Code")
-		await git.addConfig("user.email", "support@roocode.com")
+		// Only set user config if not already configured
+		const userName = await git.getConfig("user.name")
+		const userEmail = await git.getConfig("user.email")
+
+		if (!userName.value) {
+			await git.addConfig("user.name", "Roo Code")
+		}
+
+		if (!userEmail.value) {
+			await git.addConfig("user.email", "support@roocode.com")
+		}
 
 		if (!isExistingRepo) {
 			// We need at least one file to commit, otherwise the initial


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

Bug report: https://discord.com/channels/1332146336664915968/1337876241818058793/1338052909279215616

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `CheckpointService` respects existing git user configurations for `user.name` and `user.email`.
> 
>   - **Behavior**:
>     - In `CheckpointService.ts`, modify `initRepo()` to check existing `user.name` and `user.email` before setting them.
>     - Only set `user.name` to "Roo Code" and `user.email` to "support@roocode.com" if not already configured.
>   - **Tests**:
>     - Add test `respects existing git user configuration` in `CheckpointService.test.ts` to verify existing user config is not overwritten.
>     - Refactor `initRepo()` in `CheckpointService.test.ts` to accept custom user configurations for testing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 96ab5dcb1f03b99efdfc0e43a1afbd2b1d70880b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->