### PR TITLE
Add `taskCreated` event to API and subscribe to Cline events earlier

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -114,6 +114,7 @@ export type ClineOptions = {
 	rootTask?: Cline
 	parentTask?: Cline
 	taskNumber?: number
+	onCreated?: (cline: Cline) => void
 }
 
 export class Cline extends EventEmitter<ClineEvents> {
@@ -191,6 +192,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 		rootTask,
 		parentTask,
 		taskNumber,
+		onCreated,
 	}: ClineOptions) {
 		super()
 
@@ -233,6 +235,8 @@ export class Cline extends EventEmitter<ClineEvents> {
 			Experiments.isEnabled(experiments ?? {}, EXPERIMENT_IDS.DIFF_STRATEGY),
 			Experiments.isEnabled(experiments ?? {}, EXPERIMENT_IDS.MULTI_SEARCH_AND_REPLACE),
 		)
+
+		onCreated?.(this)
 
 		if (startTask) {
 			if (task || images) {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -74,7 +74,7 @@ import { getWorkspacePath } from "../../utils/path"
  */
 
 export type ClineProviderEvents = {
-	clineAdded: [cline: Cline]
+	clineCreated: [cline: Cline]
 }
 
 export class ClineProvider extends EventEmitter<ClineProviderEvents> implements vscode.WebviewViewProvider {
@@ -132,8 +132,6 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 
 		// Add this cline instance into the stack that represents the order of all the called tasks.
 		this.clineStack.push(cline)
-
-		this.emit("clineAdded", cline)
 
 		// Ensure getState() resolves correctly.
 		const state = await this.getState()
@@ -485,6 +483,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			rootTask: this.clineStack.length > 0 ? this.clineStack[0] : undefined,
 			parentTask,
 			taskNumber: this.clineStack.length + 1,
+			onCreated: (cline) => this.emit("clineCreated", cline),
 		})
 
 		await this.addClineToStack(cline)
@@ -550,6 +549,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			rootTask: historyItem.rootTask,
 			parentTask: historyItem.parentTask,
 			taskNumber: historyItem.number,
+			onCreated: (cline) => this.emit("clineCreated", cline),
 		})
 
 		await this.addClineToStack(cline)

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -870,6 +870,7 @@ describe("ClineProvider", () => {
 			rootTask: undefined,
 			parentTask: undefined,
 			taskNumber: 1,
+			onCreated: expect.any(Function),
 		})
 	})
 

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -20,7 +20,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		this.history = new MessageHistory()
 		this.tokenUsage = {}
 
-		this.provider.on("clineAdded", (cline) => {
+		this.provider.on("clineCreated", (cline) => {
 			cline.on("message", (message) => this.emit("message", { taskId: cline.taskId, ...message }))
 			cline.on("taskStarted", () => this.emit("taskStarted", cline.taskId))
 			cline.on("taskPaused", () => this.emit("taskPaused", cline.taskId))
@@ -28,6 +28,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 			cline.on("taskAskResponded", () => this.emit("taskAskResponded", cline.taskId))
 			cline.on("taskAborted", () => this.emit("taskAborted", cline.taskId))
 			cline.on("taskSpawned", (taskId) => this.emit("taskSpawned", cline.taskId, taskId))
+			this.emit("taskCreated", cline.taskId)
 		})
 
 		this.on("message", ({ taskId, action, message }) => {

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -11,6 +11,7 @@ export interface TokenUsage {
 
 export interface RooCodeEvents {
 	message: [{ taskId: string; action: "created" | "updated"; message: ClineMessage }]
+	taskCreated: [taskId: string]
 	taskStarted: [taskId: string]
 	taskPaused: [taskId: string]
 	taskUnpaused: [taskId: string]


### PR DESCRIPTION
## Context

`taskStarted` event is not the first event generated by a task. Before `taskStarted`, some messages may be sent (e.g. by the checkpoint service). It would be good to have `taskCreated` event that fires before any message is sent.

Also it would be better to attach to Cline events before the "event loop" starts.

## Implementation

Added `onCreated` callback to `ClineOptions` that is called after the `Cline` is created, but before the task "event loop" is run.
Replaced `ClineProvider`'s `clineAdded` event with `clineCreated` event that fires before the "event loop" starts.

## Screenshots

None.

## How to Test

Not tested.

## Get in Touch

Discord handle: wkordalski
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `taskCreated` event to API and adjust `Cline` event subscription timing to occur before task loop starts.
> 
>   - **Behavior**:
>     - Add `taskCreated` event emission in `API` class in `api.ts` when a `Cline` is created.
>     - Modify `ClineProvider` to emit `clineCreated` event before task event loop starts.
>   - **Cline Modifications**:
>     - Add `onCreated` callback to `ClineOptions` in `Cline.ts`.
>     - Call `onCreated` in `Cline` constructor before starting task loop.
>   - **Event Renames**:
>     - Rename `clineAdded` to `clineCreated` in `ClineProvider` and `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c9cea1e640c30180f62fca1b37af9063ca229d51. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->