### PR TITLE
Support customize storage path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12608,7 +12608,6 @@
 			"resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
 			"integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^3.2.1",
 				"chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,11 @@
 				"command": "roo-cline.terminalExplainCommandInCurrentTask",
 				"title": "Explain This Command (Current Task)",
 				"category": "Terminal"
+			},
+			{
+				"command": "roo-cline.setCustomStoragePath",
+				"title": "Set Custom Storage Path",
+				"category": "Roo Code"
 			}
 		],
 		"menus": {
@@ -288,6 +293,11 @@
 						}
 					},
 					"description": "Settings for VSCode Language Model API"
+				},
+				"roo-cline.customStoragePath": {
+					"type": "string",
+					"default": "",
+					"description": "Custom storage path. Leave empty to use the default location. Supports absolute paths (e.g. 'D:\\RooCodeStorage')"
 				}
 			}
 		}

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -85,6 +85,10 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 		"roo-cline.registerHumanRelayCallback": registerHumanRelayCallback,
 		"roo-cline.unregisterHumanRelayCallback": unregisterHumanRelayCallback,
 		"roo-cline.handleHumanRelayResponse": handleHumanRelayResponse,
+		"roo-cline.setCustomStoragePath": async () => {
+			const { promptForCustomStoragePath } = await import("../shared/storagePathManager")
+			await promptForCustomStoragePath()
+		},
 	}
 }
 

