### PR TITLE
Fix old task deletion bug

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2169,33 +2169,51 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	}> {
 		const history = ((await this.getGlobalState("taskHistory")) as HistoryItem[] | undefined) || []
 		const historyItem = history.find((item) => item.id === id)
-		if (historyItem) {
-			const taskDirPath = path.join(this.contextProxy.globalStorageUri.fsPath, "tasks", id)
-			const apiConversationHistoryFilePath = path.join(taskDirPath, GlobalFileNames.apiConversationHistory)
-			const uiMessagesFilePath = path.join(taskDirPath, GlobalFileNames.uiMessages)
-			const fileExists = await fileExistsAtPath(apiConversationHistoryFilePath)
-			if (fileExists) {
-				const apiConversationHistory = JSON.parse(await fs.readFile(apiConversationHistoryFilePath, "utf8"))
-				return {
-					historyItem,
-					taskDirPath,
-					apiConversationHistoryFilePath,
-					uiMessagesFilePath,
-					apiConversationHistory,
-				}
-			}
+		if (!historyItem) {
+			throw new Error("Task not found in history")
 		}
-		// if we tried to get a task that doesn't exist, remove it from state
-		// FIXME: this seems to happen sometimes when the json file doesnt save to disk for some reason
-		await this.deleteTaskFromState(id)
-		throw new Error("Task not found")
+
+		const taskDirPath = path.join(this.contextProxy.globalStorageUri.fsPath, "tasks", id)
+		const apiConversationHistoryFilePath = path.join(taskDirPath, GlobalFileNames.apiConversationHistory)
+		const uiMessagesFilePath = path.join(taskDirPath, GlobalFileNames.uiMessages)
+
+		const fileExists = await fileExistsAtPath(apiConversationHistoryFilePath)
+		if (!fileExists) {
+			// Instead of silently deleting, throw a specific error
+			throw new Error("TASK_FILES_MISSING")
+		}
+
+		const apiConversationHistory = JSON.parse(await fs.readFile(apiConversationHistoryFilePath, "utf8"))
+		return {
+			historyItem,
+			taskDirPath,
+			apiConversationHistoryFilePath,
+			uiMessagesFilePath,
+			apiConversationHistory,
+		}
 	}
 
 	async showTaskWithId(id: string) {
 		if (id !== this.getCurrentCline()?.taskId) {
-			// Non-current task.
-			const { historyItem } = await this.getTaskWithId(id)
-			await this.initClineWithHistoryItem(historyItem) // Clears existing task.
+			try {
+				const { historyItem } = await this.getTaskWithId(id)
+				await this.initClineWithHistoryItem(historyItem)
+			} catch (error) {
+				if (error.message === "TASK_FILES_MISSING") {
+					const response = await vscode.window.showWarningMessage(
+						"This task's files are missing. Would you like to remove it from the task list?",
+						"Remove",
+						"Keep",
+					)
+
+					if (response === "Remove") {
+						await this.deleteTaskFromState(id)
+						await this.postStateToWebview()
+					}
+					return
+				}
+				throw error
+			}
 		}
 
 		await this.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
@@ -2658,5 +2676,31 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		}
 
 		return properties
+	}
+
+	async validateTaskHistory() {
+		const history = ((await this.getGlobalState("taskHistory")) as HistoryItem[] | undefined) || []
+		const validTasks: HistoryItem[] = []
+
+		for (const item of history) {
+			const taskDirPath = path.join(this.contextProxy.globalStorageUri.fsPath, "tasks", item.id)
+			const apiConversationHistoryFilePath = path.join(taskDirPath, GlobalFileNames.apiConversationHistory)
+
+			if (await fileExistsAtPath(apiConversationHistoryFilePath)) {
+				validTasks.push(item)
+			}
+		}
+
+		if (validTasks.length !== history.length) {
+			await this.updateGlobalState("taskHistory", validTasks)
+			await this.postStateToWebview()
+
+			const removedCount = history.length - validTasks.length
+			if (removedCount > 0) {
+				await vscode.window.showInformationMessage(
+					`Cleaned up ${removedCount} task(s) with missing files from history.`,
+				)
+			}
+		}
 	}
 }

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -54,6 +54,78 @@ jest.mock("../../contextProxy", () => {
 	}
 })
 
