### PR TITLE
Try to avoid placeholders in follow-up questions

### DIFF
--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -188,7 +188,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -650,7 +650,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -1081,7 +1081,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -1461,7 +1461,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -1838,7 +1838,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -2215,7 +2215,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -2638,7 +2638,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -3067,7 +3067,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -3895,7 +3895,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -4335,7 +4335,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -4714,7 +4714,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -5267,7 +5267,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -5735,7 +5735,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -6066,7 +6066,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>
@@ -6610,7 +6610,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>

--- a/src/core/prompts/tools/ask-followup-question.ts
+++ b/src/core/prompts/tools/ask-followup-question.ts
@@ -6,7 +6,7 @@ Parameters:
 - follow_up: (required) A list of 2-4 suggested answers that logically follow from the question, ordered by priority or logical sequence. Each suggestion must:
   1. Be provided in its own <suggest> tag
   2. Be specific, actionable, and directly related to the completed task
-  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details
+  3. Be a complete answer to the question - the user should not need to provide additional information or fill in any missing details. DO NOT include placeholders with brackets or parentheses.
 Usage:
 <ask_followup_question>
 <question>Your question here</question>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1006,7 +1006,9 @@ export const ChatRowContent = ({
 								</div>
 							)}
 							<div style={{ paddingTop: 10, paddingBottom: 15 }}>
-								<Markdown markdown={followUpData?.question} />
+								<Markdown
+									markdown={message.partial === true ? message?.text : followUpData?.question}
+								/>
 							</div>
 							<FollowUpSuggest
 								suggestions={followUpData?.suggest}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances follow-up question clarity by disallowing placeholders and updating rendering logic in `ChatRow.tsx`.
> 
>   - **Behavior**:
>     - Updated `ask-followup-question.ts` to specify that follow-up answers should not include placeholders with brackets or parentheses.
>     - In `ChatRow.tsx`, modified `Markdown` rendering to handle `message.partial` state, ensuring correct display of follow-up questions.
>   - **Tests**:
>     - Updated snapshots in `system.test.ts.snap` to reflect changes in follow-up question guidelines.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 453e127322613a2979f309699b1a75510c80e7f2. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->