### PR TITLE
Open a PR to update contributors

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -38,11 +38,18 @@ jobs:
             echo "No changes to README.md"
           fi
           
-      - name: Commit and push changes
+      - name: Create Pull Request
         if: steps.check-changes.outputs.changes == 'true'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add README.md
-          git commit -m "docs: update contributors list [skip ci]"
-          git push
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: update contributors list"
+          title: "Update contributors list"
+          body: |
+            Automated update of contributors list in README.md
+            
+            This PR was created automatically by a GitHub Action workflow.
+          branch: update-contributors
+          branch-suffix: timestamp
+          delete-branch: true
+          base: main


### PR DESCRIPTION
## Context

The github action in #1630 can't write to main directly, so this changes it to open a PR instead.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `update-contributors.yml` to create a pull request for README.md changes instead of direct push.
> 
>   - **Behavior**:
>     - Changes GitHub Action in `update-contributors.yml` to create a pull request instead of pushing directly to `main`.
>     - Uses `peter-evans/create-pull-request@v5` to automate PR creation when `README.md` changes are detected.
>   - **Configuration**:
>     - Sets PR title to "Update contributors list" and commit message to "docs: update contributors list".
>     - Configures PR to delete branch after merge and adds a timestamp suffix to branch name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d9ffda56edb9ac04823683cd9359641f2b1e6652. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->