### PR TITLE
Fix mock of Cline.abort in tests

### DIFF
--- a/src/core/__tests__/Cline.test.ts
+++ b/src/core/__tests__/Cline.test.ts
@@ -475,6 +475,7 @@ describe("Cline", () => {
 				// Mock abort state
 				Object.defineProperty(cline, "abort", {
 					get: () => false,
+					set: () => {},
 					configurable: true,
 				})
 
@@ -603,10 +604,12 @@ describe("Cline", () => {
 				// Mock abort state for both instances
 				Object.defineProperty(clineWithImages, "abort", {
 					get: () => false,
+					set: () => {},
 					configurable: true,
 				})
 				Object.defineProperty(clineWithoutImages, "abort", {
 					get: () => false,
+					set: () => {},
 					configurable: true,
 				})
 


### PR DESCRIPTION
Getting occasional failures in Cline.test.ts otherwise

```
/home/runner/work/Roo-Code/Roo-Code/src/core/Cline.ts:655
        this.abort = true;
                   ^

TypeError: Cannot set property abort of #<Cline> which has only a getter
    at Cline.abortTask (/home/runner/work/Roo-Code/Roo-Code/src/core/Cline.ts:750:13)
    at Cline.recursivelyMakeClineRequests (/home/runner/work/Roo-Code/Roo-Code/src/core/Cline.ts:2956:11)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at Cline.initiateTaskLoop (/home/runner/work/Roo-Code/Roo-Code/src/core/Cline.ts:721:23)
    at Cline.startTask (/home/runner/work/Roo-Code/Roo-Code/src/core/Cline.ts:474:3)
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes mock of `abort` property in `Cline.test.ts` by adding a setter to prevent test failures.
> 
>   - **Tests**:
>     - Fixes mock of `abort` property in `Cline.test.ts` by adding a setter to prevent test failures due to `abort` being a getter-only property.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d6e775002f3f69220c131fe90974fd9c694659be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->