### PR TITLE
Fix default value assignment for preferredLanguage.

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2762,13 +2762,14 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						pl: "Polish",
 						pt: "Portuguese",
 						ru: "Russian",
+						zh: "Simplified Chinese",
 						"zh-cn": "Simplified Chinese",
 						es: "Spanish",
 						"zh-tw": "Traditional Chinese",
 						tr: "Turkish",
 					}
 					// Return mapped language or default to English
-					return langMap[vscodeLang.split("-")[0]] ?? "English"
+					return langMap[vscodeLang] ?? langMap[vscodeLang.split("-")[0]] ?? "English"
 				})(),
 			mcpEnabled: mcpEnabled ?? true,
 			enableMcpServerCreation: enableMcpServerCreation ?? true,


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

Language codes such as zh-cn are not mapped correctly

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes language code mapping in `ClineProvider.ts` to correctly map `zh` and `zh-cn` to "Simplified Chinese".
> 
>   - **Behavior**:
>     - Fixes language code mapping in `ClineProvider.ts` to correctly map `zh` and `zh-cn` to "Simplified Chinese".
>     - Updates default language mapping logic to handle full language codes before splitting by `-`.
>   - **Misc**:
>     - No changes to tests or documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bb38b4aed3d00db66d2921df2aa71e63057b6814. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->