### PR TITLE
UI tweaks to task header

### DIFF
--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -175,6 +175,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 								flexGrow: 1,
 								minWidth: 0, // This allows the div to shrink below its content size
 							}}>
+							<span style={{ fontWeight: "bold" }}>Task{!isTaskExpanded && ":"}</span>
 							{!isTaskExpanded && (
 								<span style={{ marginLeft: 4 }}>{highlightMentions(task.text, false)}</span>
 							)}
@@ -199,7 +200,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 					<VSCodeButton
 						appearance="icon"
 						onClick={onClose}
-						style={{ marginLeft: 6, flexShrink: 0 }}
+						style={{ marginLeft: 6, flexShrink: 0, color: "var(--vscode-badge-foreground)" }}
 						title="Close task and start a new one">
 						<span className="codicon codicon-close"></span>
 					</VSCodeButton>
@@ -249,9 +250,10 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 									<div
 										style={{
 											cursor: "pointer",
-											color: "var(--vscode-textLink-foreground)",
-											paddingRight: 0,
-											paddingLeft: 3,
+											color: "var(--vscode-badge-foreground)",
+											fontSize: "11px",
+											paddingRight: 8,
+											paddingLeft: 4,
 											backgroundColor: "var(--vscode-badge-background)",
 										}}
 										onClick={() => setIsTextExpanded(!isTextExpanded)}>


### PR DESCRIPTION
## Context

Noticed some UI problems with the task header

## Implementation

1. Bring back the "Task" header
2. Make the close button visible
3. Make the see more visible and adjust positioning

## Screenshots

| before | after |
| ------ | ----- |
|    ![Screenshot 2025-03-07 at 10 10 30 AM](https://github.com/user-attachments/assets/edbba38a-6cba-4138-958e-1e5a00d14cc3) |  ![Screenshot 2025-03-07 at 10 09 57 AM](https://github.com/user-attachments/assets/ab70d465-422a-408b-bce6-57add0fb3d2f)  |

## How to Test

Look at the task header for short and long task titles.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI improvements in `TaskHeader.tsx` enhance visibility of the 'Task' header, close button, and 'See more' option.
> 
>   - **UI Enhancements in `TaskHeader.tsx`**:
>     - Reintroduce "Task" header with bold styling and conditional colon.
>     - Adjust close button styling to ensure visibility by setting `color` to `var(--vscode-badge-foreground)`.
>     - Modify "See more" button styling: change `color` to `var(--vscode-badge-foreground)`, adjust `fontSize` to `11px`, and update `paddingRight` to `8` and `paddingLeft` to `4`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 25d41a59a868146bd3c361b9365b4fa4836bf92b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->