### PR TITLE
fix(deepseek): update base URL to remove /v1 endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Roo Code (prev. Roo Cline)",
 	"description": "A whole dev team of AI agents in your editor.",
 	"publisher": "RooVeterinaryInc",
-	"version": "3.7.12",
+	"version": "3.7.13",
 	"icon": "assets/icons/rocket.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/src/api/providers/__tests__/deepseek.test.ts
+++ b/src/api/providers/__tests__/deepseek.test.ts
@@ -72,7 +72,7 @@ describe("DeepSeekHandler", () => {
 		mockOptions = {
 			deepSeekApiKey: "test-api-key",
 			apiModelId: "deepseek-chat",
-			deepSeekBaseUrl: "https://api.deepseek.com/v1",
+			deepSeekBaseUrl: "https://api.deepseek.com",
 		}
 		handler = new DeepSeekHandler(mockOptions)
 		mockCreate.mockClear()
@@ -110,7 +110,7 @@ describe("DeepSeekHandler", () => {
 			// The base URL is passed to OpenAI client internally
 			expect(OpenAI).toHaveBeenCalledWith(
 				expect.objectContaining({
-					baseURL: "https://api.deepseek.com/v1",
+					baseURL: "https://api.deepseek.com",
 				}),
 			)
 		})

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -8,7 +8,7 @@ export class DeepSeekHandler extends OpenAiHandler {
 			...options,
 			openAiApiKey: options.deepSeekApiKey ?? "not-provided",
 			openAiModelId: options.apiModelId ?? deepSeekDefaultModelId,
-			openAiBaseUrl: options.deepSeekBaseUrl ?? "https://api.deepseek.com/v1",
+			openAiBaseUrl: options.deepSeekBaseUrl ?? "https://api.deepseek.com",
 			openAiStreamingEnabled: true,
 			includeMaxTokens: true,
 		})


### PR DESCRIPTION
Fixed Deepseek provider
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `DeepSeekHandler` to use new base URL without `/v1` and increment version to `3.7.13`.
> 
>   - **Behavior**:
>     - Update `DeepSeekHandler` in `deepseek.ts` to use base URL `https://api.deepseek.com` instead of `https://api.deepseek.com/v1`.
>     - Update tests in `deepseek.test.ts` to reflect the new base URL.
>   - **Versioning**:
>     - Increment version in `package.json` from `3.7.12` to `3.7.13`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 35643a38eaa2865e8d59ad5b006e828cb79de1c5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->