### PR TITLE
Internationalization support for custom storage path functionality

### DIFF
--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "El servidor de desenvolupament local no està executant-se, l'HMR no funcionarà. Si us plau, executa 'npm run dev' abans de llançar l'extensió per habilitar l'HMR.",
 		"retrieve_current_mode": "Error en recuperar el mode actual de l'estat.",
 		"failed_delete_repo": "Ha fallat l'eliminació del repositori o branca associada: {{error}}",
-		"failed_remove_directory": "Ha fallat l'eliminació del directori de tasques: {{error}}"
+		"failed_remove_directory": "Ha fallat l'eliminació del directori de tasques: {{error}}",
+		"custom_storage_path_unusable": "La ruta d'emmagatzematge personalitzada \"{{path}}\" no és utilitzable, s'utilitzarà la ruta predeterminada",
+		"cannot_access_path": "No es pot accedir a la ruta {{path}}: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "No s'ha seleccionat contingut de terminal",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Reiniciant el servidor MCP {{serverName}}...",
 		"mcp_server_connected": "Servidor MCP {{serverName}} connectat",
 		"mcp_server_deleted": "Servidor MCP eliminat: {{serverName}}",
-		"mcp_server_not_found": "Servidor \"{{serverName}}\" no trobat a la configuració"
+		"mcp_server_not_found": "Servidor \"{{serverName}}\" no trobat a la configuració",
+		"custom_storage_path_set": "Ruta d'emmagatzematge personalitzada establerta: {{path}}",
+		"default_storage_path": "S'ha reprès l'ús de la ruta d'emmagatzematge predeterminada"
 	},
 	"answers": {
 		"yes": "Sí",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Error de tasca: Ha estat aturada i cancel·lada per l'usuari.",
 		"deleted": "Fallada de tasca: Ha estat aturada i eliminada per l'usuari."
+	},
+	"storage": {
+		"prompt_custom_path": "Introdueix una ruta d'emmagatzematge personalitzada per a l'historial de converses o deixa-ho buit per utilitzar la ubicació predeterminada",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Introdueix una ruta completa (p. ex. D:\\RooCodeStorage o /home/user/storage)",
+		"enter_valid_path": "Introdueix una ruta vàlida"
 	}
 }

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "Der lokale Entwicklungsserver läuft nicht, HMR wird nicht funktionieren. Bitte führen Sie 'npm run dev' vor dem Start der Erweiterung aus, um HMR zu aktivieren.",
 		"retrieve_current_mode": "Fehler beim Abrufen des aktuellen Modus aus dem Zustand.",
 		"failed_delete_repo": "Fehler beim Löschen des zugehörigen Shadow-Repositorys oder -Zweigs: {{error}}",
-		"failed_remove_directory": "Fehler beim Entfernen des Aufgabenverzeichnisses: {{error}}"
+		"failed_remove_directory": "Fehler beim Entfernen des Aufgabenverzeichnisses: {{error}}",
+		"custom_storage_path_unusable": "Benutzerdefinierter Speicherpfad \"{{path}}\" ist nicht verwendbar, Standardpfad wird verwendet",
+		"cannot_access_path": "Zugriff auf Pfad {{path}} nicht möglich: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Kein Terminal-Inhalt ausgewählt",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "MCP-Server {{serverName}} wird neu gestartet...",
 		"mcp_server_connected": "MCP-Server {{serverName}} verbunden",
 		"mcp_server_deleted": "MCP-Server gelöscht: {{serverName}}",
-		"mcp_server_not_found": "Server \"{{serverName}}\" nicht in der Konfiguration gefunden"
+		"mcp_server_not_found": "Server \"{{serverName}}\" nicht in der Konfiguration gefunden",
+		"custom_storage_path_set": "Benutzerdefinierter Speicherpfad festgelegt: {{path}}",
+		"default_storage_path": "Auf Standardspeicherpfad zurückgesetzt"
 	},
 	"answers": {
 		"yes": "Ja",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Aufgabenfehler: Die Aufgabe wurde vom Benutzer gestoppt und abgebrochen.",
 		"deleted": "Aufgabenfehler: Die Aufgabe wurde vom Benutzer gestoppt und gelöscht."
+	},
+	"storage": {
+		"prompt_custom_path": "Gib den benutzerdefinierten Speicherpfad für den Gesprächsverlauf ein, leer lassen für Standardspeicherort",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Bitte gib einen absoluten Pfad ein (z.B. D:\\RooCodeStorage oder /home/user/storage)",
+		"enter_valid_path": "Bitte gib einen gültigen Pfad ein"
 	}
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "Local development server is not running, HMR will not work. Please run 'npm run dev' before launching the extension to enable HMR.",
 		"retrieve_current_mode": "Error: failed to retrieve current mode from state.",
 		"failed_delete_repo": "Failed to delete associated shadow repository or branch: {{error}}",
