### PR TITLE
Translate the thinking budget

### DIFF
--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo } from "react"
+import { useAppTranslation } from "@/i18n/TranslationContext"
 
 import { Slider } from "@/components/ui"
 
@@ -11,6 +12,7 @@ interface ThinkingBudgetProps {
 }
 
 export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, modelInfo }: ThinkingBudgetProps) => {
+	const { t } = useAppTranslation()
 	const tokens = apiConfiguration?.modelMaxTokens || 16_384
 	const tokensMin = 8192
 	const tokensMax = modelInfo?.maxTokens || 64_000
@@ -37,7 +39,7 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 	return (
 		<>
 			<div className="flex flex-col gap-1">
-				<div className="font-medium">Max Tokens</div>
+				<div className="font-medium">{t("settings:thinkingBudget.maxTokens")}</div>
 				<div className="flex items-center gap-1">
 					<Slider
 						min={tokensMin}
@@ -50,7 +52,7 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 				</div>
 			</div>
 			<div className="flex flex-col gap-1">
-				<div className="font-medium">Max Thinking Tokens</div>
+				<div className="font-medium">{t("settings:thinkingBudget.maxThinkingTokens")}</div>
 				<div className="flex items-center gap-1">
 					<Slider
 						min={thinkingTokensMin}

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -365,5 +365,9 @@
 			"description": "Restablir tot l'estat global i emmagatzematge secret a l'extensió.",
 			"button": "Restablir"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Tokens màxims",
+		"maxThinkingTokens": "Tokens de pensament màxims"
 	}
 }

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -365,5 +365,9 @@
 			"description": "Setzen Sie alle globalen Zustände und geheimen Speicher in der Erweiterung zurück.",
 			"button": "Zurücksetzen"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Maximale Tokens",
+		"maxThinkingTokens": "Maximale Thinking-Tokens"
 	}
 }

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -364,5 +364,9 @@
 			"description": "Reset all global state and secret storage in the extension.",
 			"button": "Reset"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Max Tokens",
+		"maxThinkingTokens": "Max Thinking Tokens"
 	}
 }

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -365,5 +365,9 @@
 			"description": "Restablecer todo el estado global y almacenamiento secreto en la extensión.",
 			"button": "Restablecer"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Tokens máximos",
+		"maxThinkingTokens": "Tokens máximos de pensamiento"
 	}
 }

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -365,5 +365,9 @@
 			"description": "Réinitialiser tous les états globaux et le stockage secret dans l'extension.",
 			"button": "Réinitialiser"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Tokens maximum",
+		"maxThinkingTokens": "Tokens de réflexion maximum"
 	}
 }

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -365,5 +365,9 @@
 			"description": "एक्सटेंशन में सभी वैश्विक स्थिति और गुप्त भंडारण को रीसेट करें।",
 			"button": "रीसेट करें"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "अधिकतम tokens",
+		"maxThinkingTokens": "अधिकतम thinking tokens"
 	}
 }

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -365,5 +365,9 @@
 			"description": "Reimposta tutti gli stati globali e l'archivio segreto nell'estensione.",
 			"button": "Ripristina"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Token massimi",
+		"maxThinkingTokens": "Token massimi di pensiero"
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -365,5 +365,9 @@
 			"description": "拡張機能内のすべてのグローバル状態とシークレットストレージをリセットします。",
 			"button": "リセット"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "最大 tokens",
+		"maxThinkingTokens": "最大思考 tokens"
 	}
 }

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -365,5 +365,9 @@
 			"description": "확장 프로그램의 모든 전역 상태 및 보안 저장소를 재설정합니다.",
 			"button": "초기화"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "최대 tokens",
+		"maxThinkingTokens": "최대 사고 tokens"
 	}
 }

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -365,5 +365,9 @@
 			"description": "Zresetuj wszystkie globalne stany i tajne magazyny w rozszerzeniu.",
 			"button": "Resetuj"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Maksymalna liczba tokenów",
+		"maxThinkingTokens": "Maksymalna liczba tokenów myślenia"
 	}
 }

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -365,5 +365,9 @@
 			"description": "Redefinir todo o estado global e armazenamento secreto na extensão.",
 			"button": "Redefinir"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Tokens máximos",
+		"maxThinkingTokens": "Tokens máximos de pensamento"
 	}
 }

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -365,5 +365,9 @@
 			"description": "Uzantıdaki tüm global durumu ve gizli depolamayı sıfırlayın.",
 			"button": "Sıfırla"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Maksimum token",
+		"maxThinkingTokens": "Maksimum düşünme tokeni"
 	}
 }

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -365,5 +365,9 @@
 			"description": "Đặt lại tất cả trạng thái toàn cầu và lưu trữ bí mật trong tiện ích mở rộng.",
 			"button": "Đặt lại"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "Tokens tối đa",
+		"maxThinkingTokens": "Tokens suy nghĩ tối đa"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -365,5 +365,9 @@
 			"description": "重置扩展中的所有全局状态和密钥存储。",
 			"button": "重置"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "最大 tokens",
+		"maxThinkingTokens": "最大思考 tokens"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -365,5 +365,9 @@
 			"description": "重設擴充功能中的所有全域狀態和秘密儲存。",
 			"button": "重設"
 		}
+	},
+	"thinkingBudget": {
+		"maxTokens": "最大 tokens",
+		"maxThinkingTokens": "最大思考 tokens"
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add internationalization support for `ThinkingBudget` component by integrating translation keys across multiple languages.
> 
>   - **Internationalization**:
>     - Add translation keys `thinkingBudget.maxTokens` and `thinkingBudget.maxThinkingTokens` to `ThinkingBudget.tsx`.
>     - Update language files (`ca/settings.json`, `de/settings.json`, `en/settings.json`) with new translation keys for `thinkingBudget`.
>     - Extend translation support to additional languages: `es`, `fr`, `hi`, `it`, `ja`, `ko`, `pl`, `pt-BR`, `tr`, `vi`, `zh-CN`, `zh-TW`.
>   - **Component Update**:
>     - Modify `ThinkingBudget.tsx` to use `useAppTranslation` for rendering translated text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 37ca6aafc7fc97f885620ddc8b4ddaa44db27845. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->