### PR TITLE
Make the question follow-up suggestions optional

### DIFF
--- a/.changeset/chilled-jobs-taste.md
+++ b/.changeset/chilled-jobs-taste.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Make the question follow-up optional


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Make follow-up question suggestions optional in `Cline` class, handling cases where `follow_up` is absent and ensuring robust error handling.
> 
>   - **Behavior**:
>     - Make follow-up question suggestions optional in `Cline` class.
>     - If `follow_up` is not provided, `suggest` is set to an empty array.
>     - Handles parsing errors for `follow_up` XML and logs errors without breaking execution.
>   - **Code Changes**:
>     - Refactor `ask_followup_question` logic to check for `follow_up` presence before parsing.
>     - Adjust `follow_up_json` construction to conditionally include `suggest` array.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 359ade729b787ff0e6baed59fee3c3fdefe6b12b. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->