### PR TITLE
Better UX for choosing between diff strategies

### DIFF
--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -36,7 +36,7 @@ export const ExperimentalSettings = ({
 
 			<Section>
 				{Object.entries(experimentConfigsMap)
-					.filter((config) => config[0] !== "DIFF_STRATEGY")
+					.filter((config) => config[0] !== "DIFF_STRATEGY" && config[0] !== "MULTI_SEARCH_AND_REPLACE")
 					.map((config) => (
 						<ExperimentalFeature
 							key={config[0]}


### PR DESCRIPTION
## Context

As a quick follow to #1234, this adds a dropdown to settings to choose your diff strategy.

## Implementation

This reuses the experimental booleans, so a little hacky. I think probably best for now, and if this multi-diff works well maybe we just go to it for everyone and remove the option.

## Screenshots

![Screenshot 2025-03-05 at 1 00 11 PM](https://github.com/user-attachments/assets/c07783ff-e2f9-4379-88de-fe3319207383)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds a dropdown in `AdvancedSettings.tsx` for selecting diff strategies and updates `ExperimentalSettings.tsx` to exclude certain experiments.
> 
>   - **Behavior**:
>     - Adds a dropdown in `AdvancedSettings.tsx` for selecting diff strategies: `standard`, `unified`, and `multiBlock`.
>     - Resets experimental strategies when diffs are disabled.
>   - **Experimental Settings**:
>     - Updates `ExperimentalSettings.tsx` to exclude `DIFF_STRATEGY` and `MULTI_SEARCH_AND_REPLACE` from the experimental features list.
>   - **Misc**:
>     - Removes `ExperimentalFeature` related to `DIFF_STRATEGY` in `AdvancedSettings.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 57cf9610ba0f6433172d6f6c4b3f5b634454b632. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->