### PR TITLE
Clearer instructions for read-only modes that can run commands

### DIFF
--- a/.changeset/proud-melons-appear.md
+++ b/.changeset/proud-melons-appear.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Support read-only modes that can run commands

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -3334,7 +3334,7 @@ export class Cline {
 		) {
 			const currentModeName = getModeBySlug(currentMode, customModes)?.name ?? currentMode
 			const defaultModeName = getModeBySlug(defaultModeSlug, customModes)?.name ?? defaultModeSlug
-			details += `\n\nNOTE: You are currently in '${currentModeName}' mode which only allows read-only operations. To write files or execute commands, the user will need to switch to '${defaultModeName}' mode. Note that only the user can switch modes.`
+			details += `\n\nNOTE: You are currently in '${currentModeName}' mode, which does not allow write operations. To write files, the user will need to switch to a mode that supports file writing, such as '${defaultModeName}' mode.`
 		}
 
 		if (includeFileDetails) {


### PR DESCRIPTION
## Context

Playing around with a code review mode that I wanted to be able to run commands but not read files, I noticed that it refused to run commands because of its instructions.

## Implementation

I just tweaked the prompt to be more specific about abilities.

## How to Test

Make a mode that can run commands but not edit files, and ask it to run a command.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Clarifies in `Cline.ts` that read-only modes can execute commands but not write files.
> 
>   - **Behavior**:
>     - Updated prompt in `Cline.ts` to clarify that read-only modes can execute commands but not write files.
>   - **Misc**:
>     - Added changeset file `proud-melons-appear.md` to document the support for read-only modes that can run commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 41b0ddecb4024db697c2e41a6eb71849c7741b9b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->