### PR TITLE
Revert "Better encapsulation for API config"

### DIFF
--- a/src/core/contextProxy.ts
+++ b/src/core/contextProxy.ts
@@ -1,7 +1,6 @@
 import * as vscode from "vscode"
 import { logger } from "../utils/logging"
-import { ApiConfiguration, API_CONFIG_KEYS } from "../shared/api"
-import { GLOBAL_STATE_KEYS, SECRET_KEYS, GlobalStateKey, SecretKey } from "../shared/globalState"
+import { GLOBAL_STATE_KEYS, SECRET_KEYS } from "../shared/globalState"
 
 export class ContextProxy {
 	private readonly originalContext: vscode.ExtensionContext
@@ -83,6 +82,7 @@ export class ContextProxy {
 	getSecret(key: string): string | undefined {
 		return this.secretCache.get(key)
 	}
+
 	storeSecret(key: string, value?: string): Thenable<void> {
 		// Update cache
 		this.secretCache.set(key, value)
@@ -92,63 +92,5 @@ export class ContextProxy {
 		} else {
 			return this.originalContext.secrets.store(key, value)
 		}
-	}
-
-	/**
-	 * Gets a complete ApiConfiguration object by fetching values
-	 * from both global state and secrets storage
-	 */
-	getApiConfiguration(): ApiConfiguration {
-		// Create an empty ApiConfiguration object
-		const config: ApiConfiguration = {}
-
-		// Add all API-related keys from global state
-		for (const key of API_CONFIG_KEYS) {
-			const value = this.getGlobalState(key)
-			if (value !== undefined) {
-				// Use type assertion to avoid TypeScript error
-				;(config as any)[key] = value
-			}
-		}
-
-		// Add all secret values
-		for (const key of SECRET_KEYS) {
-			const value = this.getSecret(key)
-			if (value !== undefined) {
-				// Use type assertion to avoid TypeScript error
-				;(config as any)[key] = value
-			}
-		}
-
-		// Handle special case for apiProvider if needed (same logic as current implementation)
-		if (!config.apiProvider) {
-			if (config.apiKey) {
-				config.apiProvider = "anthropic"
-			} else {
-				config.apiProvider = "openrouter"
-			}
-		}
-
-		return config
-	}
-
-	/**
-	 * Updates an ApiConfiguration by persisting each property
-	 * to the appropriate storage (global state or secrets)
-	 */
-	async updateApiConfiguration(apiConfiguration: ApiConfiguration): Promise<void> {
-		const promises: Array<Thenable<void>> = []
-
-		// For each property, update the appropriate storage
-		Object.entries(apiConfiguration).forEach(([key, value]) => {
-			if (SECRET_KEYS.includes(key as SecretKey)) {
-				promises.push(this.storeSecret(key, value))
-			} else if (API_CONFIG_KEYS.includes(key as GlobalStateKey)) {
-				promises.push(this.updateGlobalState(key, value))
-			}
-			// Ignore keys that aren't in either list
-		})
-
-		await Promise.all(promises)
 	}
 }

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -34,21 +34,6 @@ jest.mock("../../contextProxy", () => {
 				.mockImplementation((key, value) =>
 					value ? context.secrets.store(key, value) : context.secrets.delete(key),
 				),
-			getApiConfiguration: jest.fn().mockImplementation(() => ({
-				apiProvider: "openrouter",
-				// Add other common properties
-			})),
-			updateApiConfiguration: jest.fn().mockImplementation(async (apiConfiguration) => {
-				// Mock implementation that simulates updating state and secrets
-				for (const [key, value] of Object.entries(apiConfiguration)) {
-					if (key === "apiKey" || key === "openAiApiKey") {
-						context.secrets.store(key, value)
-					} else {
-						context.globalState.update(key, value)
-					}
-				}
-				return Promise.resolve()
-			}),
 			saveChanges: jest.fn().mockResolvedValue(undefined),
 			dispose: jest.fn().mockResolvedValue(undefined),
 			hasPendingChanges: jest.fn().mockReturnValue(false),
@@ -1594,51 +1579,5 @@ describe("ContextProxy integration", () => {
 		expect(mockContextProxy.getGlobalState).toBeDefined()
 		expect(mockContextProxy.updateGlobalState).toBeDefined()
 		expect(mockContextProxy.storeSecret).toBeDefined()
-		expect(mockContextProxy.getApiConfiguration).toBeDefined()
-		expect(mockContextProxy.updateApiConfiguration).toBeDefined()
-	})
-
-	test("getState uses contextProxy.getApiConfiguration", async () => {
-		// Setup mock API configuration
-		const mockApiConfig = {
-			apiProvider: "anthropic",
-			apiModelId: "claude-latest",
-			apiKey: "test-api-key",
-		}
-		mockContextProxy.getApiConfiguration.mockReturnValue(mockApiConfig)
-
-		// Get state
-		const state = await provider.getState()
-
-		// Verify getApiConfiguration was called
-		expect(mockContextProxy.getApiConfiguration).toHaveBeenCalled()
-		// Verify state has the API configuration from contextProxy
-		expect(state.apiConfiguration).toBe(mockApiConfig)
-	})
-
-	test("updateApiConfiguration uses contextProxy.updateApiConfiguration", async () => {
-		// Setup test config
-		const testApiConfig = {
-			apiProvider: "anthropic",
-			apiModelId: "claude-latest",
-			apiKey: "test-api-key",
-		}
-
-		// Mock methods needed for the test
-		provider.configManager = {
-			listConfig: jest.fn().mockResolvedValue([]),
-			setModeConfig: jest.fn(),
-		} as any
-
-		// Mock getState for mode
-		jest.spyOn(provider, "getState").mockResolvedValue({
-			mode: "code",
-		} as any)
-
-		// Call the private method - need to use any to access it
-		await (provider as any).updateApiConfiguration(testApiConfig)
-
-		// Verify contextProxy.updateApiConfiguration was called with the right config
-		expect(mockContextProxy.updateApiConfiguration).toHaveBeenCalledWith(testApiConfig)
 	})
 })


### PR DESCRIPTION
This reverts commit 86401faa37a56c0b6de706c862823601b39350f7.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts encapsulation of API configuration, removing `getApiConfiguration` and `updateApiConfiguration` methods from `ContextProxy` and adjusting related tests.
> 
>   - **Revert Changes**:
>     - Remove `getApiConfiguration` and `updateApiConfiguration` methods from `ContextProxy` in `contextProxy.ts`.
>     - Remove related tests from `contextProxy.test.ts`.
>     - Revert `ClineProvider.ts` to handle API configuration directly without `ContextProxy` methods.
>   - **Tests**:
>     - Remove tests for `getApiConfiguration` and `updateApiConfiguration` in `ClineProvider.test.ts`.
>     - Adjust tests in `ClineProvider.test.ts` to reflect direct handling of API configuration.
>   - **Misc**:
>     - Remove `ApiConfiguration` import from `contextProxy.ts` and `contextProxy.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f683e4530f8a55c7c9a8a2a8903cbcf9a4c1c87c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->