-		"failed_remove_directory": "Failed to remove task directory: {{error}}"
+		"failed_remove_directory": "Failed to remove task directory: {{error}}",
+		"custom_storage_path_unusable": "Custom storage path \"{{path}}\" is unusable, will use default path",
+		"cannot_access_path": "Cannot access path {{path}}: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "No terminal content selected",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Restarting {{serverName}} MCP server...",
 		"mcp_server_connected": "{{serverName}} MCP server connected",
 		"mcp_server_deleted": "Deleted MCP server: {{serverName}}",
-		"mcp_server_not_found": "Server \"{{serverName}}\" not found in configuration"
+		"mcp_server_not_found": "Server \"{{serverName}}\" not found in configuration",
+		"custom_storage_path_set": "Custom storage path set: {{path}}",
+		"default_storage_path": "Reverted to using default storage path"
 	},
 	"answers": {
 		"yes": "Yes",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Task error: It was stopped and canceled by the user.",
 		"deleted": "Task failure: It was stopped and deleted by the user."
+	},
+	"storage": {
+		"prompt_custom_path": "Enter custom conversation history storage path, leave empty to use default location",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Please enter an absolute path (e.g. D:\\RooCodeStorage or /home/user/storage)",
+		"enter_valid_path": "Please enter a valid path"
 	}
 }

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "El servidor de desarrollo local no está en ejecución, HMR no funcionará. Por favor, ejecuta 'npm run dev' antes de lanzar la extensión para habilitar HMR.",
 		"retrieve_current_mode": "Error al recuperar el modo actual del estado.",
 		"failed_delete_repo": "Error al eliminar el repositorio o rama asociada: {{error}}",
-		"failed_remove_directory": "Error al eliminar el directorio de tareas: {{error}}"
+		"failed_remove_directory": "Error al eliminar el directorio de tareas: {{error}}",
+		"custom_storage_path_unusable": "La ruta de almacenamiento personalizada \"{{path}}\" no es utilizable, se usará la ruta predeterminada",
+		"cannot_access_path": "No se puede acceder a la ruta {{path}}: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "No hay contenido de terminal seleccionado",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Reiniciando el servidor MCP {{serverName}}...",
 		"mcp_server_connected": "Servidor MCP {{serverName}} conectado",
 		"mcp_server_deleted": "Servidor MCP eliminado: {{serverName}}",
-		"mcp_server_not_found": "Servidor \"{{serverName}}\" no encontrado en la configuración"
+		"mcp_server_not_found": "Servidor \"{{serverName}}\" no encontrado en la configuración",
+		"custom_storage_path_set": "Ruta de almacenamiento personalizada establecida: {{path}}",
+		"default_storage_path": "Se ha vuelto a usar la ruta de almacenamiento predeterminada"
 	},
 	"answers": {
 		"yes": "Sí",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Error de tarea: Fue detenida y cancelada por el usuario.",
 		"deleted": "Fallo de tarea: Fue detenida y eliminada por el usuario."
+	},
+	"storage": {
+		"prompt_custom_path": "Ingresa la ruta de almacenamiento personalizada para el historial de conversaciones, déjala vacía para usar la ubicación predeterminada",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Por favor, ingresa una ruta absoluta (por ejemplo, D:\\RooCodeStorage o /home/user/storage)",
+		"enter_valid_path": "Por favor, ingresa una ruta válida"
 	}
 }

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "Le serveur de développement local n'est pas en cours d'exécution, HMR ne fonctionnera pas. Veuillez exécuter 'npm run dev' avant de lancer l'extension pour activer l'HMR.",
 		"retrieve_current_mode": "Erreur lors de la récupération du mode actuel à partir du state.",
 		"failed_delete_repo": "Échec de la suppression du repo fantôme ou de la branche associée : {{error}}",
-		"failed_remove_directory": "Échec de la suppression du répertoire de tâches : {{error}}"
+		"failed_remove_directory": "Échec de la suppression du répertoire de tâches : {{error}}",
+		"custom_storage_path_unusable": "Le chemin de stockage personnalisé \"{{path}}\" est inutilisable, le chemin par défaut sera utilisé",
+		"cannot_access_path": "Impossible d'accéder au chemin {{path}} : {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Aucun contenu de terminal sélectionné",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Redémarrage du serveur MCP {{serverName}}...",
 		"mcp_server_connected": "Serveur MCP {{serverName}} connecté",
 		"mcp_server_deleted": "Serveur MCP supprimé : {{serverName}}",
