### PR TITLE
Use openrouter stream_options include_usage

### DIFF
--- a/src/api/providers/__tests__/openrouter.test.ts
+++ b/src/api/providers/__tests__/openrouter.test.ts
@@ -112,6 +112,16 @@ describe("OpenRouterHandler", () => {
 						},
 					],
 				}
+				// Add usage information in the stream response
+				yield {
+					id: "test-id",
+					choices: [{ delta: {} }],
+					usage: {
+						prompt_tokens: 10,
+						completion_tokens: 20,
+						cost: 0.001,
+					},
+				}
 			},
 		}
 
@@ -120,17 +130,6 @@ describe("OpenRouterHandler", () => {
 		;(OpenAI as jest.MockedClass<typeof OpenAI>).prototype.chat = {
 			completions: { create: mockCreate },
 		} as any
-
-		// Mock axios.get for generation details
-		;(axios.get as jest.Mock).mockResolvedValue({
-			data: {
-				data: {
-					native_tokens_prompt: 10,
-					native_tokens_completion: 20,
-					total_cost: 0.001,
-				},
-			},
-		})
 
 		const systemPrompt = "test system prompt"
 		const messages: Anthropic.Messages.MessageParam[] = [{ role: "user" as const, content: "test message" }]
@@ -153,7 +152,6 @@ describe("OpenRouterHandler", () => {
 			inputTokens: 10,
 			outputTokens: 20,
 			totalCost: 0.001,
-			fullResponseText: "test response",
 		})
 
 		// Verify OpenAI client was called with correct parameters


### PR DESCRIPTION
## Context

Per OpenRouter: "Now you can send us stream_options: {include_usage: true} to get the usage directly in the completion request."

## Implementation

This replaces the previous polling and grabs the usage information directly.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update OpenRouter integration to use `stream_options: { include_usage: true }` for direct usage data retrieval, removing polling.
> 
>   - **Behavior**:
>     - Replaces polling with `stream_options: { include_usage: true }` in `createMessage()` in `openrouter.ts` to directly obtain usage data.
>     - Removes axios-based polling for usage data in `openrouter.ts` and `openrouter.test.ts`.
>   - **Functions**:
>     - Adds `processUsageMetrics()` in `openrouter.ts` to handle usage data processing.
>   - **Tests**:
>     - Updates `createMessage` test in `openrouter.test.ts` to verify usage data is included in stream response.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 285c4b95c37370d2e326098d50a5482166e6e894. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->