### PR TITLE
style(task-header): add padding to align task header values

### DIFF
--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -415,7 +415,7 @@ const ContextWindowProgress = ({ contextWindow, contextTokens }: { contextWindow
 		<div className="flex items-center gap-1 flex-shrink-0">
 			<span className="font-bold">Context Window:</span>
 		</div>
-		<div className="flex items-center gap-2 flex-1 whitespace-nowrap">
+		<div className="flex items-center gap-2 flex-1 whitespace-nowrap px-2">
 			<div>{formatLargeNumber(contextTokens)}</div>
 			<div className="flex items-center gap-[3px] flex-1">
 				<div className="flex-1 h-1 rounded-[2px] overflow-hidden bg-[color-mix(in_srgb,var(--vscode-badge-foreground)_20%,transparent)]">


### PR DESCRIPTION
## Context

The context window display in the TaskHeader component had inconsistent padding compared to other elements in the chat area. This PR adds horizontal padding to properly align the context window elements with the surrounding UI elements, improving visual consistency across the component.

## Implementation

The change is straightforward - I've added a `px-2` class to the context window container div to provide consistent horizontal padding. This ensures the content is properly aligned with other elements in the TaskHeader component and creates a more polished appearance.

```
<div className="flex items-center gap-2 flex-1 whitespace-nowrap px-2">
```

## Screenshots

**Before:**

<img width="613" alt="image" src="https://github.com/user-attachments/assets/c0f02e10-57ac-4d35-a173-c77a7d273c8b" />

**After:**

<img width="616" alt="image" src="https://github.com/user-attachments/assets/40021cb4-ebcf-418d-b3fb-cd3f750cdae7" />


## How to Test

- Open the VS Code extension
- Start a new chat task
- Examine the context window display in the TaskHeader
- Verify that the context window numbers have proper horizontal padding
- Check that the alignment looks consistent with other elements in the header

-->

## Get in Touch

If you have any questions about this change, please reach out to me on the [Roo Code Discord](https://discord.gg/roocode). My handle is `@monotykamary`.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `px-2` class to `ContextWindowProgress` in `TaskHeader.tsx` for consistent padding.
> 
>   - **Style Update**:
>     - Adds `px-2` class to `div` in `ContextWindowProgress` in `TaskHeader.tsx` for consistent horizontal padding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7a2a08aaa4979e79f945e539b30daa6b49c3fb14. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->