### PR TITLE
File drag and drop

### DIFF
--- a/.changeset/shaggy-spies-kneel.md
+++ b/.changeset/shaggy-spies-kneel.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add drag-and-drop for files

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2386,6 +2386,8 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 		const allowedCommands = vscode.workspace.getConfiguration("roo-cline").get<string[]>("allowedCommands") || []
 
+		const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) || ""
+
 		return {
 			version: this.context.extension?.packageJSON?.version ?? "",
 			apiConfiguration,
@@ -2432,6 +2434,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			experiments: experiments ?? experimentDefault,
 			mcpServers: this.mcpHub?.getAllServers() ?? [],
 			maxOpenTabsContext: maxOpenTabsContext ?? 20,
+			cwd: cwd,
 		}
 	}
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -129,6 +129,7 @@ export interface ExtensionState {
 	customModes: ModeConfig[]
 	toolRequirements?: Record<string, boolean> // Map of tool names to their requirements (e.g. {"apply_diff": true} if diffEnabled)
 	maxOpenTabsContext: number // Maximum number of VSCode open tabs to include in context (0-500)
+	cwd?: string // Current working directory
 }
 
 export interface ClineMessage {

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -16,6 +16,7 @@ import { vscode } from "../../utils/vscode"
 import { WebviewMessage } from "../../../../src/shared/WebviewMessage"
 import { Mode, getAllModes } from "../../../../src/shared/modes"
 import { CaretIcon } from "../common/CaretIcon"
+import { convertToMentionPath } from "../../utils/path-mentions"
 
 interface ChatTextAreaProps {
 	inputValue: string
@@ -589,19 +590,8 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 					const files = Array.from(e.dataTransfer.files)
 					const text = e.dataTransfer.getData("text")
 					if (text) {
-						let mentionText = text
-						const normalizedText = text.replace(/\\/g, "/")
-						const normalizedCwd = cwd ? cwd.replace(/\\/g, "/") : ""
-
-						// Always use case-insensitive comparison for path matching
-						if (normalizedCwd) {
-							const lowerText = normalizedText.toLowerCase()
-							const lowerCwd = normalizedCwd.toLowerCase()
-
-							if (lowerText.startsWith(lowerCwd)) {
-								mentionText = "@" + normalizedText.substring(normalizedCwd.length)
-							}
-						}
+						// Convert the path to a mention-friendly format
+						const mentionText = convertToMentionPath(text, cwd)
 
 						const newValue =
 							inputValue.slice(0, cursorPosition) + mentionText + " " + inputValue.slice(cursorPosition)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -880,9 +880,8 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 	const placeholderText = useMemo(() => {
 		const baseText = task ? "Type a message..." : "Type your task here..."
 		const contextText = "(@ to add context, / to switch modes"
-		const imageText = shouldDisableImages ? "" : ", hold shift to drag in images"
-		const helpText = imageText ? `\n${contextText}${imageText})` : `\n${contextText})`
-		return baseText + helpText
+		const imageText = shouldDisableImages ? "hold shift to drag in files" : ", hold shift to drag in files/images"
+		return baseText + `\n${contextText}${imageText})`
 	}, [task, shouldDisableImages])
 
 	const itemContent = useCallback(

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -118,6 +118,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		autoApprovalEnabled: false,
 		customModes: [],
 		maxOpenTabsContext: 20,
+		cwd: "",
 	})
 
 	const [didHydrateState, setDidHydrateState] = useState(false)

--- a/webview-ui/src/utils/__tests__/path-mentions.test.ts
+++ b/webview-ui/src/utils/__tests__/path-mentions.test.ts
@@ -1,0 +1,45 @@
+import { convertToMentionPath } from "../path-mentions"
+
+describe("path-mentions", () => {
+	describe("convertToMentionPath", () => {
+		it("should convert an absolute path to a mention path when it starts with cwd", () => {
+			// Windows-style paths
+			expect(convertToMentionPath("C:\\Users\\user\\project\\file.txt", "C:\\Users\\user\\project")).toBe(
+				"@/file.txt",
+			)
+
+			// Unix-style paths
+			expect(convertToMentionPath("/Users/user/project/file.txt", "/Users/user/project")).toBe("@/file.txt")
+		})
+
+		it("should handle paths with trailing slashes in cwd", () => {
+			expect(convertToMentionPath("/Users/user/project/file.txt", "/Users/user/project/")).toBe("@/file.txt")
+		})
+
+		it("should be case-insensitive when matching paths", () => {
+			expect(convertToMentionPath("/Users/User/Project/file.txt", "/users/user/project")).toBe("@/file.txt")
+		})
+
+		it("should return the original path when cwd is not provided", () => {
+			expect(convertToMentionPath("/Users/user/project/file.txt")).toBe("/Users/user/project/file.txt")
+		})
+
+		it("should return the original path when it does not start with cwd", () => {
+			expect(convertToMentionPath("/Users/other/project/file.txt", "/Users/user/project")).toBe(
+				"/Users/other/project/file.txt",
+			)
+		})
+
+		it("should normalize backslashes to forward slashes", () => {
+			expect(convertToMentionPath("C:\\Users\\user\\project\\subdir\\file.txt", "C:\\Users\\user\\project")).toBe(
+				"@/subdir/file.txt",
+			)
+		})
+
+		it("should handle nested paths correctly", () => {
+			expect(convertToMentionPath("/Users/user/project/nested/deeply/file.txt", "/Users/user/project")).toBe(
+				"@/nested/deeply/file.txt",
+			)
+		})
+	})
+})

--- a/webview-ui/src/utils/path-mentions.ts
+++ b/webview-ui/src/utils/path-mentions.ts
@@ -1,0 +1,38 @@
+/**
+ * Utilities for handling path-related operations in mentions
+ */
+
+/**
+ * Converts an absolute path to a mention-friendly path
+ * If the provided path starts with the current working directory,
+ * it's converted to a relative path prefixed with @
+ *
+ * @param path The path to convert
+ * @param cwd The current working directory
+ * @returns A mention-friendly path
+ */
+export function convertToMentionPath(path: string, cwd?: string): string {
+	const normalizedPath = path.replace(/\\/g, "/")
+	let normalizedCwd = cwd ? cwd.replace(/\\/g, "/") : ""
+
+	if (!normalizedCwd) {
+		return path
+	}
+
+	// Remove trailing slash from cwd if it exists
+	if (normalizedCwd.endsWith("/")) {
+		normalizedCwd = normalizedCwd.slice(0, -1)
+	}
+
+	// Always use case-insensitive comparison for path matching
+	const lowerPath = normalizedPath.toLowerCase()
+	const lowerCwd = normalizedCwd.toLowerCase()
+
+	if (lowerPath.startsWith(lowerCwd)) {
+		const relativePath = normalizedPath.substring(normalizedCwd.length)
+		// Ensure there's a slash after the @ symbol when we create the mention path
+		return "@" + (relativePath.startsWith("/") ? relativePath : "/" + relativePath)
+	}
+
+	return path
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add drag-and-drop file support in chat with path conversion to mention-friendly format.
> 
>   - **Behavior**:
>     - Add drag-and-drop support for files in `ChatTextArea.tsx`, converting paths to mention-friendly format using `convertToMentionPath()`.
>     - Update placeholder text in `ChatView.tsx` to reflect new drag-and-drop functionality.
>   - **State Management**:
>     - Add `cwd` (current working directory) to `ExtensionState` in `ExtensionMessage.ts` and `ExtensionStateContext.tsx`.
>     - Update `ClineProvider.ts` to include `cwd` in the state sent to the webview.
>   - **Utilities**:
>     - Implement `convertToMentionPath()` in `path-mentions.ts` to convert absolute paths to mention-friendly paths.
>     - Add tests for `convertToMentionPath()` in `path-mentions.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8a3b8d1b3c2edbd14b5d33f612d7f183d526694b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->