### PR TITLE
Added thinking support for Claude 3.7 via Vertex AI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
 	"name": "roo-cline",
-	"version": "3.7.4",
+	"version": "3.7.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "roo-cline",
-			"version": "3.7.4",
+			"version": "3.7.5",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
 				"@anthropic-ai/sdk": "^0.37.0",
-				"@anthropic-ai/vertex-sdk": "^0.4.1",
+				"@anthropic-ai/vertex-sdk": "^0.7.0",
 				"@aws-sdk/client-bedrock-runtime": "^3.706.0",
 				"@google/generative-ai": "^0.18.0",
 				"@mistralai/mistralai": "^1.3.6",
@@ -150,11 +150,11 @@
 			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
 		},
 		"node_modules/@anthropic-ai/vertex-sdk": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.4.3.tgz",
-			"integrity": "sha512-2Uef0C5P2Hx+T88RnUSRA3u4aZqmqnrRSOb2N64ozgKPiSUPTM5JlggAq2b32yWMj5d3MLYa6spJXKMmHXOcoA==",
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.7.0.tgz",
+			"integrity": "sha512-zNm3hUXgYmYDTyveIxOyxbcnh5VXFkrLo4bSnG6LAfGzW7k3k2iCNDSVKtR9qZrK2BCid7JtVu7jsEKaZ/9dSw==",
 			"dependencies": {
-				"@anthropic-ai/sdk": ">=0.14 <1",
+				"@anthropic-ai/sdk": ">=0.35 <1",
 				"google-auth-library": "^9.4.2"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Roo Code (prev. Roo Cline)",
 	"description": "An AI-powered autonomous coding agent that lives in your editor.",
 	"publisher": "RooVeterinaryInc",
-	"version": "3.7.5",
+	"version": "3.7.4",
 	"icon": "assets/icons/rocket.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Roo Code (prev. Roo Cline)",
 	"description": "An AI-powered autonomous coding agent that lives in your editor.",
 	"publisher": "RooVeterinaryInc",
-	"version": "3.7.4",
+	"version": "3.7.5",
 	"icon": "assets/icons/rocket.png",
 	"galleryBanner": {
 		"color": "#617A91",
@@ -305,7 +305,7 @@
 	"dependencies": {
 		"@anthropic-ai/bedrock-sdk": "^0.10.2",
 		"@anthropic-ai/sdk": "^0.37.0",
-		"@anthropic-ai/vertex-sdk": "^0.4.1",
+		"@anthropic-ai/vertex-sdk": "^0.7.0",
 		"@aws-sdk/client-bedrock-runtime": "^3.706.0",
 		"@google/generative-ai": "^0.18.0",
 		"@mistralai/mistralai": "^1.3.6",

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -566,6 +566,13 @@ const ApiOptions = ({
 							style={{ display: "inline", fontSize: "inherit" }}>
 							{"2) install the Google Cloud CLI › configure Application Default Credentials."}
 						</VSCodeLink>
+						{selectedModelId === "claude-3-7-sonnet@20250219" && (
+							<span>
+								{" "}
+								If using Claude 3.7 Sonnet, you can enable <strong>extended thinking</strong> below for
+								improved reasoning capabilities.
+							</span>
+						)}
 					</p>
 				</div>
 			)}
@@ -1270,7 +1277,8 @@ const ApiOptions = ({
 					</>
 				)}
 
-			{selectedProvider === "anthropic" && selectedModelId === "claude-3-7-sonnet-20250219" && (
+			{((selectedProvider === "anthropic" && selectedModelId === "claude-3-7-sonnet-20250219") ||
+				(selectedProvider === "vertex" && selectedModelId === "claude-3-7-sonnet@20250219")) && (
 				<div className="flex flex-col gap-2 mt-2">
 					<Checkbox
 						checked={!!anthropicThinkingBudget}
@@ -1287,7 +1295,13 @@ const ApiOptions = ({
 							<div className="flex items-center gap-2">
 								<Slider
 									min={1024}
-									max={anthropicModels["claude-3-7-sonnet-20250219"].maxTokens - 1}
+									max={
+										selectedProvider === "anthropic"
+											? anthropicModels["claude-3-7-sonnet-20250219"].maxTokens - 1
+											: selectedProvider === "vertex"
+												? vertexModels["claude-3-7-sonnet@20250219"].maxTokens - 1
+												: 32768 /* Default max if not found */
+									}
 									step={1024}
 									value={[anthropicThinkingBudget]}
 									onValueChange={(value) => setApiConfigurationField("anthropicThinking", value[0])}

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.test.tsx
@@ -46,6 +46,21 @@ jest.mock("../TemperatureControl", () => ({
 	),
 }))
 
+jest.mock("@/components/ui", () => ({
+	Slider: ({ min, max, step, value, onValueChange }: any) => (
+		<div data-testid="thinking-slider">
+			<input
+				type="range"
+				min={min}
+				max={max}
+				step={step}
+				value={value[0]}
+				onChange={(e) => onValueChange([parseInt(e.target.value)])}
+			/>
+		</div>
+	),
+}))
+
 describe("ApiOptions", () => {
 	const renderApiOptions = (props = {}) => {
 		render(
@@ -68,5 +83,81 @@ describe("ApiOptions", () => {
 	it("hides temperature control when fromWelcomeView is true", () => {
 		renderApiOptions({ fromWelcomeView: true })
 		expect(screen.queryByTestId("temperature-control")).not.toBeInTheDocument()
+	})
+
+	describe("Thinking Feature", () => {
+		it("should show thinking controls for Anthropic with Claude 3.7 Sonnet", () => {
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: "anthropic",
+					apiModelId: "claude-3-7-sonnet-20250219",
+				},
+			})
+
+			expect(screen.getByText("Thinking?")).toBeInTheDocument()
+		})
+
+		it("should show thinking controls for Vertex with Claude 3.7 Sonnet", () => {
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: "vertex",
+					apiModelId: "claude-3-7-sonnet@20250219",
+				},
+			})
+
+			expect(screen.getByText("Thinking?")).toBeInTheDocument()
+		})
+
+		it("should not show thinking controls for non-supported Anthropic models", () => {
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: "anthropic",
+					apiModelId: "claude-3-5-sonnet-20241022",
+				},
+			})
+
+			expect(screen.queryByText("Thinking?")).not.toBeInTheDocument()
+		})
+
+		it("should not show thinking controls for non-supported Vertex models", () => {
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: "vertex",
+					apiModelId: "claude-3-5-sonnet-v2@20241022",
+				},
+			})
+
+			expect(screen.queryByText("Thinking?")).not.toBeInTheDocument()
+		})
+
+		it("should show slider when thinking is enabled for Anthropic", () => {
+			const setApiConfigurationField = jest.fn()
+
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: "anthropic",
+					apiModelId: "claude-3-7-sonnet-20250219",
+					anthropicThinking: 16384,
+				},
+				setApiConfigurationField,
+			})
+
+			expect(screen.getByTestId("thinking-slider")).toBeInTheDocument()
+		})
+
+		it("should show slider when thinking is enabled for Vertex", () => {
+			const setApiConfigurationField = jest.fn()
+
+			renderApiOptions({
+				apiConfiguration: {
+					apiProvider: "vertex",
+					apiModelId: "claude-3-7-sonnet@20250219",
+					anthropicThinking: 16384,
+				},
+				setApiConfigurationField,
+			})
+
+			expect(screen.getByTestId("thinking-slider")).toBeInTheDocument()
+		})
 	})
 })


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
Screenshot of testing it with minimum thinking context (1024)
<img width="1141" alt="image" src="https://github.com/user-attachments/assets/3b83336a-a828-49a8-bbb6-56249a1358a3" />

Screenshot of testing it with maximum thinking context (16384)
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/a1a0ee82-3742-4333-9a90-f4b527efc14e" />


## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for Claude 3.7 with thinking capabilities via Vertex AI, including UI updates and tests.
> 
>   - **Behavior**:
>     - Adds support for Claude 3.7 model with thinking capabilities in `VertexHandler`.
>     - Updates `createMessage` and `completePrompt` to handle thinking configurations.
>     - Adjusts `max_tokens` and `temperature` based on thinking settings.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to show thinking controls for Claude 3.7 in Vertex AI.
>     - Adds slider for configuring thinking token budget.
>   - **Tests**:
>     - Adds tests in `vertex.test.ts` for thinking configurations and content blocks.
>     - Adds tests in `ApiOptions.test.tsx` for UI changes related to thinking feature.
>   - **Dependencies**:
>     - Updates `@anthropic-ai/vertex-sdk` to `^0.7.0` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 60f1331ab94a768ccc6de4ac4a76d99a7d2ee6ef. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->