### PR TITLE
Fix maxTokens defaults for Claude 3.7 Sonnet models

### DIFF
--- a/.changeset/tasty-grapes-suffer.md
+++ b/.changeset/tasty-grapes-suffer.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix maxTokens defaults for Claude 3.7 Sonnet models

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -278,7 +278,7 @@ export async function getOpenRouterModels() {
 					modelInfo.supportsPromptCache = true
 					modelInfo.cacheWritesPrice = 3.75
 					modelInfo.cacheReadsPrice = 0.3
-					modelInfo.maxTokens = 64_000
+					modelInfo.maxTokens = rawModel.id === "anthropic/claude-3.7-sonnet:thinking" ? 64_000 : 16_384
 					break
 				case rawModel.id.startsWith("anthropic/claude-3.5-sonnet-20240620"):
 					modelInfo.supportsPromptCache = true

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -111,7 +111,7 @@ export const anthropicModels = {
 		thinking: true,
 	},
 	"claude-3-7-sonnet-20250219": {
-		maxTokens: 64_000,
+		maxTokens: 16_384,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,
@@ -437,7 +437,7 @@ export type VertexModelId = keyof typeof vertexModels
 export const vertexDefaultModelId: VertexModelId = "claude-3-7-sonnet@20250219"
 export const vertexModels = {
 	"claude-3-7-sonnet@20250219:thinking": {
-		maxTokens: 64000,
+		maxTokens: 64_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,
@@ -449,7 +449,7 @@ export const vertexModels = {
 		thinking: true,
 	},
 	"claude-3-7-sonnet@20250219": {
-		maxTokens: 8192,
+		maxTokens: 16_384,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -7,7 +7,6 @@ import * as vscodemodels from "vscode"
 import {
 	ApiConfiguration,
 	ModelInfo,
-	ApiProvider,
 	anthropicDefaultModelId,
 	anthropicModels,
 	azureOpenAiDefaultApiVersion,
@@ -1385,7 +1384,6 @@ const ApiOptions = ({
 						apiConfiguration={apiConfiguration}
 						setApiConfigurationField={setApiConfigurationField}
 						modelInfo={selectedModelInfo}
-						provider={selectedProvider as ApiProvider}
 					/>
 					<ModelInfoView
 						selectedModelId={selectedModelId}

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo } from "react"
-import { ApiProvider } from "../../../../src/shared/api"
+
 import { Slider } from "@/components/ui"
 
 import { ApiConfiguration, ModelInfo } from "../../../../src/shared/api"
@@ -8,16 +8,10 @@ interface ThinkingBudgetProps {
 	apiConfiguration: ApiConfiguration
 	setApiConfigurationField: <K extends keyof ApiConfiguration>(field: K, value: ApiConfiguration[K]) => void
 	modelInfo?: ModelInfo
-	provider?: ApiProvider
 }
 
-export const ThinkingBudget = ({
-	apiConfiguration,
-	setApiConfigurationField,
-	modelInfo,
-	provider,
-}: ThinkingBudgetProps) => {
-	const tokens = apiConfiguration?.modelMaxTokens || modelInfo?.maxTokens || 64_000
+export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, modelInfo }: ThinkingBudgetProps) => {
+	const tokens = apiConfiguration?.modelMaxTokens || 16_384
 	const tokensMin = 8192
 	const tokensMax = modelInfo?.maxTokens || 64_000
 

--- a/webview-ui/src/components/settings/__tests__/ApiOptions.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/ApiOptions.test.tsx
@@ -92,7 +92,6 @@ describe("ApiOptions", () => {
 			})
 
 			expect(screen.getByTestId("thinking-budget")).toBeInTheDocument()
-			expect(screen.getByTestId("thinking-budget")).toHaveAttribute("data-provider", "anthropic")
 		})
 
 		it("should show ThinkingBudget for Vertex models that support thinking", () => {
@@ -104,7 +103,6 @@ describe("ApiOptions", () => {
 			})
 
 			expect(screen.getByTestId("thinking-budget")).toBeInTheDocument()
-			expect(screen.getByTestId("thinking-budget")).toHaveAttribute("data-provider", "vertex")
 		})
 
 		it("should not show ThinkingBudget for models that don't support thinking", () => {

--- a/webview-ui/src/components/settings/__tests__/ThinkingBudget.test.tsx
+++ b/webview-ui/src/components/settings/__tests__/ThinkingBudget.test.tsx
@@ -1,7 +1,6 @@
-import React from "react"
 import { render, screen, fireEvent } from "@testing-library/react"
 import { ThinkingBudget } from "../ThinkingBudget"
-import { ApiProvider, ModelInfo } from "../../../../../src/shared/api"
+import { ModelInfo } from "../../../../../src/shared/api"
 
 // Mock Slider component
 jest.mock("@/components/ui", () => ({
@@ -25,11 +24,11 @@ describe("ThinkingBudget", () => {
 		supportsPromptCache: true,
 		supportsImages: true,
 	}
+
 	const defaultProps = {
 		apiConfiguration: {},
 		setApiConfigurationField: jest.fn(),
 		modelInfo: mockModelInfo,
-		provider: "anthropic" as ApiProvider,
 	}
 
 	beforeEach(() => {
@@ -60,7 +59,7 @@ describe("ThinkingBudget", () => {
 		expect(screen.getAllByTestId("slider")).toHaveLength(2)
 	})
 
-	it("should use modelMaxThinkingTokens field for Anthropic provider", () => {
+	it("should update modelMaxThinkingTokens", () => {
 		const setApiConfigurationField = jest.fn()
 
 		render(
@@ -68,25 +67,6 @@ describe("ThinkingBudget", () => {
 				{...defaultProps}
 				apiConfiguration={{ modelMaxThinkingTokens: 4096 }}
 				setApiConfigurationField={setApiConfigurationField}
-				provider="anthropic"
-			/>,
-		)
-
-		const sliders = screen.getAllByTestId("slider")
-		fireEvent.change(sliders[1], { target: { value: "5000" } })
-
-		expect(setApiConfigurationField).toHaveBeenCalledWith("modelMaxThinkingTokens", 5000)
-	})
-
-	it("should use modelMaxThinkingTokens field for Vertex provider", () => {
-		const setApiConfigurationField = jest.fn()
-
-		render(
-			<ThinkingBudget
-				{...defaultProps}
-				apiConfiguration={{ modelMaxThinkingTokens: 4096 }}
-				setApiConfigurationField={setApiConfigurationField}
-				provider="vertex"
 			/>,
 		)
 


### PR DESCRIPTION
<!-- **Note:** Consider creating PRs as a DRAFT. For early feedback and self-review. -->

## Description

Claude 3.7 Sonnet should always use 16K as the `maxTokens`
Claude 3.7 Sonnet (Thinking) should default to 16K, but go up to 64K if desired.

## Type of change

<!-- Please ignore options that are not relevant -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes -->

## Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply -->

- [x] My code follows the patterns of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Additional context

<!-- Add any other context or screenshots about the pull request here -->

## Related Issues

<!-- List any related issues here. Use the GitHub issue linking syntax: #issue-number -->

## Reviewers

<!-- @mention specific team members or individuals who should review this PR -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix `maxTokens` defaults for Claude 3.7 Sonnet models, ensuring correct values for standard and thinking variants.
> 
>   - **Behavior**:
>     - Fix `maxTokens` default for `Claude 3.7 Sonnet` to 16,384 in `api.ts` and `openrouter.ts`.
>     - Set `maxTokens` to 64,000 for `Claude 3.7 Sonnet:thinking` in `openrouter.ts`.
>   - **UI Components**:
>     - Remove `provider` prop from `ThinkingBudget` and `ApiOptions` components.
>     - Update `ThinkingBudget` to use 16,384 as default `maxTokens`.
>   - **Tests**:
>     - Update `ApiOptions.test.tsx` and `ThinkingBudget.test.tsx` to reflect changes in `ThinkingBudget` component behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 31d2d17847abdb30cf1f7430aa5ef63df9f3eea9. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->