### PR TITLE
Disable writing in ask mode

### DIFF
--- a/.changeset/clever-news-arrive.md
+++ b/.changeset/clever-news-arrive.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Disable writing in ask mode

--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -4004,43 +4004,6 @@ Example: Requesting to list all top level source code definitions in the current
 <path>.</path>
 </list_code_definition_names>
 
-## write_to_file
-Description: Request to write full content to a file at the specified path. If the file exists, it will be overwritten with the provided content. If the file doesn't exist, it will be created. This tool will automatically create any directories needed to write the file.
-Parameters:
-- path: (required) The path of the file to write to (relative to the current working directory /test/path)
-- content: (required) The content to write to the file. ALWAYS provide the COMPLETE intended content of the file, without any truncation or omissions. You MUST include ALL parts of the file, even if they haven't been modified. Do NOT include the line numbers in the content though, just the actual content of the file.
-- line_count: (required) The number of lines in the file. Make sure to compute this based on the actual content of the file, not the number of lines in the content you're providing.
-Usage:
-<write_to_file>
-<path>File path here</path>
-<content>
-Your file content here
-</content>
-<line_count>total number of lines in the file, including empty lines</line_count>
-</write_to_file>
-
-Example: Requesting to write to frontend-config.json
-<write_to_file>
-<path>frontend-config.json</path>
-<content>
-{
-  "apiEndpoint": "https://api.example.com",
-  "theme": {
-    "primaryColor": "#007bff",
-    "secondaryColor": "#6c757d",
-    "fontFamily": "Arial, sans-serif"
-  },
-  "features": {
-    "darkMode": true,
-    "notifications": true,
-    "analytics": false
-  },
-  "version": "1.0.0"
-}
-</content>
-<line_count>14</line_count>
-</write_to_file>
-
 ## ask_followup_question
 Description: Ask the user a question to gather additional information needed to complete the task. This tool should be used when you encounter ambiguities, need clarification, or require more details to proceed effectively. It allows for interactive problem-solving by enabling direct communication with the user. Use this tool judiciously to maintain a balance between gathering necessary information and avoiding excessive back-and-forth.
 Parameters:
@@ -4213,7 +4176,7 @@ USER'S CUSTOM INSTRUCTIONS
 The following additional instructions are provided by the user, and should be followed to the best of your ability without interfering with the TOOL USE guidelines.
 
 Mode-specific Instructions:
-You can analyze code, explain concepts, and access external resources. While you primarily maintain a read-only approach to the codebase, you can create and edit markdown files to better document and explain concepts. Make sure to answer the user's questions and don't rush to switch to implementing code.
+You can analyze code, explain concepts, and access external resources. Make sure to answer the user's questions and don't rush to switch to implementing code.
 
 Rules:
 # Rules from .clinerules-ask:

--- a/src/shared/__tests__/modes.test.ts
+++ b/src/shared/__tests__/modes.test.ts
@@ -93,9 +93,9 @@ describe("isToolAllowedForMode", () => {
 				}),
 			).toBe(true)
 
-			// Should allow path-only for ask mode too
+			// Should allow path-only for architect mode too
 			expect(
-				isToolAllowedForMode("write_to_file", "ask", [], undefined, {
+				isToolAllowedForMode("write_to_file", "architect", [], undefined, {
 					path: "test.js",
 				}),
 			).toBe(true)
@@ -197,10 +197,10 @@ describe("isToolAllowedForMode", () => {
 			).toBe(true)
 		})
 
-		it("allows ask mode to edit markdown files only", () => {
+		it("allows architect mode to edit markdown files only", () => {
 			// Should allow editing markdown files
 			expect(
-				isToolAllowedForMode("write_to_file", "ask", [], undefined, {
+				isToolAllowedForMode("write_to_file", "architect", [], undefined, {
 					path: "test.md",
 					content: "# Test",
 				}),
@@ -208,7 +208,7 @@ describe("isToolAllowedForMode", () => {
 
 			// Should allow applying diffs to markdown files
 			expect(
-				isToolAllowedForMode("apply_diff", "ask", [], undefined, {
+				isToolAllowedForMode("apply_diff", "architect", [], undefined, {
 					path: "readme.md",
 					diff: "- old\n+ new",
 				}),
@@ -216,22 +216,22 @@ describe("isToolAllowedForMode", () => {
 
 			// Should reject non-markdown files
 			expect(() =>
-				isToolAllowedForMode("write_to_file", "ask", [], undefined, {
+				isToolAllowedForMode("write_to_file", "architect", [], undefined, {
 					path: "test.js",
 					content: "console.log('test')",
 				}),
 			).toThrow(FileRestrictionError)
 			expect(() =>
-				isToolAllowedForMode("write_to_file", "ask", [], undefined, {
+				isToolAllowedForMode("write_to_file", "architect", [], undefined, {
 					path: "test.js",
 					content: "console.log('test')",
 				}),
 			).toThrow(/Markdown files only/)
 
 			// Should maintain read capabilities
-			expect(isToolAllowedForMode("read_file", "ask", [])).toBe(true)
-			expect(isToolAllowedForMode("browser_action", "ask", [])).toBe(true)
-			expect(isToolAllowedForMode("use_mcp_tool", "ask", [])).toBe(true)
+			expect(isToolAllowedForMode("read_file", "architect", [])).toBe(true)
+			expect(isToolAllowedForMode("browser_action", "architect", [])).toBe(true)
+			expect(isToolAllowedForMode("use_mcp_tool", "architect", [])).toBe(true)
 		})
 	})
 

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -92,9 +92,9 @@ export const modes: readonly ModeConfig[] = [
 		name: "Ask",
 		roleDefinition:
 			"You are Roo, a knowledgeable technical assistant focused on answering questions and providing information about software development, technology, and related topics.",
-		groups: ["read", ["edit", { fileRegex: "\\.md$", description: "Markdown files only" }], "browser", "mcp"],
+		groups: ["read", "browser", "mcp"],
 		customInstructions:
-			"You can analyze code, explain concepts, and access external resources. While you primarily maintain a read-only approach to the codebase, you can create and edit markdown files to better document and explain concepts. Make sure to answer the user's questions and don't rush to switch to implementing code.",
+			"You can analyze code, explain concepts, and access external resources. Make sure to answer the user's questions and don't rush to switch to implementing code.",
 	},
 ] as const
 


### PR DESCRIPTION
https://www.reddit.com/r/RooCode/comments/1imbd4u/ask_mode_should_not_be_able_to_change_any_file/
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables writing in 'ask' mode, ensuring it remains read-only, and updates tests and documentation accordingly.
> 
>   - **Behavior**:
>     - Disables writing in 'ask' mode by removing markdown file editing capabilities in `modes.ts`.
>     - Updates `isToolAllowedForMode` in `modes.test.ts` to reflect changes, ensuring 'ask' mode cannot write to files.
>   - **Tests**:
>     - Modifies `modes.test.ts` to replace 'ask' mode with 'architect' mode for write tests.
>     - Removes 'ask' mode write tests and updates error expectations.
>   - **Documentation**:
>     - Updates `system.test.ts.snap` to remove 'write_to_file' documentation for 'ask' mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5f3ff25d6bcd5d78d45fdb291b3b1aecf6075d9c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->