### PR TITLE
Use baseURL in OpenRouter generation check

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -162,7 +162,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 			await delay(200) // FIXME: necessary delay to ensure generation endpoint is ready
 
 			try {
-				const response = await axios.get(`https://openrouter.ai/api/v1/generation?id=${genId}`, {
+				const response = await axios.get(`${this.client.baseURL}/generation?id=${genId}`, {
 					headers: {
 						Authorization: `Bearer ${this.options.openRouterApiKey}`,
 					},


### PR DESCRIPTION
https://github.com/RooVetGit/Roo-Code/issues/1571
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Use `this.client.baseURL` in `OpenRouterHandler` for generation endpoint URL in `openrouter.ts`.
> 
>   - **Behavior**:
>     - Change in `OpenRouterHandler` class in `openrouter.ts` to use `this.client.baseURL` instead of hardcoded URL for generation endpoint.
>     - Affects the `axios.get` call for fetching generation details, making the base URL configurable.
>   - **Misc**:
>     - No changes to logic or additional features added.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 76f91819c13b2172a80b8547ebb6463b06ded6d9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->