### PR TITLE
Fix i18n of footer

### DIFF
--- a/webview-ui/src/components/settings/SettingsFooter.tsx
+++ b/webview-ui/src/components/settings/SettingsFooter.tsx
@@ -1,7 +1,8 @@
 import { HTMLAttributes } from "react"
 import { useAppTranslation } from "@/i18n/TranslationContext"
+import { Trans } from "react-i18next"
 
-import { VSCodeButton, VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
+import { VSCodeButton, VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 
 import { vscode } from "@/utils/vscode"
 import { cn } from "@/lib/utils"
@@ -24,7 +25,16 @@ export const SettingsFooter = ({
 
 	return (
 		<div className={cn("text-vscode-descriptionForeground p-5", className)} {...props}>
-			<p style={{ wordWrap: "break-word", margin: 0, padding: 0 }}>{t("settings:footer.feedback")} </p>
+			<p style={{ wordWrap: "break-word", margin: 0, padding: 0 }}>
+				<Trans
+					i18nKey="settings:footer.feedback"
+					components={{
+						githubLink: <VSCodeLink href="https://github.com/RooVetGit/Roo-Code" />,
+						redditLink: <VSCodeLink href="https://reddit.com/r/RooCode" />,
+						discordLink: <VSCodeLink href="https://discord.gg/roocode" />,
+					}}
+				/>
+			</p>
 			<p className="italic">{t("settings:footer.version", { version })}</p>
 			<div className="mt-4 mb-4">
 				<div>

--- a/webview-ui/src/i18n/locales/ar/settings.json
+++ b/webview-ui/src/i18n/locales/ar/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "إذا كان لديك أي أسئلة أو ملاحظات، فلا تتردد في فتح مشكلة في github.com/RooVetGit/Roo-Code أو الانضمام إلى reddit.com/r/RooCode",
+		"feedback": "إذا كان لديك أي أسئلة أو ملاحظات، فلا تتردد في فتح مشكلة في <githubLink>github.com/RooVetGit/Roo-Code</githubLink> أو الانضمام إلى <redditLink>reddit.com/r/RooCode</redditLink> أو <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "السماح بإرسال تقارير استخدام وأخطاء مجهولة",

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Si teniu qualsevol pregunta o comentari, no dubteu a obrir un issue a github.com/RooVetGit/Roo-Code o unir-vos a reddit.com/r/RooCode",
+		"feedback": "Si teniu qualsevol pregunta o comentari, no dubteu a obrir un issue a <githubLink>github.com/RooVetGit/Roo-Code</githubLink> o unir-vos a <redditLink>reddit.com/r/RooCode</redditLink> o <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Permetre informes anònims d'errors i ús",

--- a/webview-ui/src/i18n/locales/cs/settings.json
+++ b/webview-ui/src/i18n/locales/cs/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Pokud máte jakékoliv otázky nebo zpětnou vazbu, neváhejte otevřít problém na github.com/RooVetGit/Roo-Code nebo se připojit na reddit.com/r/RooCode",
+		"feedback": "Pokud máte jakékoliv otázky nebo zpětnou vazbu, neváhejte otevřít problém na <githubLink>github.com/RooVetGit/Roo-Code</githubLink> nebo se připojit na <redditLink>reddit.com/r/RooCode</redditLink> nebo <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Povolit anonymní hlášení chyb a používání",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Wenn Sie Fragen oder Feedback haben, können Sie gerne ein Issue auf github.com/RooVetGit/Roo-Code öffnen oder reddit.com/r/RooCode beitreten",
+		"feedback": "Wenn Sie Fragen oder Feedback haben, können Sie gerne ein Issue auf <githubLink>github.com/RooVetGit/Roo-Code</githubLink> öffnen oder <redditLink>reddit.com/r/RooCode</redditLink> oder <discordLink>discord.gg/roocode</discordLink> beitreten",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Anonyme Fehler- und Nutzungsberichte zulassen",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "If you have any questions or feedback, feel free to open an issue at github.com/RooVetGit/Roo-Code or join reddit.com/r/RooCode",
+		"feedback": "If you have any questions or feedback, feel free to open an issue at <githubLink>github.com/RooVetGit/Roo-Code</githubLink> or join <redditLink>reddit.com/r/RooCode</redditLink> or <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Allow anonymous error and usage reporting",

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Si tiene alguna pregunta o comentario, no dude en abrir un issue en github.com/RooVetGit/Roo-Code o unirse a reddit.com/r/RooCode",
+		"feedback": "Si tiene alguna pregunta o comentario, no dude en abrir un issue en <githubLink>github.com/RooVetGit/Roo-Code</githubLink> o unirse a <redditLink>reddit.com/r/RooCode</redditLink> o <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Permitir informes anónimos de errores y uso",

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Si vous avez des questions ou des commentaires, n'hésitez pas à ouvrir un problème sur github.com/RooVetGit/Roo-Code ou à rejoindre reddit.com/r/RooCode",
+		"feedback": "Si vous avez des questions ou des commentaires, n'hésitez pas à ouvrir un problème sur <githubLink>github.com/RooVetGit/Roo-Code</githubLink> ou à rejoindre <redditLink>reddit.com/r/RooCode</redditLink> ou <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Autoriser les rapports anonymes d'erreurs et d'utilisation",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "यदि आपके कोई प्रश्न या प्रतिक्रिया है, तो github.com/RooVetGit/Roo-Code पर एक मुद्दा खोलने या reddit.com/r/RooCode में शामिल होने में संकोच न करें",
+		"feedback": "यदि आपके कोई प्रश्न या प्रतिक्रिया है, तो <githubLink>github.com/RooVetGit/Roo-Code</githubLink> पर एक मुद्दा खोलने या <redditLink>reddit.com/r/RooCode</redditLink> या <discordLink>discord.gg/roocode</discordLink> में शामिल होने में संकोच न करें",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "गुमनाम त्रुटि और उपयोग रिपोर्टिंग की अनुमति दें",

--- a/webview-ui/src/i18n/locales/hu/settings.json
+++ b/webview-ui/src/i18n/locales/hu/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Ha bármilyen kérdése vagy visszajelzése van, nyugodtan nyisson egy problémát a github.com/RooVetGit/Roo-Code oldalon, vagy csatlakozzon a reddit.com/r/RooCode oldalhoz",
+		"feedback": "Ha bármilyen kérdése vagy visszajelzése van, nyugodtan nyisson egy problémát a <githubLink>github.com/RooVetGit/Roo-Code</githubLink> oldalon, vagy csatlakozzon a <redditLink>reddit.com/r/RooCode</redditLink> vagy <discordLink>discord.gg/roocode</discordLink> oldalhoz",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Névtelen hiba- és használati jelentések engedélyezése",

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Se hai domande o feedback, sentiti libero di aprire un issue su github.com/RooVetGit/Roo-Code o unirti a reddit.com/r/RooCode",
+		"feedback": "Se hai domande o feedback, sentiti libero di aprire un issue su <githubLink>github.com/RooVetGit/Roo-Code</githubLink> o unirti a <redditLink>reddit.com/r/RooCode</redditLink> o <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Consenti segnalazioni anonime di errori e utilizzo",

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "質問やフィードバックがある場合は、github.com/RooVetGit/Roo-Codeで問題を開くか、reddit.com/r/RooCodeに参加してください",
+		"feedback": "質問やフィードバックがある場合は、<githubLink>github.com/RooVetGit/Roo-Code</githubLink>で問題を開くか、<redditLink>reddit.com/r/RooCode</redditLink>や<discordLink>discord.gg/roocode</discordLink>に参加してください",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "匿名のエラーと使用状況レポートを許可",

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "질문이나 피드백이 있으시면 github.com/RooVetGit/Roo-Code에서 이슈를 열거나 reddit.com/r/RooCode에 가입하세요",
+		"feedback": "질문이나 피드백이 있으시면 <githubLink>github.com/RooVetGit/Roo-Code</githubLink>에서 이슈를 열거나 <redditLink>reddit.com/r/RooCode</redditLink> 또는 <discordLink>discord.gg/roocode</discordLink>에 가입하세요",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "익명 오류 및 사용 보고 허용",

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Jeśli masz jakiekolwiek pytania lub opinie, śmiało otwórz zgłoszenie na github.com/RooVetGit/Roo-Code lub dołącz do reddit.com/r/RooCode",
+		"feedback": "Jeśli masz jakiekolwiek pytania lub opinie, śmiało otwórz zgłoszenie na <githubLink>github.com/RooVetGit/Roo-Code</githubLink> lub dołącz do <redditLink>reddit.com/r/RooCode</redditLink> lub <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Zezwól na anonimowe raportowanie błędów i użycia",

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Se tiver alguma dúvida ou feedback, sinta-se à vontade para abrir um problema em github.com/RooVetGit/Roo-Code ou juntar-se a reddit.com/r/RooCode",
+		"feedback": "Se tiver alguma dúvida ou feedback, sinta-se à vontade para abrir um problema em <githubLink>github.com/RooVetGit/Roo-Code</githubLink> ou juntar-se a <redditLink>reddit.com/r/RooCode</redditLink> ou <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Permitir relatórios anônimos de erros e uso",

--- a/webview-ui/src/i18n/locales/pt/settings.json
+++ b/webview-ui/src/i18n/locales/pt/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Se tiver alguma dúvida ou feedback, sinta-se à vontade para abrir um problema em github.com/RooVetGit/Roo-Code ou juntar-se a reddit.com/r/RooCode",
+		"feedback": "Se tiver alguma dúvida ou feedback, sinta-se à vontade para abrir um problema em <githubLink>github.com/RooVetGit/Roo-Code</githubLink> ou juntar-se a <redditLink>reddit.com/r/RooCode</redditLink> ou <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Permitir relatórios anônimos de erros e uso",

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Если у вас есть вопросы или отзывы, не стесняйтесь открыть issue на github.com/RooVetGit/Roo-Code или присоединиться к reddit.com/r/RooCode",
+		"feedback": "Если у вас есть вопросы или отзывы, не стесняйтесь открыть issue на <githubLink>github.com/RooVetGit/Roo-Code</githubLink> или присоединиться к <redditLink>reddit.com/r/RooCode</redditLink> или <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Разрешить анонимные отчеты об ошибках и использовании",

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "Herhangi bir sorunuz veya geri bildiriminiz varsa, github.com/RooVetGit/Roo-Code adresinde bir konu açmaktan veya reddit.com/r/RooCode'a katılmaktan çekinmeyin",
+		"feedback": "Herhangi bir sorunuz veya geri bildiriminiz varsa, <githubLink>github.com/RooVetGit/Roo-Code</githubLink> adresinde bir konu açmaktan veya <redditLink>reddit.com/r/RooCode</redditLink> ya da <discordLink>discord.gg/roocode</discordLink>'a katılmaktan çekinmeyin",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "Anonim hata ve kullanım raporlamaya izin ver",

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "如果您有任何问题或反馈，请随时在 github.com/RooVetGit/Roo-Code 上提出问题或加入 reddit.com/r/RooCode",
+		"feedback": "如果您有任何问题或反馈，请随时在 <githubLink>github.com/RooVetGit/Roo-Code</githubLink> 上提出问题或加入 <redditLink>reddit.com/r/RooCode</redditLink> 或 <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "允许匿名错误和使用情况报告",

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -191,7 +191,7 @@
 		}
 	},
 	"footer": {
-		"feedback": "如果您有任何問題或反饋，請隨時在 github.com/RooVetGit/Roo-Code 上提出問題或加入 reddit.com/r/RooCode",
+		"feedback": "如果您有任何問題或反饋，請隨時在 <githubLink>github.com/RooVetGit/Roo-Code</githubLink> 上提出問題或加入 <redditLink>reddit.com/r/RooCode</redditLink> 或 <discordLink>discord.gg/roocode</discordLink>",
 		"version": "Roo Code v{{version}}",
 		"telemetry": {
 			"label": "允許匿名錯誤和使用情況報告",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhances i18n of `SettingsFooter` by adding interactive links for GitHub, Reddit, and Discord in multiple languages.
> 
>   - **Behavior**:
>     - Updates `SettingsFooter.tsx` to use `Trans` component for i18n of feedback text with links to GitHub, Reddit, and Discord.
>     - Adds `VSCodeLink` for interactive links in feedback text.
>   - **Translations**:
>     - Updates `feedback` key in `settings.json` for multiple locales (e.g., `ar`, `ca`, `cs`, `de`, `en`, `es`, `fr`, `hi`, `hu`, `it`, `ja`, `ko`, `pl`, `pt-BR`, `pt`, `ru`, `tr`, `zh-CN`, `zh-TW`) to include placeholders for `githubLink`, `redditLink`, and `discordLink`.
>   - **Misc**:
>     - Imports `Trans` from `react-i18next` in `SettingsFooter.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7e29011b7930282e8f47adbf965a7839781da31d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->