### PR TITLE
Handle outputless commands

### DIFF
--- a/.changeset/wise-bats-perform.md
+++ b/.changeset/wise-bats-perform.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Handle outputless commands

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -971,6 +971,12 @@ export class Cline {
 			await this.say("shell_integration_warning")
 		})
 
+		process.once("stream_stalled", async (id: number) => {
+			if (id === terminalInfo.id && !didContinue) {
+				sendCommandOutput("")
+			}
+		})
+
 		await process
 
 		// Wait for a short delay to ensure all messages are sent to the webview.

--- a/src/integrations/terminal/__tests__/TerminalProcess.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalProcess.test.ts
@@ -20,6 +20,9 @@ jest.mock("vscode", () => ({
 	ThemeIcon: jest.fn(),
 }))
 
+const TERMINAL_OUTPUT_LIMIT = 100 * 1024
+const STALL_TIMEOUT = 100
+
 describe("TerminalProcess", () => {
 	let terminalProcess: TerminalProcess
 	let mockTerminal: jest.Mocked<
@@ -34,7 +37,7 @@ describe("TerminalProcess", () => {
 	let mockStream: AsyncIterableIterator<string>
 
 	beforeEach(() => {
-		terminalProcess = new TerminalProcess(100 * 1024)
+		terminalProcess = new TerminalProcess(TERMINAL_OUTPUT_LIMIT, STALL_TIMEOUT)
 
 		// Create properly typed mock terminal
 		mockTerminal = {
@@ -171,6 +174,158 @@ describe("TerminalProcess", () => {
 
 			expect(continueSpy).toHaveBeenCalled()
 			expect(terminalProcess["isListening"]).toBe(false)
+		})
+	})
+
+	describe("stalled stream handling", () => {
+		it("emits stream_stalled event when no output is received within timeout", async () => {
+			// Create a promise that resolves when stream_stalled is emitted
+			const streamStalledPromise = new Promise<number>((resolve) => {
+				terminalProcess.once("stream_stalled", (id: number) => {
+					resolve(id)
+				})
+			})
+
+			// Create a stream that doesn't emit any data
+			mockStream = (async function* () {
+				yield "\x1b]633;C\x07" // Command start sequence
+				// No data is yielded after this, causing the stall
+				await new Promise((resolve) => setTimeout(resolve, STALL_TIMEOUT * 2))
+				// This would normally be yielded, but the stall timer will fire first
+				yield "Output after stall"
+				yield "\x1b]633;D\x07" // Command end sequence
+				terminalProcess.emit("shell_execution_complete", mockTerminalInfo.id, { exitCode: 0 })
+			})()
+
+			mockExecution = {
+				read: jest.fn().mockReturnValue(mockStream),
+			}
+
+			mockTerminal.shellIntegration.executeCommand.mockReturnValue(mockExecution)
+
+			// Start the terminal process
+			const runPromise = terminalProcess.run(mockTerminal, "test command")
+			terminalProcess.emit("stream_available", mockTerminalInfo.id, mockStream)
+
+			// Wait for the stream_stalled event
+			const stalledId = await streamStalledPromise
+
+			// Verify the event was emitted with the correct terminal ID
+			expect(stalledId).toBe(mockTerminalInfo.id)
+
+			// Complete the run
+			await runPromise
+		})
+
+		it("clears stall timer when output is received", async () => {
+			// Spy on the emit method to check if stream_stalled is emitted
+			const emitSpy = jest.spyOn(terminalProcess, "emit")
+
+			// Create a stream that emits data before the stall timeout
+			mockStream = (async function* () {
+				yield "\x1b]633;C\x07" // Command start sequence
+				yield "Initial output\n" // This should clear the stall timer
+
+				// Wait longer than the stall timeout
+				await new Promise((resolve) => setTimeout(resolve, STALL_TIMEOUT * 2))
+
+				yield "More output\n"
+				yield "\x1b]633;D\x07" // Command end sequence
+				terminalProcess.emit("shell_execution_complete", mockTerminalInfo.id, { exitCode: 0 })
+			})()
+
+			mockExecution = {
+				read: jest.fn().mockReturnValue(mockStream),
+			}
+
+			mockTerminal.shellIntegration.executeCommand.mockReturnValue(mockExecution)
+
+			// Start the terminal process
+			const runPromise = terminalProcess.run(mockTerminal, "test command")
+			terminalProcess.emit("stream_available", mockTerminalInfo.id, mockStream)
+
+			// Wait for the run to complete
+			await runPromise
+
+			// Wait a bit longer to ensure the stall timer would have fired if not cleared
+			await new Promise((resolve) => setTimeout(resolve, STALL_TIMEOUT * 2))
+
+			// Verify stream_stalled was not emitted
+			expect(emitSpy).not.toHaveBeenCalledWith("stream_stalled", expect.anything())
+		})
+
+		it("returns true from flushLine when a line is emitted", async () => {
+			// Create a stream with output
+			mockStream = (async function* () {
+				yield "\x1b]633;C\x07" // Command start sequence
+				yield "Test output\n" // This should be flushed as a line
+				yield "\x1b]633;D\x07" // Command end sequence
+				terminalProcess.emit("shell_execution_complete", mockTerminalInfo.id, { exitCode: 0 })
+			})()
+
+			mockExecution = {
+				read: jest.fn().mockReturnValue(mockStream),
+			}
+
+			mockTerminal.shellIntegration.executeCommand.mockReturnValue(mockExecution)
+
+			// Spy on the flushLine method
+			const flushLineSpy = jest.spyOn(terminalProcess as any, "flushLine")
+
+			// Spy on the emit method to check if line is emitted
+			const emitSpy = jest.spyOn(terminalProcess, "emit")
+
+			// Start the terminal process
+			const runPromise = terminalProcess.run(mockTerminal, "test command")
+			terminalProcess.emit("stream_available", mockTerminalInfo.id, mockStream)
+
+			// Wait for the run to complete
+			await runPromise
+
+			// Verify flushLine was called and returned true
+			expect(flushLineSpy).toHaveBeenCalled()
+			expect(flushLineSpy.mock.results.some((result) => result.value === true)).toBe(true)
+
+			// Verify line event was emitted
+			expect(emitSpy).toHaveBeenCalledWith("line", expect.any(String))
+		})
+
+		it("returns false from flushLine when no line is emitted", async () => {
+			// Create a stream with no complete lines
+			mockStream = (async function* () {
+				yield "\x1b]633;C\x07" // Command start sequence
+				yield "Test output" // No newline, so this won't be flushed as a line yet
+				yield "\x1b]633;D\x07" // Command end sequence
+				terminalProcess.emit("shell_execution_complete", mockTerminalInfo.id, { exitCode: 0 })
+			})()
+
+			mockExecution = {
+				read: jest.fn().mockReturnValue(mockStream),
+			}
+
+			mockTerminal.shellIntegration.executeCommand.mockReturnValue(mockExecution)
+
+			// Create a custom implementation to test flushLine directly
+			const testFlushLine = async () => {
+				// Create a new instance with the same configuration
+				const testProcess = new TerminalProcess(TERMINAL_OUTPUT_LIMIT, STALL_TIMEOUT)
+
+				// Set up the output builder with content that doesn't have a newline
+				testProcess["outputBuilder"] = {
+					readLine: jest.fn().mockReturnValue(""),
+					append: jest.fn(),
+					reset: jest.fn(),
+					content: "Test output",
+				} as any
+
+				// Call flushLine directly
+				const result = testProcess["flushLine"]()
+				return result
+			}
+
+			// Test flushLine directly
+			const flushLineResult = await testFlushLine()
+			expect(flushLineResult).toBe(false)
 		})
 	})
 })


### PR DESCRIPTION
## Context

One last terminal bug fix for behavior that bugs me.

If you execute a command that either doesn't produce output right away or doesn't flush its output to be visible to VSCode then the task hangs indefinitely. It's preferable to present the "Proceed While Running" action so that you can continue to the task while the command is running in the background.

This issue is easy to reproduce with the following prompt:
"Run the command `yes`."

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add handling for outputless terminal commands by emitting a `stream_stalled` event when no output is detected within a timeout, allowing tasks to proceed.
> 
>   - **Behavior**:
>     - Introduces `stream_stalled` event in `TerminalProcess` to detect when no output is received within a specified timeout.
>     - In `Cline.ts`, listens for `stream_stalled` to allow user to proceed while command runs in background.
>   - **Implementation**:
>     - Adds `stallTimeout` parameter to `TerminalProcess` constructor, defaulting to 5000ms.
>     - Clears stall timer in `flushLine()` when output is received.
>   - **Testing**:
>     - Adds tests in `TerminalProcess.test.ts` for `stream_stalled` event emission and stall timer clearing behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 710284cc3da1b61b22169b621457d6ae77029ec8. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->