### PR TITLE
Clean up CSS for settings view wheel scroll

### DIFF
--- a/.changeset/cyan-owls-juggle.md
+++ b/.changeset/cyan-owls-juggle.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix SettingsView scrolling in VSCode editor tab

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -338,24 +338,13 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 			</TabHeader>
 
 			<TabContent
-				className="p-0 divide-y divide-vscode-sideBar-background"
+				className="p-0 divide-y divide-vscode-sideBar-background will-change-scroll"
 				style={{
-					maxHeight: "calc(100vh - 6rem)",
-					height: "calc(100vh - 6rem)",
-					overflowY: "scroll",
-					overflowX: "hidden",
 					WebkitOverflowScrolling: "touch",
-					position: "relative",
-					display: "block",
 					msOverflowStyle: "-ms-autohiding-scrollbar",
-					scrollbarWidth: "auto",
 					scrollbarGutter: "stable",
-					willChange: "scroll-position",
 				}}
-				onWheel={(e) => {
-					const container = e.currentTarget
-					container.scrollTop += e.deltaY
-				}}
+				onWheel={(e) => (e.currentTarget.scrollTop += e.deltaY)}
 				onScroll={handleScroll}>
 				<div ref={providersRef}>
 					<SectionHeader>


### PR DESCRIPTION
## Context

We can get away with less CSS here, and if possible we shouldn't hardcode heights.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplified CSS for `SettingsView` in `SettingsView.tsx` by removing hardcoded properties and improving scroll handling.
> 
>   - **CSS Simplification**:
>     - Removed hardcoded `maxHeight`, `height`, `overflowY`, `overflowX`, `position`, `display`, `scrollbarWidth`, and `willChange` properties from `TabContent` in `SettingsView.tsx`.
>     - Added `will-change-scroll` class to `TabContent` for smoother scrolling.
>   - **Behavior**:
>     - Simplified `onWheel` event in `SettingsView.tsx` to directly adjust `scrollTop`.
>   - **Misc**:
>     - Updated `.changeset/cyan-owls-juggle.md` to reflect the fix for scrolling in the VSCode editor tab.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7d1d5581a403830d7d3c4c78c2f78c665c90bb83. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->