### PR TITLE
Fix: Provider like SiliconFlow show wrong tokens number on task header

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -84,6 +84,7 @@ type GlobalStateKey =
 	| "openAiModelId"
 	| "openAiCustomModelInfo"
 	| "openAiUseAzure"
+	| "openAiUsageCumulation"
 	| "ollamaModelId"
 	| "ollamaBaseUrl"
 	| "lmStudioModelId"
@@ -1615,6 +1616,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openAiModelId,
 			openAiCustomModelInfo,
 			openAiUseAzure,
+			openAiUsageCumulation,
 			ollamaModelId,
 			ollamaBaseUrl,
 			lmStudioModelId,
@@ -1660,6 +1662,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		await this.updateGlobalState("openAiModelId", openAiModelId)
 		await this.updateGlobalState("openAiCustomModelInfo", openAiCustomModelInfo)
 		await this.updateGlobalState("openAiUseAzure", openAiUseAzure)
+		await this.updateGlobalState("openAiUsageCumulation", openAiUsageCumulation)
 		await this.updateGlobalState("ollamaModelId", ollamaModelId)
 		await this.updateGlobalState("ollamaBaseUrl", ollamaBaseUrl)
 		await this.updateGlobalState("lmStudioModelId", lmStudioModelId)
@@ -2481,6 +2484,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			openAiModelId,
 			openAiCustomModelInfo,
 			openAiUseAzure,
+			openAiUsageCumulation,
 			ollamaModelId,
 			ollamaBaseUrl,
 			lmStudioModelId,
@@ -2561,6 +2565,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			this.getGlobalState("openAiModelId") as Promise<string | undefined>,
 			this.getGlobalState("openAiCustomModelInfo") as Promise<ModelInfo | undefined>,
 			this.getGlobalState("openAiUseAzure") as Promise<boolean | undefined>,
+			this.getGlobalState("openAiUsageCumulation") as Promise<boolean | undefined>,
 			this.getGlobalState("ollamaModelId") as Promise<string | undefined>,
 			this.getGlobalState("ollamaBaseUrl") as Promise<string | undefined>,
 			this.getGlobalState("lmStudioModelId") as Promise<string | undefined>,
@@ -2658,6 +2663,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				openAiModelId,
 				openAiCustomModelInfo,
 				openAiUseAzure,
+				openAiUsageCumulation,
 				ollamaModelId,
 				ollamaBaseUrl,
 				lmStudioModelId,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -45,6 +45,7 @@ export interface ApiHandlerOptions {
 	openAiModelId?: string
 	openAiCustomModelInfo?: ModelInfo
 	openAiUseAzure?: boolean
+	openAiUsageCumulation?: boolean
 	ollamaModelId?: string
 	ollamaBaseUrl?: string
 	lmStudioModelId?: string

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -629,6 +629,15 @@ const ApiOptions = ({ apiErrorMessage, modelIdErrorMessage, fromWelcomeView }: A
 						</Checkbox>
 					</div>
 					<Checkbox
+						checked={apiConfiguration?.openAiUsageCumulation ?? true}
+						onChange={(checked: boolean) => {
+							handleInputChange("openAiUsageCumulation")({
+								target: { value: checked },
+							})
+						}}>
+						Enable token usage cumulation
+					</Checkbox>
+					<Checkbox
 						checked={apiConfiguration?.openAiUseAzure ?? false}
 						onChange={(checked: boolean) => {
 							handleInputChange("openAiUseAzure")({


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

Added an option openAiUsageCumulation to ApiHandlerOptions which handle tokens statistics when using SiliconFlow as api provider. SiliconFlow return every prompt_tokens and completion_tokens as total number but not incremental.

User can use checkbox ("Enable token usage cumulation") to change tokens statistics mode on model settings tab.
It is default checked which using original execution pass when counting tokens.
![screenshot-20250212-231225](https://github.com/user-attachments/assets/089fd59e-8ad2-45c3-b468-8d2b93aaaf14)


Before fix:
![wrong](https://github.com/user-attachments/assets/e67bcd25-cccd-49b5-b12b-a0952c8394cc)

After fix
![right](https://github.com/user-attachments/assets/0e22ce78-7e1b-44ca-ba1c-ab4a3b4b1194)


## Type of change

<!-- Please ignore options that are not relevant -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [X] My code follows the patterns of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->
#959

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `openAiUsageCumulation` option to handle SiliconFlow token statistics, with UI and state management updates.
> 
>   - **Behavior**:
>     - Added `openAiUsageCumulation` option to `ApiHandlerOptions` in `api.ts` to handle token statistics for SiliconFlow.
>     - Updated `processUsageMetrics()` in `openai.ts` to use `openAiUsageCumulation` for token calculation.
>     - Added checkbox in `ApiOptions.tsx` for enabling token usage cumulation.
>   - **State Management**:
>     - Integrated `openAiUsageCumulation` into global state management in `ClineProvider.ts`.
>     - Updated `getState()` and `updateApiConfiguration()` in `ClineProvider.ts` to handle `openAiUsageCumulation`.
>   - **UI**:
>     - Added checkbox for "Enable token usage cumulation" in `ApiOptions.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c8f8754ab3fdfa4b10d786feb64ebd348f532cd2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->