### PR TITLE
feat(RooCodeAPI): add event that user responded to "ask" request

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -89,6 +89,7 @@ export type ClineEvents = {
 	taskStarted: []
 	taskPaused: []
 	taskUnpaused: []
+	taskAskResponded: []
 	taskAborted: []
 	taskSpawned: [taskId: string]
 }
@@ -495,6 +496,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 		this.askResponse = undefined
 		this.askResponseText = undefined
 		this.askResponseImages = undefined
+		this.emit("taskAskResponded")
 		return result
 	}
 

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -42,6 +42,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		cline.on("taskStarted", () => this.emit("taskStarted", cline.taskId))
 		cline.on("taskPaused", () => this.emit("taskPaused", cline.taskId))
 		cline.on("taskUnpaused", () => this.emit("taskUnpaused", cline.taskId))
+		cline.on("taskAskResponded", () => this.emit("taskAskResponded", cline.taskId))
 		cline.on("taskAborted", () => this.emit("taskAborted", cline.taskId))
 		cline.on("taskSpawned", (taskId) => this.emit("taskSpawned", cline.taskId, taskId))
 

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -5,6 +5,7 @@ export interface RooCodeEvents {
 	taskStarted: [taskId: string]
 	taskPaused: [taskId: string]
 	taskUnpaused: [taskId: string]
+	taskAskResponded: [taskId: string]
 	taskAborted: [taskId: string]
 	taskSpawned: [taskId: string, childTaskId: string]
 }


### PR DESCRIPTION
## Context

Related issue: #1656

We need this in [roospawn](https://github.com/franekp/roospawn/) to detect task status more reliably. In particular, we give the user some time to respond to the ask request, and after that time we assume user is AFK, suspend current task and proceed with other tasks from the queue.

## Implementation
Quite simple.

## Screenshots
None.

## How to Test
Didn't test yet.

## Get in Touch
Discord handle: franciszekpiszcz_15867
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `taskAskResponded` event to track user responses to "ask" requests in `Cline.ts`, propagate through `API` in `api.ts`, and update `RooCodeEvents` in `roo-code.d.ts`.
> 
>   - **Behavior**:
>     - Add `taskAskResponded` event to `ClineEvents` in `Cline.ts`.
>     - Emit `taskAskResponded` in `ask()` method in `Cline.ts` when user responds to "ask" request.
>     - Propagate `taskAskResponded` event in `API` class in `api.ts`.
>   - **Types**:
>     - Add `taskAskResponded` to `RooCodeEvents` in `roo-code.d.ts`.
>   - **Misc**:
>     - Update event handling in `API` class in `api.ts` to include `taskAskResponded`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bf497119c8369f745ab5c71951445c6cec6a534e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->