### PR TITLE
Disable husky when updating contributors

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -21,6 +21,11 @@ jobs:
           node-version: '18'
           cache: 'npm'
           
+      - name: Disable Husky
+        run: |
+          echo "HUSKY=0" >> $GITHUB_ENV
+          git config --global core.hooksPath /dev/null
+          
       - name: Install dependencies
         run: npm ci
         


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Disable Husky hooks in `update-contributors.yml` to prevent interference during the update process.
> 
>   - **Workflow Update**:
>     - In `.github/workflows/update-contributors.yml`, added a step to disable Husky by setting `HUSKY=0` in `$GITHUB_ENV` and configuring Git to ignore hooks globally.
>     - This change prevents Husky hooks from running during the `update-contributors` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9bfd0c9c1b2025f1e50a23a690e9f68c39aba95f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->