### PR TITLE
Fix HTML escapes in terminal commands

### DIFF
--- a/src/core/prompts/tools/execute-command.ts
+++ b/src/core/prompts/tools/execute-command.ts
@@ -5,21 +5,33 @@ export function getExecuteCommandDescription(args: ToolArgs): string | undefined
 Description: Request to execute a CLI command on the system. Use this when you need to perform system operations or run specific commands to accomplish any step in the user's task. You must tailor your command to the user's system and provide a clear explanation of what the command does. For command chaining, use the appropriate chaining syntax for the user's shell. Prefer to execute complex CLI commands over creating executable scripts, as they are more flexible and easier to run. Prefer relative commands and paths that avoid location sensitivity for terminal consistency, e.g: \`touch ./testdata/example.file\`, \`dir ./examples/model1/data/yaml\`, or \`go test ./cmd/front --config ./cmd/front/config.yml\`. If directed by the user, you may open a terminal in a different directory by using the \`cwd\` parameter.
 Parameters:
 - command: (required) The CLI command to execute. This should be valid for the current operating system. Ensure the command is properly formatted and does not contain any harmful instructions.
-- cwd: (optional) The working directory to execute the command in (default: ${args.cwd})
+- cwd: (optional) The working directory to execute the command in (default: ${sanitizeHtmlEscapes(args.cwd)})
 Usage:
 <execute_command>
-<command>Your command here</command>
-<cwd>Working directory path (optional)</cwd>
+<command>${sanitizeHtmlEscapes("Your command here")}</command>
+<cwd>${sanitizeHtmlEscapes("Working directory path (optional)")}</cwd>
 </execute_command>
 
 Example: Requesting to execute npm run dev
 <execute_command>
-<command>npm run dev</command>
+<command>${sanitizeHtmlEscapes("npm run dev")}</command>
 </execute_command>
 
 Example: Requesting to execute ls in a specific directory if directed
 <execute_command>
-<command>ls -la</command>
-<cwd>/home/user/projects</cwd>
+<command>${sanitizeHtmlEscapes("ls -la")}</command>
+<cwd>${sanitizeHtmlEscapes("/home/user/projects")}</cwd>
 </execute_command>`
+}
+
+function sanitizeHtmlEscapes(input: string): string {
+	const htmlEscapes: Record<string, string> = {
+		"&amp;": "&",
+		"&lt;": "<",
+		"&gt;": ">",
+		"&quot;": '"',
+		"&#39;": "'",
+	}
+
+	return input.replace(/&(?:amp|lt|gt|quot|#39);/g, (match) => htmlEscapes[match] || match)
 }

--- a/src/integrations/terminal/TerminalProcess.ts
+++ b/src/integrations/terminal/TerminalProcess.ts
@@ -241,7 +241,7 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 	private hotTimer: NodeJS.Timeout | null = null
 
 	async run(command: string) {
-		this.command = command
+		this.command = this.sanitizeHtmlEscapes(command)
 		const terminal = this.terminalInfo.terminal
 
 		if (terminal.shellIntegration && terminal.shellIntegration.executeCommand) {
@@ -665,6 +665,23 @@ export class TerminalProcess extends EventEmitter<TerminalProcessEvents> {
 		}
 
 		return match133 !== undefined ? match133 : match633
+	}
+
+	/**
+	 * Sanitizes HTML escape sequences in a string.
+	 * @param input The input string to sanitize
+	 * @returns The sanitized string
+	 */
+	private sanitizeHtmlEscapes(input: string): string {
+		const htmlEscapes: Record<string, string> = {
+			"&amp;": "&",
+			"&lt;": "<",
+			"&gt;": ">",
+			"&quot;": '"',
+			"&#39;": "'",
+		}
+
+		return input.replace(/&(?:amp|lt|gt|quot|#39);/g, (match) => htmlEscapes[match] || match)
 	}
 }
 

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -128,7 +128,8 @@ export class TerminalRegistry {
 		})
 
 		const cwdString = cwd.toString()
-		const newTerminal = new Terminal(this.nextTerminalId++, terminal, cwdString)
+		const sanitizedCwd = TerminalProcess.sanitizeHtmlEscapes(cwdString)
+		const newTerminal = new Terminal(this.nextTerminalId++, terminal, sanitizedCwd)
 
 		this.terminals.push(newTerminal)
 		return newTerminal


### PR DESCRIPTION
Fixes #1916

Implemented common fixes for HTML escapes that have appeared when commands are generated in the RooCode Extension and then executed in the terminal

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/RooVetGit/Roo-Code/pull/1917?shareId=e3de10a1-72c1-406f-935e-3a91f1619846).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes HTML escape issues in terminal commands by sanitizing inputs using `sanitizeHtmlEscapes()` in multiple files.
> 
>   - **Behavior**:
>     - Fixes HTML escape issues in terminal commands by introducing `sanitizeHtmlEscapes()` in `execute-command.ts`, `Terminal.ts`, and `TerminalProcess.ts`.
>     - Ensures commands and paths are sanitized before execution to prevent errors.
>   - **Functions**:
>     - Adds `sanitizeHtmlEscapes()` to handle HTML escape sequences in `execute-command.ts`, `Terminal.ts`, and `TerminalProcess.ts`.
>     - Updates `getExecuteCommandDescription()` in `execute-command.ts` to use `sanitizeHtmlEscapes()` for command and cwd parameters.
>     - Updates `runCommand()` in `Terminal.ts` and `run()` in `TerminalProcess.ts` to sanitize commands.
>   - **Misc**:
>     - Updates `createTerminal()` in `TerminalRegistry.ts` to sanitize cwd using `sanitizeHtmlEscapes()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f5f230a5c3fbd14eff9fc38211384b280bf2b098. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->