### PR TITLE
Fix language dropdown

### DIFF
--- a/webview-ui/src/components/settings/SettingsFooter.tsx
+++ b/webview-ui/src/components/settings/SettingsFooter.tsx
@@ -12,22 +12,17 @@ import { SetCachedStateField } from "./types"
 
 // Map of language codes to their display names
 const LANGUAGES: Record<string, string> = {
-	ar: "العربية",
 	ca: "Català",
-	cs: "Čeština",
 	de: "Deutsch",
 	en: "English",
 	es: "Español",
 	fr: "Français",
 	hi: "हिन्दी",
-	hu: "Magyar",
 	it: "Italiano",
 	ja: "日本語",
 	ko: "한국어",
 	pl: "Polski",
-	pt: "Português",
-	"pt-BR": "Português do Brasil",
-	ru: "Русский",
+	"pt-BR": "Português",
 	tr: "Türkçe",
 	vi: "Tiếng Việt",
 	"zh-CN": "简体中文",


### PR DESCRIPTION
Missed a spot in #1716
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes language dropdown by removing unused codes and correcting Brazilian Portuguese display name in `SettingsFooter.tsx`.
> 
>   - **Behavior**:
>     - Removes unused language codes `ar`, `cs`, `hu`, `pt`, and `ru` from `LANGUAGES` in `SettingsFooter.tsx`.
>     - Corrects display name for `pt-BR` from "Português do Brasil" to "Português" in `SettingsFooter.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 650fcb21a431a73187ce5f658007af7ee6bf330f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->