### PR TITLE
FIX: Initialize tts speed state in ClineProvider

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -369,6 +369,11 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			setTtsEnabled(ttsEnabled ?? false)
 		})
 
+		// Initialize tts speed state
+		this.getState().then(({ ttsSpeed }) => {
+			setTtsSpeed(ttsSpeed ?? 1)
+		})
+
 		webviewView.webview.options = {
 			// Allow scripts in the webview
 			enableScripts: true,


### PR DESCRIPTION
## Context

I forgot to initialize the tts speed state in ClineProvider.ts. As a result the tts speed setting would default to 100% and the user would have to reconfigure the setting on each editor load.

## Implementation

```
this.getState().then(({ ttsSpeed }) => {
     setTtsSpeed(ttsSpeed ?? 1)
})
```
## How to Test
1. Run your usual testing environment and navigate to Settings > Notifications > Enable text-to-speech > Speed

![image](https://github.com/user-attachments/assets/a66854e0-935c-4e33-88e7-cc3e9b4f49ef)

2. Set the value of speed to a non-default value.
3. Close the testing environment.
4. Reopen testing environment.
5. Run a Roo Code task, verify that the tts speed is reflecting the saved value from before.

## Get in Touch

I can be reached at @ocean.smith on discord.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Initialize TTS speed state in `ClineProvider.ts` to use saved value or default to 100%.
> 
>   - **Behavior**:
>     - Initialize TTS speed state in `ClineProvider` to use saved value or default to 100%.
>   - **Implementation**:
>     - Added `this.getState().then(({ ttsSpeed }) => { setTtsSpeed(ttsSpeed ?? 1) })` in `ClineProvider.ts` to initialize TTS speed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a1a0eedcda0c85a00e27258c32ecc47fbe6f841c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->