### PR TITLE
Allow setting a wildcard for auto-approve commands

### DIFF
--- a/.changeset/wet-games-pay.md
+++ b/.changeset/wet-games-pay.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Allow setting a wildcard for auto-approve commands

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -401,7 +401,7 @@ const SettingsView = ({ onDone }: SettingsViewProps) => {
 										color: "var(--vscode-descriptionForeground)",
 									}}>
 									Command prefixes that can be auto-executed when "Always approve execute operations"
-									is enabled.
+									is enabled. Add * to allow all commands (use with caution).
 								</p>
 
 								<div style={{ display: "flex", gap: "5px", marginTop: "10px" }}>

--- a/webview-ui/src/utils/__tests__/command-validation.test.ts
+++ b/webview-ui/src/utils/__tests__/command-validation.test.ts
@@ -106,5 +106,16 @@ describe("Command Validation", () => {
 			expect(validateCommand("", allowedCommands)).toBe(true)
 			expect(validateCommand("	", allowedCommands)).toBe(true)
 		})
+
+		it("allows all commands when wildcard is present", () => {
+			const wildcardAllowedCommands = ["*"]
+			// Should allow any command, including dangerous ones
+			expect(validateCommand("rm -rf /", wildcardAllowedCommands)).toBe(true)
+			expect(validateCommand("dangerous-command", wildcardAllowedCommands)).toBe(true)
+			expect(validateCommand("npm test && rm -rf /", wildcardAllowedCommands)).toBe(true)
+			// Should even allow subshell commands that are normally blocked
+			expect(validateCommand("npm test $(echo dangerous)", wildcardAllowedCommands)).toBe(true)
+			expect(validateCommand("npm test `rm -rf /`", wildcardAllowedCommands)).toBe(true)
+		})
 	})
 })

--- a/webview-ui/src/utils/command-validation.ts
+++ b/webview-ui/src/utils/command-validation.ts
@@ -104,6 +104,9 @@ export function isAllowedSingleCommand(command: string, allowedCommands: string[
 export function validateCommand(command: string, allowedCommands: string[]): boolean {
 	if (!command?.trim()) return true
 
+	// If '*' is in allowed commands, everything is allowed
+	if (allowedCommands?.includes("*")) return true
+
 	// Block subshell execution attempts
 	if (command.includes("$(") || command.includes("`")) {
 		return false


### PR DESCRIPTION
<img width="622" alt="Screenshot 2025-02-19 at 9 40 00 AM" src="https://github.com/user-attachments/assets/c075d3a7-8644-469a-ab81-c38ad8e9a624" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add wildcard feature to auto-approve all commands in `SettingsView.tsx` and update `validateCommand` to support it.
> 
>   - **Behavior**:
>     - Allow setting '*' as a wildcard in `SettingsView.tsx` to auto-approve all commands when "Always approve execute operations" is enabled.
>     - Update `validateCommand` in `command-validation.ts` to return true if '*' is in `allowedCommands`, allowing all commands.
>   - **Tests**:
>     - Add test cases in `command-validation.test.ts` to verify that all commands are allowed when '*' is present in `allowedCommands`.
>   - **Documentation**:
>     - Update description in `SettingsView.tsx` to inform users about the wildcard feature for command auto-approval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e3ae2c41d3497660a46459e12bd92369a7ecd824. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->