### PR TITLE
Add Deepseek R1 On-Demand to Bedrock

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -342,6 +342,14 @@ export const bedrockModels = {
 		inputPrice: 0.25,
 		outputPrice: 1.25,
 	},
+	"deepseek.r1-v1:0": {
+		maxTokens: 32_768,
+		contextWindow: 128_000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 1.35,
+		outputPrice: 5.4,
+	},
 	"meta.llama3-3-70b-instruct-v1:0": {
 		maxTokens: 8192,
 		contextWindow: 128_000,


### PR DESCRIPTION
## Context

Add configuration for Deepseek R1 V1:0 for AWS Bedrock as it became available for On-Demand use

## Implementation

Added to `api.ts` including settings for `maxTokens`, `contextWindow`, etc.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `deepseek.r1-v1:0` model configuration to `bedrockModels` in `api.ts` with specific token limits and pricing.
> 
>   - **Behavior**:
>     - Add `deepseek.r1-v1:0` to `bedrockModels` in `api.ts` with `maxTokens` 32,768 and `contextWindow` 128,000.
>     - Set `supportsImages` to false and `supportsPromptCache` to false.
>     - Define `inputPrice` as 1.35 and `outputPrice` as 5.4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d3d1a27460dec1af11d01de2e9856cfc70e6ff47. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->