### PR TITLE
ci: update GitHub Actions publish workflow to automatically create GitHub Releases

### DIFF
--- a/.changeset/automatic-releases-publish.md
+++ b/.changeset/automatic-releases-publish.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Update GitHub Actions workflow to automatically create GitHub Releases

--- a/.github/workflows/marketplace-publish.yml
+++ b/.github/workflows/marketplace-publish.yml
@@ -62,3 +62,29 @@ jobs:
           current_package_version=$(node -p "require('./package.json').version")
           npm run publish:marketplace
           echo "Successfully published version $current_package_version to VS Code Marketplace"
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current_package_version=$(node -p "require('./package.json').version")
+
+          # Extract changelog for current version
+          changelog_content=$(awk -v ver="## [${current_package_version}]" '
+            $0 ~ ver {flag=1; next}
+            /^## \[/ {if (flag) exit}
+            flag {print}
+          ' CHANGELOG.md)
+
+          # If changelog extraction failed, use a default message
+          if [ -z "$changelog_content" ]; then
+            changelog_content="Release v${current_package_version}"
+          fi
+
+          # Create release with changelog content
+          gh release create "v${current_package_version}" \
+            --title "Release v${current_package_version}" \
+            --notes "$changelog_content" \
+            --target ${{ env.GIT_REF }} \
+            bin/roo-cline-${current_package_version}.vsix
+          echo "Successfully created GitHub Release v${current_package_version}"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Updates GitHub Actions workflow to automate GitHub Releases creation after VS Code Marketplace publishing.
> 
>   - **GitHub Actions Workflow**:
>     - Updates `marketplace-publish.yml` to automatically create GitHub Releases after publishing to VS Code Marketplace.
>     - Adds a step to extract changelog content for the current version from `CHANGELOG.md`.
>     - Uses `gh release create` to create a release with the extracted changelog or a default message if extraction fails.
>   - **Changeset**:
>     - Adds `automatic-releases-publish.md` to document the workflow update as a patch for `roo-cline`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 96ca676b1749303fbfe26806f606bb722cb1dc06. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->