-		"mcp_server_not_found": "Serveur \"{{serverName}}\" introuvable dans la configuration"
+		"mcp_server_not_found": "Serveur \"{{serverName}}\" introuvable dans la configuration",
+		"custom_storage_path_set": "Chemin de stockage personnalisé défini : {{path}}",
+		"default_storage_path": "Retour au chemin de stockage par défaut"
 	},
 	"answers": {
 		"yes": "Oui",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Erreur de tâche : Elle a été arrêtée et annulée par l'utilisateur.",
 		"deleted": "Échec de la tâche : Elle a été arrêtée et supprimée par l'utilisateur."
+	},
+	"storage": {
+		"prompt_custom_path": "Entrez le chemin de stockage personnalisé pour l'historique des conversations, laissez vide pour utiliser l'emplacement par défaut",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Veuillez entrer un chemin absolu (ex. D:\\RooCodeStorage ou /home/user/storage)",
+		"enter_valid_path": "Veuillez entrer un chemin valide"
 	}
 }

--- a/src/i18n/locales/hi/common.json
+++ b/src/i18n/locales/hi/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "स्थानीय विकास सर्वर चल नहीं रहा है, HMR काम नहीं करेगा। कृपया HMR सक्षम करने के लिए एक्सटेंशन लॉन्च करने से पहले 'npm run dev' चलाएँ।",
 		"retrieve_current_mode": "स्टेट से वर्तमान मोड प्राप्त करने में त्रुटि।",
 		"failed_delete_repo": "संबंधित शैडो रिपॉजिटरी या ब्रांच हटाने में विफल: {{error}}",
-		"failed_remove_directory": "टास्क डायरेक्टरी हटाने में विफल: {{error}}"
+		"failed_remove_directory": "टास्क डायरेक्टरी हटाने में विफल: {{error}}",
+		"custom_storage_path_unusable": "कस्टम स्टोरेज पाथ \"{{path}}\" उपयोग योग्य नहीं है, डिफ़ॉल्ट पाथ का उपयोग किया जाएगा",
+		"cannot_access_path": "पाथ {{path}} तक पहुंच नहीं पा रहे हैं: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "कोई टर्मिनल सामग्री चयनित नहीं",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "{{serverName}} MCP सर्वर पुनः प्रारंभ हो रहा है...",
 		"mcp_server_connected": "{{serverName}} MCP सर्वर कनेक्टेड",
 		"mcp_server_deleted": "MCP सर्वर हटाया गया: {{serverName}}",
-		"mcp_server_not_found": "सर्वर \"{{serverName}}\" कॉन्फ़िगरेशन में नहीं मिला"
+		"mcp_server_not_found": "सर्वर \"{{serverName}}\" कॉन्फ़िगरेशन में नहीं मिला",
+		"custom_storage_path_set": "कस्टम स्टोरेज पाथ सेट किया गया: {{path}}",
+		"default_storage_path": "डिफ़ॉल्ट स्टोरेज पाथ का उपयोग पुनः शुरू किया गया"
 	},
 	"answers": {
 		"yes": "हां",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "टास्क त्रुटि: इसे उपयोगकर्ता द्वारा रोका और रद्द किया गया था।",
 		"deleted": "टास्क विफलता: इसे उपयोगकर्ता द्वारा रोका और हटाया गया था।"
+	},
+	"storage": {
+		"prompt_custom_path": "वार्तालाप इतिहास के लिए कस्टम स्टोरेज पाथ दर्ज करें, डिफ़ॉल्ट स्थान का उपयोग करने के लिए खाली छोड़ दें",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "कृपया एक पूर्ण पाथ दर्ज करें (उदाहरण: D:\\RooCodeStorage या /home/user/storage)",
+		"enter_valid_path": "कृपया एक वैध पाथ दर्ज करें"
 	}
 }

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "Il server di sviluppo locale non è in esecuzione, l'HMR non funzionerà. Esegui 'npm run dev' prima di avviare l'estensione per abilitare l'HMR.",
 		"retrieve_current_mode": "Errore durante il recupero della modalità corrente dallo stato.",
 		"failed_delete_repo": "Impossibile eliminare il repository o il ramo associato: {{error}}",
