### PR TITLE
Fix logic for spaces after context mentions

### DIFF
--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -300,13 +300,11 @@ export function shouldShowContextMenu(text: string, position: number): boolean {
 
 	const textAfterAt = beforeCursor.slice(atIndex + 1)
 
+	// Check if there's any whitespace after the '@'
+	if (/\s/.test(textAfterAt)) return false
+
 	// Don't show the menu if it's clearly a URL
 	if (textAfterAt.toLowerCase().startsWith("http")) {
-		return false
-	}
-
-	// If there's a space after @, don't show the menu (normal @ mention)
-	if (textAfterAt.indexOf(" ") === 0) {
 		return false
 	}
 


### PR DESCRIPTION
Cut a little too deep in #1824 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `shouldShowContextMenu` to check for any whitespace after '@' in `context-mentions.ts`.
> 
>   - **Behavior**:
>     - Update `shouldShowContextMenu` in `context-mentions.ts` to check for any whitespace after '@' instead of just a space.
>     - Ensures context menu is not shown if any whitespace follows '@'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5fa3a086431b49d9c67754a380b870eb1e02e3a4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->