### PR TITLE
Revert "[clinerules] search clinerule in parent folders which make it easier to share within a github repo"

### DIFF
--- a/src/core/prompts/sections/__tests__/custom-instructions.test.ts
+++ b/src/core/prompts/sections/__tests__/custom-instructions.test.ts
@@ -106,15 +106,7 @@ describe("addCustomInstructions", () => {
 	})
 
 	it("should combine all instruction types when provided", async () => {
-		// Mock implementation to return different values based on the file path
-		mockedFs.readFile.mockImplementation(((filePath: any) => {
-			// For .clinerules-test-mode, return mode-specific rules
-			if (filePath.toString().includes(".clinerules-test-mode")) {
-				return Promise.resolve("mode specific rules")
-			}
-			// For any other read operation, return empty
-			return Promise.reject({ code: "ENOENT" })
-		}) as any)
+		mockedFs.readFile.mockResolvedValue("mode specific rules")
 
 		const result = await addCustomInstructions(
 			"mode instructions",

--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -16,47 +16,18 @@ async function safeReadFile(filePath: string): Promise<string> {
 	}
 }
 
-async function findRuleInDirectory(dir: string, ruleFile: string): Promise<string> {
-	const filePath = path.join(dir, ruleFile)
-	const content = await safeReadFile(filePath)
-
-	if (content) {
-		return content
-	}
-
-	// Check if we've reached the root directory
-	const parentDir = path.dirname(dir)
-	if (parentDir === dir) {
-		return ""
-	}
-
-	// Recursively check parent directory
-	return findRuleInDirectory(parentDir, ruleFile)
-}
-
 export async function loadRuleFiles(cwd: string): Promise<string> {
 	const ruleFiles = [".clinerules", ".cursorrules", ".windsurfrules"]
 	let combinedRules = ""
 
 	for (const file of ruleFiles) {
-		const content = await findRuleInDirectory(cwd, file)
+		const content = await safeReadFile(path.join(cwd, file))
 		if (content) {
 			combinedRules += `\n# Rules from ${file}:\n${content}\n`
 		}
 	}
 
 	return combinedRules
-}
-
-async function findCustomInstructionsFile(dir: string, filePattern: string): Promise<string> {
-	// First try to find as a direct file
-	const content = await findRuleInDirectory(dir, filePattern)
-	if (content) {
-		return content
-	}
-
-	// If not found as a file, check if it's raw content
-	return filePattern.trim()
 }
 
 export async function addCustomInstructions(
@@ -83,16 +54,14 @@ export async function addCustomInstructions(
 		)
 	}
 
-	// Add global instructions first - try to find as file or use raw content
-	const globalContent = await findCustomInstructionsFile(cwd, globalCustomInstructions)
-	if (globalContent) {
-		sections.push(`Global Instructions:\n${globalContent}`)
+	// Add global instructions first
+	if (typeof globalCustomInstructions === "string" && globalCustomInstructions.trim()) {
+		sections.push(`Global Instructions:\n${globalCustomInstructions.trim()}`)
 	}
 
-	// Add mode-specific instructions - try to find as file or use raw content
-	const modeContent = await findCustomInstructionsFile(cwd, modeCustomInstructions)
-	if (modeContent) {
-		sections.push(`Mode-specific Instructions:\n${modeContent}`)
+	// Add mode-specific instructions after
+	if (typeof modeCustomInstructions === "string" && modeCustomInstructions.trim()) {
+		sections.push(`Mode-specific Instructions:\n${modeCustomInstructions.trim()}`)
 	}
 
 	// Add rules - include both mode-specific and generic rules if they exist

--- a/src/integrations/misc/open-file.ts
+++ b/src/integrations/misc/open-file.ts
@@ -23,23 +23,6 @@ export async function openImage(dataUri: string) {
 interface OpenFileOptions {
 	create?: boolean
 	content?: string
-	searchParents?: boolean
-	startFromWorkspace?: boolean
-}
-
-async function findFileInParentDirs(searchPath: string, fileName: string): Promise<string | null> {
-	try {
-		const fullPath = path.join(searchPath, fileName)
-		await vscode.workspace.fs.stat(vscode.Uri.file(fullPath))
-		return fullPath
-	} catch {
-		const parentDir = path.dirname(searchPath)
-		if (parentDir === searchPath) {
-			// Hit root
-			return null
-		}
-		return findFileInParentDirs(parentDir, fileName)
-	}
 }
 
 export async function openFile(filePath: string, options: OpenFileOptions = {}) {
@@ -51,17 +34,7 @@ export async function openFile(filePath: string, options: OpenFileOptions = {}) 
 		}
 
 		// If path starts with ./, resolve it relative to workspace root
-		let fullPath = filePath.startsWith("./") ? path.join(workspaceRoot, filePath.slice(2)) : filePath
-
-		// Handle recursive search
-		if (options.searchParents) {
-			const startDir = options.startFromWorkspace ? workspaceRoot : path.dirname(fullPath)
-			const fileName = path.basename(filePath)
-			const foundPath = await findFileInParentDirs(startDir, fileName)
-			if (foundPath) {
-				fullPath = foundPath
-			}
-		}
+		const fullPath = filePath.startsWith("./") ? path.join(workspaceRoot, filePath.slice(2)) : filePath
 
 		const uri = vscode.Uri.file(fullPath)
 

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -462,8 +462,6 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 													values: {
 														create: true,
 														content: JSON.stringify({ customModes: [] }, null, 2),
-														searchParents: true,
-														startFromWorkspace: true,
 													},
 												})
 												setShowConfigMenu(false)
@@ -810,8 +808,6 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 													values: {
 														create: true,
 														content: "",
-														searchParents: true,
-														startFromWorkspace: true,
 													},
 												})
 											}}
@@ -919,8 +915,6 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 														values: {
 															create: true,
 															content: "",
-															searchParents: true,
-															startFromWorkspace: true,
 														},
 													})
 												}}
@@ -976,8 +970,6 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 												values: {
 													create: true,
 													content: "",
-													searchParents: true,
-													startFromWorkspace: true,
 												},
 											})
 										}


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#1832
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts recursive search for `.clinerules` in parent directories, affecting `custom-instructions.ts`, `open-file.ts`, and `PromptsView.tsx`.
> 
>   - **Behavior**:
>     - Reverts recursive search for `.clinerules` in parent directories in `custom-instructions.ts` and `open-file.ts`.
>     - Removes `searchParents` and `startFromWorkspace` options in `openFile()` in `open-file.ts`.
>   - **Tests**:
>     - Updates `custom-instructions.test.ts` to remove mock implementation for parent directory search.
>   - **UI**:
>     - Removes `searchParents` and `startFromWorkspace` options from `PromptsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 988ff761906b5e82137e4b4dc9e2287cbc6a4d5c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->