### PR TITLE
feat: update virtual id for extended output 128k claude

### DIFF
--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -92,6 +92,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 
 						// Then check for models that support prompt caching
 						switch (modelId) {
+							case "claude-3-7-sonnet-20250219":
 							case "claude-3-5-sonnet-20241022":
 							case "claude-3-5-haiku-20241022":
 							case "claude-3-opus-20240229":

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -86,7 +86,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 						const betas = []
 
 						// Check for the thinking-128k variant first
-						if (virtualId === "claude-3-7-sonnet-20250219:thinking-128k") {
+						if (virtualId === "claude-3-7-sonnet-20250219:thinking") {
 							betas.push("output-128k-2025-02-19")
 						}
 
@@ -201,7 +201,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		// The `:thinking` variant is a virtual identifier for the
 		// `claude-3-7-sonnet-20250219` model with a thinking budget.
 		// We can handle this more elegantly in the future.
-		if (id === "claude-3-7-sonnet-20250219:thinking" || id === "claude-3-7-sonnet-20250219:thinking-128k") {
+		if (id === "claude-3-7-sonnet-20250219:thinking") {
 			id = "claude-3-7-sonnet-20250219"
 		}
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -98,20 +98,8 @@ export interface ModelInfo {
 export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-3-7-sonnet-20250219"
 export const anthropicModels = {
-	"claude-3-7-sonnet-20250219:thinking-128k": {
-		maxTokens: 128_000,
-		contextWindow: 200_000,
-		supportsImages: true,
-		supportsComputerUse: true,
-		supportsPromptCache: true,
-		inputPrice: 3.0, // $3 per million input tokens
-		outputPrice: 15.0, // $15 per million output tokens
-		cacheWritesPrice: 3.75, // $3.75 per million tokens
-		cacheReadsPrice: 0.3, // $0.30 per million tokens
-		thinking: true,
-	},
 	"claude-3-7-sonnet-20250219:thinking": {
-		maxTokens: 64_000,
+		maxTokens: 128_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -98,6 +98,18 @@ export interface ModelInfo {
 export type AnthropicModelId = keyof typeof anthropicModels
 export const anthropicDefaultModelId: AnthropicModelId = "claude-3-7-sonnet-20250219"
 export const anthropicModels = {
+	"claude-3-7-sonnet-20250219:thinking-128k": {
+		maxTokens: 128_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsComputerUse: true,
+		supportsPromptCache: true,
+		inputPrice: 3.0, // $3 per million input tokens
+		outputPrice: 15.0, // $15 per million output tokens
+		cacheWritesPrice: 3.75, // $3.75 per million tokens
+		cacheReadsPrice: 0.3, // $0.30 per million tokens
+		thinking: true,
+	},
 	"claude-3-7-sonnet-20250219:thinking": {
 		maxTokens: 64_000,
 		contextWindow: 200_000,


### PR DESCRIPTION
## Context

Added support for Claude 3.7 Sonnet with both thinking and 128k output capacity through an existing variant: `claude-3-7-sonnet-20250219:thinking`. This enhancement provides users with access to the extended output capabilities of Claude 3.7 while maintaining thinking functionality.

## Implementation

The implementation required changes in several key areas:

1. Updated model definition in `anthropicModels` in `api.ts` for the 128k
2. Enhanced the `getModel()` method to track the original "virtual" model ID alongside the actual model ID
3. Added header support for the 128k output capability using the `anthropic-beta: output-128k-2025-02-19` header

I maintained a consistent pattern for handling feature-specific headers by implementing the same header selection logic across all API methods. This keeps the code maintainable while supporting both prompt caching and extended output capabilities.

## Screenshots

| before | after |
| ------ | ----- |
| Only standard Claude 3.7 Sonnet with thinking was available | Users can now select Claude 3.7 Sonnet with thinking and 128k output capacity |

<img width="613" alt="image" src="https://github.com/user-attachments/assets/baeafb80-9a5a-4e70-b862-63bb61aaaacb" />

## How to Test

1. Set your model to `claude-3-7-sonnet-20250219:thinking-128k` in your configuration
2. Generate a response that requires a large output (e.g., ask for a comprehensive analysis of a complex topic)
3. Verify that:
   - The model correctly uses the thinking capability
   - The model can generate responses beyond the standard 64k token limit
   - All API calls (streaming, completion, token counting) work correctly

## Get in Touch

I'm available on the Roo Code Discord as `@monotykamary` if you have any questions!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates `claude-3-7-sonnet-20250219:thinking` model variant with 128k output capacity and updates header handling for extended output capabilities.
> 
>   - **Behavior**:
>     - Updates `claude-3-7-sonnet-20250219:thinking` model variant in `anthropicModels` in `api.ts` with 128k output capacity.
>     - Updates `getModel()` in `anthropic.ts` to track `virtualId` for special variant handling.
>     - Adds header `anthropic-beta: output-128k-2025-02-19` for 128k output capability in `createMessage`.
>   - **Misc**:
>     - Ensures consistent header application across all API calls for prompt caching and extended output capabilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for aec03d71c36e938822cff825927b78fc1f96b9d2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->