### PR TITLE
Revert tool progress for now

### DIFF
--- a/.changeset/empty-bees-suffer.md
+++ b/.changeset/empty-bees-suffer.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Revert tool progress for now

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -1,8 +1,6 @@
 import { DiffStrategy, DiffResult } from "../types"
 import { addLineNumbers, everyLineHasLineNumbers, stripLineNumbers } from "../../../integrations/misc/extract-text"
 import { distance } from "fastest-levenshtein"
-import { ToolProgressStatus } from "../../../shared/ExtensionMessage"
-import { ToolUse } from "../../assistant-message"
 
 const BUFFER_LINES = 40 // Number of extra context lines to show before and after matches
 
@@ -363,26 +361,5 @@ Only use a single line of '=======' between search and replacement content, beca
 			content: finalContent,
 			failParts: diffResults,
 		}
-	}
-
-	getProgressStatus(toolUse: ToolUse, result?: DiffResult): ToolProgressStatus {
-		const diffContent = toolUse.params.diff
-		if (diffContent) {
-			if (toolUse.partial) {
-				if (diffContent.length < 1000 || (diffContent.length / 50) % 10 === 0) {
-					return { text: `progressing ${(diffContent.match(/SEARCH/g) || []).length} blocks...` }
-				}
-			} else if (result) {
-				const searchBlockCount = (diffContent.match(/SEARCH/g) || []).length
-				if (result.failParts) {
-					return {
-						text: `progressed ${searchBlockCount - result.failParts.length}/${searchBlockCount} blocks.`,
-					}
-				} else {
-					return { text: `progressed ${searchBlockCount} blocks.` }
-				}
-			}
-		}
-		return {}
 	}
 }

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -368,20 +368,18 @@ Only use a single line of '=======' between search and replacement content, beca
 	getProgressStatus(toolUse: ToolUse, result?: DiffResult): ToolProgressStatus {
 		const diffContent = toolUse.params.diff
 		if (diffContent) {
-			const icon = "diff-multiple"
-			const searchBlockCount = (diffContent.match(/SEARCH/g) || []).length
 			if (toolUse.partial) {
 				if (diffContent.length < 1000 || (diffContent.length / 50) % 10 === 0) {
-					return { icon, text: `${searchBlockCount}` }
+					return { text: `progressing ${(diffContent.match(/SEARCH/g) || []).length} blocks...` }
 				}
 			} else if (result) {
-				if (result.failParts?.length) {
+				const searchBlockCount = (diffContent.match(/SEARCH/g) || []).length
+				if (result.failParts) {
 					return {
-						icon,
-						text: `${searchBlockCount - result.failParts.length}/${searchBlockCount}`,
+						text: `progressed ${searchBlockCount - result.failParts.length}/${searchBlockCount} blocks.`,
 					}
 				} else {
-					return { icon, text: `${searchBlockCount}` }
+					return { text: `progressed ${searchBlockCount} blocks.` }
 				}
 			}
 		}

--- a/src/core/diff/types.ts
+++ b/src/core/diff/types.ts
@@ -2,9 +2,6 @@
  * Interface for implementing different diff strategies
  */
 
-import { ToolProgressStatus } from "../../shared/ExtensionMessage"
-import { ToolUse } from "../assistant-message"
-
 export type DiffResult =
 	| { success: true; content: string; failParts?: DiffResult[] }
 	| ({
@@ -37,6 +34,4 @@ export interface DiffStrategy {
 	 * @returns A DiffResult object containing either the successful result or error details
 	 */
 	applyDiff(originalContent: string, diffContent: string, startLine?: number, endLine?: number): Promise<DiffResult>
-
-	getProgressStatus?(toolUse: ToolUse, result?: any): ToolProgressStatus
 }

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -277,6 +277,5 @@ export interface HumanRelayCancelMessage {
 export type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled"
 
 export type ToolProgressStatus = {
-	icon?: string
 	text?: string
 }

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -155,7 +155,6 @@ export interface ClineMessage {
 	reasoning?: string
 	conversationHistoryIndex?: number
 	checkpoint?: Record<string, unknown>
-	progressStatus?: ToolProgressStatus
 }
 
 export type ClineAsk =
@@ -275,7 +274,3 @@ export interface HumanRelayCancelMessage {
 }
 
 export type ClineApiReqCancelReason = "streaming_failed" | "user_cancelled"
-
-export type ToolProgressStatus = {
-	text?: string
-}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -258,7 +258,6 @@ export const ChatRowContent = ({
 							<span style={{ fontWeight: "bold" }}>Roo wants to edit this file:</span>
 						</div>
 						<CodeAccordian
-							progressStatus={message.progressStatus}
 							isLoading={message.partial}
 							diff={tool.diff!}
 							path={tool.path!}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -99,12 +99,14 @@ const CodeAccordian = ({
 					)}
 					<div style={{ flexGrow: 1 }}></div>
 					{progressStatus && progressStatus.text && (
-						<>
-							{progressStatus.icon && <span className={`codicon codicon-${progressStatus.icon} mr-1`} />}
-							<span className="mr-1 ml-auto text-vscode-descriptionForeground">
-								{progressStatus.text}
-							</span>
-						</>
+						<span
+							style={{
+								color: "var(--vscode-descriptionForeground)",
+								borderTop: isExpanded ? "1px solid var(--vscode-editorGroup-border)" : "none",
+								marginLeft: "auto", // Right-align the text
+							}}>
+							{progressStatus.text}
+						</span>
 					)}
 					<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>
 				</div>

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -1,7 +1,6 @@
 import { memo, useMemo } from "react"
 import { getLanguageFromPath } from "../../utils/getLanguageFromPath"
 import CodeBlock, { CODE_BLOCK_BG_COLOR } from "./CodeBlock"
-import { ToolProgressStatus } from "../../../../src/shared/ExtensionMessage"
 
 interface CodeAccordianProps {
 	code?: string
@@ -13,7 +12,6 @@ interface CodeAccordianProps {
 	isExpanded: boolean
 	onToggleExpand: () => void
 	isLoading?: boolean
-	progressStatus?: ToolProgressStatus
 }
 
 /*
@@ -34,7 +32,6 @@ const CodeAccordian = ({
 	isExpanded,
 	onToggleExpand,
 	isLoading,
-	progressStatus,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -98,16 +95,6 @@ const CodeAccordian = ({
 						</>
 					)}
 					<div style={{ flexGrow: 1 }}></div>
-					{progressStatus && progressStatus.text && (
-						<span
-							style={{
-								color: "var(--vscode-descriptionForeground)",
-								borderTop: isExpanded ? "1px solid var(--vscode-editorGroup-border)" : "none",
-								marginLeft: "auto", // Right-align the text
-							}}>
-							{progressStatus.text}
-						</span>
-					)}
 					<span className={`codicon codicon-chevron-${isExpanded ? "up" : "down"}`}></span>
 				</div>
 			)}


### PR DESCRIPTION
## Context

Something about this is leading to people being asked twice to save changes, so opening a PR to revert until we figure it out.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Revert tool progress tracking changes due to issues with duplicate save prompts.
> 
>   - **Reversion**:
>     - Remove `ToolProgressStatus` type and related logic from `Cline.ts`, `multi-search-replace.ts`, and `ExtensionMessage.ts`.
>     - Remove `progressStatus` prop from `CodeAccordian` in `ChatRow.tsx` and `CodeAccordian.tsx`.
>   - **Context**:
>     - Revert due to issues with users being asked twice to save changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c9794d24525ebc1566f75f5e0b4bf6e757dba0d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->