### PR TITLE
Missed a spot in ClineProvider

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1785,7 +1785,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			const mode = message.mode ?? defaultModeSlug
 			const customModes = await this.customModesManager.getCustomModes()
 
-			const rooIgnoreInstructions = this.cline?.rooIgnoreController?.getInstructions()
+			const rooIgnoreInstructions = this.getCurrentCline()?.rooIgnoreController?.getInstructions()
 
 			const systemPrompt = await SYSTEM_PROMPT(
 				this.context,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes retrieval of `rooIgnoreInstructions` in `generateSystemPrompt` in `ClineProvider.ts` by using `getCurrentCline()` instead of `cline`.
> 
>   - **Behavior**:
>     - Fixes retrieval of `rooIgnoreInstructions` in `generateSystemPrompt` in `ClineProvider.ts` by using `getCurrentCline()` instead of `cline`.
>   - **Misc**:
>     - No other changes or additions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fb53d331cc947b8136f9aaf3dc39382e30420751. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->