### PR TITLE
Corrected bug in openrouter.ts and pre-commit and pre-push husky scripts

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,4 +5,11 @@ if [ "$branch" = "main" ]; then
   exit 1
 fi
 
-npx lint-staged
+# Detect if running on Windows and use npx.cmd, otherwise use npx
+if [ "$OS" = "Windows_NT" ]; then
+  npx_cmd="npx.cmd"
+else
+  npx_cmd="npx"
+fi
+
+"$npx_cmd" lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,7 +5,14 @@ if [ "$branch" = "main" ]; then
   exit 1
 fi
 
-npm run compile
+# Detect if running on Windows and use npm.cmd, otherwise use npm
+if [ "$OS" = "Windows_NT" ]; then
+  npm_cmd="npm.cmd"
+else
+  npm_cmd="npm"
+fi
+
+"$npm_cmd" run compile
 
 # Check for new changesets.
 NEW_CHANGESETS=$(find .changeset -name "*.md" ! -name "README.md" | wc -l | tr -d ' ')

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -289,11 +289,12 @@ export async function getOpenRouterModels(options?: ApiHandlerOptions) {
 					modelInfo.maxTokens = 8192
 					break
 				case rawModel.id.startsWith("anthropic/claude-3-haiku"):
-				default:
 					modelInfo.supportsPromptCache = true
 					modelInfo.cacheWritesPrice = 0.3
 					modelInfo.cacheReadsPrice = 0.03
 					modelInfo.maxTokens = 8192
+					break
+				default:
 					break
 			}
 


### PR DESCRIPTION
## Summary

- Corrected error causing free models listed under openrouter to show pricing information
- Updated pre-push and pre-commit scripts to work in Windows environments when pushing to branch (windows requires npm/npx to include the ".cmd" extension to recognize and compile.

## Context

This PR is primarily related to https://github.com/RooVetGit/Roo-Code/issues/1330 where selecting a free model in OpenRouter still displays pricing information when it should not. 

During the process of attempting to commit the changes to my forked copy, I also ran into issues with the husky script not finding npm and npx on my system PATH (I'm using Windows 11). I corrected the issue by adding a conditional statement to append ".cmd" to the npm and npx commands respectively to make GitBash happy when running the scripts.

## Implementation

### OpenRouter Issue

A small correction to a case statement on line 257 of openrouter.ts resolved the problem (see https://github.com/RooVetGit/Roo-Code/issues/1330 for details).

Corrected code:

```typescript
// NOTE: this needs to be synced with api.ts/openrouter default model info.
switch (true) {
	case rawModel.id.startsWith("anthropic/claude-3.7-sonnet"):
		modelInfo.supportsComputerUse = true
		modelInfo.supportsPromptCache = true
		modelInfo.cacheWritesPrice = 3.75
		modelInfo.cacheReadsPrice = 0.3
		modelInfo.maxTokens = rawModel.id === "anthropic/claude-3.7-sonnet:thinking" ? 128_000 : 16_384
		break
	case rawModel.id.startsWith("anthropic/claude-3.5-sonnet-20240620"):
		modelInfo.supportsPromptCache = true
		modelInfo.cacheWritesPrice = 3.75
		modelInfo.cacheReadsPrice = 0.3
		modelInfo.maxTokens = 8192
		break
	case rawModel.id.startsWith("anthropic/claude-3.5-sonnet"):
		modelInfo.supportsComputerUse = true
		modelInfo.supportsPromptCache = true
		modelInfo.cacheWritesPrice = 3.75
		modelInfo.cacheReadsPrice = 0.3
		modelInfo.maxTokens = 8192
		break
	case rawModel.id.startsWith("anthropic/claude-3-5-haiku"):
		modelInfo.supportsPromptCache = true
		modelInfo.cacheWritesPrice = 1.25
		modelInfo.cacheReadsPrice = 0.1
		modelInfo.maxTokens = 8192
		break
	case rawModel.id.startsWith("anthropic/claude-3-opus"):
		modelInfo.supportsPromptCache = true
		modelInfo.cacheWritesPrice = 18.75
		modelInfo.cacheReadsPrice = 1.5
		modelInfo.maxTokens = 8192
		break
	case rawModel.id.startsWith("anthropic/claude-3-haiku"):
		modelInfo.supportsPromptCache = true
		modelInfo.cacheWritesPrice = 0.3
		modelInfo.cacheReadsPrice = 0.03
		modelInfo.maxTokens = 8192
		break
	default:
		break
}
```

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/5e57b8a5-dea2-4fb0-99c9-81b1a869eadc)  | <img width="307" alt="image" src="https://github.com/user-attachments/assets/1f3afc3d-3275-4266-9f94-51a0f81456a8" /> |


## How to Test

Go to the Settings, select OpenRouter and choose the `deepseek/deepseek-r1-distill-llama-70b:free` (or any free model). The pricing information will not be shown on the panel.

## Get in Touch

I'm on Discord as Jdo300

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes free model pricing display in `openrouter.ts` and updates Husky scripts for Windows compatibility.
> 
>   - **Bug Fix in `openrouter.ts`**:
>     - Corrected case statement in `getOpenRouterModels()` to prevent free models from displaying pricing information.
>   - **Husky Script Updates**:
>     - Modified `.husky/pre-commit` and `.husky/pre-push` to append `.cmd` to `npx` and `npm` commands on Windows systems.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d2333c88c69ab51e0429e9b81ac68b53889af4f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->