### PR TITLE
fix: switch mode state

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -973,7 +973,12 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 		const allModes = getAllModes(customModes)
 		const currentModeIndex = allModes.findIndex((m) => m.slug === mode)
 		const nextModeIndex = (currentModeIndex + 1) % allModes.length
+		// Update local state and notify extension to sync mode change
 		setMode(allModes[nextModeIndex].slug)
+		vscode.postMessage({
+			type: "mode",
+			text: allModes[nextModeIndex].slug,
+		})
 	}, [mode, setMode, customModes])
 
 	// Add keyboard event handler


### PR DESCRIPTION
## Context

Fix the issue where the profile does not change when switching modes.

## Implementation

notify extension to sync mode change

## Screenshots

after 
<img width="420" alt="image" src="https://github.com/user-attachments/assets/73ad9903-8645-4679-90a4-da67544a675a" />


## How to Test

When using shortcut keys, observe the changes in the profile.

## Get in Touch


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes mode switching issue in `ChatView.tsx` by updating local state and notifying extension to sync mode change.
> 
>   - **Behavior**:
>     - Fixes issue where profile does not change when switching modes in `ChatView.tsx`.
>     - Updates local state and notifies extension to sync mode change in `switchToNextMode` function.
>   - **Implementation**:
>     - Adds `vscode.postMessage` call to send mode change notification in `switchToNextMode`.
>     - Handles mode switching via keyboard shortcut (Command/Ctrl + .).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 62677071e8b27bb4c0bf21eee9f2cbfd46e15568. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->