### PR TITLE
Thinking settings tweaks

### DIFF
--- a/.changeset/swift-kings-attack.md
+++ b/.changeset/swift-kings-attack.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Pass "thinking" params to OpenRouter

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -14,8 +14,6 @@ import { ApiStream } from "../transform/stream"
 
 const ANTHROPIC_DEFAULT_TEMPERATURE = 0
 
-const THINKING_MODELS = ["claude-3-7-sonnet-20250219"]
-
 export class AnthropicHandler implements ApiHandler, SingleCompletionHandler {
 	private options: ApiHandlerOptions
 	private client: Anthropic
@@ -32,16 +30,19 @@ export class AnthropicHandler implements ApiHandler, SingleCompletionHandler {
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {
 		let stream: AnthropicStream<Anthropic.Messages.RawMessageStreamEvent>
 		const cacheControl: CacheControlEphemeral = { type: "ephemeral" }
-		const modelId = this.getModel().id
-		const maxTokens = this.getModel().info.maxTokens || 8192
+		let { id: modelId, info: modelInfo } = this.getModel()
+		const maxTokens = modelInfo.maxTokens || 8192
+		const budgetTokens = this.options.anthropicThinking ?? Math.min(maxTokens - 1, 8192)
 		let temperature = this.options.modelTemperature ?? ANTHROPIC_DEFAULT_TEMPERATURE
 		let thinking: BetaThinkingConfigParam | undefined = undefined
 
-		if (THINKING_MODELS.includes(modelId)) {
-			thinking = this.options.anthropicThinking
-				? { type: "enabled", budget_tokens: this.options.anthropicThinking }
-				: { type: "disabled" }
-
+		// Anthropic "Thinking" models require a temperature of 1.0.
+		if (modelId === "claude-3-7-sonnet-20250219:thinking") {
+			// The `:thinking` variant is a virtual identifier for the
+			// `claude-3-7-sonnet-20250219` model with a thinking budget.
+			// We can handle this more elegantly in the future.
+			modelId = "claude-3-7-sonnet-20250219"
+			thinking = { type: "enabled", budget_tokens: budgetTokens }
 			temperature = 1.0
 		}
 
@@ -114,8 +115,8 @@ export class AnthropicHandler implements ApiHandler, SingleCompletionHandler {
 			default: {
 				stream = (await this.client.messages.create({
 					model: modelId,
-					max_tokens: this.getModel().info.maxTokens || 8192,
-					temperature: this.options.modelTemperature ?? ANTHROPIC_DEFAULT_TEMPERATURE,
+					max_tokens: maxTokens,
+					temperature,
 					system: [{ text: systemPrompt, type: "text" }],
 					messages,
 					// tools,

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -32,7 +32,6 @@ export class AnthropicHandler implements ApiHandler, SingleCompletionHandler {
 		const cacheControl: CacheControlEphemeral = { type: "ephemeral" }
 		let { id: modelId, info: modelInfo } = this.getModel()
 		const maxTokens = modelInfo.maxTokens || 8192
-		const budgetTokens = this.options.anthropicThinking ?? Math.min(maxTokens - 1, 8192)
 		let temperature = this.options.modelTemperature ?? ANTHROPIC_DEFAULT_TEMPERATURE
 		let thinking: BetaThinkingConfigParam | undefined = undefined
 
@@ -42,6 +41,7 @@ export class AnthropicHandler implements ApiHandler, SingleCompletionHandler {
 			// `claude-3-7-sonnet-20250219` model with a thinking budget.
 			// We can handle this more elegantly in the future.
 			modelId = "claude-3-7-sonnet-20250219"
+			const budgetTokens = this.options.anthropicThinking ?? Math.max(maxTokens * 0.8, 1024)
 			thinking = { type: "enabled", budget_tokens: budgetTokens }
 			temperature = 1.0
 		}

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -109,13 +109,11 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 		}
 
 		let temperature = this.options.modelTemperature ?? defaultTemperature
-
-		const maxTokens = modelInfo.maxTokens
-		const budgetTokens = this.options.anthropicThinking ?? Math.min((maxTokens ?? 8192) - 1, 8192)
 		let thinking: BetaThinkingConfigParam | undefined = undefined
 
-		// Anthropic "Thinking" models require a temperature of 1.0.
 		if (modelInfo.thinking) {
+			const maxTokens = modelInfo.maxTokens || 8192
+			const budgetTokens = this.options.anthropicThinking ?? Math.max(maxTokens * 0.8, 1024)
 			thinking = { type: "enabled", budget_tokens: budgetTokens }
 			temperature = 1.0
 		}
@@ -125,7 +123,7 @@ export class OpenRouterHandler implements ApiHandler, SingleCompletionHandler {
 
 		const completionParams: OpenRouterChatCompletionParams = {
 			model: modelId,
-			max_tokens: maxTokens,
+			max_tokens: modelInfo.maxTokens,
 			temperature,
 			thinking, // OpenRouter is temporarily supporting this.
 			top_p: topP,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -103,7 +103,7 @@ export const THINKING_BUDGET = {
 export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-3-7-sonnet-20250219"
 export const anthropicModels = {
-	"claude-3-7-sonnet-20250219": {
+	"claude-3-7-sonnet-20250219:thinking": {
 		maxTokens: 16384,
 		contextWindow: 200_000,
 		supportsImages: true,
@@ -114,6 +114,18 @@ export const anthropicModels = {
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
 		cacheReadsPrice: 0.3, // $0.30 per million tokens
 		thinking: true,
+	},
+	"claude-3-7-sonnet-20250219": {
+		maxTokens: 16384,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsComputerUse: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0, // $3 per million input tokens
+		outputPrice: 15.0, // $15 per million output tokens
+		cacheWritesPrice: 3.75, // $3.75 per million tokens
+		cacheReadsPrice: 0.3, // $0.30 per million tokens
+		thinking: false,
 	},
 	"claude-3-5-sonnet-20241022": {
 		maxTokens: 8192,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -73,7 +73,7 @@ const ApiOptions = ({
 	const [openRouterBaseUrlSelected, setOpenRouterBaseUrlSelected] = useState(!!apiConfiguration?.openRouterBaseUrl)
 	const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false)
 
-	const anthropicThinkingBudget = apiConfiguration?.anthropicThinking
+	const anthropicThinkingBudget = apiConfiguration?.anthropicThinking ?? THINKING_BUDGET.default
 
 	const noTransform = <T,>(value: T) => value
 	const inputEventTransform = <E,>(event: E) => (event as { target: HTMLInputElement })?.target?.value as any
@@ -1272,39 +1272,21 @@ const ApiOptions = ({
 				)}
 
 			{selectedModelInfo && selectedModelInfo.thinking && (
-				<div className="flex flex-col gap-2 mt-2">
-					<Checkbox
-						checked={!!anthropicThinkingBudget}
-						onChange={(checked) =>
-							setApiConfigurationField(
-								"anthropicThinking",
-								checked
-									? Math.min(
-											THINKING_BUDGET.default,
-											selectedModelInfo.maxTokens ?? THINKING_BUDGET.default,
-										)
-									: undefined,
-							)
-						}>
-						Thinking?
-					</Checkbox>
-					{anthropicThinkingBudget && (
-						<>
-							<div className="text-muted-foreground text-sm">
-								Number of tokens Claude is allowed to use for its internal reasoning process.
-							</div>
-							<div className="flex items-center gap-2">
-								<Slider
-									min={THINKING_BUDGET.min}
-									max={(selectedModelInfo.maxTokens ?? THINKING_BUDGET.default) - 1}
-									step={THINKING_BUDGET.step}
-									value={[anthropicThinkingBudget]}
-									onValueChange={(value) => setApiConfigurationField("anthropicThinking", value[0])}
-								/>
-								<div className="w-12">{anthropicThinkingBudget}</div>
-							</div>
-						</>
-					)}
+				<div className="flex flex-col gap-1 mt-2">
+					<div className="font-medium">Thinking Budget</div>
+					<div className="flex items-center gap-1">
+						<Slider
+							min={THINKING_BUDGET.min}
+							max={(selectedModelInfo.maxTokens ?? THINKING_BUDGET.default) - 1}
+							step={THINKING_BUDGET.step}
+							value={[anthropicThinkingBudget]}
+							onValueChange={(value) => setApiConfigurationField("anthropicThinking", value[0])}
+						/>
+						<div className="w-12 text-sm text-center">{anthropicThinkingBudget}</div>
+					</div>
+					<div className="text-muted-foreground text-sm">
+						Number of tokens Claude is allowed to use for its internal reasoning process.
+					</div>
 				</div>
 			)}
 


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

- Use the `thinking` params that OpenRouter is temporarily supporting
- Break Claude 3.7 Sonnet out into two separate models for the Anthropic provider
- Get rid of the "Thinking" checkbox, and always show the Thinking Budget for thinking models

<img width="493" alt="Screenshot 2025-02-25 at 3 47 42 PM" src="https://github.com/user-attachments/assets/46ea2e45-6e71-41d6-b6ff-3b42c91f7d9a" />

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [ ] My code follows the patterns of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Support 'thinking' params for OpenRouter, split Claude 3.7 Sonnet into two models, and always show Thinking Budget for thinking models.
> 
>   - **Behavior**:
>     - Passes `thinking` params to OpenRouter in `openrouter.ts`.
>     - Splits `claude-3-7-sonnet` into two models in `anthropic.ts` and `api.ts`.
>     - Always displays Thinking Budget slider in `ApiOptions.tsx` for thinking models.
>   - **Models**:
>     - Adds `claude-3-7-sonnet:thinking` model in `api.ts` with specific attributes.
>   - **UI**:
>     - Removes "Thinking" checkbox in `ApiOptions.tsx` and directly shows Thinking Budget slider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 33fd3bd6b35caafce66fcd53b9070f60279fcc0d. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->