### PR TITLE
Bring back checkpoints on Windows

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -143,7 +143,7 @@ export class Cline {
 		this.fuzzyMatchThreshold = fuzzyMatchThreshold ?? 1.0
 		this.providerRef = new WeakRef(provider)
 		this.diffViewProvider = new DiffViewProvider(cwd)
-		this.checkpointsEnabled = process.platform !== "win32" && !!enableCheckpoints
+		this.checkpointsEnabled = enableCheckpoints ?? false
 
 		if (historyItem) {
 			this.taskId = historyItem.id

--- a/src/services/checkpoints/CheckpointService.ts
+++ b/src/services/checkpoints/CheckpointService.ts
@@ -312,10 +312,6 @@ export class CheckpointService {
 	}
 
 	public static async create({ taskId, git, baseDir, log = console.log }: CheckpointServiceOptions) {
-		if (process.platform === "win32") {
-			throw new Error("Checkpoints are not supported on Windows.")
-		}
-
 		git = git || simpleGit({ baseDir })
 
 		const version = await git.version()

--- a/src/services/checkpoints/__tests__/CheckpointService.test.ts
+++ b/src/services/checkpoints/__tests__/CheckpointService.test.ts
@@ -14,7 +14,6 @@ describe("CheckpointService", () => {
 	let git: SimpleGit
 	let testFile: string
 	let service: CheckpointService
-	let originalPlatform: string
 
 	const initRepo = async ({
 		baseDir,
@@ -48,19 +47,6 @@ describe("CheckpointService", () => {
 
 		return { git, testFile }
 	}
-
-	beforeAll(() => {
-		originalPlatform = process.platform
-		Object.defineProperty(process, "platform", {
-			value: "darwin",
-		})
-	})
-
-	afterAll(() => {
-		Object.defineProperty(process, "platform", {
-			value: originalPlatform,
-		})
-	})
 
 	beforeEach(async () => {
 		const baseDir = path.join(os.tmpdir(), `checkpoint-service-test-${Date.now()}`)

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -701,29 +701,27 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 							</div>
 						)}
 
-						{process.platform !== "win32" && (
-							<div style={{ marginBottom: 15 }}>
-								<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
-									<span style={{ color: "var(--vscode-errorForeground)" }}>⚠️</span>
-									<VSCodeCheckbox
-										checked={checkpointsEnabled}
-										onChange={(e: any) => {
-											setCheckpointsEnabled(e.target.checked)
-										}}>
-										<span style={{ fontWeight: "500" }}>Enable experimental checkpoints</span>
-									</VSCodeCheckbox>
-								</div>
-								<p
-									style={{
-										fontSize: "12px",
-										marginTop: "5px",
-										color: "var(--vscode-descriptionForeground)",
+						<div style={{ marginBottom: 15 }}>
+							<div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
+								<span style={{ color: "var(--vscode-errorForeground)" }}>⚠️</span>
+								<VSCodeCheckbox
+									checked={checkpointsEnabled}
+									onChange={(e: any) => {
+										setCheckpointsEnabled(e.target.checked)
 									}}>
-									When enabled, Roo will save a checkpoint whenever a file in the workspace is
-									modified, added or deleted, letting you easily revert to a previous state.
-								</p>
+									<span style={{ fontWeight: "500" }}>Enable experimental checkpoints</span>
+								</VSCodeCheckbox>
 							</div>
-						)}
+							<p
+								style={{
+									fontSize: "12px",
+									marginTop: "5px",
+									color: "var(--vscode-descriptionForeground)",
+								}}>
+								When enabled, Roo will save a checkpoint whenever a file in the workspace is modified,
+								added or deleted, letting you easily revert to a previous state.
+							</p>
+						</div>
 
 						{Object.entries(experimentConfigsMap)
 							.filter((config) => config[0] !== "DIFF_STRATEGY")


### PR DESCRIPTION
We can bring this back now that #939 is merged right?
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-enable checkpoints on Windows by removing platform-specific restrictions in `Cline.ts`, `CheckpointService.ts`, and updating `SettingsView.tsx`.
> 
>   - **Behavior**:
>     - Re-enable checkpoints on Windows by removing platform check in `Cline.ts` and `CheckpointService.ts`.
>     - Update `SettingsView.tsx` to allow enabling checkpoints on Windows.
>   - **Code Changes**:
>     - Remove `process.platform` check in `Cline` constructor.
>     - Remove Windows-specific error in `CheckpointService.create()`.
>     - Update tests in `CheckpointService.test.ts` to reflect changes.
>   - **UI**:
>     - Remove Windows restriction for enabling checkpoints in `SettingsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 85768097d716cd1cf3835930c932764e3135c40b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->