### PR TITLE
ClineProvider.finishSubTask should wait for unpausing the parent task

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -190,15 +190,15 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		return this.clineStack.map((cline) => cline.taskId)
 	}
 
-	// remove the current task/cline instance (at the top of the stack), ao this task is finished
+	// remove the current task/cline instance (at the top of the stack), so this task is finished
 	// and resume the previous task/cline instance (if it exists)
 	// this is used when a sub task is finished and the parent task needs to be resumed
 	async finishSubTask(lastMessage?: string) {
 		console.log(`[subtasks] finishing subtask ${lastMessage}`)
 		// remove the last cline instance from the stack (this is the finished sub task)
 		await this.removeClineFromStack()
-		// resume the last cline instance in the stack (if it exists - this is the 'parnt' calling task)
-		this.getCurrentCline()?.resumePausedTask(lastMessage)
+		// resume the last cline instance in the stack (if it exists - this is the 'parent' calling task)
+		await this.getCurrentCline()?.resumePausedTask(lastMessage)
 	}
 
 	/*


### PR DESCRIPTION
## Context

Fixes: https://github.com/RooVetGit/Roo-Code/issues/1847

It looks like in `ClineProvider.finishSubTask()` someone forgotten to `await` for unpausing the parent task.
Or the "unpause in background" is intended behavior?

## Implementation

Add `await`.

## Screenshots

None.

## How to Test


## Get in Touch

Discord handle: wkordalski
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ClineProvider.finishSubTask()` to await `resumePausedTask()` ensuring proper task flow.
> 
>   - **Behavior**:
>     - Fixes `ClineProvider.finishSubTask()` in `ClineProvider.ts` to await `resumePausedTask()` ensuring the parent task is resumed only after the subtask is finished.
>   - **Misc**:
>     - Fixes typo in comment in `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 395a7c4b85e7a1f72f642f52d01815db5a46754d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->