### PR TITLE
Set Vertex maxTokens to 64000

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -477,7 +477,7 @@ export const vertexModels = {
 		outputPrice: 5,
 	},
 	"claude-3-7-sonnet@20250219:thinking": {
-		maxTokens: 128_000,
+		maxTokens: 64_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,


### PR DESCRIPTION
## Context

Follow-up to #1338 - it turns out that vertex can't handle more than 64k.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `maxTokens` to 64,000 for `claude-3-7-sonnet@20250219:thinking` in `vertexModels` to comply with Vertex AI's limit.
> 
>   - **Behavior**:
>     - Update `maxTokens` for `claude-3-7-sonnet@20250219:thinking` in `vertexModels` from 128,000 to 64,000 to comply with Vertex AI's 64k limit.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for af06af136c045fa8bfcb56f894fdf22751fd531f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->