### PR TITLE
Add type='module' to webview script

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -509,7 +509,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
           <body>
             <noscript>You need to enable JavaScript to run this app.</noscript>
             <div id="root"></div>
-            <script nonce="${nonce}" src="${scriptUri}"></script>
+            <script nonce="${nonce}" type="module" src="${scriptUri}"></script>
           </body>
         </html>
       `


### PR DESCRIPTION
## Context

![Screenshot 2025-03-01 at 8 42 57 PM](https://github.com/user-attachments/assets/a1fa183a-6ef8-457a-a9db-c2467f345953)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `type='module'` to the `<script>` tag in `ClineProvider.ts` to ensure the script is treated as a module.
> 
>   - **HTML Content**:
>     - Add `type='module'` to the `<script>` tag in `ClineProvider.ts` to ensure the script is treated as a module.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e6a49ddc5c5154d82e9c20dbfe18d5dc99ee7ff2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->