### PR TITLE
Added Gemini 2.5 Pro model to Google Gemini Provider

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -745,8 +745,16 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 // Gemini
 // https://ai.google.dev/gemini-api/docs/models/gemini
 export type GeminiModelId = keyof typeof geminiModels
-export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-001"
+export const geminiDefaultModelId: GeminiModelId = "gemini-2.5-pro-exp-03-25"
 export const geminiModels = {
+	"gemini-2.5-pro-exp-03-25": {
+		maxTokens: 8192,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+	},
 	"gemini-2.0-flash-001": {
 		maxTokens: 8192,
 		contextWindow: 1_048_576,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -745,7 +745,7 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 // Gemini
 // https://ai.google.dev/gemini-api/docs/models/gemini
 export type GeminiModelId = keyof typeof geminiModels
-export const geminiDefaultModelId: GeminiModelId = "gemini-2.5-pro-exp-03-25"
+export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-001"
 export const geminiModels = {
 	"gemini-2.5-pro-exp-03-25": {
 		maxTokens: 8192,


### PR DESCRIPTION
## Context

Added new Gemini 2.5 Pro Experimental to the Google Gemini Provider

## Implementation

Just added the model to the api file



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `gemini-2.5-pro-exp-03-25` model to `geminiModels` and set as default in `api.ts`.
> 
>   - **Models**:
>     - Add `gemini-2.5-pro-exp-03-25` to `geminiModels` in `api.ts` with `maxTokens: 8192`, `contextWindow: 1_048_576`, `supportsImages: true`, `supportsPromptCache: false`, `inputPrice: 0`, `outputPrice: 0`.
>     - Set `geminiDefaultModelId` to `gemini-2.5-pro-exp-03-25` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for db7ab1db9a5d36960d142dfcdbf0c19bfea8a8b8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->