### PR TITLE
feat(RooCodeAPI): implement resumeTask and isTaskInHistory

### DIFF
--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -56,14 +56,9 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	}
 
 	public async resumeTask(taskId: string): Promise<void> {
-		await this.provider.removeClineFromStack()
-		await this.provider.postStateToWebview()
-		await this.provider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
-		// TODO: what message should we send to the webview before resuming an old task?
-		await this.provider.postMessageToWebview({ type: "invoke", invoke: "newChat" })
-
 		const { historyItem } = await this.provider.getTaskWithId(taskId)
 		await this.provider.initClineWithHistoryItem(historyItem)
+		await this.provider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
 	}
 
 	public async isTaskInHistory(taskId: string): Promise<boolean> {

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -55,6 +55,26 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		return cline.taskId
 	}
 
+	public async resumeTask(taskId: string): Promise<void> {
+		await this.provider.removeClineFromStack()
+		await this.provider.postStateToWebview()
+		await this.provider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
+		// TODO: what message should we send to the webview before resuming an old task?
+		await this.provider.postMessageToWebview({ type: "invoke", invoke: "newChat" })
+
+		const { historyItem } = await this.provider.getTaskWithId(taskId)
+		await this.provider.initClineWithHistoryItem(historyItem)
+	}
+
+	public async isTaskInHistory(taskId: string): Promise<boolean> {
+		try {
+			await this.provider.getTaskWithId(taskId)
+			return true
+		} catch {
+			return false
+		}
+	}
+
 	public getCurrentTaskStack() {
 		return this.provider.getCurrentTaskStack()
 	}

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -31,6 +31,20 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	startNewTask(task?: string, images?: string[]): Promise<string>
 
 	/**
+	 * Resumes a task with the given ID.
+	 * @param taskId The ID of the task to resume.
+	 * @throws Error if the task is not found in the task history.
+	 */
+	resumeTask(taskId: string): Promise<void>
+
+	/**
+	 * Checks if a task with the given ID is in the task history.
+	 * @param taskId The ID of the task to check.
+	 * @returns True if the task is in the task history, false otherwise.
+	 */
+	isTaskInHistory(taskId: string): Promise<boolean>
+
+	/**
 	 * Returns the current task stack.
 	 * @returns An array of task IDs.
 	 */


### PR DESCRIPTION
## Context

Related issue: #1656

We need this in [roospawn](https://github.com/franekp/roospawn/) to enable resuming tasks which have ended with a question for the user.

## Implementation

We use the same initialization as startNewTask, but then use `ClineProvider.initClineWithHistoryItem()`.
One thing which is not clear is whether we should also send `{ type: "invoke", invoke: "newChat" }` to the webview, or some other message?

## Screenshots
None.

## How to Test
Didn't test yet.

## Get in Touch
Discord handle: franciszekpiszcz_15867
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `resumeTask` and `isTaskInHistory` methods to `API` class and `RooCodeAPI` interface for task resumption and history checking.
> 
>   - **New Methods in `API` class (`api.ts`)**:
>     - `resumeTask(taskId: string)`: Initializes a task from history and sends a chat button click action to the webview.
>     - `isTaskInHistory(taskId: string)`: Checks if a task exists in history, returning a boolean.
>   - **Interface Updates in `roo-code.d.ts`**:
>     - Added `resumeTask` and `isTaskInHistory` to `RooCodeAPI` interface with appropriate documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 91376a2ad13067b50c65a25f728ec2f1aec3c2ad. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->