### PR TITLE
Revert "Turn off ellipsis quiet mode"

### DIFF
--- a/ellipsis.yaml
+++ b/ellipsis.yaml
@@ -7,7 +7,7 @@ pr_review:
   
   # If quiet mode is enabled, Ellipsis will only leave reviews when it has comments, so “Looks good to me” reviews 
   # will be skipped. This can reduce clutter.
-  quiet: false
+  quiet: true
   
   # You can disable automatic code review using auto_review_enabled. This will override any global settings you 
   # have configured via the web UI.


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#1436

Too noisy, sorry!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `quiet` mode in `ellipsis.yaml` to reduce noise by skipping non-comment reviews.
> 
>   - **Behavior**:
>     - Reverts `quiet` mode in `ellipsis.yaml` from `false` to `true` to reduce noise by skipping "Looks good to me" reviews without comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d6d43b24f47ffb5add7da6b4118699892f2beeba. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->