-		"failed_remove_directory": "Impossibile rimuovere la directory delle attività: {{error}}"
+		"failed_remove_directory": "Impossibile rimuovere la directory delle attività: {{error}}",
+		"custom_storage_path_unusable": "Il percorso di archiviazione personalizzato \"{{path}}\" non è utilizzabile, verrà utilizzato il percorso predefinito",
+		"cannot_access_path": "Impossibile accedere al percorso {{path}}: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Nessun contenuto del terminale selezionato",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Riavvio del server MCP {{serverName}}...",
 		"mcp_server_connected": "Server MCP {{serverName}} connesso",
 		"mcp_server_deleted": "Server MCP eliminato: {{serverName}}",
-		"mcp_server_not_found": "Server \"{{serverName}}\" non trovato nella configurazione"
+		"mcp_server_not_found": "Server \"{{serverName}}\" non trovato nella configurazione",
+		"custom_storage_path_set": "Percorso di archiviazione personalizzato impostato: {{path}}",
+		"default_storage_path": "Tornato al percorso di archiviazione predefinito"
 	},
 	"answers": {
 		"yes": "Sì",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Errore attività: È stata interrotta e annullata dall'utente.",
 		"deleted": "Fallimento attività: È stata interrotta ed eliminata dall'utente."
+	},
+	"storage": {
+		"prompt_custom_path": "Inserisci il percorso di archiviazione personalizzato per la cronologia delle conversazioni, lascia vuoto per utilizzare la posizione predefinita",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Inserisci un percorso assoluto (ad esempio D:\\RooCodeStorage o /home/user/storage)",
+		"enter_valid_path": "Inserisci un percorso valido"
 	}
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "ローカル開発サーバーが実行されていないため、HMRは機能しません。HMRを有効にするには、拡張機能を起動する前に'npm run dev'を実行してください。",
 		"retrieve_current_mode": "現在のモードを状態から取得する際にエラーが発生しました。",
 		"failed_delete_repo": "関連するシャドウリポジトリまたはブランチの削除に失敗しました：{{error}}",
-		"failed_remove_directory": "タスクディレクトリの削除に失敗しました：{{error}}"
+		"failed_remove_directory": "タスクディレクトリの削除に失敗しました：{{error}}",
+		"custom_storage_path_unusable": "カスタムストレージパス \"{{path}}\" が使用できないため、デフォルトパスを使用します",
+		"cannot_access_path": "パス {{path}} にアクセスできません：{{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "選択されたターミナルコンテンツがありません",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "MCPサーバー{{serverName}}を再起動中...",
 		"mcp_server_connected": "MCPサーバー{{serverName}}が接続されました",
 		"mcp_server_deleted": "MCPサーバーが削除されました：{{serverName}}",
-		"mcp_server_not_found": "サーバー\"{{serverName}}\"が設定内に見つかりません"
+		"mcp_server_not_found": "サーバー\"{{serverName}}\"が設定内に見つかりません",
+		"custom_storage_path_set": "カスタムストレージパスが設定されました：{{path}}",
+		"default_storage_path": "デフォルトのストレージパスに戻りました"
 	},
 	"answers": {
 		"yes": "はい",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "タスクエラー：ユーザーによって停止およびキャンセルされました。",
 		"deleted": "タスク失敗：ユーザーによって停止および削除されました。"
+	},
+	"storage": {
+		"prompt_custom_path": "会話履歴のカスタムストレージパスを入力してください。デフォルトの場所を使用する場合は空のままにしてください",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "絶対パスを入力してください（例：D:\\RooCodeStorage または /home/user/storage）",
+		"enter_valid_path": "有効なパスを入力してください"
 	}
 }

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "로컬 개발 서버가 실행되고 있지 않아 HMR이 작동하지 않습니다. HMR을 활성화하려면 확장 프로그램을 실행하기 전에 'npm run dev'를 실행하세요.",
 		"retrieve_current_mode": "상태에서 현재 모드를 검색하는 데 오류가 발생했습니다.",
 		"failed_delete_repo": "관련 shadow 저장소 또는 브랜치 삭제 실패: {{error}}",
-		"failed_remove_directory": "작업 디렉토리 제거 실패: {{error}}"
+		"failed_remove_directory": "작업 디렉토리 제거 실패: {{error}}",
+		"custom_storage_path_unusable": "사용자 지정 저장 경로 \"{{path}}\"를 사용할 수 없어 기본 경로를 사용합니다",
+		"cannot_access_path": "경로 {{path}}에 접근할 수 없습니다: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "선택된 터미널 내용이 없습니다",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "{{serverName}} MCP 서버를 재시작하는 중...",
 		"mcp_server_connected": "{{serverName}} MCP 서버 연결됨",
 		"mcp_server_deleted": "MCP 서버 삭제됨: {{serverName}}",
