### PR TITLE
Add a help button

### DIFF
--- a/.changeset/clean-bears-hammer.md
+++ b/.changeset/clean-bears-hammer.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add a help button

--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
 				"icon": "$(settings-gear)"
 			},
 			{
+				"command": "roo-cline.helpButtonClicked",
+				"title": "Documentation",
+				"icon": "$(question)"
+			},
+			{
 				"command": "roo-cline.openInNewTab",
 				"title": "Open In New Tab",
 				"category": "Roo Code"
@@ -224,6 +229,11 @@
 				{
 					"command": "roo-cline.settingsButtonClicked",
 					"group": "navigation@6",
+					"when": "view == roo-cline.SidebarProvider"
+				},
+				{
+					"command": "roo-cline.helpButtonClicked",
+					"group": "navigation@7",
 					"when": "view == roo-cline.SidebarProvider"
 				}
 			]

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -38,6 +38,9 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 		"roo-cline.historyButtonClicked": () => {
 			provider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
 		},
+		"roo-cline.helpButtonClicked": () => {
+			vscode.env.openExternal(vscode.Uri.parse("https://docs.roocode.com"))
+		},
 	}
 }
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add a help button to the VS Code extension to open documentation in a browser.
> 
>   - **Behavior**:
>     - Adds a help button to the VS Code extension, which opens the documentation at `https://docs.roocode.com` when clicked.
>   - **Commands**:
>     - Adds `roo-cline.helpButtonClicked` command in `registerCommands.ts` to handle help button clicks.
>   - **Configuration**:
>     - Updates `package.json` to include the new help button command and icon.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a96443090a836274aa2fc9628a1c28b45f0d0ca8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->