### PR TITLE
fix: ensure disabled MCP servers appear in settings UI

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -628,7 +628,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						if (this.mcpHub) {
 							this.postMessageToWebview({
 								type: "mcpServers",
-								mcpServers: this.mcpHub.getServers(),
+								mcpServers: this.mcpHub.getAllServers(),
 							})
 						}
 
@@ -2259,7 +2259,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			autoApprovalEnabled: autoApprovalEnabled ?? false,
 			customModes: await this.customModesManager.getCustomModes(),
 			experiments: experiments ?? experimentDefault,
-			mcpServers: this.mcpHub?.getServers() ?? [],
+			mcpServers: this.mcpHub?.getAllServers() ?? [],
 		}
 	}
 

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -67,6 +67,11 @@ export class McpHub {
 		return this.connections.filter((conn) => !conn.server.disabled).map((conn) => conn.server)
 	}
 
+	getAllServers(): McpServer[] {
+		// Return all servers regardless of state
+		return this.connections.map((conn) => conn.server)
+	}
+
 	async getMcpServersPath(): Promise<string> {
 		const provider = this.providerRef.deref()
 		if (!provider) {


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

When the MCP server was initialized before opening RooCode, disabled servers would not appear in the settings UI. This was fixed by:

1. Using getAllServers() instead of getServers() in ClineProvider.ts for UI state updates, ensuring all servers (including disabled ones) are shown
2. Maintaining getServers() for operational use (AI prompts, tool calls) where disabled servers should be filtered out

The fix maintains clean separation between UI display and operational server filtering.

## Type of change

<!-- Please ignore options that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
Manually though debug mode (minor fix).

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] My code follows the patterns of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->
Follow up for PR #852 , concerning issue #834 . The disabled MCPs were still not showing on the list if you waited until the MCP server was initiated before openning MCP settings, this PR fixes the issue.

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->
#834 

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue where disabled MCP servers were not shown in the settings UI by using `getAllServers()` in `ClineProvider.ts`.
> 
>   - **Behavior**:
>     - Use `getAllServers()` instead of `getServers()` in `ClineProvider.ts` to ensure all MCP servers, including disabled ones, appear in the settings UI.
>     - Retain `getServers()` for operational use where only enabled servers are needed.
>   - **Functions**:
>     - Add `getAllServers()` to `McpHub.ts` to return all servers regardless of their state.
>   - **Misc**:
>     - Update `postMessageToWebview` calls in `ClineProvider.ts` to use `getAllServers()` for UI updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0bb6112257359ace911ad844da0a8ceeb9f3403f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->