### PR TITLE
Alphabetical sort of the api configuration menu in ChatTextArea

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -874,16 +874,18 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									width: "100%",
 									textOverflow: "ellipsis",
 								}}>
-								{(listApiConfigMeta || []).map((config) => (
-									<option
-										key={config.name}
-										value={config.name}
-										style={{
-											...optionStyle,
-										}}>
-										{config.name}
-									</option>
-								))}
+								{(listApiConfigMeta || [])
+									.sort((a, b) => a.name.localeCompare(b.name))
+									.map((config) => (
+										<option
+											key={config.name}
+											value={config.name}
+											style={{
+												...optionStyle,
+											}}>
+											{config.name}
+										</option>
+									))}
 								<option
 									disabled
 									style={{


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->
I added an alphabetical sort on the listApiConfigMeta so the API configurations menu in TaskChat would be in alphabetical order.

## Implementation

`.sort((a, b) => a.name.localeCompare(b.name))`

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Load the extension and click the API configuration menu in task chat to see your profiles alphabetized (as they should be).
<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
I am CFDude!