### PR TITLE
Turn off ellipsis quiet mode

### DIFF
--- a/ellipsis.yaml
+++ b/ellipsis.yaml
@@ -7,7 +7,7 @@ pr_review:
   
   # If quiet mode is enabled, Ellipsis will only leave reviews when it has comments, so “Looks good to me” reviews 
   # will be skipped. This can reduce clutter.
-  quiet: true
+  quiet: false
   
   # You can disable automatic code review using auto_review_enabled. This will override any global settings you 
   # have configured via the web UI.


### PR DESCRIPTION
I find Ellipsis's feedback valuable, even when it doesn't leave comments. Let's try this for a bit and see if it gets annoying.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables quiet mode in `ellipsis.yaml` to allow Ellipsis to leave reviews without specific comments.
> 
>   - **Behavior**:
>     - Changes `quiet` mode to `false` in `ellipsis.yaml`, enabling Ellipsis to leave reviews even without specific comments.
>   - **Configuration**:
>     - Affects the `pr_review` section in `ellipsis.yaml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 73bb4f9cfc4f95df585cbf98919b854c27d3b844. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->