### PR TITLE
add retries to openrouter generation endpoint to prevent failures on …

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -183,31 +183,34 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 			// }
 		}
 
-		await delay(500) // FIXME: necessary delay to ensure generation endpoint is ready
+		// retry fetching generation details
+		let retries = 0
+		while (retries < 3) {
+			await delay(500) // FIXME: necessary delay to ensure generation endpoint is ready
+			try {
+				const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
+					headers: {
+						Authorization: `Bearer ${this.options.openRouterApiKey}`,
+					},
+					timeout: 5_000, // this request hangs sometimes
+				})
 
-		try {
-			const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
-				headers: {
-					Authorization: `Bearer ${this.options.openRouterApiKey}`,
-				},
-				timeout: 5_000, // this request hangs sometimes
-			})
-
-			const generation = response.data?.data
-			console.log("OpenRouter generation details:", response.data)
-			yield {
-				type: "usage",
-				// cacheWriteTokens: 0,
-				// cacheReadTokens: 0,
-				// openrouter generation endpoint fails often
-				inputTokens: generation?.native_tokens_prompt || 0,
-				outputTokens: generation?.native_tokens_completion || 0,
-				totalCost: generation?.total_cost || 0,
-				fullResponseText,
-			} as OpenRouterApiStreamUsageChunk
-		} catch (error) {
-			// ignore if fails
-			console.error("Error fetching OpenRouter generation details:", error)
+				const generation = response.data?.data
+				console.log("OpenRouter generation details:", response.data)
+				yield {
+					type: "usage",
+					// cacheWriteTokens: 0,
+					// cacheReadTokens: 0,
+					// openrouter generation endpoint fails often
+					inputTokens: generation?.native_tokens_prompt || 0,
+					outputTokens: generation?.native_tokens_completion || 0,
+					totalCost: generation?.total_cost || 0,
+					fullResponseText,
+				} as OpenRouterApiStreamUsageChunk
+			} catch (error) {
+				// ignore if fails
+				console.error("Error fetching OpenRouter generation details:", error)
+			}
 		}
 	}
 	getModel(): { id: string; info: ModelInfo } {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -184,9 +184,9 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 		}
 
 		// retry fetching generation details
-		let retries = 0
-		while (retries < 3) {
-			await delay(500) // FIXME: necessary delay to ensure generation endpoint is ready
+		let attempt = 0
+		while (attempt++ < 10) {
+			await delay(200) // FIXME: necessary delay to ensure generation endpoint is ready
 			try {
 				const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
 					headers: {
@@ -207,6 +207,7 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 					totalCost: generation?.total_cost || 0,
 					fullResponseText,
 				} as OpenRouterApiStreamUsageChunk
+				return
 			} catch (error) {
 				// ignore if fails
 				console.error("Error fetching OpenRouter generation details:", error)


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

OpenRouter requests often fail NOT because the completion endpoint has failed but because it performs a follow call to the generation API for the usage stats which only waits for 500ms before the call.  It then throws an error if the "generation" is unavailable which from a lot of providers takes more than 500ms after the completion is finished to be available on the endpoint.  This adds some code to retry 3 times to make it more likely to succeed.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
Tested with deepseek and google gemini models on openrouter.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds retry logic to OpenRouter generation endpoint in `openrouter.ts` to improve reliability by retrying up to 3 times with a delay.
> 
>   - **Behavior**:
>     - Adds retry logic to OpenRouter generation endpoint in `openrouter.ts`.
>     - Retries up to 3 times with a 500ms delay between attempts if the generation endpoint is unavailable.
>   - **Misc**:
>     - Logs errors to console if fetching generation details fails.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9c480aaac2ccc0e19ed1344d1172d35168062e93. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->