### PR TITLE
Fix more hard-coded openrouter urls

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -226,11 +226,13 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 	}
 }
 
-export async function getOpenRouterModels() {
+export async function getOpenRouterModels(options?: ApiHandlerOptions) {
 	const models: Record<string, ModelInfo> = {}
 
+	const baseURL = options?.openRouterBaseUrl || "https://openrouter.ai/api/v1"
+
 	try {
-		const response = await axios.get("https://openrouter.ai/api/v1/models")
+		const response = await axios.get(`${baseURL}/models`)
 		const rawModels = response.data.data
 
 		for (const rawModel of rawModels) {


### PR DESCRIPTION
https://github.com/RooVetGit/Roo-Code/issues/1571#issuecomment-2716530428
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Make OpenRouter URL configurable in `getOpenRouterModels` and `handleOpenRouterCallback` to support different environments.
> 
>   - **Behavior**:
>     - `getOpenRouterModels` in `openrouter.ts` now accepts `options` to configure `openRouterBaseUrl`.
>     - `handleOpenRouterCallback` in `ClineProvider.ts` uses `apiConfiguration.openRouterBaseUrl` for the auth endpoint.
>   - **Functions**:
>     - Updated `getOpenRouterModels` calls in `ClineProvider.ts` to pass `apiConfiguration`.
>     - Modified `handleOpenRouterCallback` to extract base domain from `openRouterBaseUrl`.
>   - **Misc**:
>     - Adjusted `refreshOpenRouterModels` case in `ClineProvider.ts` to use `configForRefresh` for model fetching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 774248be1e9ebde67077a77371ba0b8095914fc6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->