### PR TITLE
Include custom modes in mode switching keyboard shortcut

### DIFF
--- a/.changeset/honest-queens-pump.md
+++ b/.changeset/honest-queens-pump.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Include custom modes in mode switching keyboard shortcut

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -28,7 +28,7 @@ import TaskHeader from "./TaskHeader"
 import AutoApproveMenu from "./AutoApproveMenu"
 import { AudioType } from "../../../../src/shared/WebviewMessage"
 import { validateCommand } from "../../utils/command-validation"
-import { modes } from "../../../../src/shared/modes"
+import { getAllModes } from "../../../../src/shared/modes"
 
 interface ChatViewProps {
 	isHidden: boolean
@@ -60,6 +60,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		setMode,
 		autoApprovalEnabled,
 		alwaysAllowModeSwitch,
+		customModes,
 	} = useExtensionState()
 
 	//const task = messages.length > 0 ? (messages[0].say === "task" ? messages[0] : undefined) : undefined) : undefined
@@ -967,12 +968,13 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		isWriteToolAction,
 	])
 
-	// Add this new function to handle mode switching
+	// Function to handle mode switching
 	const switchToNextMode = useCallback(() => {
-		const currentModeIndex = modes.findIndex((m) => m.slug === mode)
-		const nextModeIndex = (currentModeIndex + 1) % modes.length
-		setMode(modes[nextModeIndex].slug)
-	}, [mode, setMode])
+		const allModes = getAllModes(customModes)
+		const currentModeIndex = allModes.findIndex((m) => m.slug === mode)
+		const nextModeIndex = (currentModeIndex + 1) % allModes.length
+		setMode(allModes[nextModeIndex].slug)
+	}, [mode, setMode, customModes])
 
 	// Add keyboard event handler
 	const handleKeyDown = useCallback(


### PR DESCRIPTION
## Context

Fast follow on #1270 to also include custom modes when keyboard cycling.

## Implementation

We already have access to extension state - just pull the customModes out of it.

## How to Test

Create a custom mode and cycle through
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Include custom modes in mode switching keyboard shortcut in `ChatView.tsx` by updating `switchToNextMode` to use `getAllModes`.
> 
>   - **Behavior**:
>     - Include custom modes in mode switching via keyboard shortcut in `ChatView.tsx`.
>     - `switchToNextMode` function updated to use `getAllModes(customModes)`.
>     - Keyboard event handler updated to call `switchToNextMode()` on `Ctrl + .` or `⌘ + .`.
>   - **Imports**:
>     - Replace `modes` import with `getAllModes` in `ChatView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cd910c3435e978a0bf64854f2736c39bce1f09fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->