+describe("validateTaskHistory", () => {
+	let provider: ClineProvider
+	let mockContext: vscode.ExtensionContext
+	let mockOutputChannel: vscode.OutputChannel
+	let mockUpdate: jest.Mock
+
+	beforeEach(() => {
+		// Reset mocks
+		jest.clearAllMocks()
+
+		mockUpdate = jest.fn()
+
+		// Setup basic mocks
+		mockContext = {
+			globalState: {
+				get: jest.fn(),
+				update: mockUpdate,
+				keys: jest.fn().mockReturnValue([]),
+			},
+			secrets: { get: jest.fn(), store: jest.fn(), delete: jest.fn() },
+			extensionUri: {} as vscode.Uri,
+			globalStorageUri: { fsPath: "/test/path" },
+			extension: { packageJSON: { version: "1.0.0" } },
+		} as unknown as vscode.ExtensionContext
+
+		mockOutputChannel = { appendLine: jest.fn() } as unknown as vscode.OutputChannel
+		provider = new ClineProvider(mockContext, mockOutputChannel)
+	})
+
+	test("should remove tasks with missing files", async () => {
+		// Mock the global state with some test data
+		const mockHistory = [
+			{ id: "task1", ts: Date.now() },
+			{ id: "task2", ts: Date.now() },
+		]
+
+		// Setup mocks
+		jest.spyOn(mockContext.globalState, "get").mockReturnValue(mockHistory)
+
+		// Mock fileExistsAtPath to only return true for task1
+		const mockFs = require("../../../utils/fs")
+		mockFs.fileExistsAtPath = jest.fn().mockImplementation((path) => Promise.resolve(path.includes("task1")))
+
+		// Call validateTaskHistory
+		await provider.validateTaskHistory()
+
+		// Verify the results
+		const expectedHistory = [expect.objectContaining({ id: "task1" })]
+
+		expect(mockUpdate).toHaveBeenCalledWith("taskHistory", expect.arrayContaining(expectedHistory))
+		expect(mockUpdate.mock.calls[0][1].length).toBe(1)
+	})
+
+	test("should handle empty history", async () => {
+		// Mock empty history
+		jest.spyOn(mockContext.globalState, "get").mockReturnValue([])
+
+		await provider.validateTaskHistory()
+
+		expect(mockUpdate).toHaveBeenCalledWith("taskHistory", [])
+	})
+
+	test("should handle null history", async () => {
+		// Mock null history
+		jest.spyOn(mockContext.globalState, "get").mockReturnValue(null)
+
+		await provider.validateTaskHistory()
+
+		expect(mockUpdate).toHaveBeenCalledWith("taskHistory", [])
+	})
+})
+
 // Mock dependencies
 jest.mock("vscode")
 jest.mock("delay")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,11 @@ export function activate(context: vscode.ExtensionContext) {
 	const provider = new ClineProvider(context, outputChannel)
 	telemetryService.setProvider(provider)
 
+	// Validate task history on extension activation
+	provider.validateTaskHistory().catch((error) => {
+		outputChannel.appendLine(`Failed to validate task history: ${error}`)
+	})
+
 	context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider(ClineProvider.sideBarId, provider, {
 			webviewOptions: { retainContextWhenHidden: true },


### PR DESCRIPTION
## Context

https://github.com/RooVetGit/Roo-Code/issues/1295

The core issues are:

1. Tasks silently disappear when clicked if their files are missing
2. Task history persists in global state even when task files are gone after uninstall/reinstall

Observations:

- The current code in getTaskWithId() silently deletes tasks when files are missing
- There's no validation of task history on extension activation
- No user feedback when task files are missing

## Implementation

1. Added task history validation on extension activation to check for missing files
2. Modified getTaskWithId() to throw a specific error instead of silently deleting
3. Updated showTaskWithId() to handle missing files gracefully with user feedback
4. Added Unit tests to verify the new behaviour.

This approach:

- Maintains existing functionality while adding proper error handling
- Provides clear user feedback
- Validates task history on startup to prevent confusion
- Doesn't require clearing history on install (which could be frustrating for users upgrading)

The solution maintains existing functionality while adding proper error handling and user feedback. It doesn't automatically clear history on install/uninstall since that could be frustrating for users who are just upgrading the extension.

## Video

https://github.com/user-attachments/assets/62f63b07-6c8f-4396-a703-4d9184144282


## How to Test

1. Remove or rename a task's API conversation history file(api_conversation_history.json) from its directory 
2. Try deleting the task from Roo
3. You should see a warning and an option to remove/keep it in the task history
<img width="504" alt="image" src="https://github.com/user-attachments/assets/f74ce241-08c8-41f7-84e1-fa1bab7785d4" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes task history management by validating tasks with missing files on startup and providing user feedback in `ClineProvider.ts`.
> 
>   - **Behavior**:
>     - Validates task history on extension activation in `extension.ts` to remove tasks with missing files.
>     - `getTaskWithId()` in `ClineProvider.ts` now throws "TASK_FILES_MISSING" error instead of deleting tasks silently.
>     - `showTaskWithId()` in `ClineProvider.ts` prompts user to remove or keep tasks with missing files.
>   - **Tests**:
>     - Added tests in `ClineProvider.test.ts` to verify task history validation and user prompts for missing files.
>   - **Misc**:
>     - Minor logging changes in `extension.ts` for task history validation errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2a2e467ba48fb4f4e08e2c43f07dc1f718e8333c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->