### PR TITLE
[clinerules] search clinerule in parent folders which make it easier to share within a github repo

### DIFF
--- a/src/core/prompts/sections/__tests__/custom-instructions.test.ts
+++ b/src/core/prompts/sections/__tests__/custom-instructions.test.ts
@@ -106,7 +106,15 @@ describe("addCustomInstructions", () => {
 	})
 
 	it("should combine all instruction types when provided", async () => {
-		mockedFs.readFile.mockResolvedValue("mode specific rules")
+		// Mock implementation to return different values based on the file path
+		mockedFs.readFile.mockImplementation(((filePath: any) => {
+			// For .clinerules-test-mode, return mode-specific rules
+			if (filePath.toString().includes(".clinerules-test-mode")) {
+				return Promise.resolve("mode specific rules")
+			}
+			// For any other read operation, return empty
+			return Promise.reject({ code: "ENOENT" })
+		}) as any)
 
 		const result = await addCustomInstructions(
 			"mode instructions",

--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -4,59 +4,59 @@ import * as vscode from "vscode"
 import { LANGUAGES } from "../../../shared/language"
 
 async function safeReadFile(filePath: string): Promise<string> {
-try {
-const content = await fs.readFile(filePath, "utf-8")
-return content.trim()
-} catch (err) {
-const errorCode = (err as NodeJS.ErrnoException).code
-if (!errorCode || !["ENOENT", "EISDIR"].includes(errorCode)) {
-throw err
-}
-return ""
-}
+	try {
+		const content = await fs.readFile(filePath, "utf-8")
+		return content.trim()
+	} catch (err) {
+		const errorCode = (err as NodeJS.ErrnoException).code
+		if (!errorCode || !["ENOENT", "EISDIR"].includes(errorCode)) {
+			throw err
+		}
+		return ""
+	}
 }
 
 async function findRuleInDirectory(dir: string, ruleFile: string): Promise<string> {
-       const filePath = path.join(dir, ruleFile)
-       const content = await safeReadFile(filePath)
+	const filePath = path.join(dir, ruleFile)
+	const content = await safeReadFile(filePath)
 
-       if (content) {
-               return content
-       }
+	if (content) {
+		return content
+	}
 
-       // Check if we've reached the root directory
-       const parentDir = path.dirname(dir)
-       if (parentDir === dir) {
-               return ""
-       }
+	// Check if we've reached the root directory
+	const parentDir = path.dirname(dir)
+	if (parentDir === dir) {
+		return ""
+	}
 
-       // Recursively check parent directory
-       return findRuleInDirectory(parentDir, ruleFile)
+	// Recursively check parent directory
+	return findRuleInDirectory(parentDir, ruleFile)
 }
 
 export async function loadRuleFiles(cwd: string): Promise<string> {
-const ruleFiles = [".clinerules", ".cursorrules", ".windsurfrules"]
-let combinedRules = ""
+	const ruleFiles = [".clinerules", ".cursorrules", ".windsurfrules"]
+	let combinedRules = ""
 
-for (const file of ruleFiles) {
-       const content = await findRuleInDirectory(cwd, file)
-       if (content) {
-               combinedRules += `\n# Rules from ${file}:\n${content}\n`
-       }
-}
+	for (const file of ruleFiles) {
+		const content = await findRuleInDirectory(cwd, file)
+		if (content) {
+			combinedRules += `\n# Rules from ${file}:\n${content}\n`
+		}
+	}
 
-return combinedRules
+	return combinedRules
 }
 
 async function findCustomInstructionsFile(dir: string, filePattern: string): Promise<string> {
-       // First try to find as a direct file
-       const content = await findRuleInDirectory(dir, filePattern)
-       if (content) {
-               return content
-       }
+	// First try to find as a direct file
+	const content = await findRuleInDirectory(dir, filePattern)
+	if (content) {
+		return content
+	}
 
-       // If not found as a file, check if it's raw content
-       return filePattern.trim()
+	// If not found as a file, check if it's raw content
+	return filePattern.trim()
 }
 
 export async function addCustomInstructions(
@@ -77,22 +77,22 @@ export async function addCustomInstructions(
 
 	// Add language preference if provided
 	if (options.language) {
-	const languageName = LANGUAGES[options.language] || options.language
-	sections.push(
-		`Language Preference:\nYou should always speak and think in the "${languageName}" (${options.language}) language unless the user gives you instructions below to do otherwise.`,		
-	)
+		const languageName = LANGUAGES[options.language] || options.language
+		sections.push(
+			`Language Preference:\nYou should always speak and think in the "${languageName}" (${options.language}) language unless the user gives you instructions below to do otherwise.`,
+		)
 	}
-	
+
 	// Add global instructions first - try to find as file or use raw content
 	const globalContent = await findCustomInstructionsFile(cwd, globalCustomInstructions)
 	if (globalContent) {
-	        sections.push(`Global Instructions:\n${globalContent}`)
+		sections.push(`Global Instructions:\n${globalContent}`)
 	}
-	
+
 	// Add mode-specific instructions - try to find as file or use raw content
 	const modeContent = await findCustomInstructionsFile(cwd, modeCustomInstructions)
 	if (modeContent) {
-	        sections.push(`Mode-specific Instructions:\n${modeContent}`)
+		sections.push(`Mode-specific Instructions:\n${modeContent}`)
 	}
 
 	// Add rules - include both mode-specific and generic rules if they exist

--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -4,30 +4,59 @@ import * as vscode from "vscode"
 import { LANGUAGES } from "../../../shared/language"
 
 async function safeReadFile(filePath: string): Promise<string> {
-	try {
-		const content = await fs.readFile(filePath, "utf-8")
-		return content.trim()
-	} catch (err) {
-		const errorCode = (err as NodeJS.ErrnoException).code
-		if (!errorCode || !["ENOENT", "EISDIR"].includes(errorCode)) {
-			throw err
-		}
-		return ""
-	}
+try {
+const content = await fs.readFile(filePath, "utf-8")
+return content.trim()
+} catch (err) {
+const errorCode = (err as NodeJS.ErrnoException).code
+if (!errorCode || !["ENOENT", "EISDIR"].includes(errorCode)) {
+throw err
+}
+return ""
+}
+}
+
+async function findRuleInDirectory(dir: string, ruleFile: string): Promise<string> {
+       const filePath = path.join(dir, ruleFile)
+       const content = await safeReadFile(filePath)
+
+       if (content) {
+               return content
+       }
+
+       // Check if we've reached the root directory
+       const parentDir = path.dirname(dir)
+       if (parentDir === dir) {
+               return ""
+       }
+
+       // Recursively check parent directory
+       return findRuleInDirectory(parentDir, ruleFile)
 }
 
 export async function loadRuleFiles(cwd: string): Promise<string> {
-	const ruleFiles = [".clinerules", ".cursorrules", ".windsurfrules"]
-	let combinedRules = ""
+const ruleFiles = [".clinerules", ".cursorrules", ".windsurfrules"]
+let combinedRules = ""
 
-	for (const file of ruleFiles) {
-		const content = await safeReadFile(path.join(cwd, file))
-		if (content) {
-			combinedRules += `\n# Rules from ${file}:\n${content}\n`
-		}
-	}
+for (const file of ruleFiles) {
+       const content = await findRuleInDirectory(cwd, file)
+       if (content) {
+               combinedRules += `\n# Rules from ${file}:\n${content}\n`
+       }
+}
 
-	return combinedRules
+return combinedRules
+}
+
+async function findCustomInstructionsFile(dir: string, filePattern: string): Promise<string> {
+       // First try to find as a direct file
+       const content = await findRuleInDirectory(dir, filePattern)
+       if (content) {
+               return content
+       }
+
+       // If not found as a file, check if it's raw content
+       return filePattern.trim()
 }
 
 export async function addCustomInstructions(
@@ -48,20 +77,22 @@ export async function addCustomInstructions(
 
 	// Add language preference if provided
 	if (options.language) {
-		const languageName = LANGUAGES[options.language] || options.language
-		sections.push(
-			`Language Preference:\nYou should always speak and think in the "${languageName}" (${options.language}) language unless the user gives you instructions below to do otherwise.`,
-		)
+	const languageName = LANGUAGES[options.language] || options.language
+	sections.push(
+		`Language Preference:\nYou should always speak and think in the "${languageName}" (${options.language}) language unless the user gives you instructions below to do otherwise.`,		
+	)
 	}
-
-	// Add global instructions first
-	if (typeof globalCustomInstructions === "string" && globalCustomInstructions.trim()) {
-		sections.push(`Global Instructions:\n${globalCustomInstructions.trim()}`)
+	
+	// Add global instructions first - try to find as file or use raw content
+	const globalContent = await findCustomInstructionsFile(cwd, globalCustomInstructions)
+	if (globalContent) {
+	        sections.push(`Global Instructions:\n${globalContent}`)
 	}
-
-	// Add mode-specific instructions after
-	if (typeof modeCustomInstructions === "string" && modeCustomInstructions.trim()) {
-		sections.push(`Mode-specific Instructions:\n${modeCustomInstructions.trim()}`)
+	
+	// Add mode-specific instructions - try to find as file or use raw content
+	const modeContent = await findCustomInstructionsFile(cwd, modeCustomInstructions)
+	if (modeContent) {
+	        sections.push(`Mode-specific Instructions:\n${modeContent}`)
 	}
 
 	// Add rules - include both mode-specific and generic rules if they exist

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -21,49 +21,49 @@ export async function openImage(dataUri: string) {
 }
 
 interface OpenFileOptions {
-create?: boolean
-content?: string
-searchParents?: boolean
-startFromWorkspace?: boolean
+	create?: boolean
+	content?: string
+	searchParents?: boolean
+	startFromWorkspace?: boolean
 }
 
 async function findFileInParentDirs(searchPath: string, fileName: string): Promise<string | null> {
-       try {
-               const fullPath = path.join(searchPath, fileName)
-               await vscode.workspace.fs.stat(vscode.Uri.file(fullPath))
-               return fullPath
-       } catch {
-               const parentDir = path.dirname(searchPath)
-               if (parentDir === searchPath) {
-                       // Hit root
-                       return null
-               }
-               return findFileInParentDirs(parentDir, fileName)
-       }
+	try {
+		const fullPath = path.join(searchPath, fileName)
+		await vscode.workspace.fs.stat(vscode.Uri.file(fullPath))
+		return fullPath
+	} catch {
+		const parentDir = path.dirname(searchPath)
+		if (parentDir === searchPath) {
+			// Hit root
+			return null
+		}
+		return findFileInParentDirs(parentDir, fileName)
+	}
 }
 
 export async function openFile(filePath: string, options: OpenFileOptions = {}) {
-try {
-// Get workspace root
-const workspaceRoot = getWorkspacePath()
-if (!workspaceRoot) {
-throw new Error("No workspace root found")
-}
+	try {
+		// Get workspace root
+		const workspaceRoot = getWorkspacePath()
+		if (!workspaceRoot) {
+			throw new Error("No workspace root found")
+		}
 
-// If path starts with ./, resolve it relative to workspace root
-let fullPath = filePath.startsWith("./") ? path.join(workspaceRoot, filePath.slice(2)) : filePath
+		// If path starts with ./, resolve it relative to workspace root
+		let fullPath = filePath.startsWith("./") ? path.join(workspaceRoot, filePath.slice(2)) : filePath
 
-// Handle recursive search
-if (options.searchParents) {
-        const startDir = options.startFromWorkspace ? workspaceRoot : path.dirname(fullPath)
-        const fileName = path.basename(filePath)
-        const foundPath = await findFileInParentDirs(startDir, fileName)
-        if (foundPath) {
-                fullPath = foundPath
-        }
-}
+		// Handle recursive search
+		if (options.searchParents) {
+			const startDir = options.startFromWorkspace ? workspaceRoot : path.dirname(fullPath)
+			const fileName = path.basename(filePath)
+			const foundPath = await findFileInParentDirs(startDir, fileName)
+			if (foundPath) {
+				fullPath = foundPath
+			}
+		}
 
-const uri = vscode.Uri.file(fullPath)
+		const uri = vscode.Uri.file(fullPath)
 
 		// Check if file exists
 		try {

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -21,22 +21,49 @@ export async function openImage(dataUri: string) {
 }
 
 interface OpenFileOptions {
-	create?: boolean
-	content?: string
+create?: boolean
+content?: string
+searchParents?: boolean
+startFromWorkspace?: boolean
+}
+
+async function findFileInParentDirs(searchPath: string, fileName: string): Promise<string | null> {
+       try {
+               const fullPath = path.join(searchPath, fileName)
+               await vscode.workspace.fs.stat(vscode.Uri.file(fullPath))
+               return fullPath
+       } catch {
+               const parentDir = path.dirname(searchPath)
+               if (parentDir === searchPath) {
+                       // Hit root
+                       return null
+               }
+               return findFileInParentDirs(parentDir, fileName)
+       }
 }
 
 export async function openFile(filePath: string, options: OpenFileOptions = {}) {
-	try {
-		// Get workspace root
-		const workspaceRoot = getWorkspacePath()
-		if (!workspaceRoot) {
-			throw new Error("No workspace root found")
-		}
+try {
+// Get workspace root
+const workspaceRoot = getWorkspacePath()
+if (!workspaceRoot) {
+throw new Error("No workspace root found")
+}
 
-		// If path starts with ./, resolve it relative to workspace root
-		const fullPath = filePath.startsWith("./") ? path.join(workspaceRoot, filePath.slice(2)) : filePath
+// If path starts with ./, resolve it relative to workspace root
+let fullPath = filePath.startsWith("./") ? path.join(workspaceRoot, filePath.slice(2)) : filePath
 
-		const uri = vscode.Uri.file(fullPath)
+// Handle recursive search
+if (options.searchParents) {
+        const startDir = options.startFromWorkspace ? workspaceRoot : path.dirname(fullPath)
+        const fileName = path.basename(filePath)
+        const foundPath = await findFileInParentDirs(startDir, fileName)
+        if (foundPath) {
+                fullPath = foundPath
+        }
+}
+
+const uri = vscode.Uri.file(fullPath)
 
 		// Check if file exists
 		try {

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -460,8 +460,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 													type: "openFile",
 													text: "./.roomodes",
 													values: {
-														create: true,
-														content: JSON.stringify({ customModes: [] }, null, 2),
+													create: true,
+													content: JSON.stringify({ customModes: [] }, null, 2),
+													searchParents: true,
+													startFromWorkspace: true,
 													},
 												})
 												setShowConfigMenu(false)
@@ -806,8 +808,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 													type: "openFile",
 													text: `./.clinerules-${currentMode.slug}`,
 													values: {
-														create: true,
-														content: "",
+													create: true,
+													content: "",
+													searchParents: true,
+													startFromWorkspace: true,
 													},
 												})
 											}}
@@ -913,8 +917,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 														type: "openFile",
 														text: `./.roo/system-prompt-${currentMode.slug}`,
 														values: {
-															create: true,
-															content: "",
+														create: true,
+														content: "",
+														searchParents: true,
+														startFromWorkspace: true,
 														},
 													})
 												}}
@@ -968,8 +974,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 												type: "openFile",
 												text: "./.clinerules",
 												values: {
-													create: true,
-													content: "",
+												create: true,
+												content: "",
+												searchParents: true,
+												startFromWorkspace: true,
 												},
 											})
 										}

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -460,10 +460,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 													type: "openFile",
 													text: "./.roomodes",
 													values: {
-													create: true,
-													content: JSON.stringify({ customModes: [] }, null, 2),
-													searchParents: true,
-													startFromWorkspace: true,
+														create: true,
+														content: JSON.stringify({ customModes: [] }, null, 2),
+														searchParents: true,
+														startFromWorkspace: true,
 													},
 												})
 												setShowConfigMenu(false)
@@ -808,10 +808,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 													type: "openFile",
 													text: `./.clinerules-${currentMode.slug}`,
 													values: {
-													create: true,
-													content: "",
-													searchParents: true,
-													startFromWorkspace: true,
+														create: true,
+														content: "",
+														searchParents: true,
+														startFromWorkspace: true,
 													},
 												})
 											}}
