### PR TITLE
Allow webviews to make OpenRouter API calls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12577,6 +12577,7 @@
 			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
 			"integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"chalk": "^2.4.1",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -571,12 +571,14 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		}
 
 		const nonce = getNonce()
+
 		const stylesUri = getUri(webview, this.contextProxy.extensionUri, [
 			"webview-ui",
 			"build",
 			"assets",
 			"index.css",
 		])
+
 		const codiconsUri = getUri(webview, this.contextProxy.extensionUri, [
 			"node_modules",
 			"@vscode",
@@ -693,7 +695,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no">
             <meta name="theme-color" content="#000000">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} data:; script-src 'nonce-${nonce}' https://us-assets.i.posthog.com; connect-src https://us.i.posthog.com https://us-assets.i.posthog.com;">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; font-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; img-src ${webview.cspSource} data:; script-src 'nonce-${nonce}' https://us-assets.i.posthog.com; connect-src https://openrouter.ai https://us.i.posthog.com https://us-assets.i.posthog.com;">
             <link rel="stylesheet" type="text/css" href="${stylesUri}">
 			<link href="${codiconsUri}" rel="stylesheet" />
             <title>Roo Code</title>

--- a/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
+++ b/webview-ui/src/components/ui/hooks/useOpenRouterModelProviders.ts
@@ -14,15 +14,15 @@ const openRouterEndpointsSchema = z.object({
 		description: z.string().optional(),
 		architecture: z
 			.object({
-				modality: z.string().optional(),
-				tokenizer: z.string().optional(),
+				modality: z.string().nullish(),
+				tokenizer: z.string().nullish(),
 			})
-			.optional(),
+			.nullish(),
 		endpoints: z.array(
 			z.object({
 				name: z.string(),
 				context_length: z.number(),
-				max_completion_tokens: z.number().optional(),
+				max_completion_tokens: z.number().nullish(),
 				pricing: z
 					.object({
 						prompt: z.union([z.string(), z.number()]).optional(),
@@ -58,7 +58,7 @@ async function getOpenRouterProvidersForModel(modelId: string) {
 			const outputPrice = parseApiPrice(endpoint.pricing?.completion)
 
 			const modelInfo: OpenRouterModelProvider = {
-				maxTokens: endpoint.max_completion_tokens,
+				maxTokens: endpoint.max_completion_tokens || endpoint.context_length,
 				contextWindow: endpoint.context_length,
 				supportsImages: architecture?.modality?.includes("image"),
 				supportsPromptCache: false,


### PR DESCRIPTION
## Context

Update the content security policy so webviews can make OpenRouter API calls.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update content security policy and schema to enable OpenRouter API calls from webviews.
> 
>   - **Content Security Policy**:
>     - Updated `ClineProvider.ts` to allow `connect-src` to `https://openrouter.ai`.
>   - **Schema Changes**:
>     - In `useOpenRouterModelProviders.ts`, changed `modality`, `tokenizer`, and `max_completion_tokens` to `nullish` in `openRouterEndpointsSchema`.
>   - **Behavior**:
>     - In `getOpenRouterProvidersForModel()`, set `maxTokens` to `max_completion_tokens` or `context_length` if `max_completion_tokens` is nullish.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 94099751f82cbe1e3586dba57aca5f625f9be323. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->