### PR TITLE
Add platform to extension state so it's available in the webview

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2382,6 +2382,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			customModes: await this.customModesManager.getCustomModes(),
 			experiments: experiments ?? experimentDefault,
 			mcpServers: this.mcpHub?.getAllServers() ?? [],
+			platform: process.platform,
 		}
 	}
 

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -351,6 +351,7 @@ describe("ClineProvider", () => {
 			mode: defaultModeSlug,
 			customModes: [],
 			experiments: experimentDefault,
+			platform: "win32",
 		}
 
 		const message: ExtensionMessage = {

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -127,6 +127,7 @@ export interface ExtensionState {
 	autoApprovalEnabled?: boolean
 	customModes: ModeConfig[]
 	toolRequirements?: Record<string, boolean> // Map of tool names to their requirements (e.g. {"apply_diff": true} if diffEnabled)
+	platform: string // Operating system platform (e.g., 'win32', 'darwin', 'linux')
 }
 
 export interface ClineMessage {

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -63,6 +63,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 		setExperimentEnabled,
 		alwaysAllowModeSwitch,
 		setAlwaysAllowModeSwitch,
+		platform,
 	} = useExtensionState()
 	const [apiErrorMessage, setApiErrorMessage] = useState<string | undefined>(undefined)
 	const [modelIdErrorMessage, setModelIdErrorMessage] = useState<string | undefined>(undefined)
@@ -701,7 +702,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							</div>
 						)}
 
-						{process.platform !== "win32" && (
+						{platform !== "win32" && (
 							<div style={{ marginBottom: 15 }}>
 								<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
 									<span style={{ color: "var(--vscode-errorForeground)" }}>⚠️</span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add platform information to extension state for webview access, updating `ClineProvider`, `SettingsView`, and related tests.
> 
>   - **Behavior**:
>     - Add `platform` to `ExtensionState` in `ExtensionMessage.ts` to include OS platform info.
>     - Update `ClineProvider` in `ClineProvider.ts` to include `platform` in the state sent to the webview.
>     - Modify `SettingsView` in `SettingsView.tsx` to use `platform` for conditional rendering.
>   - **Tests**:
>     - Update `ClineProvider.test.ts` to include `platform` in mock state and test cases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 07cff2fbd76a179c173efb261e351d14d4a4104c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->