### PR TITLE
Enable streaming for o1

### DIFF
--- a/src/api/providers/__tests__/openai-native.test.ts
+++ b/src/api/providers/__tests__/openai-native.test.ts
@@ -130,11 +130,20 @@ describe("OpenAiNativeHandler", () => {
 			})
 
 			mockCreate.mockResolvedValueOnce({
-				choices: [{ message: { content: null } }],
-				usage: {
-					prompt_tokens: 0,
-					completion_tokens: 0,
-					total_tokens: 0,
+				[Symbol.asyncIterator]: async function* () {
+					yield {
+						choices: [
+							{
+								delta: { content: null },
+								index: 0,
+							},
+						],
+						usage: {
+							prompt_tokens: 0,
+							completion_tokens: 0,
+							total_tokens: 0,
+						},
+					}
 				},
 			})
 
@@ -144,10 +153,7 @@ describe("OpenAiNativeHandler", () => {
 				results.push(result)
 			}
 
-			expect(results).toEqual([
-				{ type: "text", text: "" },
-				{ type: "usage", inputTokens: 0, outputTokens: 0 },
-			])
+			expect(results).toEqual([{ type: "usage", inputTokens: 0, outputTokens: 0 }])
 
 			// Verify developer role is used for system prompt with o1 model
 			expect(mockCreate).toHaveBeenCalledWith({
@@ -156,6 +162,8 @@ describe("OpenAiNativeHandler", () => {
 					{ role: "developer", content: "Formatting re-enabled\n" + systemPrompt },
 					{ role: "user", content: "Hello!" },
 				],
+				stream: true,
+				stream_options: { include_usage: true },
 			})
 		})
 

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -56,9 +56,11 @@ export class OpenAiNativeHandler implements ApiHandler, SingleCompletionHandler 
 				},
 				...convertToOpenAiMessages(messages),
 			],
+			stream: true,
+			stream_options: { include_usage: true },
 		})
 
-		yield* this.yieldResponseData(response)
+		yield* this.handleStreamResponse(response)
 	}
 
 	private async *handleO3FamilyMessage(


### PR DESCRIPTION
o1 now supports streaming
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable streaming for `o1` model in `OpenAiNativeHandler` and update tests to verify streaming behavior.
> 
>   - **Behavior**:
>     - Enables streaming for `o1` model in `OpenAiNativeHandler`.
>     - Updates `createMessage` to handle streaming responses for `o1` model.
>     - Adds `stream: true` and `stream_options: { include_usage: true }` to `o1` model requests.
>   - **Tests**:
>     - Updates test in `openai-native.test.ts` to verify streaming behavior for `o1` model.
>     - Modifies expected results to reflect streaming response structure.
>     - Ensures `developer` role is used for `o1` model in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5ffb145c133e2edd8d19f1fc4a0080514f4f9c3a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->