### PR TITLE
fix: remove -p flag from test script to prevent git operation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
 		"package": "npm-run-all -p build:webview build:esbuild check-types lint",
 		"pretest": "npm run compile",
 		"dev": "cd webview-ui && npm run dev",
-		"test": "npm-run-all -p test:*",
+		"test": "npm-run-all test:*",
 		"test:extension": "jest",
 		"test:webview": "cd webview-ui && npm run test",
 		"prepare": "husky",


### PR DESCRIPTION
## Context

when running `npm test` (at least on windows) although the tests would pass the console would be cluttered with many of the following:

```
 Cannot log after tests are done. Did you forget to wait for something async in your test?
    Attempted to log "Strategy 2 - Search commit: 5a3e118137ada7228c3352d370c9e83a1709591c".

      227 |
      228 |                     console.log("Strategy 2 - Attempting checkout of:", searchHash)
    > 229 |                     await git.raw(["checkout", searchHash])
          |                                      ^
      230 |                     fs.writeFileSync(filePath, originalText)
      231 |                     await git.add("file.txt")
      232 |                     const originalCommit2 = await git.commit("original")

      at console.log (node_modules/@jest/console/build/BufferedConsole.js:156:10)
      at applyGitFallback (src/core/diff/strategies/new-unified/edit-strategies.ts:229:21)
      at Object.<anonymous> (src/core/diff/strategies/new-unified/__tests__/edit-strategies.test.ts:293:24)
```

The -p flag in npm-run-all was causing tests to run in parallel, which led to 'Cannot log after tests are done' errors with git operations. These errors don't appear when running test:extension alone.

The issue occurs because git-based tests create temporary directories and run async operations that can interfere with each other when executed in parallel. Running tests sequentially resolves this cleanly.

While it might increase total test time slightly, it ensures more reliable and consistent test results.

## How to Test

`npm test`

## Get in Touch

I'm available on the Roo Code Discord as @StevenTCramer
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `-p` flag from `npm-run-all` in `test` script to prevent parallel execution errors during git operations.
> 
>   - **Behavior**:
>     - Removes `-p` flag from `npm-run-all` in `test` script in `package.json` to prevent parallel execution errors.
>     - Resolves 'Cannot log after tests are done' errors during git operations in tests.
>   - **Testing**:
>     - Run `npm test` to verify sequential test execution without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 21f1d84095d3327a427048839689d9ec6f2c1814. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->