### PR TITLE
Properly reset thinking setting when changing profiles

### DIFF
--- a/.changeset/little-deers-occur.md
+++ b/.changeset/little-deers-occur.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix a bug that prevented the "Thinking" setting from properly updating when switching profiles.

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -68,15 +68,17 @@ const ApiOptions = ({
 	const [lmStudioModels, setLmStudioModels] = useState<string[]>([])
 	const [vsCodeLmModels, setVsCodeLmModels] = useState<vscodemodels.LanguageModelChatSelector[]>([])
 	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicBaseUrl)
-	const [anthropicThinkingBudget, setAnthropicThinkingBudget] = useState(apiConfiguration?.anthropicThinking)
 	const [azureApiVersionSelected, setAzureApiVersionSelected] = useState(!!apiConfiguration?.azureApiVersion)
 	const [openRouterBaseUrlSelected, setOpenRouterBaseUrlSelected] = useState(!!apiConfiguration?.openRouterBaseUrl)
 	const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
-	const inputEventTransform = <E,>(event: E) => (event as { target: HTMLInputElement })?.target?.value as any
+	const anthropicThinkingBudget = apiConfiguration?.anthropicThinking
+
 	const noTransform = <T,>(value: T) => value
+	const inputEventTransform = <E,>(event: E) => (event as { target: HTMLInputElement })?.target?.value as any
 	const dropdownEventTransform = <T,>(event: DropdownOption | string | undefined) =>
 		(typeof event == "string" ? event : event?.value) as T
+
 	const handleInputChange = useCallback(
 		<K extends keyof ApiConfiguration, E>(
 			field: K,
@@ -107,8 +109,10 @@ const ApiOptions = ({
 		250,
 		[selectedProvider, apiConfiguration?.ollamaBaseUrl, apiConfiguration?.lmStudioBaseUrl],
 	)
+
 	const handleMessage = useCallback((event: MessageEvent) => {
 		const message: ExtensionMessage = event.data
+
 		if (message.type === "ollamaModels" && Array.isArray(message.ollamaModels)) {
 			const newModels = message.ollamaModels
 			setOllamaModels(newModels)
@@ -120,6 +124,7 @@ const ApiOptions = ({
 			setVsCodeLmModels(newModels)
 		}
 	}, [])
+
 	useEvent("message", handleMessage)
 
 	const createDropdown = (models: Record<string, ModelInfo>) => {
@@ -130,6 +135,7 @@ const ApiOptions = ({
 				label: modelId,
 			})),
 		]
+
 		return (
 			<Dropdown
 				id="model-id"
@@ -1268,11 +1274,9 @@ const ApiOptions = ({
 				<div className="flex flex-col gap-2 mt-2">
 					<Checkbox
 						checked={!!anthropicThinkingBudget}
-						onChange={(checked) => {
-							const budget = checked ? 16_384 : undefined
-							setAnthropicThinkingBudget(budget)
-							setApiConfigurationField("anthropicThinking", budget)
-						}}>
+						onChange={(checked) =>
+							setApiConfigurationField("anthropicThinking", checked ? 16_384 : undefined)
+						}>
 						Thinking?
 					</Checkbox>
 					{anthropicThinkingBudget && (
@@ -1286,11 +1290,7 @@ const ApiOptions = ({
 									max={anthropicModels["claude-3-7-sonnet-20250219"].maxTokens - 1}
 									step={1024}
 									value={[anthropicThinkingBudget]}
-									onValueChange={(value) => {
-										const budget = value[0]
-										setAnthropicThinkingBudget(budget)
-										setApiConfigurationField("anthropicThinking", budget)
-									}}
+									onValueChange={(value) => setApiConfigurationField("anthropicThinking", value[0])}
 								/>
 								<div className="w-10">{anthropicThinkingBudget}</div>
 							</div>


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

Switching API configuration profiles wasn't correspondingly updating the "Thinking" settings.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `ApiOptions.tsx` to ensure 'Thinking' setting updates when switching profiles.
> 
>   - **Behavior**:
>     - Fixes bug in `ApiOptions.tsx` where `anthropicThinkingBudget` was not updating when switching profiles.
>     - Removes `setAnthropicThinkingBudget` state management to directly use `apiConfiguration?.anthropicThinking`.
>   - **Misc**:
>     - Adds changeset `little-deers-occur.md` to document the bug fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3621deb725937a5b97fcc62a49c7e464b67501f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->