### PR TITLE
feat: add x-title and http-referer header to all openai providers

### DIFF
--- a/.changeset/wise-pears-join.md
+++ b/.changeset/wise-pears-join.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Improved observability of openai compatible APIs, by sending x-title and http-referer headers, as per Open Router standard.

--- a/src/api/providers/__tests__/openai.test.ts
+++ b/src/api/providers/__tests__/openai.test.ts
@@ -90,6 +90,20 @@ describe("OpenAiHandler", () => {
 			})
 			expect(handlerWithCustomUrl).toBeInstanceOf(OpenAiHandler)
 		})
+
+		it("should set default headers correctly", () => {
+			// Get the mock constructor from the jest mock system
+			const openAiMock = jest.requireMock("openai").default
+
+			expect(openAiMock).toHaveBeenCalledWith({
+				baseURL: expect.any(String),
+				apiKey: expect.any(String),
+				defaultHeaders: {
+					"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
+					"X-Title": "Roo Code",
+				},
+			})
+		})
 	})
 
 	describe("createMessage", () => {

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -16,9 +16,13 @@ import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { BaseProvider } from "./base-provider"
 
 const DEEP_SEEK_DEFAULT_TEMPERATURE = 0.6
-export interface OpenAiHandlerOptions extends ApiHandlerOptions {
-	defaultHeaders?: Record<string, string>
+
+export const defaultHeaders = {
+	"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
+	"X-Title": "Roo Code",
 }
+
+export interface OpenAiHandlerOptions extends ApiHandlerOptions {}
 
 export class OpenAiHandler extends BaseProvider implements SingleCompletionHandler {
 	protected options: OpenAiHandlerOptions
@@ -47,9 +51,10 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				baseURL,
 				apiKey,
 				apiVersion: this.options.azureApiVersion || azureOpenAiDefaultApiVersion,
+				defaultHeaders,
 			})
 		} else {
-			this.client = new OpenAI({ baseURL, apiKey, defaultHeaders: this.options.defaultHeaders })
+			this.client = new OpenAI({ baseURL, apiKey, defaultHeaders })
 		}
 	}
 

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -13,6 +13,7 @@ import { convertToR1Format } from "../transform/r1-format"
 import { DEEP_SEEK_DEFAULT_TEMPERATURE } from "./constants"
 import { getModelParams, SingleCompletionHandler } from ".."
 import { BaseProvider } from "./base-provider"
+import { defaultHeaders } from "./openai"
 
 // Add custom interface for OpenRouter params.
 type OpenRouterChatCompletionParams = OpenAI.Chat.ChatCompletionCreateParams & {
@@ -36,11 +37,6 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 
 		const baseURL = this.options.openRouterBaseUrl || "https://openrouter.ai/api/v1"
 		const apiKey = this.options.openRouterApiKey ?? "not-provided"
-
-		const defaultHeaders = {
-			"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-			"X-Title": "Roo Code",
-		}
 
 		this.client = new OpenAI({ baseURL, apiKey, defaultHeaders })
 	}

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -16,10 +16,6 @@ export class RequestyHandler extends OpenAiHandler {
 			openAiModelId: options.requestyModelId ?? requestyDefaultModelId,
 			openAiBaseUrl: "https://router.requesty.ai/v1",
 			openAiCustomModelInfo: options.requestyModelInfo ?? requestyModelInfoSaneDefaults,
-			defaultHeaders: {
-				"HTTP-Referer": "https://github.com/RooVetGit/Roo-Cline",
-				"X-Title": "Roo Code",
-			},
 		})
 	}
 


### PR DESCRIPTION
## Context

 - Provides the ability for Open AI compatible gateways, such as LiteLLM, Open Router, Requesty to determine originating app.
 - Uses standard set by Open Router.
 
 See https://discord.com/channels/1332146336664915968/1332148077263458385/1344252789077053463 for discussion.

## Implementation

 - Defaulted these headers in base openai provider, removed in subclassed providers.

## Screenshots

| before | after |
| ------ | ----- |
|    headers not set    |    <img width="515" alt="Screenshot 2025-03-02 at 12 44 56 PM" src="https://github.com/user-attachments/assets/ed56ef89-5db2-4bdb-9773-805d0f71c91d" />   |

## How to Test

1. Enable proxy on system
2. Run Roo in debug mode and view headers in proxy
3. Headers should be set for any "Open AI Compatible", "Requesty", or "Open Router" provider.

 - I have tested this locally using the above approach using an "Open AI Compatible" provider
 - I have also regression tested Requesty and Open Router providers.

## Get in Touch

 * @refactorthis on discord

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `x-title` and `http-referer` headers to OpenAI providers for improved observability and standardization.
> 
>   - **Behavior**:
>     - Adds `x-title` and `http-referer` headers to all OpenAI providers in `openai.ts`.
>     - Removes redundant header settings in `openrouter.ts` and `requesty.ts`.
>   - **Testing**:
>     - Adds test in `openai.test.ts` to verify default headers are set correctly.
>   - **Misc**:
>     - Updates `.changeset/wise-pears-join.md` to document the change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 23fcd69d6ffbb08d67dde338f12cad4aeb89a5f2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->