### PR TITLE
Better openrouter error handling

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1227,7 +1227,16 @@ export class Cline extends EventEmitter<ClineEvents> {
 		} catch (error) {
 			// note that this api_req_failed ask is unique in that we only present this option if the api hasn't streamed any content yet (ie it fails on the first chunk due), as it would allow them to hit a retry button. However if the api failed mid-stream, it could be in any arbitrary state where some tools may have executed, so that error is handled differently and requires cancelling the task entirely.
 			if (alwaysApproveResubmit) {
-				const errorMsg = error.error?.metadata?.raw ?? error.message ?? "Unknown error"
+				let errorMsg
+
+				if (error.error?.metadata?.raw) {
+					errorMsg = JSON.stringify(error.error.metadata.raw, null, 2)
+				} else if (error.message) {
+					errorMsg = error.message
+				} else {
+					errorMsg = "Unknown error"
+				}
+
 				const baseDelay = requestDelaySeconds || 5
 				const exponentialDelay = Math.ceil(baseDelay * Math.pow(2, retryAttempt))
 				// Wait for the greater of the exponential delay or the rate limit delay


### PR DESCRIPTION
Before:
![Screenshot 2025-03-24 at 10 44 33 AM](https://github.com/user-attachments/assets/9330e63a-7e0b-4d28-8438-4554216a12c1)

After:
![Screenshot 2025-03-24 at 10 44 43 AM](https://github.com/user-attachments/assets/175282c3-2b4a-43b3-9a45-2549132834b8)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves error handling in `Cline.ts` by formatting error messages in `attemptApiRequest()` for better clarity when API requests fail before streaming.
> 
>   - **Error Handling**:
>     - In `Cline.ts`, `attemptApiRequest()` now formats error messages using `JSON.stringify()` for `error.error.metadata.raw`.
>     - Handles cases where `error.message` is available or defaults to "Unknown error" if neither is present.
>   - **Behavior**:
>     - Ensures error messages are clear and formatted for display when API request fails before streaming.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for edb04afd44358ac9e4eda80416785195b9d6e41f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->