### PR TITLE
Disable checkpoints on Windows

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -143,7 +143,7 @@ export class Cline {
 		this.fuzzyMatchThreshold = fuzzyMatchThreshold ?? 1.0
 		this.providerRef = new WeakRef(provider)
 		this.diffViewProvider = new DiffViewProvider(cwd)
-		this.checkpointsEnabled = enableCheckpoints ?? false
+		this.checkpointsEnabled = process.platform !== "win32" && !!enableCheckpoints
 
 		if (historyItem) {
 			this.taskId = historyItem.id
@@ -3240,6 +3240,7 @@ export class Cline {
 			this.checkpointService = await CheckpointService.create({
 				taskId: this.taskId,
 				baseDir: vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) ?? "",
+				log: (message) => this.providerRef.deref()?.log(message),
 			})
 		}
 

--- a/src/services/checkpoints/CheckpointService.ts
+++ b/src/services/checkpoints/CheckpointService.ts
@@ -2,7 +2,6 @@ import fs from "fs/promises"
 import { existsSync } from "fs"
 import path from "path"
 
-import debug from "debug"
 import simpleGit, { SimpleGit, CleanOptions } from "simple-git"
 
 export type CheckpointServiceOptions = {
@@ -246,15 +245,11 @@ export class CheckpointService {
 	}
 
 	public static async create({ taskId, git, baseDir, log = console.log }: CheckpointServiceOptions) {
-		git =
-			git ||
-			simpleGit({
-				baseDir,
-				binary: "git",
-				maxConcurrentProcesses: 1,
-				config: [],
-				trimmed: true,
-			})
+		if (process.platform === "win32") {
+			throw new Error("Checkpoints are not supported on Windows.")
+		}
+
+		git = git || simpleGit({ baseDir })
 
 		const version = await git.version()
 

--- a/src/services/checkpoints/__tests__/CheckpointService.test.ts
+++ b/src/services/checkpoints/__tests__/CheckpointService.test.ts
@@ -14,6 +14,7 @@ describe("CheckpointService", () => {
 	let git: SimpleGit
 	let testFile: string
 	let service: CheckpointService
+	let originalPlatform: string
 
 	const initRepo = async ({
 		baseDir,
@@ -47,6 +48,19 @@ describe("CheckpointService", () => {
 
 		return { git, testFile }
 	}
+
+	beforeAll(() => {
+		originalPlatform = process.platform
+		Object.defineProperty(process, "platform", {
+			value: "darwin",
+		})
+	})
+
+	afterAll(() => {
+		Object.defineProperty(process, "platform", {
+			value: originalPlatform,
+		})
+	})
 
 	beforeEach(async () => {
 		const baseDir = path.join(os.tmpdir(), `checkpoint-service-test-${Date.now()}`)

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -701,27 +701,29 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							</div>
 						)}
 
-						<div style={{ marginBottom: 15 }}>
-							<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
-								<span style={{ color: "var(--vscode-errorForeground)" }}>⚠️</span>
-								<VSCodeCheckbox
-									checked={checkpointsEnabled}
-									onChange={(e: any) => {
-										setCheckpointsEnabled(e.target.checked)
+						{process.platform !== "win32" && (
+							<div style={{ marginBottom: 15 }}>
+								<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+									<span style={{ color: "var(--vscode-errorForeground)" }}>⚠️</span>
+									<VSCodeCheckbox
+										checked={checkpointsEnabled}
+										onChange={(e: any) => {
+											setCheckpointsEnabled(e.target.checked)
+										}}>
+										<span style={{ fontWeight: "500" }}>Enable experimental checkpoints</span>
+									</VSCodeCheckbox>
+								</div>
+								<p
+									style={{
+										fontSize: "12px",
+										marginTop: "5px",
+										color: "var(--vscode-descriptionForeground)",
 									}}>
-									<span style={{ fontWeight: "500" }}>Enable experimental checkpoints</span>
-								</VSCodeCheckbox>
+									When enabled, Roo will save a checkpoint whenever a file in the workspace is
+									modified, added or deleted, letting you easily revert to a previous state.
+								</p>
 							</div>
-							<p
-								style={{
-									fontSize: "12px",
-									marginTop: "5px",
-									color: "var(--vscode-descriptionForeground)",
-								}}>
-								When enabled, Roo will save a checkpoint whenever a file in the workspace is modified,
-								added or deleted, letting you easily revert to a previous state.
-							</p>
-						</div>
+						)}
 
 						{Object.entries(experimentConfigsMap)
 							.filter((config) => config[0] !== "DIFF_STRATEGY")


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

On Windows, when you redirect (pipe) the output of a command into a file in your repository, Windows will place (or keep) an exclusive lock on that file while the command is still running or immediately afterward. Then, if Git tries to move, rename, or otherwise manipulate that file (as happens in a stash operation), it fails because Windows won’t allow a locked file to be changed.

On Linux and macOS, open files aren’t locked the same way. A process can rename or even delete a file that is still “open” by another process without error—the file descriptor remains valid under the hood until the last process closes it. 

This screenshot below demonstrates the issue by:
- Creating and locking an untracked file by piping the output of another process to the file.
- Calling `git clean -f`

The operation fails, and asks you to retry:

<img width="1411" alt="Screenshot 2025-02-09 at 11 10 55 PM" src="https://github.com/user-attachments/assets/d95d3c9a-c8cd-484c-968e-a0a9a7e02cf3" />

---

The checkpoints system needs to figure how to deal with locked files gracefully; currently your changes get copied into your stash and then an error is thrown, so it looks like you've lost your changes (luckily you can recover from this state).

My first thought is that we should detect if any staged, unstaged or untracked files are locked, and simply not save a checkpoint if this is the case (and maybe show a error indicating that a file is locked).

Until then, let's disable the feature on Windows.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->
