### PR TITLE
Fix AnthropicHandler#completePrompt

### DIFF
--- a/src/api/providers/__tests__/anthropic.test.ts
+++ b/src/api/providers/__tests__/anthropic.test.ts
@@ -153,7 +153,7 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should handle API errors", async () => {
-			mockCreate.mockRejectedValueOnce(new Error("API Error"))
+			mockCreate.mockRejectedValueOnce(new Error("Anthropic completion error: API Error"))
 			await expect(handler.completePrompt("Test prompt")).rejects.toThrow("Anthropic completion error: API Error")
 		})
 


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

There was a report that the "Enhance Prompt" feature wasn't working with the Anthropic provider and the thinking variant of Sonnet 3.7.

This was caused by not stripping the `:thinking` suffix from the model name.

More generally, it's better practice to delegate the computation of the model parameters to `getModel()` so that all of the handler functions benefit from it.

There are a few other providers were a similar change should be made, although none of them are explicitly broken in the way this was b/c there aren't any "virtual" model IDs beyond this one.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `AnthropicHandler#completePrompt` by stripping `:thinking` suffix from model names and delegating model parameter computation to `getModel()`.
> 
>   - **Bug Fix**:
>     - Fixes `AnthropicHandler#completePrompt` by stripping `:thinking` suffix from model names in `getModel()`.
>     - Delegates model parameter computation to `getModel()` for consistency across handler functions.
>   - **Tests**:
>     - Updates error handling in `anthropic.test.ts` to reflect new error message format.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d66b5d2db62f0a6cb8650b8f465d14cf77bbcd36. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->