-		"mcp_server_not_found": "구성에서 서버 \"{{serverName}}\"을(를) 찾을 수 없습니다"
+		"mcp_server_not_found": "구성에서 서버 \"{{serverName}}\"을(를) 찾을 수 없습니다",
+		"custom_storage_path_set": "사용자 지정 저장 경로 설정됨: {{path}}",
+		"default_storage_path": "기본 저장 경로로 되돌아갔습니다"
 	},
 	"answers": {
 		"yes": "예",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "작업 오류: 사용자에 의해 중지 및 취소되었습니다.",
 		"deleted": "작업 실패: 사용자에 의해 중지 및 삭제되었습니다."
+	},
+	"storage": {
+		"prompt_custom_path": "대화 내역을 위한 사용자 지정 저장 경로를 입력하세요. 기본 위치를 사용하려면 비워두세요",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "절대 경로를 입력하세요 (예: D:\\RooCodeStorage 또는 /home/user/storage)",
+		"enter_valid_path": "유효한 경로를 입력하세요"
 	}
 }

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "Lokalny serwer deweloperski nie jest uruchomiony, HMR nie będzie działać. Uruchom 'npm run dev' przed uruchomieniem rozszerzenia, aby włączyć HMR.",
 		"retrieve_current_mode": "Błąd podczas pobierania bieżącego trybu ze stanu.",
 		"failed_delete_repo": "Nie udało się usunąć powiązanego repozytorium lub gałęzi pomocniczej: {{error}}",
-		"failed_remove_directory": "Nie udało się usunąć katalogu zadania: {{error}}"
+		"failed_remove_directory": "Nie udało się usunąć katalogu zadania: {{error}}",
+		"custom_storage_path_unusable": "Niestandardowa ścieżka przechowywania \"{{path}}\" nie jest użyteczna, zostanie użyta domyślna ścieżka",
+		"cannot_access_path": "Nie można uzyskać dostępu do ścieżki {{path}}: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Nie wybrano zawartości terminala",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Ponowne uruchamianie serwera MCP {{serverName}}...",
 		"mcp_server_connected": "Serwer MCP {{serverName}} połączony",
 		"mcp_server_deleted": "Usunięto serwer MCP: {{serverName}}",
-		"mcp_server_not_found": "Serwer \"{{serverName}}\" nie znaleziony w konfiguracji"
+		"mcp_server_not_found": "Serwer \"{{serverName}}\" nie znaleziony w konfiguracji",
+		"custom_storage_path_set": "Ustawiono niestandardową ścieżkę przechowywania: {{path}}",
+		"default_storage_path": "Wznowiono używanie domyślnej ścieżki przechowywania"
 	},
 	"answers": {
 		"yes": "Tak",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Błąd zadania: Zostało zatrzymane i anulowane przez użytkownika.",
 		"deleted": "Niepowodzenie zadania: Zostało zatrzymane i usunięte przez użytkownika."
+	},
+	"storage": {
+		"prompt_custom_path": "Wprowadź niestandardową ścieżkę przechowywania dla historii konwersacji lub pozostaw puste, aby użyć lokalizacji domyślnej",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Wprowadź pełną ścieżkę (np. D:\\RooCodeStorage lub /home/user/storage)",
+		"enter_valid_path": "Wprowadź prawidłową ścieżkę"
 	}
 }

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "O servidor de desenvolvimento local não está em execução, o HMR não funcionará. Por favor, execute 'npm run dev' antes de iniciar a extensão para habilitar o HMR.",
 		"retrieve_current_mode": "Erro ao recuperar o modo atual do estado.",
 		"failed_delete_repo": "Falha ao excluir o repositório ou ramificação associada: {{error}}",
-		"failed_remove_directory": "Falha ao remover o diretório de tarefas: {{error}}"
+		"failed_remove_directory": "Falha ao remover o diretório de tarefas: {{error}}",
+		"custom_storage_path_unusable": "O caminho de armazenamento personalizado \"{{path}}\" não pode ser usado, será usado o caminho padrão",
+		"cannot_access_path": "Não é possível acessar o caminho {{path}}: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Nenhum conteúdo do terminal selecionado",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Reiniciando o servidor MCP {{serverName}}...",
 		"mcp_server_connected": "Servidor MCP {{serverName}} conectado",
 		"mcp_server_deleted": "Servidor MCP excluído: {{serverName}}",