@@ -917,10 +917,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 														type: "openFile",
 														text: `./.roo/system-prompt-${currentMode.slug}`,
 														values: {
-														create: true,
-														content: "",
-														searchParents: true,
-														startFromWorkspace: true,
+															create: true,
+															content: "",
+															searchParents: true,
+															startFromWorkspace: true,
 														},
 													})
 												}}
@@ -974,10 +974,10 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 												type: "openFile",
 												text: "./.clinerules",
 												values: {
-												create: true,
-												content: "",
-												searchParents: true,
-												startFromWorkspace: true,
+													create: true,
+													content: "",
+													searchParents: true,
+													startFromWorkspace: true,
 												},
 											})
 										}


### PR DESCRIPTION
# Implement parent directory search for configuration files

## Overview
This PR adds support for searching configuration files (.clinerules) recursively through parent directories, similar to how Git finds .gitignore files. This allows users to place configuration files in any parent directory up to the root.

## Usage scenario
* For a big organization,   our git repo is huge.    Devs may work vscode from any sub-folder level instead of the git root. 
* .clinerules provides a way to share the custom instructions via a file, but it work for the "<current-workspace-dir>" only, which is the folder where vscode is opened.  Then it means we may need a copy of clinerules in each sub-folder if we want to share the same custom instructions, hard to maintain.
* With this PR, we can put the .clinerules in the `git root folder` only,  then RooCode will recursively read the file from parent directories until a non-empty one detected.  
*  Also,  if we have multiple git repo in the same drive/ folder, we can put a .clinerules in the root folder directly, which can benefit multiple git repos. 

