### PR TITLE
Updated value of max tokens for gemini-2.5-pro-03-25 to correct one

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -748,7 +748,7 @@ export type GeminiModelId = keyof typeof geminiModels
 export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-001"
 export const geminiModels = {
 	"gemini-2.5-pro-exp-03-25": {
-		maxTokens: 8192,
+		maxTokens: 65_536,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,


### PR DESCRIPTION
## Context

Updated value of max token value for recently release gemini 2.5 pro 03-25

## Implementation


## Note
[Official documentation](https://ai.google.dev/gemini-api/docs/models#token-size) states that token limit is 64k but actual implementation on Google AI Studio uses 65536 as max output token limit


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updated `maxTokens` for `gemini-2.5-pro-exp-03-25` in `api.ts` to `65_536` to match Google AI Studio's implementation.
> 
>   - **Behavior**:
>     - Updated `maxTokens` for `gemini-2.5-pro-exp-03-25` in `api.ts` from `8192` to `65_536` to match Google AI Studio's implementation.
>   - **Documentation**:
>     - References official documentation stating a 64k token limit, but actual implementation uses `65_536`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 10d8d0df4b7af0dad550f8803be20956b443d852. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->