### PR TITLE
Support mcp image resource

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2874,8 +2874,16 @@ export class Cline extends EventEmitter<ClineEvents> {
 										})
 										.filter(Boolean)
 										.join("\n\n") || "(Empty response)"
-								await this.say("mcp_server_response", resourceResultPretty)
-								pushToolResult(formatResponse.toolResult(resourceResultPretty))
+
+								// handle images (image must contain mimetype and blob)
+								let images: string[] = []
+								resourceResult?.contents.forEach((item) => {
+									if (item.mimeType?.startsWith("image") && item.blob) {
+										images.push(item.blob)
+									}
+								});
+								await this.say("mcp_server_response", resourceResultPretty, images)
+								pushToolResult(formatResponse.toolResult(resourceResultPretty, images))
 								break
 							}
 						} catch (error) {


### PR DESCRIPTION
## Context
Support mcp image resource. The previous code ignored the blob field

## Implementation
Check resource mimeType and blob，then add image blob to images.

## How to Test

MCP resource like this:
```
return {
        contents: [{
          uri: uri.href,
          mimeType: "image/png",
          blob: `data:image/png;base64,${encodedImage}`
        }]};
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for handling image resources in MCP responses in `Cline.ts`.
> 
>   - **Behavior**:
>     - In `Cline.ts`, `access_mcp_resource` now checks for `mimeType` and `blob` in `resourceResult.contents`.
>     - If `mimeType` starts with "image" and `blob` is present, adds `blob` to `images` array.
>     - Passes `images` to `say()` and `pushToolResult()` functions.
>   - **Misc**:
>     - No changes to other parts of the codebase.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c33e2324b34a075ab9e170140b3c59b682d188f1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->