--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -290,9 +290,10 @@ export class Cline extends EventEmitter<ClineEvents> {
 		if (!globalStoragePath) {
 			throw new Error("Global storage uri is invalid")
 		}
-		const taskDir = path.join(globalStoragePath, "tasks", this.taskId)
-		await fs.mkdir(taskDir, { recursive: true })
-		return taskDir
+
+		// Use storagePathManager to retrieve the task storage directory
+		const { getTaskDirectoryPath } = await import("../shared/storagePathManager")
+		return getTaskDirectoryPath(globalStoragePath, this.taskId)
 	}
 
 	private async getSavedApiConversationHistory(): Promise<Anthropic.MessageParam[]> {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2230,15 +2230,15 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 	}
 
 	async ensureSettingsDirectoryExists(): Promise<string> {
-		const settingsDir = path.join(this.contextProxy.globalStorageUri.fsPath, "settings")
-		await fs.mkdir(settingsDir, { recursive: true })
-		return settingsDir
+		const { getSettingsDirectoryPath } = await import("../../shared/storagePathManager")
+		const globalStoragePath = this.contextProxy.globalStorageUri.fsPath
+		return getSettingsDirectoryPath(globalStoragePath)
 	}
 
 	private async ensureCacheDirectoryExists() {
-		const cacheDir = path.join(this.contextProxy.globalStorageUri.fsPath, "cache")
-		await fs.mkdir(cacheDir, { recursive: true })
-		return cacheDir
+		const { getCacheDirectoryPath } = await import("../../shared/storagePathManager")
+		const globalStoragePath = this.contextProxy.globalStorageUri.fsPath
+		return getCacheDirectoryPath(globalStoragePath)
 	}
 
 	private async readModelsFromCache(filename: string): Promise<Record<string, ModelInfo> | undefined> {
@@ -2368,7 +2368,9 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		const history = ((await this.getGlobalState("taskHistory")) as HistoryItem[] | undefined) || []
 		const historyItem = history.find((item) => item.id === id)
 		if (historyItem) {
-			const taskDirPath = path.join(this.contextProxy.globalStorageUri.fsPath, "tasks", id)
+			const { getTaskDirectoryPath } = await import("../../shared/storagePathManager")
+			const globalStoragePath = this.contextProxy.globalStorageUri.fsPath
+			const taskDirPath = await getTaskDirectoryPath(globalStoragePath, id)
 			const apiConversationHistoryFilePath = path.join(taskDirPath, GlobalFileNames.apiConversationHistory)
 			const uiMessagesFilePath = path.join(taskDirPath, GlobalFileNames.uiMessages)
 			const fileExists = await fileExistsAtPath(apiConversationHistoryFilePath)

--- a/src/shared/storagePathManager.ts
+++ b/src/shared/storagePathManager.ts
@@ -1,0 +1,147 @@
+import * as vscode from "vscode"
+import * as path from "path"
+import * as fs from "fs/promises"
+
+/**
+ * Gets the base storage path for conversations
+ * If a custom path is configured, uses that path
+ * Otherwise uses the default VSCode extension global storage path
+ */
+export async function getStorageBasePath(defaultPath: string): Promise<string> {
+	// Get user-configured custom storage path
+	let customStoragePath = ""
+
+	try {
+		// This is the line causing the error in tests
+		const config = vscode.workspace.getConfiguration("roo-cline")
+		customStoragePath = config.get<string>("customStoragePath", "")
+	} catch (error) {
+		console.warn("Could not access VSCode configuration - using default path")
+		return defaultPath
+	}
+
+	// If no custom path is set, use default path
+	if (!customStoragePath) {
+		return defaultPath
+	}
+
+	try {
+		// Ensure custom path exists
+		await fs.mkdir(customStoragePath, { recursive: true })
+
+		// Test if path is writable
+		const testFile = path.join(customStoragePath, ".write_test")
+		await fs.writeFile(testFile, "test")
+		await fs.rm(testFile)
+
+		return customStoragePath
+	} catch (error) {
+		// If path is unusable, report error and fall back to default path
+		console.error(`Custom storage path is unusable: ${error instanceof Error ? error.message : String(error)}`)
+		if (vscode.window) {
+			vscode.window.showErrorMessage(
+				`Custom storage path "${customStoragePath}" is unusable, will use default path`,
+			)
+		}
+		return defaultPath
+	}
+}
+
+/**
+ * Gets the storage directory path for a task
+ */
+export async function getTaskDirectoryPath(globalStoragePath: string, taskId: string): Promise<string> {
+	const basePath = await getStorageBasePath(globalStoragePath)
+	const taskDir = path.join(basePath, "tasks", taskId)
+	await fs.mkdir(taskDir, { recursive: true })
+	return taskDir
+}
+
+/**
+ * Gets the settings directory path
+ */
+export async function getSettingsDirectoryPath(globalStoragePath: string): Promise<string> {
+	const basePath = await getStorageBasePath(globalStoragePath)
+	const settingsDir = path.join(basePath, "settings")
+	await fs.mkdir(settingsDir, { recursive: true })
+	return settingsDir
+}
+
+/**
+ * Gets the cache directory path
+ */
+export async function getCacheDirectoryPath(globalStoragePath: string): Promise<string> {
+	const basePath = await getStorageBasePath(globalStoragePath)
+	const cacheDir = path.join(basePath, "cache")
+	await fs.mkdir(cacheDir, { recursive: true })
+	return cacheDir
+}
+
+/**
+ * Prompts the user to set a custom storage path
+ * Displays an input box allowing the user to enter a custom path
+ */
+export async function promptForCustomStoragePath(): Promise<void> {
+	if (!vscode.window || !vscode.workspace) {
+		console.error("VS Code API not available")
+		return
+	}
+
+	let currentPath = ""
+	try {
+		const currentConfig = vscode.workspace.getConfiguration("roo-cline")
+		currentPath = currentConfig.get<string>("customStoragePath", "")
+	} catch (error) {
+		console.error("Could not access configuration")
+		return
+	}
+
+	const result = await vscode.window.showInputBox({
+		value: currentPath,
+		placeHolder: "D:\\RooCodeStorage",
+		prompt: "Enter custom conversation history storage path, leave empty to use default location",
+		validateInput: (input) => {
+			if (!input) {
+				return null // Allow empty value (use default path)
+			}
+
+			try {
+				// Validate path format
+				path.parse(input)
+
+				// Check if path is absolute
+				if (!path.isAbsolute(input)) {
+					return "Please enter an absolute path (e.g. D:\\RooCodeStorage or /home/user/storage)"
+				}
+
+				return null // Path format is valid
+			} catch (e) {
+				return "Please enter a valid path"
+			}
+		},
+	})
+
+	// If user canceled the operation, result will be undefined
+	if (result !== undefined) {
+		try {
+			const currentConfig = vscode.workspace.getConfiguration("roo-cline")
+			await currentConfig.update("customStoragePath", result, vscode.ConfigurationTarget.Global)
+
+			if (result) {
+				try {
+					// Test if path is accessible
+					await fs.mkdir(result, { recursive: true })
+					vscode.window.showInformationMessage(`Custom storage path set: ${result}`)
+				} catch (error) {
+					vscode.window.showErrorMessage(
+						`Cannot access path ${result}: ${error instanceof Error ? error.message : String(error)}`,
+					)
+				}
+			} else {
+				vscode.window.showInformationMessage("Reverted to using default storage path")
+			}
+		} catch (error) {
+			console.error("Failed to update configuration", error)
+		}
+	}
+}


### PR DESCRIPTION
## Context

On some work machines, the space on the C drive is relatively small and can easily fill up during use, so it is necessary to be able to set the storage location for configuration and session caching

## Implementation

Added the command 'roo-cline. setCustoms Storage Path', which can be accessed through Ctrl+Shift+P (Windows/Linux) or CMD+Shift+P (macOS) to open the settings. If not set, the default storage path will be used

## Screenshots

![image](https://github.com/user-attachments/assets/bafa427f-a21f-4535-9871-a47726b79ad4)


## How to Test

Ctrl+Shift+P (Windows/Linux) or CMD+Shift+P (macOS)  -> >Roo Code:Set Custom Storage Path

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for customizable storage paths in Roo Code extension, allowing users to set custom paths for configuration and session caching.
> 
>   - **Behavior**:
>     - Adds `roo-cline.setCustomStoragePath` command in `package.json` to set a custom storage path for configuration and session caching.
>     - Default path is used if no custom path is set or if the custom path is unusable.
>   - **Functions**:
>     - `getStorageBasePath()`, `getTaskDirectoryPath()`, `getSettingsDirectoryPath()`, and `getCacheDirectoryPath()` in `storagePathManager.ts` now support custom storage paths.
>     - `promptForCustomStoragePath()` in `storagePathManager.ts` prompts user to set a custom path and validates it.
>   - **Integration**:
>     - Updates `getTaskDirectoryPath()` usage in `Cline.ts` and `ClineProvider.ts` to use `storagePathManager` for path retrieval.
>     - Registers `setCustomStoragePath` command in `registerCommands.ts` to invoke `promptForCustomStoragePath()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d7411935766499f3829da2a508c6473a3f27a0ce. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->