### PR TITLE
Run prettier before checking for contributor changes

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
         
-      - name: Update contributors and check for changes
+      - name: Update contributors and format
         run: |
           npm run update-contributors
+          npx prettier --write README.md
           if git diff --quiet README.md; then echo "changes=false" >> $GITHUB_OUTPUT; else echo "changes=true" >> $GITHUB_OUTPUT; fi
         id: check-changes
         env:


### PR DESCRIPTION
We need to run prettier on the README before checking if it changed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Run Prettier on `README.md` in the `update-contributors.yml` workflow before checking for changes.
> 
>   - **Workflow Update**:
>     - In `.github/workflows/update-contributors.yml`, added `npx prettier --write README.md` to format the README before checking for changes.
>     - Renamed step to `Update contributors and format` to reflect the new functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 68cbce8017ca8ff0f55dbd0a2a3baf4b4aacc4ec. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->