### PR TITLE
Fix mode state sharing when switching between open vscode windows

### DIFF
--- a/src/core/contextProxy.ts
+++ b/src/core/contextProxy.ts
@@ -141,9 +141,18 @@ export class ContextProxy {
 		for (const key of GLOBAL_STATE_KEYS) {
 			try {
 				if (this.isWindowSpecificKey(key)) {
-					// For window-specific keys, get the value using the window-specific key
+					// For window-specific keys, first try to get the value using the window-specific key
 					const windowKey = this.getWindowSpecificKey(key)
-					const value = this.originalContext.globalState.get(windowKey)
+					let value = this.originalContext.globalState.get(windowKey)
+
+					// If no window-specific value exists, try to get a global value as fallback
+					if (value === undefined) {
+						value = this.originalContext.globalState.get(key)
+						logger.debug(
+							`No window-specific value found for ${windowKey}, using global value for ${key}: ${value}`,
+						)
+					}
+
 					this.stateCache.set(key, value)
 					logger.debug(`Loaded window-specific key ${key} as ${windowKey} with value: ${value}`)
 				} else {


### PR DESCRIPTION
# Fix mode state sharing when switching between open vscode windows

## Context

When using Roo-Code in multiple VS Code windows simultaneously, the "mode" setting (Debug, Architect, Code, etc.) was being shared across all windows. This caused a poor user experience as switching modes in one window would unexpectedly change the mode in all other open windows.. For example one vscode project could be in Architect mode, working away on auto and then, due to another vscode window switching to Code mode, the first also does and it changes it's behavior. Annoying when working on multiple projects concurrently using Auto-approve in particular.

## Implementation

The root issue was that VS Code's extension `globalState` API stores data at the user level rather than per-window. To solve this:

1. Modified the `ContextProxy` class to support window-specific state:
   - Added a `windowId` property that generates a unique identifier for each window based on workspace paths
   - Created a `WINDOW_SPECIFIC_KEYS` array that defines which settings should be window-specific (currently just 'mode')
   - Updated the state access methods to use namespaced keys for window-specific settings

2. The implementation is designed to be flexible for future extension:
   - Other settings can easily be made window-specific by adding them to the `WINDOW_SPECIFIC_KEYS` array
   - The solution requires minimal changes to other parts of the codebase
   - Works in all environments including remote/devcontainers since it uses VS Code's built-in state storage

before - Changing mode in window 1 changes mode in window 2 (and 3 and 4..) when the next message is submitted
after - Each window maintains its own mode independently

## How to Test

1. Open two separate VS Code windows with the Roo-Code extension
2. In the first window, set the mode to "Debug"
3. In the second window, set the mode to "Code"
4. Verify that each window maintains its selected mode independently
5. Close and reopen the windows to verify that the settings persist correctly
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes mode state sharing across VS Code windows by implementing window-specific state management in `ContextProxy`.
> 
>   - **Behavior**:
>     - `ContextProxy` now supports window-specific state for 'mode' using `WINDOW_SPECIFIC_KEYS`.
>     - Introduces `windowId` in `ContextProxy` to uniquely identify VS Code windows.
>     - Updates `getGlobalState()` and `updateGlobalState()` to handle window-specific keys.
>     - `resetAllState()` now resets window-specific keys using `windowId`.
>   - **Implementation**:
>     - Adds `generateWindowId()` and `createSessionHash()` for unique window identification.
>     - `initializeStateCache()` and `initializeSecretCache()` updated for window-specific handling.
>   - **Tests**:
>     - `contextProxy.test.ts` updated to test window-specific state management.
>     - Tests for `generateWindowId()` and `createSessionHash()` added to ensure unique ID generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b818f6b8386cf11cafdd75081d6703808bd77d44. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->