### PR TITLE
Move context-mention file/folder search to the server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"diff-match-patch": "^1.0.5",
 				"fast-deep-equal": "^3.1.3",
 				"fastest-levenshtein": "^1.0.16",
+				"fzf": "^0.5.2",
 				"get-folder-size": "^5.0.0",
 				"globby": "^14.0.2",
 				"i18next": "^24.2.2",
@@ -9325,6 +9326,11 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/fzf": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
+			"integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="
 		},
 		"node_modules/gauge": {
 			"version": "5.0.2",

--- a/package.json
+++ b/package.json
@@ -345,6 +345,7 @@
 		"diff-match-patch": "^1.0.5",
 		"fast-deep-equal": "^3.1.3",
 		"fastest-levenshtein": "^1.0.16",
+		"fzf": "^0.5.2",
 		"get-folder-size": "^5.0.0",
 		"globby": "^14.0.2",
 		"i18next": "^24.2.2",

--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -4,6 +4,7 @@ import * as path from "path"
 import * as fs from "fs"
 import * as readline from "readline"
 import { RooIgnoreController } from "../../core/ignore/RooIgnoreController"
+import { fileExistsAtPath } from "../../utils/fs"
 /*
 This file provides functionality to perform regex searches on files using ripgrep.
 Inspired by: https://github.com/DiscreteTom/vscode-ripgrep-utils
@@ -71,11 +72,13 @@ const MAX_LINE_LENGTH = 500
 export function truncateLine(line: string, maxLength: number = MAX_LINE_LENGTH): string {
 	return line.length > maxLength ? line.substring(0, maxLength) + " [truncated...]" : line
 }
-
-async function getBinPath(vscodeAppRoot: string): Promise<string | undefined> {
+/**
+ * Get the path to the ripgrep binary within the VSCode installation
+ */
+export async function getBinPath(vscodeAppRoot: string): Promise<string | undefined> {
 	const checkPath = async (pkgFolder: string) => {
 		const fullPath = path.join(vscodeAppRoot, pkgFolder, binName)
-		return (await pathExists(fullPath)) ? fullPath : undefined
+		return (await fileExistsAtPath(fullPath)) ? fullPath : undefined
 	}
 
 	return (
@@ -84,14 +87,6 @@ async function getBinPath(vscodeAppRoot: string): Promise<string | undefined> {
 		(await checkPath("node_modules.asar.unpacked/vscode-ripgrep/bin/")) ||
 		(await checkPath("node_modules.asar.unpacked/@vscode/ripgrep/bin/"))
 	)
-}
-
-async function pathExists(path: string): Promise<boolean> {
-	return new Promise((resolve) => {
-		fs.access(path, (err) => {
-			resolve(err === null)
-		})
-	})
 }
 
 async function execRipgrep(bin: string, args: string[]): Promise<string> {

--- a/src/services/search/file-search.ts
+++ b/src/services/search/file-search.ts
@@ -1,0 +1,125 @@
+import * as vscode from "vscode"
+import * as path from "path"
+import * as fs from "fs"
+import * as childProcess from "child_process"
+import * as readline from "readline"
+import { Fzf } from "fzf"
+import { getBinPath } from "../ripgrep"
+
+async function executeRipgrepForFiles(
+	rgPath: string,
+	workspacePath: string,
+	limit: number = 5000,
+): Promise<{ path: string; type: "file" | "folder"; label?: string }[]> {
+	return new Promise((resolve, reject) => {
+		const args = [
+			"--files",
+			"--follow",
+			"-g",
+			"!**/node_modules/**",
+			"-g",
+			"!**/.git/**",
+			"-g",
+			"!**/out/**",
+			"-g",
+			"!**/dist/**",
+			workspacePath,
+		]
+
+		const rgProcess = childProcess.spawn(rgPath, args)
+		const rl = readline.createInterface({
+			input: rgProcess.stdout,
+			crlfDelay: Infinity,
+		})
+
+		const results: { path: string; type: "file" | "folder"; label?: string }[] = []
+		let count = 0
+
+		rl.on("line", (line) => {
+			if (count < limit) {
+				try {
+					const relativePath = path.relative(workspacePath, line)
+					results.push({
+						path: relativePath,
+						type: "file",
+						label: path.basename(relativePath),
+					})
+					count++
+				} catch (error) {
+					// Silently ignore errors processing individual paths
+				}
+			} else {
+				rl.close()
+				rgProcess.kill()
+			}
+		})
+
+		let errorOutput = ""
+		rgProcess.stderr.on("data", (data) => {
+			errorOutput += data.toString()
+		})
+
+		rl.on("close", () => {
+			if (errorOutput && results.length === 0) {
+				reject(new Error(`ripgrep process error: ${errorOutput}`))
+			} else {
+				resolve(results)
+			}
+		})
+
+		rgProcess.on("error", (error) => {
+			reject(new Error(`ripgrep process error: ${error.message}`))
+		})
+	})
+}
+
+export async function searchWorkspaceFiles(
+	query: string,
+	workspacePath: string,
+	limit: number = 20,
+): Promise<{ path: string; type: "file" | "folder"; label?: string }[]> {
+	try {
+		const vscodeAppRoot = vscode.env.appRoot
+		const rgPath = await getBinPath(vscodeAppRoot)
+
+		if (!rgPath) {
+			throw new Error("Could not find ripgrep binary")
+		}
+
+		const allFiles = await executeRipgrepForFiles(rgPath, workspacePath, 5000)
+
+		if (!query.trim()) {
+			return allFiles.slice(0, limit)
+		}
+
+		const searchItems = allFiles.map((file) => ({
+			original: file,
+			searchStr: `${file.path} ${file.label || ""}`,
+		}))
+
+		const fzf = new Fzf(searchItems, {
+			selector: (item) => item.searchStr,
+		})
+
+		const results = fzf
+			.find(query)
+			.slice(0, limit)
+			.map((result) => result.item.original)
+
+		const resultsWithDirectoryCheck = await Promise.all(
+			results.map(async (result) => {
+				const fullPath = path.join(workspacePath, result.path)
+				const isDirectory = fs.existsSync(fullPath) && fs.lstatSync(fullPath).isDirectory()
+
+				return {
+					...result,
+					type: isDirectory ? ("folder" as const) : ("file" as const),
+				}
+			}),
+		)
+
+		return resultsWithDirectoryCheck
+	} catch (error) {
+		return []
+	}
+}

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -56,6 +56,7 @@ export interface ExtensionMessage {
 		| "remoteBrowserEnabled"
 		| "ttsStart"
 		| "ttsStop"
+		| "fileSearchResults"
 	text?: string
 	action?:
 		| "chatButtonClicked"
@@ -92,6 +93,12 @@ export interface ExtensionMessage {
 	values?: Record<string, any>
 	requestId?: string
 	promptText?: string
+	results?: Array<{
+		path: string
+		type: "file" | "folder"
+		label?: string
+	}>
+	error?: string
 }
 
 export interface ApiConfigMeta {

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -114,6 +114,7 @@ export interface WebviewMessage {
 		| "browserConnectionResult"
 		| "remoteBrowserEnabled"
 		| "language"
+		| "searchFiles"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/webview-ui/src/utils/__tests__/context-mentions.test.ts
+++ b/webview-ui/src/utils/__tests__/context-mentions.test.ts
@@ -131,8 +131,8 @@ describe("shouldShowContextMenu", () => {
 		expect(shouldShowContextMenu("Hello @http://test.com", 17)).toBe(false)
 	})
 
-	it("should return false for @problems", () => {
+	it("should return true for @problems", () => {
 		// Position cursor at the end to test the full word
-		expect(shouldShowContextMenu("@problems", 9)).toBe(false)
+		expect(shouldShowContextMenu("@problems", 9)).toBe(true)
 	})
 })

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -1,7 +1,13 @@
 import { mentionRegex } from "../../../src/shared/context-mentions"
 import { Fzf } from "fzf"
 import { ModeConfig } from "../../../src/shared/modes"
+import * as path from "path"
 
+export interface SearchResult {
+	path: string
+	type: "file" | "folder"
+	label?: string
+}
 export function insertMention(
 	text: string,
 	position: number,
@@ -80,6 +86,7 @@ export function getContextMenuOptions(
 	query: string,
 	selectedType: ContextMenuOptionType | null = null,
 	queryItems: ContextMenuQueryItem[],
+	dynamicSearchResults: SearchResult[] = [],
 	modes?: ModeConfig[],
 ): ContextMenuQueryItem[] {
 	// Handle slash commands for modes
@@ -203,7 +210,34 @@ export function getContextMenuOptions(
 		}
 	}
 
-	// Create searchable strings array for fzf
+	if (dynamicSearchResults.length > 0) {
+		// Convert search results to queryItems format
+		const searchResultItems = dynamicSearchResults.map((result) => {
+			const formattedPath = result.path.startsWith("/") ? result.path : `/${result.path}`
+
+			return {
+				type: result.type === "folder" ? ContextMenuOptionType.Folder : ContextMenuOptionType.File,
+				value: formattedPath,
+				label: result.label || path.basename(result.path),
+				description: formattedPath,
+			}
+		})
+
+		const allItems = [...suggestions, ...searchResultItems]
+
+		// Remove duplicates
+		const seen = new Set()
+		const deduped = allItems.filter((item) => {
+			const key = `${item.type}-${item.value}`
+			if (seen.has(key)) return false
+			seen.add(key)
+			return true
+		})
+
+		return deduped
+	}
+
+	// Fallback to original static filtering if no dynamic results
 	const searchableItems = queryItems.map((item) => ({
 		original: item,
 		searchStr: [item.value, item.label, item.description].filter(Boolean).join(" "),
@@ -257,26 +291,25 @@ export function shouldShowContextMenu(text: string, position: number): boolean {
 	if (text.startsWith("/")) {
 		return position <= text.length && !text.includes(" ")
 	}
-
 	const beforeCursor = text.slice(0, position)
 	const atIndex = beforeCursor.lastIndexOf("@")
 
-	if (atIndex === -1) return false
+	if (atIndex === -1) {
+		return false
+	}
 
 	const textAfterAt = beforeCursor.slice(atIndex + 1)
 
-	// Check if there's any whitespace after the '@'
-	if (/\s/.test(textAfterAt)) return false
-
-	// Don't show the menu if it's a URL
-	if (textAfterAt.toLowerCase().startsWith("http")) return false
-
-	// Don't show the menu if it's a problems or terminal
-	if (textAfterAt.toLowerCase().startsWith("problems") || textAfterAt.toLowerCase().startsWith("terminal"))
+	// Don't show the menu if it's clearly a URL
+	if (textAfterAt.toLowerCase().startsWith("http")) {
 		return false
+	}
 
-	// NOTE: it's okay that menu shows when there's trailing punctuation since user could be inputting a path with marks
+	// If there's a space after @, don't show the menu (normal @ mention)
+	if (textAfterAt.indexOf(" ") === 0) {
+		return false
+	}
 
-	// Show the menu if there's just '@' or '@' followed by some text (but not a URL)
+	// Show menu in all other cases
 	return true
 }


### PR DESCRIPTION
## Context

Context mentions are extremely frustrating, see https://github.com/RooVetGit/Roo-Code/issues/1471. There's a limited set of files available on the client, it doesn't respect gitignore, etc.

## Implementation

This PR takes a different approach and just moves the heavy-lifting to the server. Now, every time you type in a mention search (+/- a debounce delay) it sends a message to the extension, which uses ripgrep to get a list of up to 5000 workspace files (excluding .gitignored ones) and filters them through fzf to find the 20 most relevant to your query.

It seems to work better for me but I would love for other people to try this out and let me know. Thanks!

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Move file/folder search to server using `ripgrep` and `fzf`, updating webview components to handle dynamic search results.
> 
>   - **Behavior**:
>     - Moves file/folder search to server using `ripgrep` and `fzf` in `file-search.ts`.
>     - Handles up to 5000 files, respects `.gitignore`, and returns top 20 results.
>     - Updates `ClineProvider.ts` to handle `searchFiles` message and return results to webview.
>   - **Webview**:
>     - Updates `ChatTextArea.tsx` to send `searchFiles` message and handle results.
>     - Updates `ContextMenu.tsx` to display dynamic search results.
>   - **Misc**:
>     - Adds `fzf` dependency in `package.json`.
>     - Removes `pathExists()` in `ripgrep/index.ts` and uses `fileExistsAtPath()` instead.
>     - Fixes test expectation in `context-mentions.test.ts` for `@problems`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d80d8e47506d628e7d4b5d67799c4abd53d33c01. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->