### PR TITLE
Fix terminal process unit tests on MacOS

### DIFF
--- a/src/integrations/terminal/__tests__/TerminalProcessExec.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalProcessExec.test.ts
@@ -274,23 +274,19 @@ describe("TerminalProcess with Real Command Output", () => {
 		)
 	})
 
-	// Configure the number of lines for the base64 test
-	const BASE64_TEST_LINES = 1_000_000
+	const TEST_LINES = 1_000_000
 
-	it(`should execute 'yes AAA... | head -n ${BASE64_TEST_LINES}' and verify ${BASE64_TEST_LINES} lines of 'A's`, async () => {
-		// Create an expected output pattern that matches what base64 produces
-		// Each line is 76 'A's followed by a newline
-		const expectedOutput = Array(BASE64_TEST_LINES).fill("A".repeat(76)).join("\n") + "\n"
+	it(`should execute 'yes AAA... | head -n ${TEST_LINES}' and verify ${TEST_LINES} lines of 'A's`, async () => {
+		const expectedOutput = Array(TEST_LINES).fill("A".repeat(76)).join("\n") + "\n"
 
-		// This command will generate BASE64_TEST_LINES lines of base64 encoded zeros
-		// Each line will contain 76 'A' characters (base64 encoding of zeros)
+		// This command will generate 1M lines with 76 'A's each.
 		const { executionTimeUs, capturedOutput } = await testTerminalCommand(
-			`yes "${"A".repeat(76)}" | head -n ${BASE64_TEST_LINES}`,
+			`yes "${"A".repeat(76)}" | head -n ${TEST_LINES}`,
 			expectedOutput,
 		)
 
 		console.log(
-			`'base64 < /dev/zero | head -n ${BASE64_TEST_LINES}' execution time: ${executionTimeUs} microseconds (${executionTimeUs / 1000} milliseconds)`,
+			`'base64 < /dev/zero | head -n ${TEST_LINES}' execution time: ${executionTimeUs} microseconds (${executionTimeUs / 1000} milliseconds)`,
 		)
 
 		// Display a truncated output sample (first 3 lines and last 3 lines)
@@ -299,21 +295,23 @@ describe("TerminalProcess with Real Command Output", () => {
 			lines.slice(0, 3).join("\n") +
 			`\n... (truncated ${lines.length - 6} lines) ...\n` +
 			lines.slice(Math.max(0, lines.length - 3), lines.length).join("\n")
+
 		console.log("Output sample (first 3 lines):\n", truncatedOutput)
-		// Verify the output
 
-		// Check if we have BASE64_TEST_LINES lines (may have an empty line at the end)
-		expect(lines.length).toBeGreaterThanOrEqual(BASE64_TEST_LINES)
+		// Verify the output.
+		// Check if we have TEST_LINES lines (may have an empty line at the end).
+		expect(lines.length).toBeGreaterThanOrEqual(TEST_LINES)
 
-		// Sample some lines to verify they contain 76 'A' characters
-		// Sample indices at beginning, 1%, 10%, 50%, and end of the output
+		// Sample some lines to verify they contain 76 'A' characters.
+		// Sample indices at beginning, 1%, 10%, 50%, and end of the output.
 		const sampleIndices = [
 			0,
-			Math.floor(BASE64_TEST_LINES * 0.01),
-			Math.floor(BASE64_TEST_LINES * 0.1),
-			Math.floor(BASE64_TEST_LINES * 0.5),
-			BASE64_TEST_LINES - 1,
+			Math.floor(TEST_LINES * 0.01),
+			Math.floor(TEST_LINES * 0.1),
+			Math.floor(TEST_LINES * 0.5),
+			TEST_LINES - 1,
 		].filter((i) => i < lines.length)
+
 		for (const index of sampleIndices) {
 			expect(lines[index]).toBe("A".repeat(76))
 		}

--- a/src/integrations/terminal/__tests__/TerminalProcessExec.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalProcessExec.test.ts
@@ -253,7 +253,7 @@ describe("TerminalProcess with Real Command Output", () => {
 	})
 
 	it("should execute 'echo -n a' and return exactly 'a'", async () => {
-		const { executionTimeUs } = await testTerminalCommand("echo -n a", "a")
+		const { executionTimeUs } = await testTerminalCommand("/bin/echo -n a", "a")
 		console.log(
 			`'echo -n a' execution time: ${executionTimeUs} microseconds (${executionTimeUs / 1000} milliseconds)`,
 		)
@@ -275,9 +275,9 @@ describe("TerminalProcess with Real Command Output", () => {
 	})
 
 	// Configure the number of lines for the base64 test
-	const BASE64_TEST_LINES = 1000000
+	const BASE64_TEST_LINES = 1_000_000
 
-	it(`should execute 'base64 < /dev/zero | head -n ${BASE64_TEST_LINES}' and verify ${BASE64_TEST_LINES} lines of 'A's`, async () => {
+	it(`should execute 'yes AAA... | head -n ${BASE64_TEST_LINES}' and verify ${BASE64_TEST_LINES} lines of 'A's`, async () => {
 		// Create an expected output pattern that matches what base64 produces
 		// Each line is 76 'A's followed by a newline
 		const expectedOutput = Array(BASE64_TEST_LINES).fill("A".repeat(76)).join("\n") + "\n"
@@ -285,7 +285,7 @@ describe("TerminalProcess with Real Command Output", () => {
 		// This command will generate BASE64_TEST_LINES lines of base64 encoded zeros
 		// Each line will contain 76 'A' characters (base64 encoding of zeros)
 		const { executionTimeUs, capturedOutput } = await testTerminalCommand(
-			`base64 < /dev/zero | head -n ${BASE64_TEST_LINES}`,
+			`yes "${"A".repeat(76)}" | head -n ${BASE64_TEST_LINES}`,
 			expectedOutput,
 		)
 

--- a/src/integrations/terminal/__tests__/TerminalProcessExec.test.ts
+++ b/src/integrations/terminal/__tests__/TerminalProcessExec.test.ts
@@ -286,7 +286,7 @@ describe("TerminalProcess with Real Command Output", () => {
 		)
 
 		console.log(
-			`'base64 < /dev/zero | head -n ${TEST_LINES}' execution time: ${executionTimeUs} microseconds (${executionTimeUs / 1000} milliseconds)`,
+			`'yes "${"A".repeat(76)}" | head -n ${TEST_LINES}' execution time: ${executionTimeUs} microseconds (${executionTimeUs / 1000} milliseconds)`,
 		)
 
 		// Display a truncated output sample (first 3 lines and last 3 lines)


### PR DESCRIPTION
## Context

This particular test isn't platform agnostic.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix platform-specific terminal process unit test in `TerminalProcessExec.test.ts` for MacOS compatibility.
> 
>   - **Tests**:
>     - In `TerminalProcessExec.test.ts`, change command from `base64 < /dev/zero | head -n BASE64_TEST_LINES` to `yes "A" | head -n TEST_LINES` for platform compatibility.
>     - Update variable `BASE64_TEST_LINES` to `TEST_LINES` and adjust related logic.
>     - Modify test to verify output of 1,000,000 lines of 'A's, ensuring compatibility with MacOS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0d55593fa86dd844f59edb6b2205b58b3dc73353. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->