### PR TITLE
fix(ui): remove trailing code delimiters from markdown content

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -986,13 +986,21 @@ const Markdown = memo(({ markdown, partial }: { markdown?: string; partial?: boo
 	const [isHovering, setIsHovering] = useState(false)
 	const { copyWithFeedback } = useCopyToClipboard(200) // shorter feedback duration for copy button flash
 
+	// Remove trailing code delimiters like "```tool_code" or "```xml"
+	const cleanedMarkdown = useMemo(() => {
+		if (!markdown) return markdown
+
+		// Regex to match trailing code block delimiters at the very end of the string
+		return markdown.replace(/```[a-zA-Z0-9_-]*\s*$/g, "")
+	}, [markdown])
+
 	return (
 		<div
 			onMouseEnter={() => setIsHovering(true)}
 			onMouseLeave={() => setIsHovering(false)}
 			style={{ position: "relative" }}>
 			<div style={{ wordBreak: "break-word", overflowWrap: "anywhere", marginBottom: -15, marginTop: -15 }}>
-				<MarkdownBlock markdown={markdown} />
+				<MarkdownBlock markdown={cleanedMarkdown} />
 			</div>
 			{markdown && !partial && isHovering && (
 				<div


### PR DESCRIPTION
## Context

Trailing code delimiters (like "```tool_code" or "```xml") are sometimes displayed in the markdown content when rendered in the ChatRowContent component. This is particularly common with content generated by the Gemini 2.0 thinking model. These delimiters are not meant to be displayed to the user and can make the UI look unpolished.

## Implementation

The implementation adds a regex-based cleaning function in the Markdown component that removes trailing code block delimiters at the end of markdown strings. The function is implemented using useMemo for performance optimization, ensuring it only runs when the markdown content changes.

The regex pattern `/```[a-zA-Z0-9_-]*\s*$/g` specifically targets only trailing delimiters at the very end of the content, preserving code blocks in the middle of the content.

## Screenshots

| before | after |
| ------ | ----- |
| ![Before](https://i.imgur.com/placeholder-before.png) | ![After](https://i.imgur.com/placeholder-after.png) |

## How to Test

1. Open a chat with Roo
2. Ask a question that would result in a code block response (e.g., "Write a React component")
3. Observe that there are no trailing code delimiters at the end of the response
4. For more direct testing, you can modify the markdown content in the ChatRowContent component to include trailing delimiters and verify they are removed

## Get in Touch

If you have any questions or need clarification, please reach out on the [Roo Code Discord](https://discord.gg/roocode).