### PR TITLE
Default middle-out compression to on

### DIFF
--- a/.changeset/weak-cameras-hope.md
+++ b/.changeset/weak-cameras-hope.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Default middle-out compression to on for OpenRouter

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -114,7 +114,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			stream: true,
 			include_reasoning: true,
 			// This way, the transforms field will only be included in the parameters when openRouterUseMiddleOutTransform is true.
-			...(this.options.openRouterUseMiddleOutTransform && { transforms: ["middle-out"] }),
+			...((this.options.openRouterUseMiddleOutTransform ?? true) && { transforms: ["middle-out"] }),
 		}
 
 		const stream = await this.client.chat.completions.create(completionParams)

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2430,6 +2430,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			autoApprovalEnabled: autoApprovalEnabled ?? false,
 			customModes,
 			maxOpenTabsContext: maxOpenTabsContext ?? 20,
+			openRouterUseMiddleOutTransform: openRouterUseMiddleOutTransform ?? true,
 		}
 	}
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -498,7 +498,7 @@ const ApiOptions = ({
 								/>
 							)}
 							<Checkbox
-								checked={apiConfiguration?.openRouterUseMiddleOutTransform || false}
+								checked={apiConfiguration?.openRouterUseMiddleOutTransform ?? true}
 								onChange={handleInputChange("openRouterUseMiddleOutTransform", noTransform)}>
 								Compress prompts and message chains to the context size (
 								<a href="https://openrouter.ai/docs/transforms">OpenRouter Transforms</a>)


### PR DESCRIPTION
## Context

Related to the other PRs around trying to do a better job of context window management - one thing I realized is that [middle-out compression](https://openrouter.ai/docs/features/message-transforms) is off by default for OpenRouter. Since it's a last line of defense after we fail to fit the conversation within the context window, I don't see any reason not to default it to on.

## Implementation

I turned it on by default for new users.

## How to Test

Clear your state and go through the setup as a new user.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Default middle-out compression to on for OpenRouter, affecting new users.
> 
>   - **Behavior**:
>     - Default middle-out compression to `on` for OpenRouter in `openrouter.ts`, `ClineProvider.ts`, and `ApiOptions.tsx`.
>     - Affects new users; existing users retain their settings.
>   - **Implementation**:
>     - In `openrouter.ts`, set `openRouterUseMiddleOutTransform` to `true` by default.
>     - In `ClineProvider.ts`, update `openRouterUseMiddleOutTransform` default to `true` in state management.
>     - In `ApiOptions.tsx`, update checkbox default to `true` for middle-out compression.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9b91ab21b6447eaba420fb2f585a24e243322e06. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->