### PR TITLE
Support mentioning binary files

### DIFF
--- a/.changeset/wise-icons-sort.md
+++ b/.changeset/wise-icons-sort.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Support mentioning binary files

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -152,12 +152,12 @@ async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise
 		const stats = await fs.stat(absPath)
 
 		if (stats.isFile()) {
-			const isBinary = await isBinaryFile(absPath).catch(() => false)
-			if (isBinary) {
-				return "(Binary file, unable to display content)"
+			try {
+				const content = await extractTextFromFile(absPath)
+				return content
+			} catch (error) {
+				return `(Failed to read contents of ${mentionPath}): ${error.message}`
 			}
-			const content = await extractTextFromFile(absPath)
-			return content
 		} else if (stats.isDirectory()) {
 			const entries = await fs.readdir(absPath, { withFileTypes: true })
 			let folderContent = ""


### PR DESCRIPTION
This makes it so you can @-mention pdf, docx, ipynb files
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Support mentioning binary files by attempting text extraction and handling errors in `getFileOrFolderContent()` in `index.ts`.
> 
>   - **Behavior**:
>     - `getFileOrFolderContent()` in `index.ts` now supports mentioning binary files (e.g., pdf, docx, ipynb) by attempting to extract text and returning an error message if it fails.
>     - Removed binary file check using `isBinaryFile()` and directly attempts to extract text.
>   - **Error Handling**:
>     - If text extraction fails, returns `(Failed to read contents of <file>): <error message>`.
>   - **Misc**:
>     - Added changeset `wise-icons-sort.md` to document the update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e66bd8ebbdc0c4ad94730910c0a7bd483379bca3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->