### PR TITLE
support tool progress status

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -48,6 +48,7 @@ import {
 	ClineSay,
 	ClineSayBrowserAction,
 	ClineSayTool,
+	ToolProgressStatus,
 } from "../shared/ExtensionMessage"
 import { getApiMetrics } from "../shared/getApiMetrics"
 import { HistoryItem } from "../shared/HistoryItem"
@@ -408,6 +409,7 @@ export class Cline {
 		type: ClineAsk,
 		text?: string,
 		partial?: boolean,
+		progressStatus?: ToolProgressStatus,
 	): Promise<{ response: ClineAskResponse; text?: string; images?: string[] }> {
 		// If this Cline instance was aborted by the provider, then the only thing keeping us alive is a promise still running in the background, in which case we don't want to send its result to the webview as it is attached to a new instance of Cline now. So we can safely ignore the result of any active promises, and this class will be deallocated. (Although we set Cline = undefined in provider, that simply removes the reference to this instance, but the instance is still alive until this promise resolves or rejects.)
 		if (this.abort) {
@@ -423,6 +425,7 @@ export class Cline {
 					// existing partial message, so update it
 					lastMessage.text = text
 					lastMessage.partial = partial
+					lastMessage.progressStatus = progressStatus
 					// todo be more efficient about saving and posting only new data or one whole message at a time so ignore partial for saves, and only post parts of partial message instead of whole array in new listener
 					// await this.saveClineMessages()
 					// await this.providerRef.deref()?.postStateToWebview()
@@ -460,6 +463,8 @@ export class Cline {
 					// lastMessage.ts = askTs
 					lastMessage.text = text
 					lastMessage.partial = false
+					lastMessage.progressStatus = progressStatus
+
 					await this.saveClineMessages()
 					// await this.providerRef.deref()?.postStateToWebview()
 					await this.providerRef
@@ -511,6 +516,7 @@ export class Cline {
 		images?: string[],
 		partial?: boolean,
 		checkpoint?: Record<string, unknown>,
+		progressStatus?: ToolProgressStatus,
 	): Promise<undefined> {
 		if (this.abort) {
 			throw new Error(`Task: ${this.taskNumber} Roo Code instance aborted (#2)`)
@@ -526,6 +532,7 @@ export class Cline {
 					lastMessage.text = text
 					lastMessage.images = images
 					lastMessage.partial = partial
+					lastMessage.progressStatus = progressStatus
 					await this.providerRef
 						.deref()
 						?.postMessageToWebview({ type: "partialMessage", partialMessage: lastMessage })
@@ -545,6 +552,7 @@ export class Cline {
 					lastMessage.text = text
 					lastMessage.images = images
 					lastMessage.partial = false
+					lastMessage.progressStatus = progressStatus
 
 					// instead of streaming partialMessage events, we do a save and post like normal to persist to disk
 					await this.saveClineMessages()
@@ -1691,8 +1699,16 @@ export class Cline {
 						try {
 							if (block.partial) {
 								// update gui message
+								let toolProgressStatus
+								if (this.diffStrategy && this.diffStrategy.getProgressStatus) {
+									toolProgressStatus = this.diffStrategy.getProgressStatus(block)
+								}
+
 								const partialMessage = JSON.stringify(sharedMessageProps)
-								await this.ask("tool", partialMessage, block.partial).catch(() => {})
+
+								await this.ask("tool", partialMessage, block.partial, toolProgressStatus).catch(
+									() => {},
+								)
 								break
 							} else {
 								if (!relPath) {
@@ -1786,6 +1802,14 @@ export class Cline {
 									...sharedMessageProps,
 									diff: diffContent,
 								} satisfies ClineSayTool)
+
+								let toolProgressStatus
+								if (this.diffStrategy && this.diffStrategy.getProgressStatus) {
+									toolProgressStatus = this.diffStrategy.getProgressStatus(block, diffResult)
+								}
+								await this.ask("tool", completeMessage, block.partial, toolProgressStatus).catch(
+									() => {},
+								)
 
 								const didApprove = await askApproval("tool", completeMessage)
 								if (!didApprove) {

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -1,6 +1,8 @@
 import { DiffStrategy, DiffResult } from "../types"
 import { addLineNumbers, everyLineHasLineNumbers, stripLineNumbers } from "../../../integrations/misc/extract-text"
 import { distance } from "fastest-levenshtein"
+import { ToolProgressStatus } from "../../../shared/ExtensionMessage"
+import { ToolUse } from "../../assistant-message"
 
 const BUFFER_LINES = 40 // Number of extra context lines to show before and after matches
 
@@ -361,5 +363,26 @@ Only use a single line of '=======' between search and replacement content, beca
 			content: finalContent,
 			failParts: diffResults,
 		}
+	}
+
+	getProgressStatus(toolUse: ToolUse, result?: DiffResult): ToolProgressStatus {
+		const diffContent = toolUse.params.diff
+		if (diffContent) {
+			if (toolUse.partial) {
+				if (diffContent.length < 1000 || (diffContent.length / 50) % 10 === 0) {
+					return { text: `progressing ${(diffContent.match(/SEARCH/g) || []).length} blocks...` }
+				}
+			} else if (result) {
+				const searchBlockCount = (diffContent.match(/SEARCH/g) || []).length
+				if (result.failParts) {
+					return {
+						text: `progressed ${searchBlockCount - result.failParts.length}/${searchBlockCount} blocks.`,
+					}
+				} else {
+					return { text: `progressed ${searchBlockCount} blocks.` }
+				}
+			}
+		}
+		return {}
 	}
 }

--- a/src/core/diff/types.ts
+++ b/src/core/diff/types.ts
@@ -2,6 +2,9 @@
  * Interface for implementing different diff strategies
  */
 
+import { ToolProgressStatus } from "../../shared/ExtensionMessage"
+import { ToolUse } from "../assistant-message"
+
 export type DiffResult =
 	| { success: true; content: string; failParts?: DiffResult[] }
 	| ({
@@ -34,4 +37,6 @@ export interface DiffStrategy {
 	 * @returns A DiffResult object containing either the successful result or error details
 	 */
 	applyDiff(originalContent: string, diffContent: string, startLine?: number, endLine?: number): Promise<DiffResult>
+
+	getProgressStatus?(toolUse: ToolUse, result?: any): ToolProgressStatus
 }

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -154,6 +154,7 @@ export interface ClineMessage {
 	reasoning?: string
 	conversationHistoryIndex?: number
 	checkpoint?: Record<string, unknown>
+	progressStatus?: ToolProgressStatus
 }
 
 export type ClineAsk =
@@ -271,3 +272,7 @@ export interface HumanRelayCancelMessage {
 }
 
 export type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled"
+
+export type ToolProgressStatus = {
+	text?: string
+}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -258,6 +258,7 @@ export const ChatRowContent = ({
 							<span style={{ fontWeight: "bold" }}>Roo wants to edit this file:</span>
 						</div>
 						<CodeAccordian
+							progressStatus={message.progressStatus}
 							isLoading={message.partial}
 							diff={tool.diff!}
 							path={tool.path!}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo } from "react"
 import { getLanguageFromPath } from "../../utils/getLanguageFromPath"
 import CodeBlock, { CODE_BLOCK_BG_COLOR } from "./CodeBlock"
+import { ToolProgressStatus } from "../../../../src/shared/ExtensionMessage"
 
 interface CodeAccordianProps {
 	code?: string
@@ -12,6 +13,7 @@ interface CodeAccordianProps {
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
+	progressStatus?: ToolProgressStatus
 }
 
 /*
@@ -32,6 +34,7 @@ const CodeAccordian = ({
 	isExpanded,
 	onToggleExpand,
 	isLoading,
+	progressStatus,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -95,6 +98,16 @@ const CodeAccordian = ({
 						</>
 					)}
 					<div style={{ flexGrow: 1 }}></div>
+					{progressStatus && progressStatus.text && (
+						<span
+							style={{
+								color: "var(--vscode-descriptionForeground)",
+								borderTop: isExpanded ? "1px solid var(--vscode-editorGroup-border)" : "none",
+								marginLeft: "auto", // Right-align the text
+							}}>
+							{progressStatus.text}
+						</span>
+					)}
 					<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>
 				</div>
 			)}


### PR DESCRIPTION
## Context

When roo processes a large change, it takes a long time to wait. During this process, the UI only has a spinning animation, which makes people feel impatient.

The PR uses multi-block search as an example, which will display the number of blocks to be updated in real time. Other diff strategies can also achieve similar functions. In addition,  this method can also be used to update other non-text progress messages.

## Implementation

1. Add an optional getProgressStatus method to the diffStrategy interface and call it in presentAssistantMessage
2. Add ClineMessage.progressStatus attribute 
3. post ToolProgressStatus to the webview when called cline.ask

## Screenshots

| before | after |
| ------ | ----- |
|        |       |
![progress](https://github.com/user-attachments/assets/cd2ab240-76db-45b7-8c7c-18d61ea47987)


## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds progress status updates for tool operations in diff strategies, enhancing real-time feedback in the UI.
> 
>   - **Behavior**:
>     - Adds `getProgressStatus` method to `DiffStrategy` interface in `types.ts`.
>     - Implements `getProgressStatus` in `MultiSearchReplaceDiffStrategy` in `multi-search-replace.ts` to provide real-time progress updates.
>     - Updates `Cline` class in `Cline.ts` to handle `progressStatus` in `ask()` and `say()` methods.
>   - **UI Components**:
>     - Adds `progressStatus` prop to `CodeAccordian` in `CodeAccordian.tsx`.
>     - Displays progress status in `ChatRow` and `ChatRowContent` in `ChatRow.tsx`.
>   - **Misc**:
>     - Adds `ToolProgressStatus` type to `ExtensionMessage.ts` for progress status representation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a1d742f0d2e688a2c5d185849b735f08c1d07e17. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->