### PR TITLE
Add diffStrategy name to telemetry

### DIFF
--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -33,6 +33,10 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 	private fuzzyThreshold: number
 	private bufferLines: number
 
+	getName(): string {
+		return "MultiSearchReplace"
+	}
+
 	constructor(fuzzyThreshold?: number, bufferLines?: number) {
 		// Use provided threshold or default to exact matching (1.0)
 		// Note: fuzzyThreshold is inverted in UI (0% = 1.0, 10% = 0.9)

--- a/src/core/diff/strategies/new-unified/index.ts
+++ b/src/core/diff/strategies/new-unified/index.ts
@@ -6,6 +6,10 @@ import { DiffResult, DiffStrategy } from "../../types"
 export class NewUnifiedDiffStrategy implements DiffStrategy {
 	private readonly confidenceThreshold: number
 
+	getName(): string {
+		return "NewUnified"
+	}
+
 	constructor(confidenceThreshold: number = 1) {
 		this.confidenceThreshold = Math.max(confidenceThreshold, 0.8)
 	}

--- a/src/core/diff/strategies/search-replace.ts
+++ b/src/core/diff/strategies/search-replace.ts
@@ -31,6 +31,10 @@ export class SearchReplaceDiffStrategy implements DiffStrategy {
 	private fuzzyThreshold: number
 	private bufferLines: number
 
+	getName(): string {
+		return "SearchReplace"
+	}
+
 	constructor(fuzzyThreshold?: number, bufferLines?: number) {
 		// Use provided threshold or default to exact matching (1.0)
 		// Note: fuzzyThreshold is inverted in UI (0% = 1.0, 10% = 0.9)

--- a/src/core/diff/strategies/unified.ts
+++ b/src/core/diff/strategies/unified.ts
@@ -2,6 +2,9 @@ import { applyPatch } from "diff"
 import { DiffStrategy, DiffResult } from "../types"
 
 export class UnifiedDiffStrategy implements DiffStrategy {
+	getName(): string {
+		return "Unified"
+	}
 	getToolDescription(args: { cwd: string; toolOptions?: { [key: string]: string } }): string {
 		return `## apply_diff
 Description: Apply a unified diff to a file at the specified path. This tool is useful when you need to make specific modifications to a file based on a set of changes provided in unified diff format (diff -U3).

--- a/src/core/diff/types.ts
+++ b/src/core/diff/types.ts
@@ -19,8 +19,13 @@ export type DiffResult =
 			}
 			failParts?: DiffResult[]
 	  } & ({ error: string } | { failParts: DiffResult[] }))
-
 export interface DiffStrategy {
+	/**
+	 * Get the name of this diff strategy for analytics and debugging
+	 * @returns The name of the diff strategy
+	 */
+	getName(): string
+
 	/**
 	 * Get the tool description for this diff strategy
 	 * @param args The tool arguments including cwd and toolOptions

--- a/src/core/prompts/__tests__/sections.test.ts
+++ b/src/core/prompts/__tests__/sections.test.ts
@@ -33,6 +33,7 @@ describe("getCapabilitiesSection", () => {
 	const cwd = "/test/path"
 	const mcpHub = undefined
 	const mockDiffStrategy: DiffStrategy = {
+		getName: () => "MockStrategy",
 		getToolDescription: () => "apply_diff tool description",
 		applyDiff: async (originalContent: string, diffContent: string): Promise<DiffResult> => {
 			return { success: true, content: "mock result" }

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2704,6 +2704,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			}
 		}
 
+		if (currentCline?.diffStrategy) {
+			properties.diffStrategy = currentCline.diffStrategy.getName()
+		}
+
 		return properties
 	}
 }


### PR DESCRIPTION
## Context

I want to gather some info on which diff strategies people are using and how it affects the number of messages they send.

## Implementation

I added a getName method to DiffStrategy and then added it to the list of global properties.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `getName()` to diff strategies and includes strategy name in telemetry data.
> 
>   - **Behavior**:
>     - Adds `getName()` method to `DiffStrategy` interface in `types.ts` to return the strategy name.
>     - Updates `ClineProvider.ts` to include `diffStrategy` name in telemetry properties if `currentCline` has a `diffStrategy`.
>   - **Strategies**:
>     - Implements `getName()` in `MultiSearchReplaceDiffStrategy`, `NewUnifiedDiffStrategy`, `SearchReplaceDiffStrategy`, and `UnifiedDiffStrategy` to return respective strategy names.
>   - **Tests**:
>     - Adds `getName()` to `mockDiffStrategy` in `sections.test.ts` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0d8c6e7ae0607470a9b834d33be6e54707b665af. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->