### PR TITLE
fix(chat-area): dynamic sizing for select options

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -510,16 +510,27 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			setIsMouseDownOnMenu(true)
 		}, [])
 
-		// Utility function to estimate text width
+		// Utility function to accurately measure text width
 		const estimateTextWidth = useCallback((text: string, fontSize: number = 11): number => {
-			// Approximate character width based on font size (in pixels)
-			const avgCharWidth = fontSize * 0.6
+			// Create a hidden canvas for text measurement
+			const canvas = document.createElement("canvas")
+			const context = canvas.getContext("2d")
 
-			// Add extra space for the caret icon and padding
+			if (!context) {
+				// Fallback if canvas context is not available
+				return text.length * 6 + 30
+			}
+
+			// Set the font to match our select element
+			context.font = `${fontSize}px system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif`
+
+			// Measure the text width
+			const metrics = context.measureText(text)
+
+			// Add padding for the caret icon and select element padding
 			const paddingWidth = 30
 
-			// Calculate estimated width
-			return text.length * avgCharWidth + paddingWidth
+			return Math.ceil(metrics.width) + paddingWidth
 		}, [])
 
 		// Update mode select width when mode changes


### PR DESCRIPTION
# Dynamic Select Box Sizing in ChatTextArea

https://github.com/user-attachments/assets/e2c5014c-ce53-4f34-a47c-a5e093e130cc

## Context

This PR implements dynamic sizing for select boxes in the ChatTextArea component. Previously, the Mode selector and API Configuration selector had fixed widths, which could lead to text truncation with longer options and inefficient space usage with shorter options. This change makes the select boxes resize based on the selected option's text length, improving readability and user experience.

## Implementation

The implementation adds dynamic width calculation for both select boxes:

1. Added state variables to track the widths of both select boxes:
   ```typescript
   const [modeSelectWidth, setModeSelectWidth] = useState(70) // Default min width for mode select
   const [apiSelectWidth, setApiSelectWidth] = useState(100) // Default min width for API config select
   ```

2. Created a utility function to estimate text width based on character count:
   ```typescript
   const estimateTextWidth = useCallback((text: string, fontSize: number = 11): number => {
     // Approximate character width based on font size (in pixels)
     const avgCharWidth = fontSize * 0.6
     
     // Add extra space for the caret icon and padding
     const paddingWidth = 30
     
     // Calculate estimated width
     return text.length * avgCharWidth + paddingWidth
   }, [])
   ```

3. Added useEffect hooks to update the widths when selections change:
   - One for the Mode selector that updates when `mode` changes
   - One for the API Configuration selector that updates when `currentApiConfigName` changes

4. Added smooth transitions for width changes:
   ```typescript
   transition: "width 0.2s ease-in-out"
   ```

5. Applied calculated widths to both select boxes with appropriate min/max constraints:
   - Mode selector: min 70px, max 200px
   - API Configuration selector: min 100px, max 250px

This approach ensures that select boxes are always appropriately sized for their content, improving readability while maintaining a clean UI.

## Screenshots

| before | after |
| ------ | ----- |
| Select boxes have fixed widths, causing text truncation and some wasted space | Select boxes dynamically resize based on content, showing full text |

## How to Test

1. Open the Roo Code extension in VS Code
2. Open the chat panel
3. Try selecting different modes from the dropdown - notice how the width adjusts based on the selected mode name
4. Try selecting different API configurations - notice how the width adjusts based on the selected configuration name
5. Verify that transitions between different widths are smooth and not jarring

## Get in Touch

I'm available in the Roo Code Discord as @monotykamary
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Dynamic sizing for select boxes in `ChatTextArea.tsx` to prevent text truncation and optimize space usage.
> 
>   - **Behavior**:
>     - Dynamic sizing for `Mode` and `API Configuration` select boxes in `ChatTextArea.tsx` based on text length.
>     - Prevents text truncation and optimizes space usage.
>   - **Implementation**:
>     - Added state variables `modeSelectWidth` and `apiSelectWidth` to track select box widths.
>     - Created `estimateTextWidth` utility function to calculate text width.
>     - Added `useEffect` hooks to update widths when `mode` or `currentApiConfigName` changes.
>     - Applied smooth transitions for width changes with `transition: "width 0.2s ease-in-out"`.
>     - Set min/max width constraints: Mode (70px-200px), API Config (100px-250px).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1f20d49615bd49e0299d8805377f9bfd7491f846. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->