### PR TITLE
Localize formatting helpers

### DIFF
--- a/webview-ui/src/i18n/locales/ca/common.json
+++ b/webview-ui/src/i18n/locales/ca/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "mil",
+		"million_suffix": "M",
+		"billion_suffix": "MM"
+	}
+}

--- a/webview-ui/src/i18n/locales/de/common.json
+++ b/webview-ui/src/i18n/locales/de/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "Tsd.",
+		"million_suffix": "Mio.",
+		"billion_suffix": "Mrd."
+	}
+}

--- a/webview-ui/src/i18n/locales/en/common.json
+++ b/webview-ui/src/i18n/locales/en/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "k",
+		"million_suffix": "m",
+		"billion_suffix": "b"
+	}
+}

--- a/webview-ui/src/i18n/locales/es/common.json
+++ b/webview-ui/src/i18n/locales/es/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "k",
+		"million_suffix": "M",
+		"billion_suffix": "MM"
+	}
+}

--- a/webview-ui/src/i18n/locales/fr/common.json
+++ b/webview-ui/src/i18n/locales/fr/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "k",
+		"million_suffix": "M",
+		"billion_suffix": "Md"
+	}
+}

--- a/webview-ui/src/i18n/locales/hi/common.json
+++ b/webview-ui/src/i18n/locales/hi/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "ह",
+		"million_suffix": "लाख",
+		"billion_suffix": "अरब"
+	}
+}

--- a/webview-ui/src/i18n/locales/it/common.json
+++ b/webview-ui/src/i18n/locales/it/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "k",
+		"million_suffix": "Mln",
+		"billion_suffix": "Mrd"
+	}
+}

--- a/webview-ui/src/i18n/locales/it/common.json
+++ b/webview-ui/src/i18n/locales/it/common.json
@@ -2,6 +2,6 @@
 	"number_format": {
 		"thousand_suffix": "k",
 		"million_suffix": "Mln",
-		"billion_suffix": "Mrd"
+		"billion_suffix": "Mld"
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/common.json
+++ b/webview-ui/src/i18n/locales/ja/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "k",
+		"million_suffix": "M",
+		"billion_suffix": "B"
+	}
+}

--- a/webview-ui/src/i18n/locales/ko/common.json
+++ b/webview-ui/src/i18n/locales/ko/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "천",
+		"million_suffix": "백만",
+		"billion_suffix": "십억"
+	}
+}

--- a/webview-ui/src/i18n/locales/pl/common.json
+++ b/webview-ui/src/i18n/locales/pl/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "tys.",
+		"million_suffix": "mln",
+		"billion_suffix": "mld"
+	}
+}

--- a/webview-ui/src/i18n/locales/pt-BR/common.json
+++ b/webview-ui/src/i18n/locales/pt-BR/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "mil",
+		"million_suffix": "mi",
+		"billion_suffix": "bi"
+	}
+}

--- a/webview-ui/src/i18n/locales/tr/common.json
+++ b/webview-ui/src/i18n/locales/tr/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "B",
+		"million_suffix": "Mn",
+		"billion_suffix": "Mr"
+	}
+}

--- a/webview-ui/src/i18n/locales/vi/common.json
+++ b/webview-ui/src/i18n/locales/vi/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "k",
+		"million_suffix": "tr",
+		"billion_suffix": "tỷ"
+	}
+}

--- a/webview-ui/src/i18n/locales/zh-CN/common.json
+++ b/webview-ui/src/i18n/locales/zh-CN/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "千",
+		"million_suffix": "百万",
+		"billion_suffix": "十亿"
+	}
+}

--- a/webview-ui/src/i18n/locales/zh-TW/common.json
+++ b/webview-ui/src/i18n/locales/zh-TW/common.json
@@ -1,1 +1,7 @@
-{}
+{
+	"number_format": {
+		"thousand_suffix": "千",
+		"million_suffix": "百萬",
+		"billion_suffix": "十億"
+	}
+}

--- a/webview-ui/src/utils/format.ts
+++ b/webview-ui/src/utils/format.ts
@@ -1,27 +1,35 @@
+import i18next from "i18next"
+
 export function formatLargeNumber(num: number): string {
 	if (num >= 1e9) {
-		return (num / 1e9).toFixed(1) + "b"
+		return (num / 1e9).toFixed(1) + i18next.t("common:number_format.billion_suffix")
 	}
 	if (num >= 1e6) {
-		return (num / 1e6).toFixed(1) + "m"
+		return (num / 1e6).toFixed(1) + i18next.t("common:number_format.million_suffix")
 	}
 	if (num >= 1e3) {
-		return (num / 1e3).toFixed(1) + "k"
+		return (num / 1e3).toFixed(1) + i18next.t("common:number_format.thousand_suffix")
 	}
 	return num.toString()
 }
 
 export const formatDate = (timestamp: number) => {
 	const date = new Date(timestamp)
-	return date
-		.toLocaleString("en-US", {
-			month: "long",
-			day: "numeric",
-			hour: "numeric",
-			minute: "2-digit",
-			hour12: true,
-		})
-		.replace(", ", " ")
-		.replace(" at", ",")
-		.toUpperCase()
+	const locale = i18next.language || "en"
+
+	// Get date format style from translations or use default transformations
+	const dateStr = date.toLocaleString(locale, {
+		month: "long",
+		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+		hour12: true,
+	})
+
+	// Apply transformations based on locale or use default
+	if (locale === "en") {
+		return dateStr.replace(", ", " ").replace(" at", ",").toUpperCase()
+	}
+
+	return dateStr.toUpperCase()
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Localize number formatting and update `formatLargeNumber` and `formatDate` in `format.ts` to use locale-specific formats.
> 
>   - **Localization**:
>     - Add `number_format` suffixes for thousands, millions, and billions in `common.json` for multiple locales (e.g., `ca`, `de`, `en`, `es`, `fr`, `hi`, `it`, `ja`, `ko`, `pl`, `pt-BR`, `tr`, `vi`, `zh-CN`, `zh-TW`).
>   - **Functions**:
>     - Update `formatLargeNumber` in `format.ts` to use localized suffixes via `i18next.t()`.
>     - Modify `formatDate` in `format.ts` to use locale-specific formatting and transformations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 76b37b11ca198f2f627788e731e4dd0c0c3ddd63. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->