-		"mcp_server_not_found": "Servidor \"{{serverName}}\" não encontrado na configuração"
+		"mcp_server_not_found": "Servidor \"{{serverName}}\" não encontrado na configuração",
+		"custom_storage_path_set": "Caminho de armazenamento personalizado definido: {{path}}",
+		"default_storage_path": "Retornado ao caminho de armazenamento padrão"
 	},
 	"answers": {
 		"yes": "Sim",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Erro na tarefa: Foi interrompida e cancelada pelo usuário.",
 		"deleted": "Falha na tarefa: Foi interrompida e excluída pelo usuário."
+	},
+	"storage": {
+		"prompt_custom_path": "Digite o caminho de armazenamento personalizado para o histórico de conversas, deixe em branco para usar o local padrão",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Por favor, digite um caminho absoluto (ex: D:\\RooCodeStorage ou /home/user/storage)",
+		"enter_valid_path": "Por favor, digite um caminho válido"
 	}
 }

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "Yerel geliştirme sunucusu çalışmıyor, HMR çalışmayacak. HMR'yi etkinleştirmek için uzantıyı başlatmadan önce lütfen 'npm run dev' komutunu çalıştırın.",
 		"retrieve_current_mode": "Mevcut mod durumdan alınırken hata oluştu.",
 		"failed_delete_repo": "İlişkili gölge depo veya dal silinemedi: {{error}}",
-		"failed_remove_directory": "Görev dizini kaldırılamadı: {{error}}"
+		"failed_remove_directory": "Görev dizini kaldırılamadı: {{error}}",
+		"custom_storage_path_unusable": "Özel depolama yolu \"{{path}}\" kullanılamıyor, varsayılan yol kullanılacak",
+		"cannot_access_path": "{{path}} yoluna erişilemiyor: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Seçili terminal içeriği yok",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "{{serverName}} MCP sunucusu yeniden başlatılıyor...",
 		"mcp_server_connected": "{{serverName}} MCP sunucusu bağlandı",
 		"mcp_server_deleted": "MCP sunucusu silindi: {{serverName}}",
-		"mcp_server_not_found": "Yapılandırmada \"{{serverName}}\" sunucusu bulunamadı"
+		"mcp_server_not_found": "Yapılandırmada \"{{serverName}}\" sunucusu bulunamadı",
+		"custom_storage_path_set": "Özel depolama yolu ayarlandı: {{path}}",
+		"default_storage_path": "Varsayılan depolama yoluna geri dönüldü"
 	},
 	"answers": {
 		"yes": "Evet",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Görev hatası: Kullanıcı tarafından durduruldu ve iptal edildi.",
 		"deleted": "Görev başarısız: Kullanıcı tarafından durduruldu ve silindi."
+	},
+	"storage": {
+		"prompt_custom_path": "Konuşma geçmişi için özel depolama yolunu girin, varsayılan konumu kullanmak için boş bırakın",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Lütfen mutlak bir yol girin (örn. D:\\RooCodeStorage veya /home/user/storage)",
+		"enter_valid_path": "Lütfen geçerli bir yol girin"
 	}
 }

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "Máy chủ phát triển cục bộ không chạy, HMR sẽ không hoạt động. Vui lòng chạy 'npm run dev' trước khi khởi chạy tiện ích mở rộng để bật HMR.",
 		"retrieve_current_mode": "Lỗi không thể truy xuất chế độ hiện tại từ trạng thái.",
 		"failed_delete_repo": "Không thể xóa kho lưu trữ hoặc nhánh liên quan: {{error}}",
-		"failed_remove_directory": "Không thể xóa thư mục nhiệm vụ: {{error}}"
+		"failed_remove_directory": "Không thể xóa thư mục nhiệm vụ: {{error}}",
+		"custom_storage_path_unusable": "Đường dẫn lưu trữ tùy chỉnh \"{{path}}\" không thể sử dụng được, sẽ sử dụng đường dẫn mặc định",
+		"cannot_access_path": "Không thể truy cập đường dẫn {{path}}: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Không có nội dung terminal được chọn",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "Đang khởi động lại máy chủ MCP {{serverName}}...",
 		"mcp_server_connected": "Máy chủ MCP {{serverName}} đã kết nối",
 		"mcp_server_deleted": "Đã xóa máy chủ MCP: {{serverName}}",
