### PR TITLE
fix: prevent negative line index when maxReadFileLine is zero

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2341,11 +2341,11 @@ export class Cline extends EventEmitter<ClineEvents> {
 									isFileTruncated = true
 
 									const res = await Promise.all([
-										readLines(absolutePath, maxReadFileLine - 1, 0),
+										maxReadFileLine > 0 ? readLines(absolutePath, maxReadFileLine - 1, 0) : "",
 										parseSourceCodeDefinitionsForFile(absolutePath, this.rooIgnoreController),
 									])
 
-									content = addLineNumbers(res[0])
+									content = res[0].length > 0 ? addLineNumbers(res[0]) : ""
 									const result = res[1]
 									if (result) {
 										sourceCodeDef = `\n\n${result}`

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2341,7 +2341,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 									isFileTruncated = true
 
 									const res = await Promise.all([
-										maxReadFileLine > 0 ? readLines(absolutePath, maxReadFileLine - 1, 0) : "",
+										maxReadFileLine > 0 ? readLines(absolutePath, maxReadFileLine - 1, 0) : [],
 										parseSourceCodeDefinitionsForFile(absolutePath, this.rooIgnoreController),
 									])
 


### PR DESCRIPTION
## Context

Fixed an issue where the read_file tool would fail when maxReadFileLine=0, as the code attempted to access a negative line index.

## Implementation

Added checks to:
- Only call readLines when maxReadFileLine > 0
- Return empty string when maxReadFileLine = 0

## Before

![image](https://github.com/user-attachments/assets/a21bc52c-91ee-4255-82d3-5be410d19281)

## After

works :)

## How to Test

- Set maxReadFileLine=0 in VS Code settings
- Use read_file tool on any file
- Verify it completes successfully instead of throwing an error

## Get in Touch

Discord: KJ7LNW

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes negative line index error in `Cline.ts` for `read_file` tool when `maxReadFileLine=0`.
> 
>   - **Behavior**:
>     - Fixes issue in `Cline.ts` where `read_file` tool fails with `maxReadFileLine=0` by preventing negative line index access.
>     - Adds check to only call `readLines` if `maxReadFileLine > 0`.
>     - Returns empty string if `maxReadFileLine = 0`.
>   - **Code Changes**:
>     - Modifies `Cline.ts` to include conditional logic around `readLines` call and `content` assignment.
>     - Updates logic to handle empty content when no lines are read.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fc828736eb9a437c7101de65cb105836d7b00bff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->