### PR TITLE
fix claude 3.7 think enhance prompt problem.

### DIFF
--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -214,12 +214,12 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 	}
 
 	async completePrompt(prompt: string) {
-		let { id: modelId, maxTokens, thinking, temperature } = this.getModel()
+		let { id: modelId, temperature } = this.getModel()
 
 		const message = await this.client.messages.create({
 			model: modelId,
-			max_tokens: maxTokens ?? ANTHROPIC_DEFAULT_MAX_TOKENS,
-			thinking,
+			max_tokens: ANTHROPIC_DEFAULT_MAX_TOKENS,
+			thinking: undefined,
 			temperature,
 			messages: [{ role: "user", content: prompt }],
 			stream: false,


### PR DESCRIPTION
## Context

Fixed the issue that [Prompt Word Enhancement] cladue non-streaming call failed

## Implementation

* Due to the current [Anthropic's SDK non-streaming Timeout settings](https://github.com/anthropics/anthropic-sdk-typescript/blob/main/src/core.ts#L411-L421), the maximum allowable token for non-streaming calls is 21333.
* If the user configures the Claude model Max Token is greater than this number, the prompt word enhancement and other functions will immediately report an error, the specific error is as follows:

```text
'Error: Streaming is strongly recommended for operations that may take longer than 10 minutes. See https://github.com/anthropics/anthropic-sdk-python#streaming-responses for more details\n    at Anthropic._calculateNonstreamingTimeout (/Users/moqi/Code/Roo-Code/node_modules/@anthropic-ai/sdk/src/core.ts:415:13)\n    at Messages3.create (/Users/moqi/Code/Roo-Code/node_modules/@anthropic-ai/sdk/src/resources/messages/messages.ts:64:46)\n    at AnthropicHandler.completePrompt (/Users/moqi/Code/Roo-Code/src/api/providers/anthropic.ts:224:46)\n    at WecoderHandler.completePrompt (/Users/moqi/Code/Roo-Code/src/api/providers/wecoder.ts:142:18)\n    at singleCompletionHandler (/Users/moqi/Code/Roo-Code/src/utils/single-completion-handler.ts:23:46)\n    at Lh.value (/Users/moqi/Code/Roo-Code/src/core/webview/ClineProvider.ts:1266:38)'
```

* The typical user optimization prompt is generally no longer than this constant size: ANTHROPIC_DEFAULT_MAX_TOKENS
* In the case of claude non-streaming calls, setting thinking can cause the user to wait for a very long time, In my prompt word enhancement test, using claude 3.7 and keeping think would give the following error:

```text
"TypeError: Cannot read properties of undefined (reading 'find')\n    at AnthropicHandler.completePrompt (/Users/moqi/Code/Roo-Code/src/api/providers/anthropic.ts:236:35)\n    at processTicksAndRejections (node:internal/process/task_queues:95:5)\n    at Lh.value (/Users/moqi/Code/Roo-Code/src/core/webview/ClineProvider.ts:1266:32)"
```

## Screenshots

before:

![image](https://github.com/user-attachments/assets/ddda09a3-5d79-4f53-82a9-ab61d724b220)

after:

No errors, successful execution of prompt word enhancements using Claude 3.7 Think

## How to Test

Use the Claude 3.7 Think model to perform prompt word enhancements

## Get in Touch

moqi

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes non-streaming call issue for Claude 3.7 in `completePrompt()` by adjusting token handling and removing `thinking` parameter.
> 
>   - **Behavior**:
>     - Fixes non-streaming call failure for Claude 3.7 in `completePrompt()` in `anthropic.ts` by setting `max_tokens` to `ANTHROPIC_DEFAULT_MAX_TOKENS` and removing `thinking` parameter.
>     - Addresses error when `maxTokens` exceeds 21333 due to Anthropic's SDK timeout settings.
>   - **Misc**:
>     - Removes unused `maxTokens` and `thinking` from `getModel()` call in `completePrompt()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for aa70d755f80955f7bc07694241936f75f87a40f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->