### PR TITLE
Move task to end of initial message to prevent it from being drowned out by environment details.

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -455,7 +455,7 @@ export class Cline {
 			...imageBlocks,
 			{
 				type: "text",
-				text: `<environment_details>Loading...</environment_details>\n\n<task>\n${task}\n</task>`,
+				text: `<task>\n${task}\n</task>`,
 			},
 		])
 	}
@@ -2765,8 +2765,8 @@ export class Cline {
 
 		const [parsedUserContent, environmentDetails] = await this.loadContext(userContent, includeFileDetails)
 		userContent = parsedUserContent
-		// add environment details as its own text block, separate from tool results
-		userContent.push({ type: "text", text: environmentDetails })
+		// prepend environment details as its own text block, separate from tool results
+		userContent.unshift({ type: "text", text: environmentDetails })
 
 		await this.addToApiConversationHistory({ role: "user", content: userContent })
 

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -441,25 +441,24 @@ export class Cline {
 	// Task lifecycle
 
 	private async startTask(task?: string, images?: string[]): Promise<void> {
-    // conversationHistory (for API) and clineMessages (for webview) need to be in sync
-    // if the extension process were killed, then on restart the clineMessages might not be empty, so we need to set it to [] when we create a new Cline client (otherwise webview would show stale messages from previous session)
-    this.clineMessages = [];
-    this.apiConversationHistory = [];
-    await this.providerRef.deref()?.postStateToWebview();
+		// conversationHistory (for API) and clineMessages (for webview) need to be in sync
+		// if the extension process were killed, then on restart the clineMessages might not be empty, so we need to set it to [] when we create a new Cline client (otherwise webview would show stale messages from previous session)
+		this.clineMessages = []
+		this.apiConversationHistory = []
+		await this.providerRef.deref()?.postStateToWebview()
 
-    await this.say("text", task, images);
-    this.isInitialized = true;
+		await this.say("text", task, images)
+		this.isInitialized = true
 
-    let imageBlocks: Anthropic.ImageBlockParam[] = formatResponse.imageBlocks(images);
-    await this.initiateTaskLoop([
-        ...imageBlocks,
-        {
-            type: "text",
-            text: `<environment_details>Loading...</environment_details>\n\n<task>\n${task}\n</task>`,
-        },
-    ]);
-}
-
+		let imageBlocks: Anthropic.ImageBlockParam[] = formatResponse.imageBlocks(images)
+		await this.initiateTaskLoop([
+			...imageBlocks,
+			{
+				type: "text",
+				text: `<environment_details>Loading...</environment_details>\n\n<task>\n${task}\n</task>`,
+			},
+		])
+	}
 
 	private async resumeTaskFromHistory() {
 		const modifiedClineMessages = await this.getSavedClineMessages()

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -441,24 +441,25 @@ export class Cline {
 	// Task lifecycle
 
 	private async startTask(task?: string, images?: string[]): Promise<void> {
-		// conversationHistory (for API) and clineMessages (for webview) need to be in sync
-		// if the extension process were killed, then on restart the clineMessages might not be empty, so we need to set it to [] when we create a new Cline client (otherwise webview would show stale messages from previous session)
-		this.clineMessages = []
-		this.apiConversationHistory = []
-		await this.providerRef.deref()?.postStateToWebview()
+    // conversationHistory (for API) and clineMessages (for webview) need to be in sync
+    // if the extension process were killed, then on restart the clineMessages might not be empty, so we need to set it to [] when we create a new Cline client (otherwise webview would show stale messages from previous session)
+    this.clineMessages = [];
+    this.apiConversationHistory = [];
+    await this.providerRef.deref()?.postStateToWebview();
 
-		await this.say("text", task, images)
-		this.isInitialized = true
+    await this.say("text", task, images);
+    this.isInitialized = true;
 
-		let imageBlocks: Anthropic.ImageBlockParam[] = formatResponse.imageBlocks(images)
-		await this.initiateTaskLoop([
-			{
-				type: "text",
-				text: `<task>\n${task}\n</task>`,
-			},
-			...imageBlocks,
-		])
-	}
+    let imageBlocks: Anthropic.ImageBlockParam[] = formatResponse.imageBlocks(images);
+    await this.initiateTaskLoop([
+        ...imageBlocks,
+        {
+            type: "text",
+            text: `<environment_details>Loading...</environment_details>\n\n<task>\n${task}\n</task>`,
+        },
+    ]);
+}
+
 
 	private async resumeTaskFromHistory() {
 		const modifiedClineMessages = await this.getSavedClineMessages()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> In `Cline.ts`, `startTask()` now appends environment details before the task message to improve task visibility.
> 
>   - **Behavior**:
>     - In `Cline.ts`, `startTask()` now appends environment details before the task message in `initiateTaskLoop()` to ensure task visibility.
>   - **Misc**:
>     - Minor formatting changes in `startTask()` for consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0b38426fff64918d37f98e6ec5c959d13bfabf28. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->