### PR TITLE
feat(config): migrate global rate limit to profile-specific settings

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1059,7 +1059,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 	async *attemptApiRequest(previousApiReqIndex: number, retryAttempt: number = 0): ApiStream {
 		let mcpHub: McpHub | undefined
 
-		const { mcpEnabled, alwaysApproveResubmit, requestDelaySeconds, rateLimitSeconds } =
+		const { mcpEnabled, alwaysApproveResubmit, requestDelaySeconds } =
 			(await this.providerRef.deref()?.getState()) ?? {}
 
 		let rateLimitDelay = 0
@@ -1068,7 +1068,8 @@ export class Cline extends EventEmitter<ClineEvents> {
 		if (this.lastApiRequestTime) {
 			const now = Date.now()
 			const timeSinceLastRequest = now - this.lastApiRequestTime
-			const rateLimit = rateLimitSeconds || 0
+			// Get rate limit from the current API configuration instead of global state
+			const rateLimit = this.apiConfiguration.rateLimitSeconds || 0
 			rateLimitDelay = Math.ceil(Math.max(0, rateLimit * 1000 - timeSinceLastRequest) / 1000)
 		}
 

--- a/src/core/config/__tests__/ConfigManager.test.ts
+++ b/src/core/config/__tests__/ConfigManager.test.ts
@@ -216,6 +216,7 @@ describe("ConfigManager", () => {
 						apiProvider: "anthropic",
 						apiKey: "new-key",
 						id: "test-id",
+						rateLimitSeconds: 0, // Default rate limit is 0 seconds
 					},
 				},
 			}
@@ -544,8 +545,11 @@ describe("ConfigManager", () => {
 
 			mockSecrets.get.mockResolvedValue(JSON.stringify(emptyConfig))
 
+			// Create a new instance with the mock context
+			const localConfigManager = new ConfigManager(mockContext)
+
 			// Call the migration method
-			await configManager.migrateRateLimitToProfiles()
+			await localConfigManager.migrateRateLimitToProfiles()
 
 			// Verify the global rate limit was removed even with empty config
 			expect(mockGlobalState.update).toHaveBeenCalledWith("rateLimitSeconds", undefined)
@@ -562,8 +566,11 @@ describe("ConfigManager", () => {
 			// Force an error during read
 			mockSecrets.get.mockRejectedValue(new Error("Storage failed"))
 
+			// Create a new instance with the mock context
+			const localConfigManager = new ConfigManager(mockContext)
+
 			// Expect the migration to throw an error
-			await expect(configManager.migrateRateLimitToProfiles()).rejects.toThrow(
+			await expect(localConfigManager.migrateRateLimitToProfiles()).rejects.toThrow(
 				"Failed to migrate rate limit settings: Error: Failed to read config from secrets: Error: Storage failed",
 			)
 		})

--- a/src/core/config/__tests__/ConfigManager.test.ts
+++ b/src/core/config/__tests__/ConfigManager.test.ts
@@ -173,6 +173,7 @@ describe("ConfigManager", () => {
 					test: {
 						...newConfig,
 						id: testConfigId,
+						rateLimitSeconds: 0, // Default rate limit is 0 seconds
 					},
 				},
 				modeApiConfigs: {

--- a/src/core/config/__tests__/ConfigManager.test.ts
+++ b/src/core/config/__tests__/ConfigManager.test.ts
@@ -544,13 +544,12 @@ describe("ConfigManager", () => {
 				apiConfigs: {},
 			}
 
+			// Mock the readConfig and writeConfig methods
 			mockSecrets.get.mockResolvedValue(JSON.stringify(emptyConfig))
+			mockSecrets.store.mockResolvedValue(undefined)
 
-			// Create a new instance with the mock context
-			const localConfigManager = new ConfigManager(mockContext)
-
-			// Call the migration method
-			await localConfigManager.migrateRateLimitToProfiles()
+			// Use the existing configManager instance
+			await configManager.migrateRateLimitToProfiles()
 
 			// Verify the global rate limit was removed even with empty config
 			expect(mockGlobalState.update).toHaveBeenCalledWith("rateLimitSeconds", undefined)
@@ -567,11 +566,8 @@ describe("ConfigManager", () => {
 			// Force an error during read
 			mockSecrets.get.mockRejectedValue(new Error("Storage failed"))
 
-			// Create a new instance with the mock context
-			const localConfigManager = new ConfigManager(mockContext)
-
 			// Expect the migration to throw an error
-			await expect(localConfigManager.migrateRateLimitToProfiles()).rejects.toThrow(
+			await expect(configManager.migrateRateLimitToProfiles()).rejects.toThrow(
 				"Failed to migrate rate limit settings: Error: Failed to read config from secrets: Error: Storage failed",
 			)
 		})

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1331,7 +1331,14 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						await this.postStateToWebview()
 						break
 					case "rateLimitSeconds":
-						await this.updateGlobalState("rateLimitSeconds", message.value ?? 0)
+						// Update the current API configuration with the rate limit value
+						const currentApiConfigName = (await this.getGlobalState("currentApiConfigName")) as string
+						if (currentApiConfigName) {
+							const apiConfig = await this.configManager.loadConfig(currentApiConfigName)
+							apiConfig.rateLimitSeconds = message.value ?? 0
+							await this.configManager.saveConfig(currentApiConfigName, apiConfig)
+							await this.updateApiConfiguration(apiConfig)
+						}
 						await this.postStateToWebview()
 						break
 					case "writeDelayMs":
@@ -2296,7 +2303,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			enableMcpServerCreation,
 			alwaysApproveResubmit,
 			requestDelaySeconds,
-			rateLimitSeconds,
+			// rateLimitSeconds is now part of apiConfiguration
 			currentApiConfigName,
 			listApiConfigMeta,
 			mode,
@@ -2357,7 +2364,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			enableMcpServerCreation: enableMcpServerCreation ?? true,
 			alwaysApproveResubmit: alwaysApproveResubmit ?? false,
 			requestDelaySeconds: requestDelaySeconds ?? 10,
-			rateLimitSeconds: rateLimitSeconds ?? 0,
+			rateLimitSeconds: apiConfiguration.rateLimitSeconds ?? 0,
 			currentApiConfigName: currentApiConfigName ?? "default",
 			listApiConfigMeta: listApiConfigMeta ?? [],
 			mode: mode ?? defaultModeSlug,
@@ -2515,7 +2522,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 			enableMcpServerCreation: stateValues.enableMcpServerCreation ?? true,
 			alwaysApproveResubmit: stateValues.alwaysApproveResubmit ?? false,
 			requestDelaySeconds: Math.max(5, stateValues.requestDelaySeconds ?? 10),
-			rateLimitSeconds: stateValues.rateLimitSeconds ?? 0,
+			// rateLimitSeconds is now part of the API configuration
 			currentApiConfigName: stateValues.currentApiConfigName ?? "default",
 			listApiConfigMeta: stateValues.listApiConfigMeta ?? [],
 			modeApiConfigs: stateValues.modeApiConfigs ?? ({} as Record<Mode, string>),

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -119,7 +119,7 @@ export interface ExtensionState {
 	alwaysAllowSubtasks?: boolean
 	browserToolEnabled?: boolean
 	requestDelaySeconds: number
-	rateLimitSeconds: number // Minimum time between successive requests (0 = disabled)
+	rateLimitSeconds?: number // Minimum time between successive requests (0 = disabled)
 	uriScheme?: string
 	currentTaskItem?: HistoryItem
 	allowedCommands?: string[]

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -80,6 +80,7 @@ export interface ApiHandlerOptions {
 export type ApiConfiguration = ApiHandlerOptions & {
 	apiProvider?: ApiProvider
 	id?: string // stable unique identifier
+	rateLimitSeconds?: number // Rate limit in seconds between API requests
 }
 
 // Import GlobalStateKey type from globalState.ts
@@ -130,6 +131,7 @@ export const API_CONFIG_KEYS: GlobalStateKey[] = [
 	"modelTemperature",
 	"modelMaxTokens",
 	"modelMaxThinkingTokens",
+	"rateLimitSeconds", // Added for profile-specific rate limiting
 ]
 
 // Models

--- a/webview-ui/src/components/settings/AdvancedSettings.tsx
+++ b/webview-ui/src/components/settings/AdvancedSettings.tsx
@@ -13,7 +13,7 @@ import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 
 type AdvancedSettingsProps = HTMLAttributes<HTMLDivElement> & {
-	rateLimitSeconds: number
+	rateLimitSeconds?: number
 	diffEnabled?: boolean
 	fuzzyMatchThreshold?: number
 	setCachedStateField: SetCachedStateField<"rateLimitSeconds" | "diffEnabled" | "fuzzyMatchThreshold">
@@ -50,11 +50,11 @@ export const AdvancedSettings = ({
 								min="0"
 								max="60"
 								step="1"
-								value={rateLimitSeconds}
+								value={rateLimitSeconds || 0}
 								onChange={(e) => setCachedStateField("rateLimitSeconds", parseInt(e.target.value))}
 								className="h-2 focus:outline-0 w-4/5 accent-vscode-button-background"
 							/>
-							<span style={{ ...sliderLabelStyle }}>{rateLimitSeconds}s</span>
+							<span style={{ ...sliderLabelStyle }}>{rateLimitSeconds || 0}s</span>
 						</div>
 					</div>
 					<p className="text-vscode-descriptionForeground text-sm mt-0">

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -199,7 +199,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 			vscode.postMessage({ type: "mcpEnabled", bool: mcpEnabled })
 			vscode.postMessage({ type: "alwaysApproveResubmit", bool: alwaysApproveResubmit })
 			vscode.postMessage({ type: "requestDelaySeconds", value: requestDelaySeconds })
-			vscode.postMessage({ type: "rateLimitSeconds", value: rateLimitSeconds })
+			vscode.postMessage({ type: "rateLimitSeconds", value: rateLimitSeconds || 0 })
 			vscode.postMessage({ type: "maxOpenTabsContext", value: maxOpenTabsContext })
 			vscode.postMessage({ type: "maxWorkspaceFiles", value: maxWorkspaceFiles ?? 200 })
 			vscode.postMessage({ type: "showRooIgnoredFiles", bool: showRooIgnoredFiles })
@@ -440,7 +440,7 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 
 				<div ref={advancedRef}>
 					<AdvancedSettings
-						rateLimitSeconds={rateLimitSeconds}
+						rateLimitSeconds={rateLimitSeconds || 0}
 						diffEnabled={diffEnabled}
 						fuzzyMatchThreshold={fuzzyMatchThreshold}
 						setCachedStateField={setCachedStateField}

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -54,7 +54,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setAlwaysApproveResubmit: (value: boolean) => void
 	requestDelaySeconds: number
 	setRequestDelaySeconds: (value: number) => void
-	rateLimitSeconds: number
+	rateLimitSeconds?: number
 	setRateLimitSeconds: (value: number) => void
 	setCurrentApiConfigName: (value: string) => void
 	setListApiConfigMeta: (value: ApiConfigMeta[]) => void


### PR DESCRIPTION
This commit introduces a new method to migrate the global rate limit setting to individual Profiles configurations. The `migrateRateLimitToProfiles` method updates all existing configurations with the global rate limit value and removes the global setting. Additionally, the rate limit is now part of the Profile configuration, allowing for more granular control.

- Added migration logic in `ConfigManager`.
- Updated `ClineProvider` to handle rate limit updates.
- Adjusted related components to accommodate the new rate limit structure.

Tests have been added to ensure the migration works correctly and handles edge cases.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates global rate limit to profile-specific settings, updating configuration management and UI components accordingly.
> 
>   - **Behavior**:
>     - Migrates global rate limit to profile-specific settings using `migrateRateLimitToProfiles()` in `ConfigManager`.
>     - Removes global rate limit setting from `globalState`.
>     - Updates `ClineProvider` to handle rate limit per profile.
>   - **UI**:
>     - Updates `AdvancedSettings.tsx` to use `rateLimitSeconds` from profile settings.
>     - Adjusts `SettingsView.tsx` to handle `rateLimitSeconds` changes.
>   - **Tests**:
>     - Adds tests for `migrateRateLimitToProfiles()` in `ConfigManager.test.ts` to ensure correct migration and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b4a1506a4f69be06264ceacfe5bcf80f35c1575e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->