-		"mcp_server_not_found": "Không tìm thấy máy chủ \"{{serverName}}\" trong cấu hình"
+		"mcp_server_not_found": "Không tìm thấy máy chủ \"{{serverName}}\" trong cấu hình",
+		"custom_storage_path_set": "Đã thiết lập đường dẫn lưu trữ tùy chỉnh: {{path}}",
+		"default_storage_path": "Đã quay lại sử dụng đường dẫn lưu trữ mặc định"
 	},
 	"answers": {
 		"yes": "Có",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "Lỗi nhiệm vụ: Nó đã bị dừng và hủy bởi người dùng.",
 		"deleted": "Nhiệm vụ thất bại: Nó đã bị dừng và xóa bởi người dùng."
+	},
+	"storage": {
+		"prompt_custom_path": "Nhập đường dẫn lưu trữ tùy chỉnh cho lịch sử hội thoại, để trống để sử dụng vị trí mặc định",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "Vui lòng nhập đường dẫn tuyệt đối (ví dụ: D:\\RooCodeStorage hoặc /home/user/storage)",
+		"enter_valid_path": "Vui lòng nhập đường dẫn hợp lệ"
 	}
 }

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "本地开发服务器未运行，HMR将不起作用。请在启动扩展前运行'npm run dev'以启用HMR。",
 		"retrieve_current_mode": "从状态中检索当前模式失败。",
 		"failed_delete_repo": "删除关联的影子仓库或分支失败：{{error}}",
-		"failed_remove_directory": "删除任务目录失败：{{error}}"
+		"failed_remove_directory": "删除任务目录失败：{{error}}",
+		"custom_storage_path_unusable": "自定义存储路径 \"{{path}}\" 不可用，将使用默认路径",
+		"cannot_access_path": "无法访问路径 {{path}}：{{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "没有选择终端内容",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "正在重启{{serverName}}MCP服务器...",
 		"mcp_server_connected": "{{serverName}}MCP服务器已连接",
 		"mcp_server_deleted": "已删除MCP服务器：{{serverName}}",
-		"mcp_server_not_found": "在配置中未找到服务器\"{{serverName}}\""
+		"mcp_server_not_found": "在配置中未找到服务器\"{{serverName}}\"",
+		"custom_storage_path_set": "自定义存储路径已设置：{{path}}",
+		"default_storage_path": "已恢复使用默认存储路径"
 	},
 	"answers": {
 		"yes": "是",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "任务错误：它已被用户停止并取消。",
 		"deleted": "任务失败：它已被用户停止并删除。"
+	},
+	"storage": {
+		"prompt_custom_path": "输入自定义会话历史存储路径，留空以使用默认位置",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "请输入绝对路径（例如 D:\\RooCodeStorage 或 /home/user/storage）",
+		"enter_valid_path": "请输入有效的路径"
 	}
 }

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -48,7 +48,9 @@
 		"hmr_not_running": "本地開發服務器未運行，HMR將不起作用。請在啟動擴展前運行'npm run dev'以啟用HMR。",
 		"retrieve_current_mode": "從狀態中檢索當前模式失敗。",
 		"failed_delete_repo": "刪除關聯的影子倉庫或分支失敗：{{error}}",
-		"failed_remove_directory": "刪除任務目錄失敗：{{error}}"
+		"failed_remove_directory": "刪除任務目錄失敗：{{error}}",
+		"custom_storage_path_unusable": "自定義存儲路徑 \"{{path}}\" 不可用，將使用默認路徑",
+		"cannot_access_path": "無法訪問路徑 {{path}}：{{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "沒有選擇終端內容",
@@ -61,7 +63,9 @@
 		"mcp_server_restarting": "正在重啟{{serverName}}MCP服務器...",
 		"mcp_server_connected": "{{serverName}}MCP服務器已連接",
 		"mcp_server_deleted": "已刪除MCP服務器：{{serverName}}",
-		"mcp_server_not_found": "在配置中未找到服務器\"{{serverName}}\""
+		"mcp_server_not_found": "在配置中未找到服務器\"{{serverName}}\"",
+		"custom_storage_path_set": "自定義存儲路徑已設置：{{path}}",
+		"default_storage_path": "已恢復使用默認存儲路徑"
 	},
 	"answers": {
 		"yes": "是",
@@ -73,5 +77,11 @@
 	"tasks": {
 		"canceled": "任務錯誤：它已被用戶停止並取消。",
 		"deleted": "任務失敗：它已被用戶停止並刪除。"
+	},
+	"storage": {
+		"prompt_custom_path": "輸入自定義會話歷史存儲路徑，留空以使用默認位置",
+		"path_placeholder": "D:\\RooCodeStorage",
+		"enter_absolute_path": "請輸入絕對路徑（例如 D:\\RooCodeStorage 或 /home/user/storage）",
+		"enter_valid_path": "請輸入有效的路徑"
 	}
 }

