### PR TITLE
add multiple workspaces support

### DIFF
--- a/.changeset/fast-taxis-speak.md
+++ b/.changeset/fast-taxis-speak.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+add multiple workspaces support

--- a/src/core/config/CustomModesManager.ts
+++ b/src/core/config/CustomModesManager.ts
@@ -4,7 +4,7 @@ import * as fs from "fs/promises"
 import { CustomModesSettingsSchema } from "./CustomModesSchema"
 import { ModeConfig } from "../../shared/modes"
 import { fileExistsAtPath } from "../../utils/fs"
-import { arePathsEqual } from "../../utils/path"
+import { arePathsEqual, getWorkspacePath } from "../../utils/path"
 import { logger } from "../../utils/logging"
 
 const ROOMODES_FILENAME = ".roomodes"
@@ -51,7 +51,7 @@ export class CustomModesManager {
 		if (!workspaceFolders || workspaceFolders.length === 0) {
 			return undefined
 		}
-		const workspaceRoot = workspaceFolders[0].uri.fsPath
+		const workspaceRoot = getWorkspacePath()
 		const roomodesPath = path.join(workspaceRoot, ROOMODES_FILENAME)
 		const exists = await fileExistsAtPath(roomodesPath)
 		return exists ? roomodesPath : undefined
@@ -226,7 +226,7 @@ export class CustomModesManager {
 					logger.error("Failed to update project mode: No workspace folder found", { slug })
 					throw new Error("No workspace folder found for project-specific mode")
 				}
-				const workspaceRoot = workspaceFolders[0].uri.fsPath
+				const workspaceRoot = getWorkspacePath()
 				targetPath = path.join(workspaceRoot, ROOMODES_FILENAME)
 				const exists = await fileExistsAtPath(targetPath)
 				logger.info(`${exists ? "Updating" : "Creating"} project mode in ${ROOMODES_FILENAME}`, {

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -9,13 +9,14 @@ import { isBinaryFile } from "isbinaryfile"
 import { diagnosticsToProblemsString } from "../../integrations/diagnostics"
 import { getCommitInfo, getWorkingState } from "../../utils/git"
 import { getLatestTerminalOutput } from "../../integrations/terminal/get-latest-output"
+import { getWorkspacePath } from "../../utils/path"
 
 export async function openMention(mention?: string): Promise<void> {
 	if (!mention) {
 		return
 	}
 
-	const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0)
+	const cwd = getWorkspacePath()
 	if (!cwd) {
 		return
 	}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -61,6 +61,7 @@ import { getNonce } from "./getNonce"
 import { getUri } from "./getUri"
 import { telemetryService } from "../../services/telemetry/TelemetryService"
 import { TelemetrySetting } from "../../shared/TelemetrySetting"
+import { getWorkspacePath } from "../../utils/path"
 
 /**
  * https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -81,7 +82,9 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 	private contextProxy: ContextProxy
 	configManager: ConfigManager
 	customModesManager: CustomModesManager
-
+	get cwd() {
+		return getWorkspacePath()
+	}
 	constructor(
 		readonly context: vscode.ExtensionContext,
 		private readonly outputChannel: vscode.OutputChannel,
@@ -482,7 +485,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 		const taskId = historyItem.id
 		const globalStorageDir = this.contextProxy.globalStorageUri.fsPath
-		const workspaceDir = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? ""
+		const workspaceDir = this.cwd
 
 		const checkpoints: Pick<ClineOptions, "enableCheckpoints" | "checkpointStorage"> = {
 			enableCheckpoints,
@@ -1627,7 +1630,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 						}
 						break
 					case "searchCommits": {
-						const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0)
+						const cwd = this.cwd
 						if (cwd) {
 							try {
 								const commits = await searchCommits(message.query || "", cwd)
@@ -1895,7 +1898,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 				fuzzyMatchThreshold,
 				Experiments.isEnabled(experiments, EXPERIMENT_IDS.DIFF_STRATEGY),
 			)
-			const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) || ""
+			const cwd = this.cwd
 
 			const mode = message.mode ?? defaultModeSlug
 			const customModes = await this.customModesManager.getCustomModes()
@@ -2225,13 +2228,10 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 		// delete task from the task history state
 		await this.deleteTaskFromState(id)
 
-		// get the base directory of the project
-		const baseDir = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0)
-
 		// Delete associated shadow repository or branch.
 		// TODO: Store `workspaceDir` in the `HistoryItem` object.
 		const globalStorageDir = this.contextProxy.globalStorageUri.fsPath
-		const workspaceDir = baseDir ?? ""
+		const workspaceDir = this.cwd
 
 		try {
 			await ShadowCheckpointService.deleteTask({ taskId: id, globalStorageDir, workspaceDir })
@@ -2317,7 +2317,7 @@ export class ClineProvider implements vscode.WebviewViewProvider {
 
 		const allowedCommands = vscode.workspace.getConfiguration("roo-cline").get<string[]>("allowedCommands") || []
 
-		const cwd = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) || ""
+		const cwd = this.cwd
 
 		return {
 			version: this.context.extension?.packageJSON?.version ?? "",

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -1,7 +1,7 @@
 import * as path from "path"
 import * as os from "os"
 import * as vscode from "vscode"
-import { arePathsEqual } from "../../utils/path"
+import { arePathsEqual, getWorkspacePath } from "../../utils/path"
 
 export async function openImage(dataUri: string) {
 	const matches = dataUri.match(/^data:image\/([a-zA-Z]+);base64,(.+)$/)
@@ -28,7 +28,7 @@ interface OpenFileOptions {
 export async function openFile(filePath: string, options: OpenFileOptions = {}) {
 	try {
 		// Get workspace root
-		const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath
+		const workspaceRoot = getWorkspacePath()
 		if (!workspaceRoot) {
 			throw new Error("No workspace root found")
 		}

--- a/src/integrations/workspace/__tests__/WorkspaceTracker.test.ts
+++ b/src/integrations/workspace/__tests__/WorkspaceTracker.test.ts
@@ -2,25 +2,40 @@ import * as vscode from "vscode"
 import WorkspaceTracker from "../WorkspaceTracker"
 import { ClineProvider } from "../../../core/webview/ClineProvider"
 import { listFiles } from "../../../services/glob/list-files"
+import { getWorkspacePath } from "../../../utils/path"
 
-// Mock modules
+// Mock functions - must be defined before jest.mock calls
 const mockOnDidCreate = jest.fn()
 const mockOnDidDelete = jest.fn()
-const mockOnDidChange = jest.fn()
 const mockDispose = jest.fn()
 
+// Store registered tab change callback
+let registeredTabChangeCallback: (() => Promise<void>) | null = null
+
+// Mock workspace path
+jest.mock("../../../utils/path", () => ({
+	getWorkspacePath: jest.fn().mockReturnValue("/test/workspace"),
+	toRelativePath: jest.fn((path, cwd) => path.replace(`${cwd}/`, "")),
+}))
+
+// Mock watcher - must be defined after mockDispose but before jest.mock("vscode")
 const mockWatcher = {
 	onDidCreate: mockOnDidCreate.mockReturnValue({ dispose: mockDispose }),
 	onDidDelete: mockOnDidDelete.mockReturnValue({ dispose: mockDispose }),
 	dispose: mockDispose,
 }
 
+// Mock vscode
 jest.mock("vscode", () => ({
 	window: {
 		tabGroups: {
-			onDidChangeTabs: jest.fn(() => ({ dispose: jest.fn() })),
+			onDidChangeTabs: jest.fn((callback) => {
+				registeredTabChangeCallback = callback
+				return { dispose: mockDispose }
+			}),
 			all: [],
 		},
+		onDidChangeActiveTextEditor: jest.fn(() => ({ dispose: jest.fn() })),
 	},
 	workspace: {
 		workspaceFolders: [
@@ -48,6 +63,12 @@ describe("WorkspaceTracker", () => {
 		jest.clearAllMocks()
 		jest.useFakeTimers()
 
+		// Reset all mock implementations
+		registeredTabChangeCallback = null
+
+		// Reset workspace path mock
+		;(getWorkspacePath as jest.Mock).mockReturnValue("/test/workspace")
+
 		// Create provider mock
 		mockProvider = {
 			postMessageToWebview: jest.fn().mockResolvedValue(undefined),
@@ -55,6 +76,9 @@ describe("WorkspaceTracker", () => {
 
 		// Create tracker instance
 		workspaceTracker = new WorkspaceTracker(mockProvider)
+
+		// Ensure the tab change callback was registered
+		expect(registeredTabChangeCallback).not.toBeNull()
 	})
 
 	it("should initialize with workspace files", async () => {
@@ -159,8 +183,148 @@ describe("WorkspaceTracker", () => {
 	})
 
 	it("should clean up watchers and timers on dispose", () => {
+		// Set up updateTimer
+		const [[callback]] = mockOnDidCreate.mock.calls
+		callback({ fsPath: "/test/workspace/file.ts" })
+
 		workspaceTracker.dispose()
 		expect(mockDispose).toHaveBeenCalled()
 		jest.runAllTimers() // Ensure any pending timers are cleared
+
+		// No more updates should happen after dispose
+		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
+	})
+
+	it("should handle workspace path changes when tabs change", async () => {
+		expect(registeredTabChangeCallback).not.toBeNull()
+
+		// Set initial workspace path and create tracker
+		;(getWorkspacePath as jest.Mock).mockReturnValue("/test/workspace")
+		workspaceTracker = new WorkspaceTracker(mockProvider)
+
+		// Clear any initialization calls
+		jest.clearAllMocks()
+
+		// Mock listFiles to return some files
+		const mockFiles = [["/test/new-workspace/file1.ts"], false]
+		;(listFiles as jest.Mock).mockResolvedValue(mockFiles)
+
+		// Change workspace path
+		;(getWorkspacePath as jest.Mock).mockReturnValue("/test/new-workspace")
+
+		// Simulate tab change event
+		await registeredTabChangeCallback!()
+
+		// Run the debounce timer for workspaceDidReset
+		jest.advanceTimersByTime(300)
+
+		// Should clear file paths and reset workspace
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "workspaceUpdated",
+			filePaths: [],
+			openedTabs: [],
+		})
+
+		// Run all remaining timers to complete initialization
+		await Promise.resolve() // Wait for initializeFilePaths to complete
+		jest.runAllTimers()
+
+		// Should initialize file paths for new workspace
+		expect(listFiles).toHaveBeenCalledWith("/test/new-workspace", true, 1000)
+		jest.runAllTimers()
+	})
+
+	it("should not update file paths if workspace changes during initialization", async () => {
+		// Setup initial workspace path
+		;(getWorkspacePath as jest.Mock).mockReturnValue("/test/workspace")
+		workspaceTracker = new WorkspaceTracker(mockProvider)
+
+		// Clear any initialization calls
+		jest.clearAllMocks()
+		;(mockProvider.postMessageToWebview as jest.Mock).mockClear()
+
+		// Create a promise to control listFiles timing
+		let resolveListFiles: (value: [string[], boolean]) => void
+		const listFilesPromise = new Promise<[string[], boolean]>((resolve) => {
+			resolveListFiles = resolve
+		})
+
+		// Setup listFiles to use our controlled promise
+		;(listFiles as jest.Mock).mockImplementation(() => {
+			// Change workspace path before listFiles resolves
+			;(getWorkspacePath as jest.Mock).mockReturnValue("/test/changed-workspace")
+			return listFilesPromise
+		})
+
+		// Start initialization
+		const initPromise = workspaceTracker.initializeFilePaths()
+
+		// Resolve listFiles after workspace path change
+		resolveListFiles!([["/test/workspace/file1.ts", "/test/workspace/file2.ts"], false])
+
+		// Wait for initialization to complete
+		await initPromise
+		jest.runAllTimers()
+
+		// Should not update file paths because workspace changed during initialization
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
+			filePaths: ["/test/workspace/file1.ts", "/test/workspace/file2.ts"],
+			openedTabs: [],
+			type: "workspaceUpdated",
+		})
+	})
+
+	it("should clear resetTimer when calling workspaceDidReset multiple times", async () => {
+		expect(registeredTabChangeCallback).not.toBeNull()
+
+		// Set initial workspace path
+		;(getWorkspacePath as jest.Mock).mockReturnValue("/test/workspace")
+
+		// Create tracker instance to set initial prevWorkSpacePath
+		workspaceTracker = new WorkspaceTracker(mockProvider)
+
+		// Change workspace path to trigger update
+		;(getWorkspacePath as jest.Mock).mockReturnValue("/test/new-workspace")
+
+		// Call workspaceDidReset through tab change event
+		await registeredTabChangeCallback!()
+
+		// Call again before timer completes
+		await registeredTabChangeCallback!()
+
+		// Advance timer
+		jest.advanceTimersByTime(300)
+
+		// Should only have one call to postMessageToWebview
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith({
+			type: "workspaceUpdated",
+			filePaths: [],
+			openedTabs: [],
+		})
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledTimes(1)
+	})
+
+	it("should handle dispose with active resetTimer", async () => {
+		expect(registeredTabChangeCallback).not.toBeNull()
+
+		// Mock workspace path change to trigger resetTimer
+		;(getWorkspacePath as jest.Mock)
+			.mockReturnValueOnce("/test/workspace")
+			.mockReturnValueOnce("/test/new-workspace")
+
+		// Trigger resetTimer
+		await registeredTabChangeCallback!()
+
+		// Dispose before timer completes
+		workspaceTracker.dispose()
+
+		// Advance timer
+		jest.advanceTimersByTime(300)
+
+		// Should have called dispose on all disposables
+		expect(mockDispose).toHaveBeenCalled()
+
+		// No postMessage should be called after dispose
+		expect(mockProvider.postMessageToWebview).not.toHaveBeenCalled()
 	})
 })

--- a/src/utils/__tests__/path.test.ts
+++ b/src/utils/__tests__/path.test.ts
@@ -1,12 +1,37 @@
 // npx jest src/utils/__tests__/path.test.ts
-
 import os from "os"
 import * as path from "path"
 
-import { arePathsEqual, getReadablePath } from "../path"
+import { arePathsEqual, getReadablePath, getWorkspacePath } from "../path"
 
+// Mock modules
+
+jest.mock("vscode", () => ({
+	window: {
+		activeTextEditor: {
+			document: {
+				uri: { fsPath: "/test/workspaceFolder/file.ts" },
+			},
+		},
+	},
+	workspace: {
+		workspaceFolders: [
+			{
+				uri: { fsPath: "/test/workspace" },
+				name: "test",
+				index: 0,
+			},
+		],
+		getWorkspaceFolder: jest.fn().mockReturnValue({
+			uri: {
+				fsPath: "/test/workspaceFolder",
+			},
+		}),
+	},
+}))
 describe("Path Utilities", () => {
 	const originalPlatform = process.platform
+	// Helper to mock VS Code configuration
 
 	afterEach(() => {
 		Object.defineProperty(process, "platform", {
@@ -30,7 +55,14 @@ describe("Path Utilities", () => {
 			expect(extendedPath.toPosix()).toBe("\\\\?\\C:\\Very\\Long\\Path")
 		})
 	})
+	describe("getWorkspacePath", () => {
+		it("should return the current workspace path", () => {
+			const workspacePath = "/Users/test/project"
+			expect(getWorkspacePath(workspacePath)).toBe("/test/workspaceFolder")
+		})
 
+		it("should return undefined when outside a workspace", () => {})
+	})
 	describe("arePathsEqual", () => {
 		describe("on Windows", () => {
 			beforeEach(() => {

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,5 +1,6 @@
 import * as path from "path"
 import os from "os"
+import * as vscode from "vscode"
 
 /*
 The Node.js 'path' module resolves and normalizes paths differently depending on the platform:
@@ -103,4 +104,14 @@ export function getReadablePath(cwd: string, relPath?: string): string {
 export const toRelativePath = (filePath: string, cwd: string) => {
 	const relativePath = path.relative(cwd, filePath).toPosix()
 	return filePath.endsWith("/") ? relativePath + "/" : relativePath
+}
+
+export const getWorkspacePath = (defaultCwdPath = "") => {
+	const cwdPath = vscode.workspace.workspaceFolders?.map((folder) => folder.uri.fsPath).at(0) || defaultCwdPath
+	const currentFileUri = vscode.window.activeTextEditor?.document.uri
+	if (currentFileUri) {
+		const workspaceFolder = vscode.workspace.getWorkspaceFolder(currentFileUri)
+		return workspaceFolder?.uri.fsPath || cwdPath
+	}
+	return cwdPath
 }


### PR DESCRIPTION
- Add getWorkspacePath function to centralize workspace directory path retrieval
- Use the new workspace directory retrieval logic in Cline, Mentions, ClineProvider, and WorkspaceTracker
- Update WorkspaceFile on tab switch and prevent redundant updates by checking prevWorkSpacePath

## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->
When using multiple workspaces, I am currently working with files from the second workspace, but the @context plugin only shows me the directories from the first workspace.
## Screenshots
![image](https://github.com/user-attachments/assets/40424298-0bf5-47d3-9e5e-6fc56a39d4eb)



| before | after |
| ------ | ----- |
|     ![image](https://github.com/user-attachments/assets/7f4977b0-e687-4818-98cc-1da5fd0bd941)   |     
![image](https://github.com/user-attachments/assets/5df7f233-174d-429f-806b-f25c1dd5fc41)
![image](https://github.com/user-attachments/assets/9bbdff5c-7f83-4a0d-96c6-5d9beeab2512)
  |

## How to Test
Create a multi-workspace project, add files from several different projects into the tabs in VSCode, and observe the behavior of @Add Folder and Add File.
<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for multiple workspaces by centralizing workspace path retrieval and updating core components to use this logic.
> 
>   - **Behavior**:
>     - Introduces `getWorkspacePath` function in `path.ts` to centralize workspace path retrieval.
>     - Updates `Cline`, `Mentions`, `ClineProvider`, and `WorkspaceTracker` to use `getWorkspacePath` for workspace path management.
>     - Prevents redundant updates in `WorkspaceTracker` by checking `prevWorkSpacePath` on tab switch.
>   - **Testing**:
>     - Adds tests for `getWorkspacePath` in `path.test.ts` to verify correct path retrieval.
>     - Updates `WorkspaceTracker.test.ts` to ensure correct handling of file events and workspace updates.
>   - **Misc**:
>     - Minor logging changes in `WorkspaceTracker.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4d66821160e66ecfa4d04fe0076baa3e3f81798a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->