### PR TITLE
Debug test flakes

### DIFF
--- a/src/core/diff/strategies/new-unified/__tests__/edit-strategies.test.ts
+++ b/src/core/diff/strategies/new-unified/__tests__/edit-strategies.test.ts
@@ -1,5 +1,3 @@
-/// <reference types="jest" />
-
 import { applyContextMatching, applyDMP, applyGitFallback } from "../edit-strategies"
 import { Hunk } from "../types"
 
@@ -277,7 +275,7 @@ describe("applyGitFallback", () => {
 		expect(result.result.join("\n")).toEqual("line1\nnew line2\nline3")
 		expect(result.confidence).toBe(1)
 		expect(result.strategy).toBe("git-fallback")
-	}, 10_000)
+	})
 
 	it("should return original content with 0 confidence when changes cannot be applied", async () => {
 		const hunk = {
@@ -293,5 +291,5 @@ describe("applyGitFallback", () => {
 		expect(result.result).toEqual(content)
 		expect(result.confidence).toBe(0)
 		expect(result.strategy).toBe("git-fallback")
-	}, 10_000)
+	})
 })


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

We need a way to await Cline tasks and abort them when necessary for our tests.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances `Cline` class with task initialization and abandonment handling, updates tests for image handling and API retries, and removes a test timeout.
> 
>   - **Cline Class**:
>     - Adds `create()` method to `Cline` for task initialization, allowing tasks to be started without immediately executing them.
>     - Modifies `abortTask()` to handle `isAbandoned` parameter, marking tasks as abandoned.
>     - Updates task start logic to check `startTask` flag.
>   - **Tests**:
>     - Updates `Cline.test.ts` to use `Cline.create()` for task initialization.
>     - Adds handling for image blocks based on model capabilities in `Cline.test.ts`.
>     - Implements API retry logic with countdown in `Cline.test.ts`.
>     - Removes timeout from `applyGitFallback` tests in `edit-strategies.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 40a86b1f709e8be2988d69bcba27f44b640b441a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->