### PR TITLE
feat(RooCodeAPI): add getCurrentTaskStack() returning stack of task IDs

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -169,6 +169,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		return this.clineStack.length
 	}
 
+	public getCurrentTaskStack(): string[] {
+		return this.clineStack.map((cline) => cline.taskId)
+	}
+
 	// remove the current task/cline instance (at the top of the stack), ao this task is finished
 	// and resume the previous task/cline instance (if it exists)
 	// this is used when a sub task is finished and the parent task needs to be resumed

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -79,4 +79,8 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	public getMessages(taskId: string) {
 		return this.history.getMessages(taskId)
 	}
+
+	public getCurrentTaskStack(): string[] {
+		return this.provider.getCurrentTaskStack()
+	}
 }

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -62,6 +62,12 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 * @returns An array of ClineMessage objects.
 	 */
 	getMessages(taskId: string): ClineMessage[]
+
+	/**
+	 * Returns the current task stack.
+	 * @returns An array of task IDs.
+	 */
+	getCurrentTaskStack(): string[]
 }
 
 export type ClineAsk =


### PR DESCRIPTION
## Context

Related issue: #1656

We need this to make [roospawn](https://github.com/franekp/roospawn/) work seamlessly with subtasks. When starting task from the queue, we need to observe its execution, and associate subtasks with parent task. The simplest way is to expose the stack of task IDs from RooCodeAPI.

## Implementation

Very simple.

## Screenshots
None.

## How to Test
Didn't test it yet.

## Get in Touch
Discord handle: franciszekpiszcz_15867

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `getCurrentTaskStack()` to `ClineProvider` and expose it in `API` to retrieve task ID stack.
> 
>   - **Behavior**:
>     - Adds `getCurrentTaskStack()` method to `ClineProvider` to return the stack of task IDs.
>     - Exposes `getCurrentTaskStack()` in `API` class to provide access to the task ID stack.
>   - **Misc**:
>     - No changes to existing functionality, only additions to support task stack retrieval.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3b5b34012f02de2e1fbfe78b9159dfc524a1ee25. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->