### PR TITLE
Support 128k max tokens for openrouter and vertex thinking

### DIFF
--- a/src/api/providers/__tests__/openrouter.test.ts
+++ b/src/api/providers/__tests__/openrouter.test.ts
@@ -72,7 +72,7 @@ describe("OpenRouterHandler", () => {
 			openRouterModelId: "test-model",
 			openRouterModelInfo: {
 				...mockOpenRouterModelInfo,
-				maxTokens: 64_000,
+				maxTokens: 128_000,
 				thinking: true,
 			},
 			modelMaxTokens: 32_768,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -263,7 +263,7 @@ export async function getOpenRouterModels() {
 					modelInfo.supportsPromptCache = true
 					modelInfo.cacheWritesPrice = 3.75
 					modelInfo.cacheReadsPrice = 0.3
-					modelInfo.maxTokens = rawModel.id === "anthropic/claude-3.7-sonnet:thinking" ? 64_000 : 16_384
+					modelInfo.maxTokens = rawModel.id === "anthropic/claude-3.7-sonnet:thinking" ? 128_000 : 16_384
 					break
 				case rawModel.id.startsWith("anthropic/claude-3.5-sonnet-20240620"):
 					modelInfo.supportsPromptCache = true

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -477,7 +477,7 @@ export const vertexModels = {
 		outputPrice: 5,
 	},
 	"claude-3-7-sonnet@20250219:thinking": {
-		maxTokens: 64_000,
+		maxTokens: 128_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,


### PR DESCRIPTION
#1327 for OpenRouter and Vertex too @cte @monotykamary
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase `maxTokens` to 128,000 for `anthropic/claude-3.7-sonnet:thinking` in OpenRouter API and update tests accordingly.
> 
>   - **Behavior**:
>     - Increase `maxTokens` to 128,000 for `anthropic/claude-3.7-sonnet:thinking` in `openrouter.ts` and `openrouter.test.ts`.
>   - **Tests**:
>     - Update `OpenRouterHandler` test in `openrouter.test.ts` to reflect new `maxTokens` limit.
>   - **Implementation**:
>     - Modify `getOpenRouterModels()` in `openrouter.ts` to set `maxTokens` to 128,000 for `anthropic/claude-3.7-sonnet:thinking`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 63cecf8b22b91b0d2b3e78277eda9e424768d394. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->