### PR TITLE
Adds Unbound metadata for non-streaming requests

### DIFF
--- a/src/api/providers/__tests__/unbound.test.ts
+++ b/src/api/providers/__tests__/unbound.test.ts
@@ -192,6 +192,11 @@ describe("UnboundHandler", () => {
 					temperature: 0,
 					max_tokens: 8192,
 				}),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						"X-Unbound-Metadata": expect.stringContaining("roo-code"),
+					}),
+				}),
 			)
 		})
 
@@ -232,6 +237,11 @@ describe("UnboundHandler", () => {
 					model: "gpt-4o",
 					messages: [{ role: "user", content: "Test prompt" }],
 					temperature: 0,
+				}),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						"X-Unbound-Metadata": expect.stringContaining("roo-code"),
+					}),
 				}),
 			)
 			expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("max_tokens")

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -147,6 +147,7 @@ export class UnboundHandler extends BaseProvider implements SingleCompletionHand
 
 	async completePrompt(prompt: string): Promise<string> {
 		try {
+			console.log("completePrompt running in Unbound: ", prompt)
 			const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
 				model: this.getModel().id.split("/")[1],
 				messages: [{ role: "user", content: prompt }],
@@ -157,7 +158,18 @@ export class UnboundHandler extends BaseProvider implements SingleCompletionHand
 				requestOptions.max_tokens = this.getModel().info.maxTokens
 			}
 
-			const response = await this.client.chat.completions.create(requestOptions)
+			const response = await this.client.chat.completions.create(requestOptions, {
+				headers: {
+					"X-Unbound-Metadata": JSON.stringify({
+						labels: [
+							{
+								key: "app",
+								value: "roo-code",
+							},
+						],
+					}),
+				},
+			})
 			return response.choices[0]?.message.content || ""
 		} catch (error) {
 			if (error instanceof Error) {

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -147,7 +147,6 @@ export class UnboundHandler extends BaseProvider implements SingleCompletionHand
 
 	async completePrompt(prompt: string): Promise<string> {
 		try {
-			console.log("completePrompt running in Unbound: ", prompt)
 			const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
 				model: this.getModel().id.split("/")[1],
 				messages: [{ role: "user", content: prompt }],


### PR DESCRIPTION
## Context
Adds a custom header to requests to track the origin of the request. Streaming requests already contain the custom header. This change is to add the same for non-streaming requests.
<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation
Added a custom header "X-Unbound-Metadata" which has the application name "roo-code". This is used to track the origin of the requests.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test
Modified test files to verify the presence of custom header.
<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `X-Unbound-Metadata` header to non-streaming requests in `UnboundHandler` to track request origin.
> 
>   - **Behavior**:
>     - Adds custom header `X-Unbound-Metadata` with app name `roo-code` to non-streaming requests in `UnboundHandler`.
>     - Header was already present in streaming requests.
>   - **Tests**:
>     - Updates `unbound.test.ts` to verify presence of `X-Unbound-Metadata` header in both streaming and non-streaming requests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4073bdcb20c8635f58e1d867504674dffd479d22. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->