### PR TITLE
Change update-contributors script to use a single branch

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -49,7 +49,6 @@ jobs:
           commit-message: "docs: update contributors list [skip ci]"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           branch: update-contributors
-          branch-suffix: timestamp
           delete-branch: true
           title: "Update contributors list"
           body: |


### PR DESCRIPTION
Trying to make it so we don't get a ton of these PRs in parallel when we merge stuff
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `branch-suffix: timestamp` in `update-contributors.yml` to use a single branch for updates, preventing multiple parallel PRs.
> 
>   - **Behavior**:
>     - Removes `branch-suffix: timestamp` from `update-contributors.yml` to use a single branch for updates.
>     - Prevents multiple parallel PRs by using a consistent branch name `update-contributors`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 94f176b9bc1ffae51c6a15c570b6486529a16dcc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->