### PR TITLE
Revert "Stop removing commas from terminal output"

### DIFF
--- a/.changeset/sour-parents-hug.md
+++ b/.changeset/sour-parents-hug.md
@@ -1,5 +1,0 @@
----
-"roo-cline": patch
----
-
-Stop removing commas from terminal output

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -110,6 +110,9 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 					data = lines.join("\n")
 				}
 
+				// FIXME: right now it seems that data chunks returned to us from the shell integration stream contains random commas, which from what I can tell is not the expected behavior. There has to be a better solution here than just removing all commas.
+				data = data.replace(/,/g, "")
+
 				// 2. Set isHot depending on the command
 				// Set to hot to stall API requests until terminal is cool again
 				this.isHot = true


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#1228

Cursor is still on 1.96.2 and this is fixed in 1.97.2 😞 