### PR TITLE
Fix settings done button with unsaved changes

### DIFF
--- a/.changeset/twenty-rice-own.md
+++ b/.changeset/twenty-rice-own.md
@@ -1,5 +1,0 @@
----
-"roo-cline": patch
----
-
-Fix settings done button with unsaved changes

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -28,16 +28,13 @@ const App = () => {
 	const [tab, setTab] = useState<Tab>("chat")
 	const settingsRef = useRef<SettingsViewRef>(null)
 
-	const switchTab = useCallback(
-		(newTab: Tab) => {
-			if (tab === "settings" && settingsRef.current?.checkUnsaveChanges) {
-				settingsRef.current.checkUnsaveChanges(() => setTab(newTab))
-			} else {
-				setTab(newTab)
-			}
-		},
-		[tab],
-	)
+	const switchTab = useCallback((newTab: Tab) => {
+		if (settingsRef.current?.checkUnsaveChanges) {
+			settingsRef.current.checkUnsaveChanges(() => setTab(newTab))
+		} else {
+			setTab(newTab)
+		}
+	}, [])
 
 	const onMessage = useCallback(
 		(e: MessageEvent) => {
@@ -73,7 +70,7 @@ const App = () => {
 		<WelcomeView />
 	) : (
 		<>
-			{tab === "settings" && <SettingsView ref={settingsRef} onDone={() => switchTab("chat")} />}
+			{tab === "settings" && <SettingsView ref={settingsRef} onDone={() => setTab("chat")} />}
 			{tab === "history" && <HistoryView onDone={() => switchTab("chat")} />}
 			{tab === "mcp" && <McpView onDone={() => switchTab("chat")} />}
 			{tab === "prompts" && <PromptsView onDone={() => switchTab("chat")} />}

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -173,6 +173,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 				text: currentApiConfigName,
 				apiConfiguration,
 			})
+			// onDone()
 			setChangeDetected(false)
 		}
 	}
@@ -216,11 +217,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 
 	const onConfirmDialogResult = useCallback((confirm: boolean) => {
 		if (confirm) {
-			setChangeDetected(false)
-			// Wait for the change detection to be updated
-			setTimeout(() => {
-				confirmDialogHandler.current?.()
-			}, 100)
+			confirmDialogHandler.current?.()
 		}
 	}, [])
 


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

In the new version, the confirmation button on the save warning dialog causes an `onDone -> switchTab -> onDone` loop, preventing the dialog from closing. We need to break this loop. 
Try to avoid using `setTimeout` for synchronization.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->
@mrubens 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes loop issue with settings done button by adjusting `switchTab` and `onDone` behavior in `App.tsx` and `SettingsView.tsx`.
> 
>   - **Behavior**:
>     - Fixes `onDone -> switchTab -> onDone` loop in `App.tsx` by modifying `switchTab` to handle unsaved changes without looping.
>     - `SettingsView` `onDone` now directly sets tab to 'chat' instead of using `switchTab`.
>   - **Functions**:
>     - `switchTab` in `App.tsx` now checks `settingsRef.current?.checkUnsaveChanges` without looping back to `onDone`.
>     - `onConfirmDialogResult` in `SettingsView.tsx` no longer uses `setTimeout` for synchronization.
>   - **Misc**:
>     - Removes unused `setTimeout` in `SettingsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7d58fe76bb733daf91f2fbfdf91da4a906ab0b48. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->