### PR TITLE
Added support for scrolling in the ‘Open in Editor’ instance, similar…

### DIFF
--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -317,7 +317,26 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 				</div>
 			</TabHeader>
 
-			<TabContent className="p-0 divide-y divide-vscode-sideBar-background" onScroll={handleScroll}>
+			<TabContent
+				className="p-0 divide-y divide-vscode-sideBar-background"
+				style={{
+					maxHeight: "calc(100vh - 6rem)",
+					height: "calc(100vh - 6rem)",
+					overflowY: "scroll",
+					overflowX: "hidden",
+					WebkitOverflowScrolling: "touch",
+					position: "relative",
+					display: "block",
+					msOverflowStyle: "-ms-autohiding-scrollbar",
+					scrollbarWidth: "auto",
+					scrollbarGutter: "stable",
+					willChange: "scroll-position",
+				}}
+				onWheel={(e) => {
+					const container = e.currentTarget
+					container.scrollTop += e.deltaY
+				}}
+				onScroll={handleScroll}>
 				<div ref={providersRef}>
 					<SectionHeader>
 						<div className="flex items-center gap-2">


### PR DESCRIPTION
Added support for scrolling in the ‘Open in Editor’ instance, simila to how scrolling functions in the main instance.

## Context

https://github.com/RooVetGit/Roo-Code/issues/1529

## Implementation

Ensured that:
1. The scrollbar is always visible and draggable
2. Mousewheel events are explicitly handled
3. Scrolling works in both the main instance and "Open in Editor" instance


## Video

https://github.com/user-attachments/assets/962128a0-d689-49a6-868a-aa75a1391366




<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds scrolling support to the 'Open in Editor' instance in `SettingsView.tsx`, ensuring consistent scrollbar visibility and mousewheel handling.
> 
>   - **Behavior**:
>     - Adds scrolling support to the 'Open in Editor' instance in `SettingsView.tsx`.
>     - Ensures scrollbar is always visible and draggable.
>     - Handles mousewheel events for vertical scrolling.
>   - **Implementation**:
>     - Updates `TabContent` styles to enable vertical scrolling and hide horizontal scrolling.
>     - Adds `onWheel` event handler to manage scroll position in `SettingsView.tsx`.
>     - Adjusts `onScroll` to handle active section updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 70b19a4b6b2a8a82f40ba0bd6051dd2addcf5b6f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->