### PR TITLE
We should post state to webview at the end of `RooCodeAPI.clearCurrentTask()`

### DIFF
--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -61,6 +61,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	public async clearCurrentTask(lastMessage?: string) {
 		await this.provider.finishSubTask(lastMessage)
+		await this.provider.postStateToWebview()
 	}
 
 	public async cancelCurrentTask() {


### PR DESCRIPTION
## Context

`RooCodeAPI.clearCurrentTask()` does not post state to webview at the end of  `RooCodeAPI.clearCurrentTask()`.
Therefore webview become out-of-sync with ClineProvider. The webview still presents a question to the user, but the related Cline is already aborted.

## Implementation

Trivial.

## Screenshots

None.

## How to Test

Create a task, possibly with subtask, call `RooCodeAPI.clearCurrentTask()` and observe the sidebar.

## Get in Touch

Discord handle: wkordalski
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `postStateToWebview()` call in `clearCurrentTask()` to sync webview with ClineProvider after task clearance.
> 
>   - **Behavior**:
>     - Adds `postStateToWebview()` call in `clearCurrentTask()` in `api.ts` to update webview state after clearing a task.
>     - Ensures webview syncs with ClineProvider when a task is cleared.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 505389fddc37a61303d6c8af41d67da1874ae947. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->