### PR TITLE
fix: allow opening files without workspace root

### DIFF
--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -29,12 +29,14 @@ export async function openFile(filePath: string, options: OpenFileOptions = {}) 
 	try {
 		// Get workspace root
 		const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
-		if (!workspaceRoot) {
-			throw new Error("No workspace root found")
-		}
 
-		// If path starts with ./, resolve it relative to workspace root
-		const fullPath = filePath.startsWith("./") ? path.join(workspaceRoot, filePath.slice(2)) : filePath
+		// If path starts with ./, resolve it relative to workspace root if available
+		// Otherwise, treat it as an absolute path
+		const fullPath = filePath.startsWith("./")
+			? workspaceRoot
+				? path.join(workspaceRoot, filePath.slice(2))
+				: filePath
+			: filePath
 
 		const uri = vscode.Uri.file(fullPath)
 


### PR DESCRIPTION
The openFile function in open-file.ts was requiring a workspace root to be present, which prevented opening global files (like MCP settings) when no workspace was open. Modified the function to handle absolute paths without this requirement.

Previously, trying to open MCP settings in a new window without a workspace would error with "Could not open file: No workspace root found". Now the function properly handles both workspace-relative and absolute paths, allowing global settings files to be accessed in any context.

Changes:
- Removed workspace root requirement in openFile
- Added fallback for relative paths when no workspace is present

This solves #1053 

<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->
