### PR TITLE
Fix maxTokens to 8192 only for compatible Anthropic models

### DIFF
--- a/.changeset/twelve-pumpkins-sit.md
+++ b/.changeset/twelve-pumpkins-sit.md
@@ -1,0 +1,7 @@
+---
+"roo-cline": patch
+---
+
+Changes maxTokens to 8192 for anthropic models that supports it
+anthropic/claude-3-sonnet, claude-3-opus, claude-3-haiku supports maxTokens of 4096.
+This change keeps the max tokens the same for those models

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -212,7 +212,10 @@ export async function getUnboundModels() {
 
 				switch (true) {
 					case modelId.startsWith("anthropic/"):
-						modelInfo.maxTokens = 8192
+						// Set max tokens to 8192 for supported Anthropic models
+						if (modelInfo.maxTokens !== 4096) {
+							modelInfo.maxTokens = 8192
+						}
 						break
 					default:
 						break


### PR DESCRIPTION
## Context

Current implementation changes maxTokens for anthropic models to 8192. Some models do not support the maxTokens of 8096. This change is to fix the configuration for those models.

## Implementation

Adds a condition for anthropic models to not change the maxTokens if it is 4096. This applies to claude-3-sonnet, claude-3-opus and claude-3-haiku

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjusts `maxTokens` to 8192 only for compatible Anthropic models, keeping it at 4096 for others like `claude-3-sonnet`.
> 
>   - **Behavior**:
>     - Adjusts `maxTokens` to 8192 only for Anthropic models that support it in `getUnboundModels()` in `unbound.ts`.
>     - Keeps `maxTokens` at 4096 for `claude-3-sonnet`, `claude-3-opus`, and `claude-3-haiku` models.
>   - **Misc**:
>     - Adds a changeset file `twelve-pumpkins-sit.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 96a0875447991d298125ef802b223bbe69ab1eb8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->