### PR TITLE
Add a dynamic token buffer

### DIFF
--- a/.changeset/swift-lamps-decide.md
+++ b/.changeset/swift-lamps-decide.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add a dynamic token buffer

--- a/src/core/sliding-window/index.ts
+++ b/src/core/sliding-window/index.ts
@@ -4,7 +4,10 @@ import { Tiktoken } from "js-tiktoken/lite"
 import o200kBase from "js-tiktoken/ranks/o200k_base"
 
 export const TOKEN_FUDGE_FACTOR = 1.5
-export const TOKEN_BUFFER = 5000
+/**
+ * Default percentage of the context window to use as a buffer when deciding when to truncate
+ */
+export const TOKEN_BUFFER_PERCENTAGE = 0.1
 
 /**
  * Counts tokens for user content using tiktoken for text
@@ -108,9 +111,9 @@ export function truncateConversationIfNeeded({
 	const effectiveTokens = totalTokens + lastMessageTokens
 
 	// Calculate available tokens for conversation history
-	const allowedTokens = contextWindow - reservedTokens
+	// Truncate if we're within TOKEN_BUFFER_PERCENTAGE of the context window
+	const allowedTokens = contextWindow * (1 - TOKEN_BUFFER_PERCENTAGE) - reservedTokens
 
 	// Determine if truncation is needed and apply if necessary
-	// Truncate if we're within TOKEN_BUFFER of the limit
-	return effectiveTokens > allowedTokens - TOKEN_BUFFER ? truncateConversation(messages, 0.5) : messages
+	return effectiveTokens > allowedTokens ? truncateConversation(messages, 0.5) : messages
 }


### PR DESCRIPTION
## Context

Follow-up to #1289 - in my testing I saw Gemini go over the 1M limit.

## Implementation

Seems like we don't need to let it get within 5k of 1M, so I changed this to use 10% of the context window. 6.4k for Deepseek, 20k for Claude, 100k for Gemini. This is all short term until we do something smarter.

## How to Test

Get close to the end of the context window.