### PR TITLE
Copy the system prompt of the current mode

### DIFF
--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -892,10 +892,13 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							appearance="icon"
 							title="Copy system prompt to clipboard"
 							onClick={() => {
-								vscode.postMessage({
-									type: "copySystemPrompt",
-									text: selectedPromptContent,
-								})
+								const currentMode = getCurrentMode()
+								if (currentMode) {
+									vscode.postMessage({
+										type: "copySystemPrompt",
+										mode: currentMode.slug,
+									})
+								}
 							}}
 							data-testid="copy-prompt-button">
 							<span className="codicon codicon-copy"></span>


### PR DESCRIPTION
#1046
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates 'Copy system prompt to clipboard' button in `PromptsView.tsx` to use the current mode's slug for copying the system prompt.
> 
>   - **Behavior**:
>     - Updates 'Copy system prompt to clipboard' button in `PromptsView.tsx` to send the current mode's slug instead of selected prompt content.
>     - Uses `getCurrentMode()` to determine the current mode and its slug.
>   - **Functions**:
>     - Modifies the `onClick` handler for the copy button to use `getCurrentMode()` and send a message with `type: "copySystemPrompt"` and `mode: currentMode.slug`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3524378bf2a56db3d8598d7f4ea95f316f3031cd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->