### PR TITLE
Stop removing commas from terminal output

### DIFF
--- a/.changeset/sour-parents-hug.md
+++ b/.changeset/sour-parents-hug.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Stop removing commas from terminal output

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -110,9 +110,6 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 					data = lines.join("\n")
 				}
 
-				// FIXME: right now it seems that data chunks returned to us from the shell integration stream contains random commas, which from what I can tell is not the expected behavior. There has to be a better solution here than just removing all commas.
-				data = data.replace(/,/g, "")
-
 				// 2. Set isHot depending on the command
 				// Set to hot to stall API requests until terminal is cool again
 				this.isHot = true


### PR DESCRIPTION
Per https://github.com/cline/cline/issues/274 - this issue has been driving me nuts!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Stops removing commas from terminal output in `TerminalProcess` class.
> 
>   - **Behavior**:
>     - Stops removing commas from terminal output in `TerminalProcess` class in `TerminalProcess.ts` by deleting `data.replace(/,/g, "")`.
>   - **Misc**:
>     - Adds changeset `sour-parents-hug.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5c5bf8502094fb87397eebadda89acd3512dcf84. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->