### PR TITLE
Use full width for Configuration Profile dropdown

### DIFF
--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -219,6 +219,7 @@ const ApiConfigManager = ({
 								value: config.name,
 								label: config.name,
 							}))}
+							className="w-full"
 						/>
 						<VSCodeButton
 							appearance="icon"


### PR DESCRIPTION
## Context

Increase the width of the Configuration Profile dropdown to allow displaying longer profile names. Also follow the same dropdown with style of the API Provider and Model selector ones.

## Implementation

Add a CSS class to make the API config dropdown take up the full width of its container. This improves the layout and appearance of the settings page.

## Screenshots

| before | after |
| ------ | ----- |
|<img width="400" alt="image" src="https://github.com/user-attachments/assets/170a366a-7b6a-4ab9-9885-2bde9061d747" />|<img width="400" alt="image" src="https://github.com/user-attachments/assets/6c0837b1-307e-49ba-bfe5-60f0410e1305" />|
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make Configuration Profile dropdown full-width in `ApiConfigManager.tsx` for better UI consistency.
> 
>   - **UI Enhancement**:
>     - In `ApiConfigManager.tsx`, added `className="w-full"` to the `Dropdown` component to make the Configuration Profile dropdown full-width.
>     - Aligns the dropdown style with API Provider and Model selector dropdowns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 03d4c7f35937fd396277e5b1efb9ec4e4db33058. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->