### PR TITLE
Don't do partial reads on binary files

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -82,6 +82,7 @@ import { validateToolUse, isToolAllowedForMode, ToolName } from "./mode-validato
 import { parseXml } from "../utils/xml"
 import { readLines } from "../integrations/misc/read-lines"
 import { getWorkspacePath } from "../utils/path"
+import { isBinaryFile } from "isbinaryfile"
 
 type ToolResponse = string | Array<Anthropic.TextBlockParam | Anthropic.ImageBlockParam>
 type UserContent = Array<Anthropic.Messages.ContentBlockParam>
@@ -2324,6 +2325,8 @@ export class Cline extends EventEmitter<ClineEvents> {
 								let isFileTruncated = false
 								let sourceCodeDef = ""
 
+								const isBinary = await isBinaryFile(absolutePath).catch(() => false)
+
 								if (isRangeRead) {
 									if (startLine === undefined) {
 										content = addLineNumbers(await readLines(absolutePath, endLine, startLine))
@@ -2333,7 +2336,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 											startLine,
 										)
 									}
-								} else if (totalLines > maxReadFileLine) {
+								} else if (!isBinary && totalLines > maxReadFileLine) {
 									// If file is too large, only read the first maxReadFileLine lines
 									isFileTruncated = true
 


### PR DESCRIPTION
https://discord.com/channels/1332146336664915968/1352649492167528539
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents partial reads on binary files in `Cline` class by checking file type before reading.
> 
>   - **Behavior**:
>     - Prevents partial reads on binary files in `Cline` class by checking if a file is binary using `isBinaryFile()` before reading.
>     - Affects `read_file` tool use case, ensuring only non-binary files are partially read.
>   - **Imports**:
>     - Adds `isBinaryFile` import from `isbinaryfile` package.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 21899b534a3c629997d1ae8bcc0401fba00db5a7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->