--- a/src/shared/storagePathManager.ts
+++ b/src/shared/storagePathManager.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
+import { t } from "../i18n"
 
 /**
  * Gets the base storage path for conversations
@@ -39,9 +40,7 @@ export async function getStorageBasePath(defaultPath: string): Promise<string> {
 		// If path is unusable, report error and fall back to default path
 		console.error(`Custom storage path is unusable: ${error instanceof Error ? error.message : String(error)}`)
 		if (vscode.window) {
-			vscode.window.showErrorMessage(
-				`Custom storage path "${customStoragePath}" is unusable, will use default path`,
-			)
+			vscode.window.showErrorMessage(t("common:errors.custom_storage_path_unusable", { path: customStoragePath }))
 		}
 		return defaultPath
 	}
@@ -98,8 +97,8 @@ export async function promptForCustomStoragePath(): Promise<void> {
 
 	const result = await vscode.window.showInputBox({
 		value: currentPath,
-		placeHolder: "D:\\RooCodeStorage",
-		prompt: "Enter custom conversation history storage path, leave empty to use default location",
+		placeHolder: t("common:storage.path_placeholder"),
+		prompt: t("common:storage.prompt_custom_path"),
 		validateInput: (input) => {
 			if (!input) {
 				return null // Allow empty value (use default path)
@@ -111,12 +110,12 @@ export async function promptForCustomStoragePath(): Promise<void> {
 
 				// Check if path is absolute
 				if (!path.isAbsolute(input)) {
-					return "Please enter an absolute path (e.g. D:\\RooCodeStorage or /home/user/storage)"
+					return t("common:storage.enter_absolute_path")
 				}
 
 				return null // Path format is valid
 			} catch (e) {
-				return "Please enter a valid path"
+				return t("common:storage.enter_valid_path")
 			}
 		},
 	})
@@ -131,14 +130,17 @@ export async function promptForCustomStoragePath(): Promise<void> {
 				try {
 					// Test if path is accessible
 					await fs.mkdir(result, { recursive: true })
-					vscode.window.showInformationMessage(`Custom storage path set: ${result}`)
+					vscode.window.showInformationMessage(t("common:info.custom_storage_path_set", { path: result }))
 				} catch (error) {
 					vscode.window.showErrorMessage(
-						`Cannot access path ${result}: ${error instanceof Error ? error.message : String(error)}`,
+						t("common:errors.cannot_access_path", {
+							path: result,
+							error: error instanceof Error ? error.message : String(error),
+						}),
 					)
 				}
 			} else {
-				vscode.window.showInformationMessage("Reverted to using default storage path")
+				vscode.window.showInformationMessage(t("common:info.default_storage_path"))
 			}
 		} catch (error) {
 			console.error("Failed to update configuration", error)


### PR DESCRIPTION
## Context


https://github.com/RooVetGit/Roo-Code/pull/1941 Add internationalization support to this feature

## Implementation

Added multiple languages

## Screenshots
Taking Chinese as an example
![image](https://github.com/user-attachments/assets/59180266-9af7-41a0-af69-9bf1f9af21e8)
![image](https://github.com/user-attachments/assets/7c27671a-901b-49fc-8c5b-567c20be1994)

## How to Test

Ctrl+Shift+P (Windows/Linux) or CMD+Shift+P (macOS) -> >Roo Code:Set Custom Storage Path

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds internationalization support for custom storage path functionality with translations in multiple languages and updates to `storagePathManager.ts` for using these translations.
> 
>   - **Internationalization**:
>     - Added translations for custom storage path messages in `common.json` files for multiple languages including `ca`, `de`, `en`, `es`, `fr`, `hi`, `it`, `ja`, `ko`, `pl`, `pt-BR`, `tr`, `vi`, `zh-CN`, and `zh-TW`.
>   - **Functionality**:
>     - Updated `getStorageBasePath()` and `promptForCustomStoragePath()` in `storagePathManager.ts` to use translated messages for errors and prompts related to custom storage paths.
>     - Handles cases where the custom storage path is unusable or inaccessible, reverting to default path and displaying appropriate messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4118e7bf2f1be949ad64987361e524c9990af38b. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->