### PR TITLE
allow shift+click to bypass delete confirmation prompt

### DIFF
--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -227,7 +227,12 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 											title="Delete Task"
 											onClick={(e) => {
 												e.stopPropagation()
-												setDeleteTaskId(item.id)
+												if (e.shiftKey) {
+													// directly delete without prompting if shift is pressed
+													vscode.postMessage({ type: "deleteTaskWithId", text: item.id })
+												} else {
+													setDeleteTaskId(item.id)
+												}
 											}}>
 											<span className="codicon codicon-trash" />
 											{item.size && prettyBytes(item.size)}

--- a/webview-ui/src/components/history/__tests__/HistoryView.test.tsx
+++ b/webview-ui/src/components/history/__tests__/HistoryView.test.tsx
@@ -135,26 +135,54 @@ describe("HistoryView", () => {
 		})
 	})
 
-	it("handles task deletion", async () => {
-		const onDone = jest.fn()
-		render(<HistoryView onDone={onDone} />)
+	describe("task deletion", () => {
+		it("shows confirmation dialog on regular click", () => {
+			const onDone = jest.fn()
+			render(<HistoryView onDone={onDone} />)
 
-		// Find and hover over first task
-		const taskContainer = screen.getByTestId("virtuoso-item-1")
-		fireEvent.mouseEnter(taskContainer)
+			// Find and hover over first task
+			const taskContainer = screen.getByTestId("virtuoso-item-1")
+			fireEvent.mouseEnter(taskContainer)
 
-		// Click delete button to open confirmation dialog
-		const deleteButton = within(taskContainer).getByTitle("Delete Task")
-		fireEvent.click(deleteButton)
+			// Click delete button to open confirmation dialog
+			const deleteButton = within(taskContainer).getByTitle("Delete Task")
+			fireEvent.click(deleteButton)
 
-		// Find and click the confirm delete button in the dialog
-		const confirmDeleteButton = screen.getByRole("button", { name: /delete/i })
-		fireEvent.click(confirmDeleteButton)
+			// Verify dialog is shown
+			const dialog = screen.getByRole("alertdialog")
+			expect(dialog).toBeInTheDocument()
 
-		// Verify vscode message was sent
-		expect(vscode.postMessage).toHaveBeenCalledWith({
-			type: "deleteTaskWithId",
-			text: "1",
+			// Find and click the confirm delete button in the dialog
+			const confirmDeleteButton = within(dialog).getByRole("button", { name: /delete/i })
+			fireEvent.click(confirmDeleteButton)
+
+			// Verify vscode message was sent
+			expect(vscode.postMessage).toHaveBeenCalledWith({
+				type: "deleteTaskWithId",
+				text: "1",
+			})
+		})
+
+		it("deletes immediately on shift-click without confirmation", () => {
+			const onDone = jest.fn()
+			render(<HistoryView onDone={onDone} />)
+
+			// Find and hover over first task
+			const taskContainer = screen.getByTestId("virtuoso-item-1")
+			fireEvent.mouseEnter(taskContainer)
+
+			// Shift-click delete button
+			const deleteButton = within(taskContainer).getByTitle("Delete Task")
+			fireEvent.click(deleteButton, { shiftKey: true })
+
+			// Verify no dialog is shown
+			expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument()
+
+			// Verify vscode message was sent
+			expect(vscode.postMessage).toHaveBeenCalledWith({
+				type: "deleteTaskWithId",
+				text: "1",
+			})
 		})
 	})
 


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description
It's incredibly annoying to have to go through a prompt if you want to bulk delete chats. This PR allows shift-clicking the delete button to bypass the prompt. Regular clicking will still show the prompt.

## Type of change

<!-- Please ignore options that are not relevant -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->
I updated `HistoryView.test.tsx` with tests for regular clicking and shift clicking. Used Jest to run it, 11 out of 11 tests pass.

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context
My first PR here, please lmk if any changes are needed.
<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

#854 #1100 #1245
<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Shift-clicking the delete button in `HistoryView` now bypasses the confirmation dialog, allowing immediate task deletion.
> 
>   - **Behavior**:
>     - In `HistoryView.tsx`, shift-clicking the delete button bypasses the confirmation dialog and deletes the task immediately.
>     - Regular click still shows the confirmation dialog.
>   - **Testing**:
>     - `HistoryView.test.tsx` updated with tests for both regular and shift-click delete actions.
>     - Tests ensure correct message is sent to `vscode` and dialog behavior is as expected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for caaac26ae806b1658ca88a4f6a782bc29175174f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->