### PR TITLE
build: prevent $esbuild-watch error

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -41,7 +41,17 @@
 			"type": "npm",
 			"script": "watch:esbuild",
 			"group": "build",
-			"problemMatcher": "$esbuild-watch",
+			"problemMatcher": {
+				"owner": "esbuild",
+				"pattern": {
+					"regexp": "^$"
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "\\[watch\\] build started",
+					"endsPattern": "\\[watch\\] build finished"
+				}
+			},
 			"isBackground": true,
 			"presentation": {
 				"group": "watch",


### PR DESCRIPTION
When running Roo from development build of vscode main emit the following error:

    Error: Invalid problemMatcher reference: $esbuild-watch

This commit prevents that error by avoiding the use of $esbuild-watch

Please review this change before merging and make sure it works for you, I am not so familiar with the inner workings of vscode and npm, but this fix worked for me.

## Context

I am bisecting a problem in `vscode` itself which prevents Shift+CTRL+F5 from restarting the debug instance of Roo.it or some reason running the development build of `vscode` from their git tree produces that error, and this patch fixes a.

## Implementation

replace the built in watch with a simple check for started/finished 

## Testing

### From Roo in a normal vscode deployment:

1. code /path/to/roo-code-git
2. press F5
3. let it load
4. click back on main vscode (not the extension host)
5. Press CTRL+SHIFT+F5
6. make sure it restarts 

### From Roo in vscode dev build tree:

1. git clone vscode
2. cd vscode
3. npm install
4. npm compile
5. ./scripts/code.sh /path/to/roo-code-git
7. press F5
8. let it load
9. click back on main vscode (not the extension host)
10. Press CTRL+SHIFT+F5
11.  make sure it restarts 
