### PR TITLE
Add app version to telemetry

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2535,8 +2535,13 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	public async getTelemetryProperties(): Promise<Record<string, any>> {
 		const { mode, apiConfiguration } = await this.getState()
 		const appVersion = this.context.extension?.packageJSON?.version
+		const vscodeVersion = vscode.version
+		const platform = process.platform
 
-		const properties: Record<string, any> = {}
+		const properties: Record<string, any> = {
+			vscodeVersion,
+			platform,
+		}
 
 		// Add extension version
 		if (appVersion) {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2534,8 +2534,14 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	 */
 	public async getTelemetryProperties(): Promise<Record<string, any>> {
 		const { mode, apiConfiguration } = await this.getState()
+		const appVersion = this.context.extension?.packageJSON?.version
 
 		const properties: Record<string, any> = {}
+
+		// Add extension version
+		if (appVersion) {
+			properties.appVersion = appVersion
+		}
 
 		// Add current mode
 		if (mode) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance telemetry in `ClineProvider.ts` by adding app version, VSCode version, and platform to telemetry properties.
> 
>   - **Telemetry Enhancements**:
>     - In `ClineProvider.ts`, `getTelemetryProperties()` now includes `appVersion`, `vscodeVersion`, and `platform` in the telemetry properties.
>     - `appVersion` is conditionally added if available.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4c6f0628e3c4e82a51601f33773c0e810a2d6512. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->