### PR TITLE
Fixes for prompts suite unit tests on windows

### DIFF
--- a/src/core/prompts/__tests__/custom-system-prompt.test.ts
+++ b/src/core/prompts/__tests__/custom-system-prompt.test.ts
@@ -2,6 +2,7 @@ import { SYSTEM_PROMPT } from "../system"
 import { defaultModeSlug, modes } from "../../../shared/modes"
 import * as vscode from "vscode"
 import * as fs from "fs/promises"
+import { unixLike } from "./utils"
 
 // Mock the fs/promises module
 jest.mock("fs/promises", () => ({
@@ -89,7 +90,7 @@ describe("File-Based Custom System Prompt", () => {
 		const fileCustomSystemPrompt = "Custom system prompt from file"
 		// When called with utf-8 encoding, return a string
 		mockedFs.readFile.mockImplementation((filePath, options) => {
-			if (filePath.toString().includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
+			if (unixLike(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
 				return Promise.resolve(fileCustomSystemPrompt)
 			}
 			return Promise.reject({ code: "ENOENT" })
@@ -124,7 +125,7 @@ describe("File-Based Custom System Prompt", () => {
 		// Mock the readFile to return content from a file
 		const fileCustomSystemPrompt = "Custom system prompt from file"
 		mockedFs.readFile.mockImplementation((filePath, options) => {
-			if (filePath.toString().includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
+			if (unixLike(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
 				return Promise.resolve(fileCustomSystemPrompt)
 			}
 			return Promise.reject({ code: "ENOENT" })

--- a/src/core/prompts/__tests__/custom-system-prompt.test.ts
+++ b/src/core/prompts/__tests__/custom-system-prompt.test.ts
@@ -2,7 +2,7 @@ import { SYSTEM_PROMPT } from "../system"
 import { defaultModeSlug, modes } from "../../../shared/modes"
 import * as vscode from "vscode"
 import * as fs from "fs/promises"
-import { unixLike } from "./utils"
+import { toPosix } from "./utils"
 
 // Mock the fs/promises module
 jest.mock("fs/promises", () => ({
@@ -90,7 +90,7 @@ describe("File-Based Custom System Prompt", () => {
 		const fileCustomSystemPrompt = "Custom system prompt from file"
 		// When called with utf-8 encoding, return a string
 		mockedFs.readFile.mockImplementation((filePath, options) => {
-			if (unixLike(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
+			if (toPosix(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
 				return Promise.resolve(fileCustomSystemPrompt)
 			}
 			return Promise.reject({ code: "ENOENT" })
@@ -125,7 +125,7 @@ describe("File-Based Custom System Prompt", () => {
 		// Mock the readFile to return content from a file
 		const fileCustomSystemPrompt = "Custom system prompt from file"
 		mockedFs.readFile.mockImplementation((filePath, options) => {
-			if (unixLike(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
+			if (toPosix(filePath).includes(`.roo/system-prompt-${defaultModeSlug}`) && options === "utf-8") {
 				return Promise.resolve(fileCustomSystemPrompt)
 			}
 			return Promise.reject({ code: "ENOENT" })

--- a/src/core/prompts/__tests__/responses-rooignore.test.ts
+++ b/src/core/prompts/__tests__/responses-rooignore.test.ts
@@ -4,7 +4,7 @@ import { formatResponse } from "../responses"
 import { RooIgnoreController, LOCK_TEXT_SYMBOL } from "../../ignore/RooIgnoreController"
 import { fileExistsAtPath } from "../../../utils/fs"
 import * as fs from "fs/promises"
-import { unixLike } from "./utils"
+import { toPosix } from "./utils"
 
 // Mock dependencies
 jest.mock("../../../utils/fs")
@@ -84,7 +84,7 @@ describe("RooIgnore Response Formatting", () => {
 				return (
 					!filePath.includes("node_modules") &&
 					!filePath.includes(".git") &&
-					!unixLike(filePath).includes("secrets/")
+					!toPosix(filePath).includes("secrets/")
 				)
 			})
 
@@ -128,7 +128,7 @@ describe("RooIgnore Response Formatting", () => {
 				return (
 					!filePath.includes("node_modules") &&
 					!filePath.includes(".git") &&
-					!unixLike(filePath).includes("secrets/")
+					!toPosix(filePath).includes("secrets/")
 				)
 			})
 

--- a/src/core/prompts/__tests__/responses-rooignore.test.ts
+++ b/src/core/prompts/__tests__/responses-rooignore.test.ts
@@ -2,9 +2,9 @@
 
 import { formatResponse } from "../responses"
 import { RooIgnoreController, LOCK_TEXT_SYMBOL } from "../../ignore/RooIgnoreController"
-import * as path from "path"
 import { fileExistsAtPath } from "../../../utils/fs"
 import * as fs from "fs/promises"
+import { unixLike } from "./utils"
 
 // Mock dependencies
 jest.mock("../../../utils/fs")
@@ -82,7 +82,9 @@ describe("RooIgnore Response Formatting", () => {
 			controller.validateAccess = jest.fn().mockImplementation((filePath: string) => {
 				// Only allow files not matching these patterns
 				return (
-					!filePath.includes("node_modules") && !filePath.includes(".git") && !filePath.includes("secrets/")
+					!filePath.includes("node_modules") &&
+					!filePath.includes(".git") &&
+					!unixLike(filePath).includes("secrets/")
 				)
 			})
 
@@ -124,7 +126,9 @@ describe("RooIgnore Response Formatting", () => {
 			controller.validateAccess = jest.fn().mockImplementation((filePath: string) => {
 				// Only allow files not matching these patterns
 				return (
-					!filePath.includes("node_modules") && !filePath.includes(".git") && !filePath.includes("secrets/")
+					!filePath.includes("node_modules") &&
+					!filePath.includes(".git") &&
+					!unixLike(filePath).includes("secrets/")
 				)
 			})
 

--- a/src/core/prompts/__tests__/utils.ts
+++ b/src/core/prompts/__tests__/utils.ts
@@ -1,0 +1,7 @@
+import * as fs from "fs/promises"
+import { PathLike } from "fs"
+
+// Make a path take a unix-like form.  Useful for making path comparisons.
+export function unixLike(filePath: PathLike | fs.FileHandle) {
+	return filePath.toString().split("\\").join("/")
+}

--- a/src/core/prompts/__tests__/utils.ts
+++ b/src/core/prompts/__tests__/utils.ts
@@ -2,6 +2,6 @@ import * as fs from "fs/promises"
 import { PathLike } from "fs"
 
 // Make a path take a unix-like form.  Useful for making path comparisons.
-export function unixLike(filePath: PathLike | fs.FileHandle) {
-	return filePath.toString().split("\\").join("/")
+export function toPosix(filePath: PathLike | fs.FileHandle) {
+	return filePath.toString().toPosix()
 }


### PR DESCRIPTION
## Context

Unit Tests don't run on WIndows
https://github.com/RooVetGit/Roo-Code/issues/1835

This PR is an incremental move towards fixing that.  It addresses issues with the "prompts" UTs.
`npm run test:extension -- src/core/prompts/`

I hope to fix more UTs over time, but this is useful in itself as it allows Windows developers to update prompt snapshots with the -u option without switching to Linux/WSL.

## Implementation

Fixed some places where code assumed Unix-like paths, by making sure paths are transformed into Unix-like form before checking them.

## Screenshots

This subset of the Unit Tests now run cleanly on Windows and Linux (I tested on WSL)
```
C:\Users\ASUS\Documents\GitHub\Projects\Roo-Code>npm run test:extension -- src/core/prompts/

> roo-cline@3.10.2 test:extension
> jest src/core/prompts/

Determining test suites to run...
Found 5 test suites
................................................................
Ran 64 tests in 2.971 s
 64 passing 0 failing 0 pending

C:\Users\ASUS\Documents\GitHub\Projects\Roo-Code>
```

## How to Test

`npm run test:extension -- src/core/prompts/`

## Get in Touch

@diarmid on Discord

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Windows compatibility for unit tests in `custom-system-prompt.test.ts` and `responses-rooignore.test.ts` by converting paths to Unix-like format.
> 
>   - **Behavior**:
>     - Ensures unit tests in `custom-system-prompt.test.ts` and `responses-rooignore.test.ts` run on Windows by converting paths to Unix-like format using `unixLike()`.
>     - Allows Windows developers to update prompt snapshots without switching to Linux/WSL.
>   - **Functions**:
>     - Adds `unixLike()` in `utils.ts` to convert paths to Unix-like format.
>   - **Tests**:
>     - Modifies path checks in `custom-system-prompt.test.ts` and `responses-rooignore.test.ts` to use `unixLike()` for compatibility with Windows.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f77dd795f5aa5d991f9a2e230a6e8d919beb36cf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->