### PR TITLE
Fix issues with select dropdown

### DIFF
--- a/webview-ui/src/components/ui/__tests__/select-dropdown.test.tsx
+++ b/webview-ui/src/components/ui/__tests__/select-dropdown.test.tsx
@@ -115,6 +115,21 @@ describe("SelectDropdown", () => {
 		expect(trigger.classList.toString()).toContain("custom-trigger-class")
 	})
 
+	it("ensures open state is controlled via props", () => {
+		// Test that the component accepts and uses the open state controlled prop
+		render(<SelectDropdown value="option1" options={options} onChange={onChangeMock} />)
+
+		// The component should render the dropdown root with correct props
+		const dropdown = screen.getByTestId("dropdown-root")
+		expect(dropdown).toBeInTheDocument()
+
+		// Verify trigger and content are rendered
+		const trigger = screen.getByTestId("dropdown-trigger")
+		const content = screen.getByTestId("dropdown-content")
+		expect(trigger).toBeInTheDocument()
+		expect(content).toBeInTheDocument()
+	})
+
 	// Tests for the new functionality
 	describe("Option types", () => {
 		it("renders separator options correctly", () => {
@@ -125,20 +140,6 @@ describe("SelectDropdown", () => {
 			]
 
 			render(<SelectDropdown value="option1" options={optionsWithTypedSeparator} onChange={onChangeMock} />)
-
-			// Check for separator
-			const separators = screen.getAllByTestId("dropdown-separator")
-			expect(separators.length).toBe(1)
-		})
-
-		it("renders string separator (backward compatibility) correctly", () => {
-			const optionsWithStringSeparator = [
-				{ value: "option1", label: "Option 1" },
-				{ value: "sep-1", label: "────", disabled: true },
-				{ value: "option2", label: "Option 2" },
-			]
-
-			render(<SelectDropdown value="option1" options={optionsWithStringSeparator} onChange={onChangeMock} />)
 
 			// Check for separator
 			const separators = screen.getAllByTestId("dropdown-separator")


### PR DESCRIPTION
## Context

Found a couple issues when playing around with #1329 
- If you went to another tab when the dropdown was open, it would jump to the top left
- Clicking outside didn't close the dropdowns
- We still had logic looking for a fixed string separator

## Implementation

- Fixed the main issue by specifying the portal to use
- Added `onEscapeKeyDown` and `onInteractOutside` handlers
- Removed the old code

## Screenshots

Before:

![Screenshot 2025-03-04 at 3 23 19 PM](https://github.com/user-attachments/assets/7ff72484-0a7d-49b9-b8e8-78e5211f4a8e)

After: Goes away
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `SelectDropdown` issues by adding event handlers for closing dropdown and removing outdated string separator logic.
> 
>   - **Behavior**:
>     - Adds `onEscapeKeyDown` and `onInteractOutside` handlers in `select-dropdown.tsx` to close dropdown on escape key or outside interaction.
>     - Removes logic for string separator handling in `select-dropdown.tsx`.
>   - **Tests**:
>     - Adds test for controlled open state in `select-dropdown.test.tsx`.
>     - Removes test for string separator in `select-dropdown.test.tsx`.
>   - **Misc**:
>     - Uses `useEffect` to set `portalContainer` for dropdown rendering in `select-dropdown.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 74d52aafcb0dca322a1d781a115ebd11d634ac10. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->