### PR TITLE
Allow users to clear out custom instructions for the built-in modes

### DIFF
--- a/.changeset/orange-geese-provide.md
+++ b/.changeset/orange-geese-provide.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Allow users to clear out custom instructions for the built-in modes

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -804,7 +804,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 									const existingPrompt = customModePrompts?.[mode] as PromptComponent
 									updateAgentPrompt(mode, {
 										...existingPrompt,
-										customInstructions: value.trim() || undefined,
+										customInstructions: value.trim(),
 									})
 								}
 							}}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Allows users to clear custom instructions for built-in modes by setting `customInstructions` to an empty string in `PromptsView.tsx`.
> 
>   - **Behavior**:
>     - Allows users to clear custom instructions for built-in modes by setting `customInstructions` to an empty string instead of `undefined` in `PromptsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9e5c6b170c906e0938911a9d070138b302b7fcdd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->