### PR TITLE
Add o3-mini support to openai compatible

### DIFF
--- a/.changeset/wild-dragons-leave.md
+++ b/.changeset/wild-dragons-leave.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add o3-mini support to openai compatible


### PR DESCRIPTION
## Context

This PR is a modification to support the use of the o3-mini model in Azure OpenAI.

Previously, an error occurred when using the "OpenAI Compatible" API Provider with the "o3-mini" model selected and stream enabled. This fix resolves the issue and ensures it functions correctly.

### Related issue
- https://github.com/RooVetGit/Roo-Code/issues/683
- https://github.com/RooVetGit/Roo-Code/issues/1099



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for `o3-mini` model in `OpenAiHandler`, including streaming and non-streaming message handling.
> 
>   - **Behavior**:
>     - Adds support for `o3-mini` model in `OpenAiHandler` in `openai.ts`.
>     - Introduces `handleO3FamilyMessage()` to process `o3-mini` messages, supporting both streaming and non-streaming modes.
>     - Fixes issue with streaming enabled for `o3-mini` model.
>   - **Functions**:
>     - Adds `handleO3FamilyMessage()` and `handleStreamResponse()` in `openai.ts` to manage `o3-mini` model responses.
>     - Modifies `createMessage()` to route `o3-mini` model requests to `handleO3FamilyMessage()`.
>   - **Misc**:
>     - Updates logic to check for `o3-mini` model in `createMessage()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9246cf8f6dbe0f2a429872ea16f4ab2666e13d88. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->