### PR TITLE
Hide advanced openrouter config in the welcome view

### DIFF
--- a/.changeset/polite-lizards-rhyme.md
+++ b/.changeset/polite-lizards-rhyme.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Hide advanced openrouter config in the welcome view

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -355,30 +355,6 @@ const ApiOptions = ({ apiErrorMessage, modelIdErrorMessage, fromWelcomeView }: A
 							</VSCodeButtonLink>
 						</p>
 					)}
-					<Checkbox
-						checked={openRouterBaseUrlSelected}
-						onChange={(checked: boolean) => {
-							setOpenRouterBaseUrlSelected(checked)
-							if (!checked) {
-								handleInputChange("openRouterBaseUrl")({
-									target: {
-										value: "",
-									},
-								})
-							}
-						}}>
-						Use custom base URL
-					</Checkbox>
-
-					{openRouterBaseUrlSelected && (
-						<VSCodeTextField
-							value={apiConfiguration?.openRouterBaseUrl || ""}
-							style={{ width: "100%", marginTop: 3 }}
-							type="url"
-							onBlur={handleInputChange("openRouterBaseUrl")}
-							placeholder="Default: https://openrouter.ai/api/v1"
-						/>
-					)}
 					<p
 						style={{
 							fontSize: "12px",
@@ -386,24 +362,45 @@ const ApiOptions = ({ apiErrorMessage, modelIdErrorMessage, fromWelcomeView }: A
 							color: "var(--vscode-descriptionForeground)",
 						}}>
 						This key is stored locally and only used to make API requests from this extension.{" "}
-						{/* {!apiConfiguration?.openRouterApiKey && (
-							<span style={{ color: "var(--vscode-charts-green)" }}>
-								(<span style={{ fontWeight: 500 }}>Note:</span> OpenRouter is recommended for high rate
-								limits, prompt caching, and wider selection of models.)
-							</span>
-						)} */}
 					</p>
-					<Checkbox
-						checked={apiConfiguration?.openRouterUseMiddleOutTransform || false}
-						onChange={(checked: boolean) => {
-							handleInputChange("openRouterUseMiddleOutTransform")({
-								target: { value: checked },
-							})
-						}}>
-						Compress prompts and message chains to the context size (
-						<a href="https://openrouter.ai/docs/transforms">OpenRouter Transforms</a>)
-					</Checkbox>
-					<br />
+					{!fromWelcomeView && (
+						<>
+							<Checkbox
+								checked={openRouterBaseUrlSelected}
+								onChange={(checked: boolean) => {
+									setOpenRouterBaseUrlSelected(checked)
+									if (!checked) {
+										handleInputChange("openRouterBaseUrl")({
+											target: {
+												value: "",
+											},
+										})
+									}
+								}}>
+								Use custom base URL
+							</Checkbox>
+
+							{openRouterBaseUrlSelected && (
+								<VSCodeTextField
+									value={apiConfiguration?.openRouterBaseUrl || ""}
+									style={{ width: "100%", marginTop: 3 }}
+									type="url"
+									onBlur={handleInputChange("openRouterBaseUrl")}
+									placeholder="Default: https://openrouter.ai/api/v1"
+								/>
+							)}
+							<Checkbox
+								checked={apiConfiguration?.openRouterUseMiddleOutTransform || false}
+								onChange={(checked: boolean) => {
+									handleInputChange("openRouterUseMiddleOutTransform")({
+										target: { value: checked },
+									})
+								}}>
+								Compress prompts and message chains to the context size (
+								<a href="https://openrouter.ai/docs/transforms">OpenRouter Transforms</a>)
+							</Checkbox>
+						</>
+					)}
 				</div>
 			)}
 

--- a/webview-ui/src/components/welcome/WelcomeView.tsx
+++ b/webview-ui/src/components/welcome/WelcomeView.tsx
@@ -21,23 +21,26 @@ const WelcomeView = () => {
 	}
 
 	return (
-		<div style={{ position: "fixed", top: 0, left: 0, right: 0, bottom: 0, padding: "0 20px" }}>
-			<h2>Hi, I'm Roo!</h2>
-			<p>
-				I can do all kinds of tasks thanks to the latest breakthroughs in agentic coding capabilities and access
-				to tools that let me create & edit files, explore complex projects, use the browser, and execute
-				terminal commands (with your permission, of course). I can even use MCP to create new tools and extend
-				my own capabilities.
-			</p>
+		<div className="flex flex-col min-h-screen px-0 pb-5">
+			<div className="flex-grow">
+				<h2>Hi, I'm Roo!</h2>
+				<p>
+					I can do all kinds of tasks thanks to the latest breakthroughs in agentic coding capabilities and
+					access to tools that let me create & edit files, explore complex projects, use the browser, and
+					execute terminal commands (with your permission, of course). I can even use MCP to create new tools
+					and extend my own capabilities.
+				</p>
 
-			<b>To get started, this extension needs an API provider.</b>
+				<b>To get started, this extension needs an API provider.</b>
 
-			<div style={{ marginTop: "10px" }}>
-				<ApiOptions fromWelcomeView />
-				<div style={{ display: "flex", flexDirection: "column", gap: "5px" }}>
-					<VSCodeButton onClick={handleSubmit} style={{ marginTop: "3px" }}>
-						Let's go!
-					</VSCodeButton>
+				<div className="mt-3">
+					<ApiOptions fromWelcomeView />
+				</div>
+			</div>
+
+			<div className="sticky bottom-0 bg-[var(--vscode-editor-background)] py-3">
+				<div className="flex flex-col gap-1.5">
+					<VSCodeButton onClick={handleSubmit}>Let's go!</VSCodeButton>
 					{errorMessage && <span className="text-destructive">{errorMessage}</span>}
 				</div>
 			</div>

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -319,6 +319,11 @@ vscode-dropdown::part(listbox) {
 	max-height: unset !important;
 }
 
+.vscrui-checkbox svg {
+	min-width: 16px;
+	min-height: 16px;
+}
+
 /**
  * @shadcn/ui Overrides / Hacks
  */


### PR DESCRIPTION
Before:
![Screenshot 2025-02-11 at 12 38 00 PM](https://github.com/user-attachments/assets/fa667d14-b446-4be4-9a0c-9d3e8d9006a1)

After:
![Screenshot 2025-02-11 at 12 39 25 PM](https://github.com/user-attachments/assets/37abe7cb-d5c8-4b09-88b4-8131d67a81b2)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Hide advanced OpenRouter configurations in the welcome view by conditionally rendering UI elements in `ApiOptions`.
> 
>   - **Behavior**:
>     - Hide advanced OpenRouter configurations in `ApiOptions` when `fromWelcomeView` is true.
>     - Affects `Checkbox` for custom base URL and `VSCodeTextField` for OpenRouter base URL.
>   - **UI Components**:
>     - Modify `WelcomeView` to pass `fromWelcomeView` prop to `ApiOptions`.
>     - Adjust layout in `WelcomeView` for sticky button positioning.
>   - **Styles**:
>     - Add CSS for `.vscrui-checkbox svg` in `index.css` to ensure minimum size.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c97eef753cb31fc6f1846238c8136c241f3d02c4. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->