### PR TITLE
Make sure the agent knows about all available modes with the correct overrides

### DIFF
--- a/src/core/prompts/sections/modes.ts
+++ b/src/core/prompts/sections/modes.ts
@@ -1,20 +1,22 @@
 import * as path from "path"
 import * as vscode from "vscode"
 import { promises as fs } from "fs"
-import { modes, ModeConfig } from "../../../shared/modes"
+import { ModeConfig, getAllModesWithPrompts } from "../../../shared/modes"
 
 export async function getModesSection(context: vscode.ExtensionContext): Promise<string> {
 	const settingsDir = path.join(context.globalStorageUri.fsPath, "settings")
 	await fs.mkdir(settingsDir, { recursive: true })
 	const customModesPath = path.join(settingsDir, "cline_custom_modes.json")
 
+	// Get all modes with their overrides from extension state
+	const allModes = await getAllModesWithPrompts(context)
+
 	return `====
 
 MODES
 
-- When referring to modes, always use their display names. The built-in modes are:
-${modes.map((mode: ModeConfig) => `  * "${mode.name}" mode - ${mode.roleDefinition.split(".")[0]}`).join("\n")}
-  Custom modes will be referred to by their configured name property.
+- These are the currently available modes:
+${allModes.map((mode: ModeConfig) => `  * "${mode.name}" mode (${mode.slug}) - ${mode.roleDefinition.split(".")[0]}`).join("\n")}
 
 - Custom modes can be configured in two ways:
   1. Globally via '${customModesPath}' (created automatically on startup)

--- a/src/shared/modes.ts
+++ b/src/shared/modes.ts
@@ -1,3 +1,4 @@
+import * as vscode from "vscode"
 import { TOOL_GROUPS, ToolGroup, ALWAYS_AVAILABLE_TOOLS } from "./tool-groups"
 
 // Mode types
@@ -238,6 +239,19 @@ export const defaultPrompts: Readonly<CustomModePrompts> = Object.freeze(
 		]),
 	),
 )
+
+// Helper function to get all modes with their prompt overrides from extension state
+export async function getAllModesWithPrompts(context: vscode.ExtensionContext): Promise<ModeConfig[]> {
+	const customModes = (await context.globalState.get<ModeConfig[]>("customModes")) || []
+	const customModePrompts = (await context.globalState.get<CustomModePrompts>("customModePrompts")) || {}
+
+	const allModes = getAllModes(customModes)
+	return allModes.map((mode) => ({
+		...mode,
+		roleDefinition: customModePrompts[mode.slug]?.roleDefinition ?? mode.roleDefinition,
+		customInstructions: customModePrompts[mode.slug]?.customInstructions ?? mode.customInstructions,
+	}))
+}
 
 // Helper function to safely get role definition
 export function getRoleDefinition(modeSlug: string, customModes?: ModeConfig[]): string {


### PR DESCRIPTION
Fix a couple issues:
1. The system prompt only told the agent about the built-in modes, not the custom modes
2. The system prompt did not reflect any overrides to the role definition of the built-in modes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure system prompt includes all modes and reflects role definition overrides using `getAllModesWithPrompts()` in `modes.ts`.
> 
>   - **Behavior**:
>     - `getModesSection()` in `modes.ts` now includes both built-in and custom modes in the system prompt.
>     - Reflects role definition overrides for built-in modes using `getAllModesWithPrompts()`.
>   - **Functions**:
>     - Adds `getAllModesWithPrompts()` in `modes.ts` to fetch all modes with prompt overrides from extension state.
>   - **Misc**:
>     - Updates system prompt format in `modes.ts` to list all available modes with their slugs and role definitions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e66b0853b35997bc81f3e6ebc2a34bce6d55d2e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->