### PR TITLE
Fix regex i18n

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -418,11 +418,13 @@ export const ChatRowContent = ({
 									<Trans
 										i18nKey="chat:directoryOperations.wantsToSearch"
 										components={{ code: <code>{tool.regex}</code> }}
+										values={{ regex: tool.regex }}
 									/>
 								) : (
 									<Trans
 										i18nKey="chat:directoryOperations.didSearch"
 										components={{ code: <code>{tool.regex}</code> }}
+										values={{ regex: tool.regex }}
 									/>
 								)}
 							</span>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes missing `values` prop for `regex` in `Trans` component in `ChatRowContent` to ensure correct i18n display.
> 
>   - **Behavior**:
>     - Fixes missing `values` prop in `Trans` component for `regex` in `ChatRowContent` in `ChatRow.tsx`.
>     - Ensures `regex` is correctly displayed in `chat:directoryOperations.wantsToSearch` and `chat:directoryOperations.didSearch` translations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 80c5ff11276f6d2857adf97be0eab88dbd4eacd0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->