### PR TITLE
feat: openai-compatible deepseek/qwq reasoning support

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -14,6 +14,7 @@ import { convertToR1Format } from "../transform/r1-format"
 import { convertToSimpleMessages } from "../transform/simple-format"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { BaseProvider } from "./base-provider"
+import { XmlMatcher } from "../../utils/xml-matcher"
 
 const DEEP_SEEK_DEFAULT_TEMPERATURE = 0.6
 
@@ -99,15 +100,23 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 
 			const stream = await this.client.chat.completions.create(requestOptions)
 
+			const matcher = new XmlMatcher(
+				"think",
+				(chunk) =>
+					({
+						type: chunk.matched ? "reasoning" : "text",
+						text: chunk.data,
+					}) as const,
+			)
+
 			let lastUsage
 
 			for await (const chunk of stream) {
 				const delta = chunk.choices[0]?.delta ?? {}
 
 				if (delta.content) {
-					yield {
-						type: "text",
-						text: delta.content,
+					for (const chunk of matcher.update(delta.content)) {
+						yield chunk
 					}
 				}
 
@@ -120,6 +129,9 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				if (chunk.usage) {
 					lastUsage = chunk.usage
 				}
+			}
+			for (const chunk of matcher.final()) {
+				yield chunk
 			}
 
 			if (lastUsage) {


### PR DESCRIPTION
## Context

Implemented parsing support for think tags output by openai-compatible API.

Similar to PR #1080, not only the deepseek-r1:* models in Ollama use think tags to output reasoning content, but the [QwQ](https://qwenlm.github.io/blog/qwq-32b/) model will also use the same approach to output reasoning content. When using vendors like Alibaba Cloud Baolian or VolcEngine, these providers will directly output content containing think tags instead of placing them in the reasoning field. Therefore, it's also necessary for OpenAI-compatible APIs to support processing think tags.

## Implementation

Similar to PR #1080, I added XmlMatcher to src/api/providers/openai.ts, and it now works properly.

## Screenshots

![Provider Settings](https://github.com/user-attachments/assets/fc4c1186-e846-4db0-bcf2-454b79e2255e)


| before | after |
| ------ | ----- |
| ![Before](https://github.com/user-attachments/assets/b856e2cb-55d6-46e0-9136-b038a7ad6d7b) | ![After](https://github.com/user-attachments/assets/a3a7599b-a312-4bad-945c-ac5cb5512112) |

## How to Test

- Add support for OpenAI-compatible API providers that support deepseek-r1 or QwQ models.
- Ask the model a question that triggers its reasoning.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
