### PR TITLE
Pass current language to system prompt correctly

### DIFF
--- a/.changeset/serious-rules-laugh.md
+++ b/.changeset/serious-rules-laugh.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Pass current language to system prompt correctly

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1125,6 +1125,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 			experiments,
 			enableMcpServerCreation,
 			browserToolEnabled,
+			language,
 		} = (await this.providerRef.deref()?.getState()) ?? {}
 		const { customModes } = (await this.providerRef.deref()?.getState()) ?? {}
 		const systemPrompt = await (async () => {
@@ -1146,6 +1147,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 				this.diffEnabled,
 				experiments,
 				enableMcpServerCreation,
+				language,
 				rooIgnoreInstructions,
 			)
 		})()

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1988,6 +1988,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 				experiments,
 				enableMcpServerCreation,
 				browserToolEnabled,
+				language,
 			} = await this.getState()
 
 			// Create diffStrategy based on current model and settings
@@ -2021,6 +2022,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 				diffEnabled,
 				experiments,
 				enableMcpServerCreation,
+				language,
 				rooIgnoreInstructions,
 			)
 			return systemPrompt


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Pass `language` to system prompt in `Cline.ts` and `ClineProvider.ts` to ensure correct language setting is used.
> 
>   - **Behavior**:
>     - Pass `language` to system prompt in `Cline.ts` and `ClineProvider.ts` to ensure correct language setting is used.
>   - **Misc**:
>     - Add `language` to destructured state in `Cline.ts` and `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 15ed128e32e0420dec4158e1dc1b6b6464cd813e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->