### PR TITLE
Reflect Cross-region inference option in `ap-xx` region

### DIFF
--- a/.changeset/itchy-waves-move.md
+++ b/.changeset/itchy-waves-move.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Reflect Cross-region inference option in `ap-xx` region

--- a/src/api/providers/__tests__/bedrock.test.ts
+++ b/src/api/providers/__tests__/bedrock.test.ts
@@ -260,7 +260,7 @@ describe("AwsBedrockHandler", () => {
 			expect(result).toBe("")
 		})
 
-		it("should handle cross-region inference", async () => {
+		it("should handle cross-region inference for us-xx region", async () => {
 			handler = new AwsBedrockHandler({
 				apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
 				awsAccessKey: "test-access-key",
@@ -288,6 +288,105 @@ describe("AwsBedrockHandler", () => {
 				expect.objectContaining({
 					input: expect.objectContaining({
 						modelId: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+					}),
+				}),
+			)
+		})
+
+		it("should handle cross-region inference for eu-xx region", async () => {
+			handler = new AwsBedrockHandler({
+				apiModelId: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+				awsAccessKey: "test-access-key",
+				awsSecretKey: "test-secret-key",
+				awsRegion: "eu-west-1",
+				awsUseCrossRegionInference: true,
+			})
+
+			const mockResponse = {
+				output: new TextEncoder().encode(
+					JSON.stringify({
+						content: "Test response",
+					}),
+				),
+			}
+
+			const mockSend = jest.fn().mockResolvedValue(mockResponse)
+			handler["client"] = {
+				send: mockSend,
+			} as unknown as BedrockRuntimeClient
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe("Test response")
+			expect(mockSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({
+						modelId: "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+					}),
+				}),
+			)
+		})
+
+		it("should handle cross-region inference for ap-xx region", async () => {
+			handler = new AwsBedrockHandler({
+				apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+				awsAccessKey: "test-access-key",
+				awsSecretKey: "test-secret-key",
+				awsRegion: "ap-northeast-1",
+				awsUseCrossRegionInference: true,
+			})
+
+			const mockResponse = {
+				output: new TextEncoder().encode(
+					JSON.stringify({
+						content: "Test response",
+					}),
+				),
+			}
+
+			const mockSend = jest.fn().mockResolvedValue(mockResponse)
+			handler["client"] = {
+				send: mockSend,
+			} as unknown as BedrockRuntimeClient
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe("Test response")
+			expect(mockSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({
+						modelId: "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+					}),
+				}),
+			)
+		})
+
+		it("should handle cross-region inference for other regions", async () => {
+			handler = new AwsBedrockHandler({
+				apiModelId: "anthropic.claude-3-sonnet-20240229-v1:0",
+				awsAccessKey: "test-access-key",
+				awsSecretKey: "test-secret-key",
+				awsRegion: "ca-central-1",
+				awsUseCrossRegionInference: true,
+			})
+
+			const mockResponse = {
+				output: new TextEncoder().encode(
+					JSON.stringify({
+						content: "Test response",
+					}),
+				),
+			}
+
+			const mockSend = jest.fn().mockResolvedValue(mockResponse)
+			handler["client"] = {
+				send: mockSend,
+			} as unknown as BedrockRuntimeClient
+
+			const result = await handler.completePrompt("Test prompt")
+			expect(result).toBe("Test response")
+			expect(mockSend).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({
+						modelId: "anthropic.claude-3-sonnet-20240229-v1:0",
 					}),
 				}),
 			)

--- a/src/api/providers/__tests__/bedrock.test.ts
+++ b/src/api/providers/__tests__/bedrock.test.ts
@@ -165,6 +165,222 @@ describe("AwsBedrockHandler", () => {
 			)
 		})
 
+		it("should handle cross-region inference for us-xx region", async () => {
+			const handlerWithProfile = new AwsBedrockHandler({
+				apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+				awsAccessKey: "test-access-key",
+				awsSecretKey: "test-secret-key",
+				awsRegion: "us-east-1",
+				awsUseCrossRegionInference: true,
+			})
+
+			// Mock AWS SDK invoke
+			const mockStream = {
+				[Symbol.asyncIterator]: async function* () {
+					yield {
+						metadata: {
+							usage: {
+								inputTokens: 10,
+								outputTokens: 5,
+							},
+						},
+					}
+				},
+			}
+
+			const mockInvoke = jest.fn().mockResolvedValue({
+				stream: mockStream,
+			})
+
+			handlerWithProfile["client"] = {
+				send: mockInvoke,
+			} as unknown as BedrockRuntimeClient
+
+			const stream = handlerWithProfile.createMessage(systemPrompt, mockMessages)
+			const chunks = []
+
+			for await (const chunk of stream) {
+				chunks.push(chunk)
+			}
+
+			expect(chunks.length).toBeGreaterThan(0)
+			expect(chunks[0]).toEqual({
+				type: "usage",
+				inputTokens: 10,
+				outputTokens: 5,
+			})
+
+			expect(mockInvoke).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({
+						modelId: "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+					}),
+				}),
+			)
+		})
+
+		it("should handle cross-region inference for eu-xx region", async () => {
+			const handlerWithProfile = new AwsBedrockHandler({
+				apiModelId: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+				awsAccessKey: "test-access-key",
+				awsSecretKey: "test-secret-key",
+				awsRegion: "eu-west-1",
+				awsUseCrossRegionInference: true,
+			})
+
+			// Mock AWS SDK invoke
+			const mockStream = {
+				[Symbol.asyncIterator]: async function* () {
+					yield {
+						metadata: {
+							usage: {
+								inputTokens: 10,
+								outputTokens: 5,
+							},
+						},
+					}
+				},
+			}
+
+			const mockInvoke = jest.fn().mockResolvedValue({
+				stream: mockStream,
+			})
+
+			handlerWithProfile["client"] = {
+				send: mockInvoke,
+			} as unknown as BedrockRuntimeClient
+
+			const stream = handlerWithProfile.createMessage(systemPrompt, mockMessages)
+			const chunks = []
+
+			for await (const chunk of stream) {
+				chunks.push(chunk)
+			}
+
+			expect(chunks.length).toBeGreaterThan(0)
+			expect(chunks[0]).toEqual({
+				type: "usage",
+				inputTokens: 10,
+				outputTokens: 5,
+			})
+
+			expect(mockInvoke).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({
+						modelId: "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+					}),
+				}),
+			)
+		})
+
+		it("should handle cross-region inference for ap-xx region", async () => {
+			const handlerWithProfile = new AwsBedrockHandler({
+				apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
+				awsAccessKey: "test-access-key",
+				awsSecretKey: "test-secret-key",
+				awsRegion: "ap-northeast-1",
+				awsUseCrossRegionInference: true,
+			})
+
+			// Mock AWS SDK invoke
+			const mockStream = {
+				[Symbol.asyncIterator]: async function* () {
+					yield {
+						metadata: {
+							usage: {
+								inputTokens: 10,
+								outputTokens: 5,
+							},
+						},
+					}
+				},
+			}
+
+			const mockInvoke = jest.fn().mockResolvedValue({
+				stream: mockStream,
+			})
+
+			handlerWithProfile["client"] = {
+				send: mockInvoke,
+			} as unknown as BedrockRuntimeClient
+
+			const stream = handlerWithProfile.createMessage(systemPrompt, mockMessages)
+			const chunks = []
+
+			for await (const chunk of stream) {
+				chunks.push(chunk)
+			}
+
+			expect(chunks.length).toBeGreaterThan(0)
+			expect(chunks[0]).toEqual({
+				type: "usage",
+				inputTokens: 10,
+				outputTokens: 5,
+			})
+
+			expect(mockInvoke).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({
+						modelId: "apac.anthropic.claude-3-5-sonnet-20241022-v2:0",
+					}),
+				}),
+			)
+		})
+
+		it("should handle cross-region inference for other region", async () => {
+			const handlerWithProfile = new AwsBedrockHandler({
+				apiModelId: "anthropic.claude-3-sonnet-20240229-v1:0",
+				awsAccessKey: "test-access-key",
+				awsSecretKey: "test-secret-key",
+				awsRegion: "ca-central-1",
+				awsUseCrossRegionInference: true,
+			})
+
+			// Mock AWS SDK invoke
+			const mockStream = {
+				[Symbol.asyncIterator]: async function* () {
+					yield {
+						metadata: {
+							usage: {
+								inputTokens: 10,
+								outputTokens: 5,
+							},
+						},
+					}
+				},
+			}
+
+			const mockInvoke = jest.fn().mockResolvedValue({
+				stream: mockStream,
+			})
+
+			handlerWithProfile["client"] = {
+				send: mockInvoke,
+			} as unknown as BedrockRuntimeClient
+
+			const stream = handlerWithProfile.createMessage(systemPrompt, mockMessages)
+			const chunks = []
+
+			for await (const chunk of stream) {
+				chunks.push(chunk)
+			}
+
+			expect(chunks.length).toBeGreaterThan(0)
+			expect(chunks[0]).toEqual({
+				type: "usage",
+				inputTokens: 10,
+				outputTokens: 5,
+			})
+
+			expect(mockInvoke).toHaveBeenCalledWith(
+				expect.objectContaining({
+					input: expect.objectContaining({
+						modelId: "anthropic.claude-3-sonnet-20240229-v1:0",
+					}),
+				}),
+			)
+		})
+
 		it("should handle API errors", async () => {
 			// Mock AWS SDK invoke with error
 			const mockInvoke = jest.fn().mockRejectedValue(new Error("AWS Bedrock error"))

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -610,6 +610,9 @@ Please check:
 					case "eu-":
 						modelId = `eu.${modelConfig.id}`
 						break
+					case "ap-":
+						modelId = `apac.${modelConfig.id}`
+						break
 					default:
 						modelId = modelConfig.id
 						break

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -211,6 +211,9 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 				case "eu-":
 					modelId = `eu.${modelConfig.id}`
 					break
+				case "ap-":
+					modelId = `apac.${modelConfig.id}`
+					break
 				default:
 					modelId = modelConfig.id
 					break


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

Cross-region inference option is not reflected in 'ap-xx' region.
resolve #1823 

## Implementation

Modified to prepend 'apac.' to the model ID if the region name starts with 'ap-' when the Cross-region inference option is enabled. This allows Cross-region inference to be used in the 'ap-xx' region. 
Additionally, added a test case to verify this.

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

before
<img width="358" alt="スクリーンショット 2025-03-21 0 24 43" src="https://github.com/user-attachments/assets/f2f59445-9900-43b3-9548-44417bfc4922" />
after
<img width="357" alt="スクリーンショット 2025-03-21 0 26 32" src="https://github.com/user-attachments/assets/3cbaf883-7908-4572-acdd-d26c25f23c24" />
   

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

I configured the appropriate AWS profile and sent the request.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

Yukky

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for cross-region inference in 'ap-xx' region by modifying model ID handling in `AwsBedrockHandler`.
> 
>   - **Behavior**:
>     - Modify `AwsBedrockHandler` in `bedrock.ts` to prepend 'apac.' to model ID for 'ap-xx' regions when cross-region inference is enabled.
>     - Add test cases in `bedrock.test.ts` to verify cross-region inference for 'ap-xx', 'us-xx', 'eu-xx', and other regions.
>   - **Tests**:
>     - Add test case for 'ap-xx' region in `bedrock.test.ts` to ensure correct model ID handling.
>     - Update existing test cases to include cross-region inference scenarios for 'us-xx', 'eu-xx', and other regions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d032db25e5ee19d32b2c1726be4af3c8cbe50ea0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->