### PR TITLE
Exclude MCP from system prompt if mode does not support it

### DIFF
--- a/.changeset/fluffy-pumpkins-sip.md
+++ b/.changeset/fluffy-pumpkins-sip.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Exclude MCP instructions from the prompt if the mode doesn't support MCP


### PR DESCRIPTION
## Context

https://github.com/RooVetGit/Roo-Code/discussions/1000

## Implementation

If MCP isn't supported by the mode, exclude that part of the prompt.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Exclude MCP instructions from prompts in `system.ts` if the mode does not support MCP.
> 
>   - **Behavior**:
>     - In `generatePrompt` in `system.ts`, exclude MCP instructions if the mode does not support MCP by checking `modeConfig.groups`.
>   - **Misc**:
>     - Add `getGroupName` import in `system.ts` to facilitate MCP support check.
>     - Add changeset file `fluffy-pumpkins-sip.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 003cd1bce172bc5caf1e64925e83fd5c71fac5c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->