### PR TITLE
gpt 4o price update

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -622,8 +622,8 @@ export const openAiNativeModels = {
 		contextWindow: 128_000,
 		supportsImages: true,
 		supportsPromptCache: false,
-		inputPrice: 5,
-		outputPrice: 15,
+		inputPrice: 2.5,
+		outputPrice: 10,
 	},
 	"gpt-4o-mini": {
 		maxTokens: 16_384,


### PR DESCRIPTION
Update GPT 4o price from $5/$15 to $2.5/$10 input/output per million tokens

## Description
OpenAI reduced the price of GPT 4o from $5/$15 to $2.5/$10 input output per million tokens

## Type of change

<!-- Please ignore options that are not relevant -->

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Just a change of pricing values, tested by running the extension in debug mode.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x ] My code follows the patterns of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

## Related Issues

## Reviewers

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update GPT 4o pricing in `openAiNativeModels` in `api.ts` to reflect new OpenAI rates.
> 
>   - **Pricing Update**:
>     - Updated `inputPrice` from 5 to 2.5 and `outputPrice` from 15 to 10 for `gpt-4o` in `openAiNativeModels` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a7c842fd9d9871f562844a9c05375090981a2365. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->