### PR TITLE
fix(RooCodeAPI): re-add clineAskResponded event that got lost in rebase

### DIFF
--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -23,6 +23,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 			cline.on("taskStarted", () => this.emit("taskStarted", cline.taskId))
 			cline.on("taskPaused", () => this.emit("taskPaused", cline.taskId))
 			cline.on("taskUnpaused", () => this.emit("taskUnpaused", cline.taskId))
+			cline.on("taskAskResponded", () => this.emit("taskAskResponded", cline.taskId))
 			cline.on("taskAborted", () => this.emit("taskAborted", cline.taskId))
 			cline.on("taskSpawned", (taskId) => this.emit("taskSpawned", cline.taskId, taskId))
 		})


### PR DESCRIPTION
## Context

https://github.com/RooVetGit/Roo-Code/pull/1671

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Re-adds `taskAskResponded` event listener in `API` class to emit event with `cline.taskId`.
> 
>   - **Behavior**:
>     - Re-adds `taskAskResponded` event listener in `API` class in `src/exports/api.ts`.
>     - Ensures `taskAskResponded` event is emitted with `cline.taskId` when triggered.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2270c722755dcab19471259f830bdff27a7dd154. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->