### PR TITLE
Fix MarkdownBlock text color for Dark High Contrast theme

### DIFF
--- a/webview-ui/src/components/common/MarkdownBlock.tsx
+++ b/webview-ui/src/components/common/MarkdownBlock.tsx
@@ -63,9 +63,9 @@ const StyledMarkdown = styled.div`
 		white-space: pre-wrap;
 	}
 
- 	:where(h1, h2, h3, h4, h5, h6):has(code) code {
-    		font-size: inherit;
- 	}
+	:where(h1, h2, h3, h4, h5, h6):has(code) code {
+		font-size: inherit;
+	}
 
 	pre > code {
 		.hljs-deletion {
@@ -101,6 +101,14 @@ const StyledMarkdown = styled.div`
 		white-space: pre-line;
 		word-break: break-word;
 		overflow-wrap: anywhere;
+	}
+
+	/* Target only Dark High Contrast theme using the data attribute VS Code adds to the body */
+	body[data-vscode-theme-kind="vscode-high-contrast"] & code:not(pre > code) {
+		color: var(
+			--vscode-editorInlayHint-foreground,
+			var(--vscode-symbolIcon-stringForeground, var(--vscode-charts-orange, #e9a700))
+		);
 	}
 
 	font-family:


### PR DESCRIPTION
## Context

When using the "Dark High Contrast" Theme in VS Code, file references like filename in Roo Code's chat responses were not visible because they appeared as black text on a black background, creating a contrast issue that made the text unreadable.

## Implementation

I fixed this issue by adding a theme-specific CSS rule that only applies when the Dark High Contrast theme is active. The implementation:

Identified the issue in the MarkdownBlock.tsx component where inline code blocks (code:not(pre > code)) were styled
Added a specific CSS rule that targets only the Dark High Contrast theme using VS Code's theme data attribute
Used VS Code theme tokens for the text color to ensure proper theming and contrast
Implemented a fallback chain of theme tokens to ensure compatibility
The key part of the implementation is this CSS rule:
```
body[data-vscode-theme-kind="vscode-high-contrast"] & code:not(pre > code) {
    color: var(--vscode-editorInlayHint-foreground, var(--vscode-symbolIcon-stringForeground, var(--vscode-charts-orange, #e9a700)));
}
```
This approach ensures that:

Only the Dark High Contrast theme is affected, preserving the styling in other themes
The color is derived from VS Code's theme tokens rather than hardcoded.
Multiple fallbacks are provided to ensure compatibility across different VS Code versions

## Screenshots

<img width="522" alt="Screenshot 2025-03-12 at 02 32 08" src="https://github.com/user-attachments/assets/8be98c84-8ec3-46af-ad7c-69c2cee4a05a" />
<img width="508" alt="Screenshot 2025-03-12 at 02 31 50" src="https://github.com/user-attachments/assets/46a8d746-a8a2-408a-b91e-3978bddf8312" />

## How to Test

Open VS Code and switch to the "Dark High Contrast" theme (File > Preferences > Color Theme > Dark High Contrast)
Open Roo Code and start a conversation
Look for file references in Roo's responses (text wrapped in backticks like filename)
Verify that these file references are now clearly visible with proper contrast
Switch to other themes and verify that file references appear with their normal styling
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes text visibility issue in Dark High Contrast theme by adding a CSS rule to `MarkdownBlock.tsx` for inline code blocks.
> 
>   - **Behavior**:
>     - Fixes text visibility issue in Dark High Contrast theme by adding a CSS rule in `MarkdownBlock.tsx`.
>     - Targets `code:not(pre > code)` elements to change text color using VS Code theme tokens.
>     - Provides multiple fallbacks for color to ensure compatibility across VS Code versions.
>   - **Implementation**:
>     - CSS rule added to `StyledMarkdown` in `MarkdownBlock.tsx` to apply only when Dark High Contrast theme is active.
>     - Uses `--vscode-editorInlayHint-foreground` and other theme tokens for color.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 49fca1074fc9af90adc8d9eb98f42119f40b0062. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->