### PR TITLE
Add gpt-4.5-preview

### DIFF
--- a/.changeset/flat-avocados-carry.md
+++ b/.changeset/flat-avocados-carry.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add gpt-4.5-preview

--- a/src/api/providers/__tests__/openai-native.test.ts
+++ b/src/api/providers/__tests__/openai-native.test.ts
@@ -357,7 +357,7 @@ describe("OpenAiNativeHandler", () => {
 			const modelInfo = handler.getModel()
 			expect(modelInfo.id).toBe(mockOptions.apiModelId)
 			expect(modelInfo.info).toBeDefined()
-			expect(modelInfo.info.maxTokens).toBe(4096)
+			expect(modelInfo.info.maxTokens).toBe(16384)
 			expect(modelInfo.info.contextWindow).toBe(128_000)
 		})
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -678,8 +678,16 @@ export const openAiNativeModels = {
 		inputPrice: 1.1,
 		outputPrice: 4.4,
 	},
+	"gpt-4.5-preview": {
+		maxTokens: 16_384,
+		contextWindow: 128_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 75,
+		outputPrice: 150,
+	},
 	"gpt-4o": {
-		maxTokens: 4_096,
+		maxTokens: 16_384,
 		contextWindow: 128_000,
 		supportsImages: true,
 		supportsPromptCache: false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add `gpt-4.5-preview` model and update `gpt-4o` max tokens in OpenAI Native models.
> 
>   - **Models**:
>     - Add `gpt-4.5-preview` to `openAiNativeModels` in `api.ts` with 16,384 max tokens, 128,000 context window, supports images, and specific pricing.
>     - Update `gpt-4o` max tokens to 16,384 in `api.ts`.
>   - **Tests**:
>     - Update `openai-native.test.ts` to expect `maxTokens` of 16,384 for `gpt-4o`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e7769cea574b7608557bb91e160d4e3f7e123c42. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->