## Changes

### src/core/prompts/sections/custom-instructions.ts
- Added `findRuleInDirectory` function to recursively search parent directories
- Modified `loadRuleFiles` to use the new recursive search functionality
- Added `findCustomInstructionsFile` to handle both file paths and raw content
- Updated `addCustomInstructions` to use recursive search for both global and mode-specific rules

### src/integrations/misc/open-file.ts
- Added new options to OpenFileOptions interface:
  ```typescript
  {
    searchParents?: boolean,     // Enable recursive parent search
    startFromWorkspace?: boolean // Start search from workspace root
  }
  ```
- Added `findFileInParentDirs` helper function for recursive file search
- Modified `openFile` to support recursive search through parent directories

### webview-ui/src/components/prompts/PromptsView.tsx
- Updated .clinerules file click handler to use new recursive search options:
  ```typescript
  values: {
    create: true,
    content: "",
    searchParents: true,
    startFromWorkspace: true
  }
  ```

## Testing
- Place .clinerules in any parent directory up to root
- Files in closer directories take precedence over those in parent directories
- If no file is found, creates one in the workspace root
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR adds recursive search for `.clinerules` files in parent directories, enhancing configuration management in large repositories.
> 
>   - **Behavior**:
>     - `.clinerules` files are now searched recursively in parent directories up to the root, similar to `.gitignore` behavior.
>     - Files in closer directories take precedence.
>     - If no file is found, a new one is created in the workspace root.
>   - **Functions**:
>     - `findRuleInDirectory` in `custom-instructions.ts` recursively searches for rule files.
>     - `findFileInParentDirs` in `open-file.ts` added for recursive file search.
>     - `openFile` in `open-file.ts` updated to support recursive search.
>   - **UI**:
>     - `PromptsView.tsx` updated to use new recursive search options for `.clinerules` file handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 100ac97202571f2f5970cab97556279340b190b4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->