### PR TITLE
API provider: Choose specific provider when using OpenRouter

### DIFF
--- a/.changeset/lovely-jeans-worry.md
+++ b/.changeset/lovely-jeans-worry.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": minor
+---
+
+API provider: Choose specific provider when using OpenRouter

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 coverage/
 
 .DS_Store
+.history/
 
 # Builds
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules
 coverage/
 
 .DS_Store
+.history/
+.aider*
 
 # Builds
 bin/

--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,6 @@ node_modules
 coverage/
 
 .DS_Store
-.history/
-.aider*
 
 # Builds
 bin/

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -113,7 +113,6 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			include_reasoning: true,
 			// Only include provider if openRouterSpecificProvider is not "[default]".
 			...(this.options.openRouterSpecificProvider &&
-				this.options.openRouterSpecificProvider !== "" &&
 				this.options.openRouterSpecificProvider !== OPENROUTER_DEFAULT_PROVIDER_NAME && {
 					provider: { order: [this.options.openRouterSpecificProvider] },
 				}),

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -15,6 +15,8 @@ import { getModelParams, SingleCompletionHandler } from ".."
 import { BaseProvider } from "./base-provider"
 import { defaultHeaders } from "./openai"
 
+const OPENROUTER_DEFAULT_PROVIDER_NAME = "[default]"
+
 // Add custom interface for OpenRouter params.
 type OpenRouterChatCompletionParams = OpenAI.Chat.ChatCompletionCreateParams & {
 	transforms?: string[]
@@ -109,6 +111,12 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			messages: openAiMessages,
 			stream: true,
 			include_reasoning: true,
+			// Only include provider if openRouterSpecificProvider is not "[default]".
+			...(this.options.openRouterSpecificProvider &&
+				this.options.openRouterSpecificProvider !== "" &&
+				this.options.openRouterSpecificProvider !== OPENROUTER_DEFAULT_PROVIDER_NAME && {
+					provider: { order: [this.options.openRouterSpecificProvider] },
+				}),
 			// This way, the transforms field will only be included in the parameters when openRouterUseMiddleOutTransform is true.
 			...((this.options.openRouterUseMiddleOutTransform ?? true) && { transforms: ["middle-out"] }),
 		}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -94,6 +94,7 @@ export const API_CONFIG_KEYS: GlobalStateKey[] = [
 	"openRouterModelId",
 	"openRouterModelInfo",
 	"openRouterBaseUrl",
+	"openRouterSpecificProvider",
 	"awsRegion",
 	"awsUseCrossRegionInference",
 	// "awsUsePromptCache", // NOT exist on GlobalStateKey

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -30,6 +30,7 @@ export interface ApiHandlerOptions {
 	openRouterModelId?: string
 	openRouterModelInfo?: ModelInfo
 	openRouterBaseUrl?: string
+	openRouterSpecificProvider?: string
 	awsAccessKey?: string
 	awsSecretKey?: string
 	awsSessionToken?: string

--- a/src/shared/globalState.ts
+++ b/src/shared/globalState.ts
@@ -56,6 +56,7 @@ export const GLOBAL_STATE_KEYS = [
 	"openRouterModelId",
 	"openRouterModelInfo",
 	"openRouterBaseUrl",
+	"openRouterSpecificProvider",
 	"openRouterUseMiddleOutTransform",
 	"allowedCommands",
 	"soundEnabled",

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -1266,7 +1266,7 @@ const ApiOptions = ({
 				<>
 					<div className="dropdown-container" style={{ marginTop: 3 }}>
 						<label htmlFor="openrouter-specific-provider" className="font-medium">
-							Provider (more infos on{" "}
+							Provider (more info at{" "}
 							<a href={`https://openrouter.ai/${selectedModelId}/providers`}>OpenRouter</a>)
 						</label>
 						<Dropdown

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -221,7 +221,7 @@ const ApiOptions = ({
 			const currentModelInfoString = JSON.stringify(apiConfiguration.openRouterModelInfo)
 			const targetModelInfoString = JSON.stringify(targetModelInfo)
 
-			if (currentModelInfoString !== targetModelInfoString) {
+			if (targetModelInfoString && currentModelInfoString !== targetModelInfoString) {
 				setApiConfigurationField("openRouterModelInfo", targetModelInfo)
 			}
 		}
@@ -1266,7 +1266,8 @@ const ApiOptions = ({
 				<>
 					<div className="dropdown-container" style={{ marginTop: 3 }}>
 						<label htmlFor="openrouter-specific-provider" className="font-medium">
-							Provider
+							Provider (more infos on{" "}
+							<a href={`https://openrouter.ai/${selectedModelId}/providers`}>OpenRouter</a>)
 						</label>
 						<Dropdown
 							id="openrouter-specific-provider"

--- a/webview-ui/src/utils/openrouter-helper.ts
+++ b/webview-ui/src/utils/openrouter-helper.ts
@@ -1,0 +1,56 @@
+import axios from "axios"
+import { ModelInfo } from "../../../src/shared/api"
+import { parseApiPrice } from "../../../src/utils/cost"
+
+export const OPENROUTER_DEFAULT_PROVIDER_NAME = "[default]"
+export async function getOpenRouterProvidersForModel(modelId: string) {
+	const models: Record<string, ModelInfo> = {}
+
+	try {
+		const response = await axios.get(`https://openrouter.ai/api/v1/models/${modelId}/endpoints`)
+		const rawEndpoints = response.data.data
+
+		for (const rawEndpoint of rawEndpoints.endpoints) {
+			const modelInfo: ModelInfo = {
+				maxTokens: rawEndpoint.max_completion_tokens,
+				contextWindow: rawEndpoint.context_length,
+				supportsImages: rawEndpoints.architecture?.modality?.includes("image"),
+				supportsPromptCache: false,
+				inputPrice: parseApiPrice(rawEndpoint.pricing?.prompt),
+				outputPrice: parseApiPrice(rawEndpoint.pricing?.completion),
+				description: rawEndpoints.description,
+				thinking: modelId === "anthropic/claude-3.7-sonnet:thinking",
+			}
+
+			// Set additional properties based on model type
+			switch (true) {
+				case modelId.startsWith("anthropic/claude-3.7-sonnet"):
+					modelInfo.supportsComputerUse = true
+					modelInfo.supportsPromptCache = true
+					modelInfo.cacheWritesPrice = 3.75
+					modelInfo.cacheReadsPrice = 0.3
+					modelInfo.maxTokens = rawEndpoint.id === "anthropic/claude-3.7-sonnet:thinking" ? 64_000 : 16_384
+					break
+				case modelId.startsWith("anthropic/claude-3.5-sonnet-20240620"):
+					modelInfo.supportsPromptCache = true
+					modelInfo.cacheWritesPrice = 3.75
+					modelInfo.cacheReadsPrice = 0.3
+					modelInfo.maxTokens = 8192
+					break
+				// Add other cases as needed
+				default:
+					modelInfo.supportsPromptCache = true
+					modelInfo.cacheWritesPrice = 0.3
+					modelInfo.cacheReadsPrice = 0.03
+					break
+			}
+
+			const providerName = rawEndpoint.name.split("|")[0].trim()
+			models[providerName] = modelInfo
+		}
+	} catch (error) {
+		console.error(`Error fetching OpenRouter providers:`, error)
+	}
+
+	return models
+}


### PR DESCRIPTION
## Context

In OpenRouter, for the same model it's possible to use different providers.
By default, OpenRouter choose by itslef regarding the price and the availability.
For some models, different providers have different properties, like the context window or the speed.

![image](https://github.com/user-attachments/assets/a256841b-99e9-45f7-812a-e2ef6eb52f70)

This PR aims to let the user choose the provider he wants to use.

Solves https://github.com/RooVetGit/Roo-Code/discussions/663

## Implementation
- Add a function `getOpenRouterProvidersForModel` in a new file `webview-ui\src\utils\openrouter-helper.ts` to get all providers available for a specific model, using [OpenRouter API)[https://openrouter.ai/docs/api-reference/list-endpoints-for-a-model].
- Add a list of providers in the `webview-ui\src\components\settings\ApiOptions.tsx` (only when OpenRouter is selected).
- Add a parameter `openRouterSpecificProvider` in the options to store the choice made by the user.
- When the provider is changed, `ApiConfiguration` is updated with the new price / context window.
- When a request is made in `createMessage` of `src\api\providers\openrouter.ts`, if a specific provider is asked, we add the [corresponding parameter](https://openrouter.ai/docs/features/provider-routing) (`order` and `allow_fallbacks`) in the query.

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/2f7d5347-2033-44f6-a57d-fcc265b72e6e) | ![image](https://github.com/user-attachments/assets/ef4b9559-a5ff-4a67-8c08-8a064363b7ae)|
| Price and context are the default ones | Price and context are updated |

## How to Test

- Go to Roo Code settings.
- Use "OpenRouter" as API Provider.
- Select model `qwen/qwen-2.5-coder-32b-instruct` and keep default value.
- Save and close.
- Make a query.
➡️ context window will be of 33k


- Go to Roo Code settings.
- Use "OpenRouter" as API Provider.
- Select model `qwen/qwen-2.5-coder-32b-instruct`.
- In the provider list, choose `Groq`.
- Save and close.
- Make a query.
➡️ context window will be of 128k
➡️ answer will be blazing fast

- Go to [Activity Dashbord](https://openrouter.ai/activity) in your OpenRouter account.
➡️ Your two requests will have a different provider, cost and speed.



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to select specific providers for OpenRouter models, allowing customization of model properties like context window and pricing.
> 
>   - **Behavior**:
>     - Adds `getOpenRouterProvidersForModel` in `openrouter-helper.ts` to fetch providers for a model.
>     - Updates `ApiOptions.tsx` to include a dropdown for selecting OpenRouter providers.
>     - Modifies `createMessage` in `openrouter.ts` to include provider parameters if specified.
>   - **State Management**:
>     - Adds `openRouterSpecificProvider` to `ApiHandlerOptions` in `api.ts`.
>     - Updates `ClineProvider.ts` to handle `openRouterSpecificProvider` in global state.
>   - **UI**:
>     - Updates `ApiOptions.tsx` to display provider options with context and pricing details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0d8020391c8505cbfaa7ed4b1474f0abc03bce99. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->