### PR TITLE
Fix settings done button with unsaved changes

### DIFF
--- a/.changeset/twenty-rice-own.md
+++ b/.changeset/twenty-rice-own.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix settings done button with unsaved changes

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -173,7 +173,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 				text: currentApiConfigName,
 				apiConfiguration,
 			})
-			// onDone()
 			setChangeDetected(false)
 		}
 	}
@@ -217,7 +216,11 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 
 	const onConfirmDialogResult = useCallback((confirm: boolean) => {
 		if (confirm) {
-			confirmDialogHandler.current?.()
+			setChangeDetected(false)
+			// Wait for the change detection to be updated
+			setTimeout(() => {
+				confirmDialogHandler.current?.()
+			}, 100)
 		}
 	}, [])
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes 'Done' button behavior in `SettingsView.tsx` to handle unsaved changes correctly by delaying confirmation handler execution.
> 
>   - **Behavior**:
>     - Fixes issue with 'Done' button in `SettingsView.tsx` when unsaved changes exist.
>     - `onConfirmDialogResult` now sets `isChangeDetected` to false and uses `setTimeout` to delay confirmation handler execution by 100ms.
>   - **Misc**:
>     - Removes commented-out `onDone()` call in `handleSubmit` function in `SettingsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e69f27d3193e816c62dc58f0e811932b4d733f9c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->