### PR TITLE
Strip all BOMs

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -105,7 +105,7 @@ export class DiffViewProvider {
 		const edit = new vscode.WorkspaceEdit()
 		const rangeToReplace = new vscode.Range(0, 0, endLine + 1, 0)
 		const contentToReplace = accumulatedLines.slice(0, endLine + 1).join("\n") + "\n"
-		edit.replace(document.uri, rangeToReplace, stripBom(stripBom(contentToReplace)))
+		edit.replace(document.uri, rangeToReplace, this.stripAllBOMs(contentToReplace))
 		await vscode.workspace.applyEdit(edit)
 		// Update decorations
 		this.activeLineController.setActiveLine(endLine)
@@ -132,7 +132,7 @@ export class DiffViewProvider {
 			finalEdit.replace(
 				document.uri,
 				new vscode.Range(0, 0, document.lineCount, 0),
-				stripBom(stripBom(accumulatedContent)),
+				this.stripAllBOMs(accumulatedContent),
 			)
 			await vscode.workspace.applyEdit(finalEdit)
 			// Clear all decorations at the end (after applying final edit)
@@ -339,6 +339,16 @@ export class DiffViewProvider {
 				lineCount += part.count || 0
 			}
 		}
+	}
+
+	private stripAllBOMs(input: string): string {
+		let result = input
+		let previous
+		do {
+			previous = result
+			result = stripBom(result)
+		} while (result !== previous)
+		return result
 	}
 
 	// close editor if open?


### PR DESCRIPTION
Cleaner version of #1500 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces multiple `stripBom()` calls with `stripAllBOMs()` in `DiffViewProvider.ts` to iteratively remove all BOMs from content.
> 
>   - **Behavior**:
>     - Replaces `stripBom(stripBom(...))` with `this.stripAllBOMs(...)` in `update()` method of `DiffViewProvider` to iteratively remove all BOMs from content.
>   - **Functions**:
>     - Adds `stripAllBOMs()` method to `DiffViewProvider` to remove all BOMs from a string iteratively.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 585d5aba5ac0f3188cdb7b8e78f22ab8d088efd7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->