### PR TITLE
Make configuration profile drop-down alpha order

### DIFF
--- a/.changeset/few-impalas-flow.md
+++ b/.changeset/few-impalas-flow.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+small function that alphabetizes the configuration profile names in the dropdown

--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -15,6 +15,10 @@ interface ApiConfigManagerProps {
 	onUpsertConfig: (configName: string) => void
 }
 
+const sortConfigOptions = (configs: ApiConfigMeta[]) => {
+	return [...configs].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+}
+
 const ApiConfigManager = ({
 	currentApiConfigName = "",
 	listApiConfigMeta = [],
@@ -225,7 +229,7 @@ const ApiConfigManager = ({
 									zIndex: 1002,
 								}}
 								role="combobox"
-								options={listApiConfigMeta.map((config) => ({
+								options={sortConfigOptions(listApiConfigMeta).map((config) => ({
 									value: config.name,
 									label: config.name,
 								}))}


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->
I got tired of seeing all my configuration profile names not being alphabetized and hard to easily find what I wanted so I made a very small function to sort the drop-down into alphabetical order.  Works for display, after new entry, rename entry and delete.  

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->
very small function created:

```
const sortConfigOptions = (configs: ApiConfigMeta[]) => {
	return [...configs].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
}
```

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->
Load the extension and look at your drop-down list of configuration profile names

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
I am CFDude!