### PR TITLE
feat: ollama-deepseek reasoning support

### DIFF
--- a/src/utils/__tests__/xml-matcher.test.ts
+++ b/src/utils/__tests__/xml-matcher.test.ts
@@ -1,0 +1,124 @@
+import { XmlMatcher } from "../xml-matcher"
+
+describe("XmlMatcher", () => {
+	it("only match at position 0", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("<think>data</think>"), ...matcher.final()]
+		expect(chunks).toHaveLength(1)
+		expect(chunks).toEqual([
+			{
+				matched: true,
+				data: "data",
+			},
+		])
+	})
+	it("tag with space", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("< think >data</ think >"), ...matcher.final()]
+		expect(chunks).toHaveLength(1)
+		expect(chunks).toEqual([
+			{
+				matched: true,
+				data: "data",
+			},
+		])
+	})
+
+	it("invalid tag", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("< think 1>data</ think >"), ...matcher.final()]
+		expect(chunks).toHaveLength(1)
+		expect(chunks).toEqual([
+			{
+				matched: false,
+				data: "< think 1>data</ think >",
+			},
+		])
+	})
+
+	it("anonymous tag", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("<>data</>"), ...matcher.final()]
+		expect(chunks).toHaveLength(1)
+		expect(chunks).toEqual([
+			{
+				matched: false,
+				data: "<>data</>",
+			},
+		])
+	})
+
+	it("streaming push", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [
+			...matcher.update("<thi"),
+			...matcher.update("nk"),
+			...matcher.update(">dat"),
+			...matcher.update("a</"),
+			...matcher.update("think>"),
+		]
+		expect(chunks).toHaveLength(2)
+		expect(chunks).toEqual([
+			{
+				matched: true,
+				data: "dat",
+			},
+			{
+				matched: true,
+				data: "a",
+			},
+		])
+	})
+
+	it("nested tag", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("<think>X<think>Y</think>Z</think>"), ...matcher.final()]
+		expect(chunks).toHaveLength(1)
+		expect(chunks).toEqual([
+			{
+				matched: true,
+				data: "X<think>Y</think>Z",
+			},
+		])
+	})
+
+	it("nested invalid tag", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("<think>X<think>Y</thxink>Z</think>"), ...matcher.final()]
+		expect(chunks).toHaveLength(2)
+		expect(chunks).toEqual([
+			{
+				matched: true,
+				data: "X<think>Y</thxink>Z",
+			},
+			{
+				matched: true,
+				data: "</think>",
+			},
+		])
+	})
+
+	it("Wrong matching position", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("1<think>data</think>"), ...matcher.final()]
+		expect(chunks).toHaveLength(1)
+		expect(chunks).toEqual([
+			{
+				matched: false,
+				data: "1<think>data</think>",
+			},
+		])
+	})
+
+	it("Unclosed tag", () => {
+		const matcher = new XmlMatcher("think")
+		const chunks = [...matcher.update("<think>data"), ...matcher.final()]
+		expect(chunks).toHaveLength(1)
+		expect(chunks).toEqual([
+			{
+				matched: true,
+				data: "data",
+			},
+		])
+	})
+})

--- a/src/utils/xml-matcher.ts
+++ b/src/utils/xml-matcher.ts
@@ -1,0 +1,105 @@
+export interface XmlMatcherResult {
+	matched: boolean
+	data: string
+}
+export class XmlMatcher<Result = XmlMatcherResult> {
+	index = 0
+	chunks: XmlMatcherResult[] = []
+	cached: string[] = []
+	matched: boolean = false
+	state: "TEXT" | "TAG_OPEN" | "TAG_CLOSE" = "TEXT"
+	depth = 0
+	pointer = 0
+	constructor(
+		readonly tagName: string,
+		readonly transform?: (chunks: XmlMatcherResult) => Result,
+		readonly position = 0,
+	) {}
+	private collect() {
+		if (!this.cached.length) {
+			return
+		}
+		const last = this.chunks.at(-1)
+		const data = this.cached.join("")
+		const matched = this.matched
+		if (last?.matched === matched) {
+			last.data += data
+		} else {
+			this.chunks.push({
+				data,
+				matched,
+			})
+		}
+		this.cached = []
+	}
+	private pop() {
+		const chunks = this.chunks
+		this.chunks = []
+		if (!this.transform) {
+			return chunks as Result[]
+		}
+		return chunks.map(this.transform)
+	}
+
+	private _update(chunk: string) {
+		for (let i = 0; i < chunk.length; i++) {
+			const char = chunk[i]
+			this.cached.push(char)
+			this.pointer++
+
+			if (this.state === "TEXT") {
+				if (char === "<" && (this.pointer <= this.position + 1 || this.matched)) {
+					this.state = "TAG_OPEN"
+					this.index = 0
+				} else {
+					this.collect()
+				}
+			} else if (this.state === "TAG_OPEN") {
+				if (char === ">" && this.index === this.tagName.length) {
+					this.state = "TEXT"
+					if (!this.matched) {
+						this.cached = []
+					}
+					this.depth++
+					this.matched = true
+				} else if (this.index === 0 && char === "/") {
+					this.state = "TAG_CLOSE"
+				} else if (char === " " && (this.index === 0 || this.index === this.tagName.length)) {
+					continue
+				} else if (this.tagName[this.index] === char) {
+					this.index++
+				} else {
+					this.state = "TEXT"
+					this.collect()
+				}
+			} else if (this.state === "TAG_CLOSE") {
+				if (char === ">" && this.index === this.tagName.length) {
+					this.state = "TEXT"
+					this.depth--
+					this.matched = this.depth > 0
+					if (!this.matched) {
+						this.cached = []
+					}
+				} else if (char === " " && (this.index === 0 || this.index === this.tagName.length)) {
+					continue
+				} else if (this.tagName[this.index] === char) {
+					this.index++
+				} else {
+					this.state = "TEXT"
+					this.collect()
+				}
+			}
+		}
+	}
+	final(chunk?: string) {
+		if (chunk) {
+			this._update(chunk)
+		}
+		this.collect()
+		return this.pop()
+	}
+	update(chunk: string) {
+		this._update(chunk)
+		return this.pop()
+	}
+}


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->
Fixes #1087 

## Description
Implemented parsing support for think tags output by ollama
![image](https://github.com/user-attachments/assets/f3efa606-29f7-4233-a753-5a7b59cb5611)
![image](https://github.com/user-attachments/assets/dad0ed9b-afb2-450b-b75c-6e056ab1082d)

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `XmlMatcher` to parse 'think' tags in `OllamaHandler`, enabling reasoning support with comprehensive tests.
> 
>   - **Behavior**:
>     - `OllamaHandler` in `ollama.ts` now parses 'think' tags using `XmlMatcher` to differentiate between reasoning and text outputs.
>     - Yields parsed chunks as either `reasoning` or `text` based on tag matching.
>   - **Utilities**:
>     - Introduces `XmlMatcher` class in `xml-matcher.ts` to parse XML-like tags, handling nested and malformed tags.
>   - **Testing**:
>     - Adds `xml-matcher.test.ts` to test `XmlMatcher` for various cases like nested tags, malformed tags, and streaming input.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0eecda2dc334a9c183a1514ee85b8c9345c6af02. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->