### PR TITLE
Remove item number from history preview cards

### DIFF
--- a/.changeset/shiny-mugs-care.md
+++ b/.changeset/shiny-mugs-care.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Remove item number from history preview cards

--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -35,12 +35,6 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 							<span className="text-xs font-medium text-vscode-descriptionForeground uppercase">
 								{formatDate(item.ts)}
 							</span>
-							<span
-								style={{
-									marginLeft: "auto",
-								}}>
-								({item.number === 0 ? "Main" : item.number})
-							</span>
 							<CopyButton itemTask={item.task} />
 						</div>
 						<div


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove item number display from history preview cards in `HistoryPreview.tsx`.
> 
>   - **UI Changes**:
>     - Removed item number display from history preview cards in `HistoryPreview.tsx`.
>     - Specifically removed the span displaying `item.number` in the task history map function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1cc57c47ce02a51858317a3fc9270000bb5dbeab. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->