### PR TITLE
Theoretical handling of stream non-availability or delayed availability

### DIFF
--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -47,6 +47,7 @@ export interface TerminalProcessEvents {
 	 */
 	shell_execution_complete: [id: number, exitDetails: ExitCodeDetails]
 	stream_available: [id: number, stream: AsyncIterable<string>]
+	stream_unavailable: [id: number]
 	/**
 	 * Emitted when an execution fails to emit a "line" event for a given period of time.
 	 * @param id The terminal ID
@@ -85,15 +86,24 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 			const terminalInfo = TerminalRegistry.getTerminalInfoByTerminal(terminal)
 
 			if (!terminalInfo) {
-				console.error("[TerminalProcess] Terminal not found in registry")
+				console.error("[TerminalProcess#run] terminal not found in registry")
 				this.emit("no_shell_integration")
 				this.emit("completed")
 				this.emit("continue")
 				return
 			}
 
-			// When executeCommand() is called, onDidStartTerminalShellExecution will fire in TerminalManager
-			// which creates a new stream via execution.read() and emits 'stream_available'
+			this.once("stream_unavailable", (id: number) => {
+				if (id === terminalInfo.id) {
+					console.error(`[TerminalProcess#run] stream_unavailable`)
+					this.emit("completed")
+					this.emit("continue")
+				}
+			})
+
+			// When `executeCommand()` is called, `onDidStartTerminalShellExecution`
+			// will fire in `TerminalManager` which creates a new stream via
+			// `execution.read()` and emits `stream_available`.
 			const streamAvailable = new Promise<AsyncIterable<string>>((resolve) => {
 				this.once("stream_available", (id: number, stream: AsyncIterable<string>) => {
 					if (id === terminalInfo.id) {
@@ -111,15 +121,35 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 				})
 			})
 
-			// readLine needs to know if streamClosed, so store this for later
+			// `readLine()` needs to know if streamClosed, so store this for later.
+			// NOTE: This doesn't seem to be used anywhere.
 			this.terminalInfo = terminalInfo
 
-			// Execute command
+			// Execute command.
 			terminal.shellIntegration.executeCommand(command)
 			this.isHot = true
 
-			// Wait for stream to be available
-			const stream = await streamAvailable
+			// Wait for stream to be available.
+			// const stream = await streamAvailable
+
+			// Wait for stream to be available.
+			let stream: AsyncIterable<string>
+
+			try {
+				stream = await Promise.race([
+					streamAvailable,
+					new Promise<never>((_, reject) => {
+						setTimeout(
+							() => reject(new Error("Timeout waiting for terminal stream to become available")),
+							10_000,
+						)
+					}),
+				])
+			} catch (error) {
+				console.error(`[TerminalProcess#run] timed out waiting for stream`)
+				this.emit("stream_stalled", terminalInfo.id)
+				stream = await streamAvailable
+			}
 
 			let preOutput = ""
 			let commandOutputStarted = false
@@ -256,6 +286,7 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	}
 
 	public continue() {
+		console.log(`[TerminalProcess#continue] flushing all`)
 		this.flushAll()
 		this.isListening = false
 		this.removeAllListeners("line")


### PR DESCRIPTION
## Context

Earlier today I encountered another instance of the task UI hanging indefinitely after a command execution. I didn't have the logging in place to diagnose the issue, and I'm still trying to repro it in my dogfooding build, but in the meantime these are some theoretical edge cases that may be worth handling.

- If for some reason an execution stream is undefined by we have a process object then emit a `stream_unavailable` event so that we can close the process out instead of waiting indefinitely for a stream that is never to going to be available. This is a theoretical fix; I don't know if it can happen in practice.
- Add a 10s timeout to `await streamAvailable` using `Promise.race`. This ensures that we can unlock the UI if there's some delay on stream availability. Again, this is theoretical.
- Adds additional logging.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent UI lock by handling unavailable streams and adding timeouts in terminal command executions.
> 
>   - **Behavior**:
>     - Emit `stream_unavailable` event in `TerminalManager` if execution stream is undefined but process object exists.
>     - Add 10s timeout to `await streamAvailable` in `TerminalProcess` using `Promise.race` to prevent indefinite UI lock.
>   - **Logging**:
>     - Add additional logging in `TerminalManager` and `TerminalProcess` for better diagnostics.
>   - **Events**:
>     - Add `stream_unavailable` event to `TerminalProcessEvents` in `TerminalProcess.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for eee7bbe104eff25a434854c91b8bb4cf92d02dcb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->