### PR TITLE
fix: make dropdown menu background fully opaque

### DIFF
--- a/webview-ui/src/components/ui/dropdown-menu.tsx
+++ b/webview-ui/src/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuContent = React.forwardRef<
 				"z-50 min-w-[8rem] overflow-hidden rounded-xs p-1 shadow-xs",
 				"data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
 				"border border-vscode-focusBorder",
-				"bg-vscode-dropdown-background",
+				"bg-vscode-dropdown-background bg-opacity-100",
 				"text-vscode-dropdown-foreground",
 				className,
 			)}


### PR DESCRIPTION
Fixes the issue where dropdown menus in the configuration screen appeared transparent, making text difficult to read against background content.

# Before

![image](https://github.com/user-attachments/assets/9ea04234-4bab-471a-94d6-65302b8d25a1)

# After
![image](https://github.com/user-attachments/assets/44dedc22-1157-42f2-ad5f-0f57086cb9b5)

- Added bg-opacity-100 to ensure dropdown background is fully opaque



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensures dropdown menu background is fully opaque in `dropdown-menu.tsx` to improve text readability.
> 
>   - **Behavior**:
>     - Ensures dropdown menu background is fully opaque by adding `bg-opacity-100` to the class list in `DropdownMenuContent` in `dropdown-menu.tsx`.
>     - Fixes issue with text readability against background content in configuration screen dropdowns.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0d2b6da65552e4542fd16d220826720fad20e211. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->