### PR TITLE
refactor: align tree-sitter output with other tools

### DIFF
--- a/src/services/tree-sitter/__tests__/index.test.ts
+++ b/src/services/tree-sitter/__tests__/index.test.ts
@@ -122,7 +122,6 @@ describe("Tree-sitter Service", () => {
 
 			expect(result).toContain("class TestClass")
 			expect(result).toContain("testMethod()")
-			expect(result).toContain("|----")
 		})
 
 		it("should handle parsing errors gracefully", async () => {


### PR DESCRIPTION
## Context

Update the output format of `list_code_definition_names` to use a more compact line number format, aligning it with the style used in `read_file` and `search_files`. This change aims to reduce token usage in AI responses and simplify output parsing for users.

## Implementation

The implementation involves modifying the `parseFile` and `parseSourceCodeDefinitionsForFile` functions within `src/services/tree-sitter/index.ts`. The changes will primarily focus on adjusting the string formatting logic to produce the desired compact output, removing verbose headers and separators, and adopting the `read_file`/`search_files` line number style.  The core logic of parsing and extracting definitions remains unchanged; only the presentation of the results is being updated.

## Before
```text
index.ts
|----
// File: src/services/tree-sitter/index.ts (2 definitions)
│| 34 - 61 ||export async function parseSourceCodeDefinitionsForFile(
||    ||----
│| 64 - 113 ||export async function parseSourceCodeForDefinitionsTopLevel(
|----
// Summary: 2 functions/methods,
``` 

## After
```text
# src/services/tree-sitter/index.ts
34--61 | export async function parseSourceCodeDefinitionsForFile(
64--113 | export async function parseSourceCodeForDefinitionsTopLevel(
```

## How to Test

To test these changes:

1. Run the `list_code_definition_names` tool on any directory containing source code files (e.g., `src/services/tree-sitter`).
