### PR TITLE
Discards temperature setting on o3-mini for Unbound

### DIFF
--- a/.changeset/twenty-spoons-shout.md
+++ b/.changeset/twenty-spoons-shout.md
@@ -1,0 +1,7 @@
+---
+"roo-cline": patch
+---
+
+Adds a function to add temperature setting based on the model id
+This is added because openai/o3-mini does not support temperature parameter which causes the request to fail.
+This update will allow users to use o3-mini on Unbound without facing any issues.

--- a/src/api/providers/__tests__/unbound.test.ts
+++ b/src/api/providers/__tests__/unbound.test.ts
@@ -246,6 +246,38 @@ describe("UnboundHandler", () => {
 			)
 			expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("max_tokens")
 		})
+
+		it("should not set temperature for openai/o3-mini", async () => {
+			mockCreate.mockClear()
+
+			const openaiOptions = {
+				apiModelId: "openai/o3-mini",
+				unboundApiKey: "test-key",
+				unboundModelId: "openai/o3-mini",
+				unboundModelInfo: {
+					maxTokens: undefined,
+					contextWindow: 128000,
+					supportsPromptCache: true,
+					inputPrice: 0.01,
+					outputPrice: 0.03,
+				},
+			}
+			const openaiHandler = new UnboundHandler(openaiOptions)
+
+			await openaiHandler.completePrompt("Test prompt")
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: "o3-mini",
+					messages: [{ role: "user", content: "Test prompt" }],
+				}),
+				expect.objectContaining({
+					headers: expect.objectContaining({
+						"X-Unbound-Metadata": expect.stringContaining("roo-code"),
+					}),
+				}),
+			)
+			expect(mockCreate.mock.calls[0][0]).not.toHaveProperty("temperature")
+		})
 	})
 
 	describe("getModel", () => {


### PR DESCRIPTION
## Context

openai/o3-mini does not support temperature setting. This PR is to add temperature only for the supported models

## Implementation

Added a function to add temperature parameter based on model id

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Wrote a test to validate the request options when the model is o3-mini
Any prompt when the model is set as o3-mini should go through with this change. It was failing previously

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds conditional temperature setting in `UnboundHandler` for models, excluding `openai/o3-mini`.
> 
>   - **Behavior**:
>     - Adds `supportsTemperature()` in `UnboundHandler` to check if model supports temperature.
>     - Modifies `createMessage()` and `completePrompt()` in `unbound.ts` to conditionally add temperature based on `supportsTemperature()`.
>     - Ensures `openai/o3-mini` model does not set temperature.
>   - **Tests**:
>     - Adds test in `unbound.test.ts` to verify temperature is not set for `openai/o3-mini` model.
>     - Validates request options for `openai/o3-mini` in `completePrompt()` test.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e46f70f82c66bdf11af2fa2bf44b594daa8777dc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->