### PR TITLE
Fix 'See less' style

### DIFF
--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -267,10 +267,11 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 							<div
 								style={{
 									cursor: "pointer",
-									color: "var(--vscode-textLink-foreground)",
+									color: "var(--vscode-badge-foreground)",
+									fontSize: "11px",
 									marginLeft: "auto",
 									textAlign: "right",
-									paddingRight: 2,
+									paddingRight: 8,
 								}}
 								onClick={() => setIsTextExpanded(!isTextExpanded)}>
 								See less


### PR DESCRIPTION
Before:
<img width="493" alt="Screenshot 2025-03-13 at 3 16 28 PM" src="https://github.com/user-attachments/assets/43e3bb89-ccdb-4f7d-908c-4ab2fb2cd105" />

After:
<img width="490" alt="Screenshot 2025-03-13 at 3 15 59 PM" src="https://github.com/user-attachments/assets/8b300c47-b844-40f9-9284-0d32ec3174dd" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update 'See less' button style in `TaskHeader.tsx` to improve visual consistency.
> 
>   - **Style Changes**:
>     - In `TaskHeader.tsx`, updated the `color` property of the 'See less' button from `var(--vscode-textLink-foreground)` to `var(--vscode-badge-foreground)`.
>     - Adjusted `fontSize` to `11px` and `paddingRight` to `8px` for the 'See less' button in `TaskHeader.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3ad198b8e686e8378653bed7ef0461070c3de211. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->