### PR TITLE
Add a 5k token buffer before the end of the context window

### DIFF
--- a/src/core/sliding-window/index.ts
+++ b/src/core/sliding-window/index.ts
@@ -3,7 +3,8 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { Tiktoken } from "js-tiktoken/lite"
 import o200kBase from "js-tiktoken/ranks/o200k_base"
 
-const TOKEN_FUDGE_FACTOR = 1.5
+export const TOKEN_FUDGE_FACTOR = 1.5
+export const TOKEN_BUFFER = 5000
 
 /**
  * Counts tokens for user content using tiktoken for text
@@ -110,5 +111,6 @@ export function truncateConversationIfNeeded({
 	const allowedTokens = contextWindow - reservedTokens
 
 	// Determine if truncation is needed and apply if necessary
-	return effectiveTokens < allowedTokens ? messages : truncateConversation(messages, 0.5)
+	// Truncate if we're within TOKEN_BUFFER of the limit
+	return effectiveTokens > allowedTokens - TOKEN_BUFFER ? truncateConversation(messages, 0.5) : messages
 }


### PR DESCRIPTION
## Context

Follow-up on #1275 to give more of a buffer, just because it's currently so painful to recover from the case where you go beyond the context window and tiktoken is not an exact estimate.

## Implementation

This truncates when you're within 5,000 tokens of the end of the window.

## How to Test

Get a conversation near the end and confirm you never make it to within 5,000 tokens of the end of the window.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a 5,000 token buffer in `index.ts` to prevent exceeding the context window, with updated tests in `sliding-window.test.ts`.
> 
>   - **Behavior**:
>     - Adds `TOKEN_BUFFER` constant in `index.ts` to introduce a 5,000 token buffer before the context window limit.
>     - Modifies `truncateConversationIfNeeded()` in `index.ts` to truncate messages if within `TOKEN_BUFFER` of the token limit.
>   - **Tests**:
>     - Updates `sliding-window.test.ts` to reflect new buffer logic, ensuring truncation occurs when within 5,000 tokens of the limit.
>     - Adds test case in `sliding-window.test.ts` to verify truncation when tokens are within `TOKEN_BUFFER` of the threshold.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 764d963c104be512187ee9cb600029952c58d0a0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->