### PR TITLE
Fix "Restore Checkpoint" popover

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1910,7 +1910,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				this.outputChannel.appendLine("Invalid response from Glama API")
 			}
 			await fs.writeFile(glamaModelsFilePath, JSON.stringify(models))
-			this.outputChannel.appendLine(`Glama models fetched and saved: ${JSON.stringify(models, null, 2)}`)
 		} catch (error) {
 			this.outputChannel.appendLine(
 				`Error fetching Glama models: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`,
@@ -2026,7 +2025,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				this.outputChannel.appendLine("Invalid response from OpenRouter API")
 			}
 			await fs.writeFile(openRouterModelsFilePath, JSON.stringify(models))
-			this.outputChannel.appendLine(`OpenRouter models fetched and saved: ${JSON.stringify(models, null, 2)}`)
 		} catch (error) {
 			this.outputChannel.appendLine(
 				`Error fetching OpenRouter models: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`,
@@ -2066,7 +2064,6 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				}
 			}
 			await fs.writeFile(unboundModelsFilePath, JSON.stringify(models))
-			this.outputChannel.appendLine(`Unbound models fetched and saved: ${JSON.stringify(models, null, 2)}`)
 		} catch (error) {
 			this.outputChannel.appendLine(
 				`Error fetching Unbound models: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`,

--- a/webview-ui/src/components/chat/checkpoints/CheckpointMenu.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointMenu.tsx
@@ -3,16 +3,7 @@ import { CheckIcon, Cross2Icon } from "@radix-ui/react-icons"
 
 import { vscode } from "../../../utils/vscode"
 
-import {
-	Button,
-	Popover,
-	PopoverContent,
-	PopoverTrigger,
-	Tooltip,
-	TooltipContent,
-	TooltipProvider,
-	TooltipTrigger,
-} from "@/components/ui"
+import { Button, Popover, PopoverContent, PopoverTrigger } from "@/components/ui"
 
 type CheckpointMenuProps = {
 	ts: number
@@ -52,16 +43,9 @@ export const CheckpointMenu = ({ ts, commitHash, currentCheckpointHash }: Checkp
 
 	return (
 		<div className="flex flex-row gap-1">
-			<TooltipProvider>
-				<Tooltip>
-					<TooltipTrigger asChild>
-						<Button variant="ghost" size="icon" onClick={onCheckpointDiff}>
-							<span className="codicon codicon-diff-single" />
-						</Button>
-					</TooltipTrigger>
-					<TooltipContent align="end">View Diff</TooltipContent>
-				</Tooltip>
-			</TooltipProvider>
+			<Button variant="ghost" size="icon" onClick={onCheckpointDiff} title="View Diff">
+				<span className="codicon codicon-diff-single" />
+			</Button>
 			<Popover
 				open={isOpen}
 				onOpenChange={(open) => {
@@ -69,16 +53,9 @@ export const CheckpointMenu = ({ ts, commitHash, currentCheckpointHash }: Checkp
 					setIsConfirming(false)
 				}}>
 				<PopoverTrigger asChild>
-					<TooltipProvider>
-						<Tooltip>
-							<TooltipTrigger asChild>
-								<Button variant="ghost" size="icon">
-									<span className="codicon codicon-history" />
-								</Button>
-							</TooltipTrigger>
-							<TooltipContent align="end">Restore Checkpoint</TooltipContent>
-						</Tooltip>
-					</TooltipProvider>
+					<Button variant="ghost" size="icon" title="Restore Checkpoint">
+						<span className="codicon codicon-history" />
+					</Button>
 				</PopoverTrigger>
 				<PopoverContent align="end" container={portalContainer}>
 					<div className="flex flex-col gap-2">


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

For some reason nesting a tooltip trigger inside of popover triggers breaks the popover trigger, and clicking the "Restore Checkpoint" button was doing nothing. I'll add an integration test for this stuff when the dust settles.

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->
