### PR TITLE
Fix issue where Ollama/LMStudio URLs would flicker back to previous while entering

### DIFF
--- a/.changeset/funny-bananas-sneeze.md
+++ b/.changeset/funny-bananas-sneeze.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix issue where Ollama/LMStudio URLs would flicker back to previous while entering

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -88,12 +88,21 @@ const ApiOptions = ({ apiErrorMessage, modelIdErrorMessage, fromWelcomeView }: A
 	)
 	const handleMessage = useCallback((event: MessageEvent) => {
 		const message: ExtensionMessage = event.data
-		if (message.type === "ollamaModels" && message.ollamaModels) {
-			setOllamaModels(message.ollamaModels)
-		} else if (message.type === "lmStudioModels" && message.lmStudioModels) {
-			setLmStudioModels(message.lmStudioModels)
-		} else if (message.type === "vsCodeLmModels" && message.vsCodeLmModels) {
-			setVsCodeLmModels(message.vsCodeLmModels)
+		if (message.type === "ollamaModels" && Array.isArray(message.ollamaModels)) {
+			const newModels = message.ollamaModels
+			setOllamaModels((prevModels) => {
+				return JSON.stringify(prevModels) === JSON.stringify(newModels) ? prevModels : newModels
+			})
+		} else if (message.type === "lmStudioModels" && Array.isArray(message.lmStudioModels)) {
+			const newModels = message.lmStudioModels
+			setLmStudioModels((prevModels) => {
+				return JSON.stringify(prevModels) === JSON.stringify(newModels) ? prevModels : newModels
+			})
+		} else if (message.type === "vsCodeLmModels" && Array.isArray(message.vsCodeLmModels)) {
+			const newModels = message.vsCodeLmModels
+			setVsCodeLmModels((prevModels) => {
+				return JSON.stringify(prevModels) === JSON.stringify(newModels) ? prevModels : newModels
+			})
 		}
 	}, [])
 	useEvent("message", handleMessage)


### PR DESCRIPTION
For some reason we try to reload the models every 2 seconds, and that causes ApiOptions to re-render. There's probably something deeper to figure out here, but checking equality before updating state seems to alleviate this.

Before:

https://github.com/user-attachments/assets/e6fb6ec0-1958-4bac-9e00-3c69f81a87b4

After:

https://github.com/user-attachments/assets/19c28753-1936-468e-b188-71b1e25ab99f


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix flickering issue in `ApiOptions.tsx` by checking model data equality before updating state.
> 
>   - **Behavior**:
>     - Fix flickering issue in `ApiOptions.tsx` by checking equality before updating state for `ollamaModels`, `lmStudioModels`, and `vsCodeLmModels`.
>     - Prevents unnecessary state updates by comparing new and previous model data using `JSON.stringify()`.
>   - **Misc**:
>     - Add changeset file `funny-bananas-sneeze.md` for patch release.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for febf434fc19c84ce2e2f36b666dce650f9e5dc56. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->