### PR TITLE
fix: prevent negative line index when maxReadFileLine is zero

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2341,11 +2341,11 @@ export class Cline extends EventEmitter<ClineEvents> {
 									isFileTruncated = true
 
 									const res = await Promise.all([
-										readLines(absolutePath, maxReadFileLine - 1, 0),
+										maxReadFileLine > 0 ? readLines(absolutePath, maxReadFileLine - 1, 0) : "",
 										parseSourceCodeDefinitionsForFile(absolutePath, this.rooIgnoreController),
 									])
 
-									content = addLineNumbers(res[0])
+									content = res[0].length > 0 ? addLineNumbers(res[0]) : ""
 									const result = res[1]
 									if (result) {
 										sourceCodeDef = `\n\n${result}`


### PR DESCRIPTION
#1910 without the ellipsis suggestion that I shouldn't have accepted
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes potential negative line index in `Cline.ts` by adding a check for `maxReadFileLine` being zero.
> 
>   - **Behavior**:
>     - Fixes potential negative line index in `Cline` class in `Cline.ts` when `maxReadFileLine` is zero.
>     - Adds conditional check to return empty string if `maxReadFileLine` is zero before calling `readLines`.
>     - Ensures `addLineNumbers` is only called if `res[0]` has content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fc828736eb9a437c7101de65cb105836d7b00bff. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->