### PR TITLE
Include the original task in the power steering content

### DIFF
--- a/.changeset/weak-swans-study.md
+++ b/.changeset/weak-swans-study.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Include the original task in the power steering content

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3243,6 +3243,9 @@ export class Cline {
 			customInstructions: globalCustomInstructions,
 			preferredLanguage,
 		} = (await this.providerRef.deref()?.getState()) ?? {}
+
+		const powerSteering = Experiments.isEnabled(experiments ?? {}, EXPERIMENT_IDS.POWER_STEERING)
+
 		const currentMode = mode ?? defaultModeSlug
 		const modeDetails = await getFullModeDetails(currentMode, customModes, customModePrompts, {
 			cwd,
@@ -3252,11 +3255,8 @@ export class Cline {
 		details += `\n\n# Current Mode\n`
 		details += `<slug>${currentMode}</slug>\n`
 		details += `<name>${modeDetails.name}</name>\n`
-		if (Experiments.isEnabled(experiments ?? {}, EXPERIMENT_IDS.POWER_STEERING)) {
+		if (powerSteering) {
 			details += `<role>${modeDetails.roleDefinition}</role>\n`
-			if (modeDetails.customInstructions) {
-				details += `<custom_instructions>${modeDetails.customInstructions}</custom_instructions>\n`
-			}
 		}
 
 		// Add warning if not in code mode
@@ -3268,7 +3268,21 @@ export class Cline {
 		) {
 			const currentModeName = getModeBySlug(currentMode, customModes)?.name ?? currentMode
 			const defaultModeName = getModeBySlug(defaultModeSlug, customModes)?.name ?? defaultModeSlug
-			details += `\n\nNOTE: You are currently in '${currentModeName}' mode which only allows read-only operations. To write files or execute commands, the user will need to switch to '${defaultModeName}' mode. Note that only the user can switch modes.`
+			details += `\n\nNOTE: You are currently in '${currentModeName}' mode which only allows read-only operations. To write files or execute commands, the user will need to switch to '${defaultModeName}' mode or another mode with these capabilities. Note that only the user can switch modes.`
+		}
+
+		if (powerSteering) {
+			if (modeDetails.customInstructions) {
+				details += `\n\n# Custom Instructions\n`
+				details += `<custom_instructions>${modeDetails.customInstructions}</custom_instructions>\n`
+			}
+
+			const taskMessage = this.clineMessages[0]?.text ?? ""
+
+			if (taskMessage) {
+				details += `\n\n# Current Task\n\n`
+				details += `<task>${taskMessage}</task>\n`
+			}
 		}
 
 		if (includeFileDetails) {

--- a/src/shared/__tests__/experiments.test.ts
+++ b/src/shared/__tests__/experiments.test.ts
@@ -7,7 +7,7 @@ describe("experiments", () => {
 			expect(experimentConfigsMap.POWER_STEERING).toMatchObject({
 				name: 'Use experimental "power steering" mode',
 				description:
-					"When enabled, Roo will remind the model about the details of its current mode definition more frequently. This will lead to stronger adherence to role definitions and custom instructions, but will use more tokens per message.",
+					"When enabled, Roo will remind the model about the details of the original task and its current mode definition more frequently. This will lead to stronger adherence to its instructions, but will use more tokens per message.",
 				enabled: false,
 			})
 		})

--- a/src/shared/experiments.ts
+++ b/src/shared/experiments.ts
@@ -39,7 +39,7 @@ export const experimentConfigsMap: Record<ExperimentKey, ExperimentConfig> = {
 	POWER_STEERING: {
 		name: 'Use experimental "power steering" mode',
 		description:
-			"When enabled, Roo will remind the model about the details of its current mode definition more frequently. This will lead to stronger adherence to role definitions and custom instructions, but will use more tokens per message.",
+			"When enabled, Roo will remind the model about the details of the original task and its current mode definition more frequently. This will lead to stronger adherence to its instructions, but will use more tokens per message.",
 		enabled: false,
 	},
 }


### PR DESCRIPTION
<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Include original task in power steering content and adjust environment details order in `Cline.ts`.
> 
>   - **Behavior**:
>     - Include original task in power steering content in `Cline.ts` when `POWER_STEERING` experiment is enabled.
>     - Adjust order of environment details in `getEnvironmentDetails()` in `Cline.ts`.
>   - **Tests**:
>     - Add tests in `Cline.test.ts` to verify inclusion/exclusion of power steering content based on experiment state.
>     - Update `experiments.test.ts` to reflect changes in `POWER_STEERING` description.
>   - **Experiments**:
>     - Update `POWER_STEERING` description in `experiments.ts` to include original task details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 86896a8865bf1222a546a60d2857f2efb9191841. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->