### PR TITLE
feat: add pinning and sorting for API configurations dropdown

### DIFF
--- a/src/core/config/ConfigManager.ts
+++ b/src/core/config/ConfigManager.ts
@@ -98,9 +98,12 @@ export class ConfigManager {
 			return await this.lock(async () => {
 				const currentConfig = await this.readConfig()
 
+				// Preserve the existing ID if this is an update to an existing config
+				const existingId = currentConfig.apiConfigs[name]?.id
+
 				currentConfig.apiConfigs[name] = {
 					...config,
-					id: config.id || this.generateId(),
+					id: config.id || existingId || this.generateId(),
 				}
 
 				await this.writeConfig(currentConfig)

--- a/src/core/config/ConfigManager.ts
+++ b/src/core/config/ConfigManager.ts
@@ -89,17 +89,20 @@ export class ConfigManager {
 	}
 
 	/**
-	 * Save a config with the given name
+	 * Save a config with the given name.
+	 * Preserves the ID from the input 'config' object if it exists,
+	 * otherwise generates a new one (for creation scenarios).
 	 */
 	async saveConfig(name: string, config: ApiConfiguration): Promise<void> {
 		try {
 			return await this.lock(async () => {
 				const currentConfig = await this.readConfig()
-				const existingConfig = currentConfig.apiConfigs[name]
+
 				currentConfig.apiConfigs[name] = {
 					...config,
-					id: existingConfig?.id || this.generateId(),
+					id: config.id || this.generateId(),
 				}
+
 				await this.writeConfig(currentConfig)
 			})
 		} catch (error) {
@@ -127,6 +130,34 @@ export class ConfigManager {
 			})
 		} catch (error) {
 			throw new Error(`Failed to load config: ${error}`)
+		}
+	}
+
+	/**
+	 * Load a config by ID
+	 */
+	async loadConfigById(id: string): Promise<{ config: ApiConfiguration; name: string }> {
+		try {
+			return await this.lock(async () => {
+				const config = await this.readConfig()
+
+				// Find the config with the matching ID
+				const entry = Object.entries(config.apiConfigs).find(([_, apiConfig]) => apiConfig.id === id)
+
+				if (!entry) {
+					throw new Error(`Config with ID '${id}' not found`)
+				}
+
+				const [name, apiConfig] = entry
+
+				// Update current config name
+				config.currentApiConfigName = name
+				await this.writeConfig(config)
+
+				return { config: apiConfig, name }
+			})
+		} catch (error) {
+			throw new Error(`Failed to load config by ID: ${error}`)
 		}
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1867,16 +1867,24 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 									break
 								}
 
-								await this.configManager.saveConfig(newName, message.apiConfiguration)
+								// Load the old configuration to get its ID
+								const oldConfig = await this.configManager.loadConfig(oldName)
+
+								// Create a new configuration with the same ID
+								const newConfig = {
+									...message.apiConfiguration,
+									id: oldConfig.id, // Preserve the ID
+								}
+
+								// Save with the new name but same ID
+								await this.configManager.saveConfig(newName, newConfig)
 								await this.configManager.deleteConfig(oldName)
 
 								const listApiConfig = await this.configManager.listConfig()
-								const config = listApiConfig?.find((c) => c.name === newName)
 
 								// Update listApiConfigMeta first to ensure UI has latest data
 								await this.updateGlobalState("listApiConfigMeta", listApiConfig)
-
-								await Promise.all([this.updateGlobalState("currentApiConfigName", newName)])
+								await this.updateGlobalState("currentApiConfigName", newName)
 
 								await this.postStateToWebview()
 							} catch (error) {
@@ -1903,6 +1911,29 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 							} catch (error) {
 								this.outputChannel.appendLine(
 									`Error load api configuration: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`,
+								)
+								vscode.window.showErrorMessage(t("common:errors.load_api_config"))
+							}
+						}
+						break
+					case "loadApiConfigurationById":
+						if (message.text) {
+							try {
+								const { config: apiConfig, name } = await this.configManager.loadConfigById(
+									message.text,
+								)
+								const listApiConfig = await this.configManager.listConfig()
+
+								await Promise.all([
+									this.updateGlobalState("listApiConfigMeta", listApiConfig),
+									this.updateGlobalState("currentApiConfigName", name),
+									this.updateApiConfiguration(apiConfig),
+								])
+
+								await this.postStateToWebview()
+							} catch (error) {
+								this.outputChannel.appendLine(
+									`Error load api configuration by ID: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`,
 								)
 								vscode.window.showErrorMessage(t("common:errors.load_api_config"))
 							}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1675,6 +1675,25 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 						await this.updateGlobalState("maxReadFileLine", message.value)
 						await this.postStateToWebview()
 						break
+					case "toggleApiConfigPin":
+						if (message.text) {
+							const currentPinned = ((await this.getGlobalState("pinnedApiConfigs")) || {}) as Record<
+								string,
+								boolean
+							>
+							const updatedPinned: Record<string, boolean> = { ...currentPinned }
+
+							// Toggle the pinned state
+							if (currentPinned[message.text]) {
+								delete updatedPinned[message.text]
+							} else {
+								updatedPinned[message.text] = true
+							}
+
+							await this.updateGlobalState("pinnedApiConfigs", updatedPinned)
+							await this.postStateToWebview()
+						}
+						break
 					case "enhancementApiConfigId":
 						await this.updateGlobalState("enhancementApiConfigId", message.text)
 						await this.postStateToWebview()
@@ -2610,6 +2629,9 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			language,
 			renderContext: this.renderContext,
 			maxReadFileLine: maxReadFileLine ?? 500,
+			pinnedApiConfigs:
+				((await this.getGlobalState("pinnedApiConfigs")) as Record<string, boolean>) ??
+				({} as Record<string, boolean>),
 		}
 	}
 

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -259,6 +259,7 @@ export type GlobalStateKey =
 	| "language"
 	| "maxReadFileLine"
 	| "fakeAi"
+	| "pinnedApiConfigs" // Record of API config names that should be pinned to the top of the API provides dropdown
 
 export type ConfigurationKey = GlobalStateKey | SecretKey
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -58,6 +58,7 @@ export interface ExtensionMessage {
 		| "ttsStop"
 		| "maxReadFileLine"
 		| "fileSearchResults"
+		| "toggleApiConfigPin"
 	text?: string
 	action?:
 		| "chatButtonClicked"
@@ -168,6 +169,7 @@ export interface ExtensionState {
 	machineId?: string
 	showRooIgnoredFiles: boolean // Whether to show .rooignore'd files in listings
 	renderContext: "sidebar" | "editor"
+	pinnedApiConfigs?: Record<string, boolean> // Map of API config names to pinned state
 	maxReadFileLine: number // Maximum number of lines to read from a file before truncating
 }
 

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -117,6 +117,7 @@ export interface WebviewMessage {
 		| "language"
 		| "maxReadFileLine"
 		| "searchFiles"
+		| "toggleApiConfigPin"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -17,6 +17,7 @@ export interface WebviewMessage {
 		| "upsertApiConfiguration"
 		| "deleteApiConfiguration"
 		| "loadApiConfiguration"
+		| "loadApiConfigurationById"
 		| "renameApiConfiguration"
 		| "getListApiConfiguration"
 		| "customInstructions"

--- a/src/shared/globalState.ts
+++ b/src/shared/globalState.ts
@@ -126,6 +126,7 @@ export const GLOBAL_STATE_KEYS = [
 	"maxWorkspaceFiles",
 	"maxReadFileLine",
 	"fakeAi",
+	"pinnedApiConfigs",
 ] as const
 
 export const PASS_THROUGH_STATE_KEYS = ["taskHistory"] as const

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1026,52 +1026,39 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								]}
 								onChange={(value) => {
 									if (value === "settingsButtonClicked") {
-										// Handle special actions
-										vscode.postMessage({
-											type: "loadApiConfiguration",
-											text: value,
-										})
+										vscode.postMessage({ type: "loadApiConfiguration", text: value })
 									} else {
-										// Use the ID directly with our new message type
-										vscode.postMessage({
-											type: "loadApiConfigurationById",
-											text: value,
-										})
+										vscode.postMessage({ type: "loadApiConfigurationById", text: value })
 									}
 								}}
 								contentClassName="max-h-[300px] overflow-y-auto"
 								triggerClassName="w-full text-ellipsis overflow-hidden"
-								renderItem={(option) => {
-									if (option.type !== DropdownOptionType.ITEM) {
-										return option.label
+								renderItem={({ type, value, label, pinned }) => {
+									if (type !== DropdownOptionType.ITEM) {
+										return label
 									}
 
-									// Get the config from listApiConfigMeta by ID
-									const config = listApiConfigMeta?.find((c) => c.id === option.value)
+									const config = listApiConfigMeta?.find((c) => c.id === value)
 									const isCurrentConfig = config?.name === currentApiConfigName
 
 									return (
-										<div className="flex items-center justify-between w-full">
-											<span>{option.label}</span>
-											<div
-												className={cn(
-													"ml-2 p-1 rounded-sm cursor-pointer hover:bg-[rgba(255,255,255,0.1)]",
-													option.pinned
-														? "text-vscode-focusBorder"
-														: "text-vscode-descriptionForeground opacity-50 hover:opacity-100",
-												)}
-												onClick={(e) => {
-													e.stopPropagation()
-													togglePinnedApiConfig(option.value)
-													vscode.postMessage({
-														type: "toggleApiConfigPin",
-														text: option.value, // Send ID as text
-													})
-												}}
-												title={option.pinned ? t("chat:unpin") : t("chat:pin")}>
-												<Pin className="size-3" />
+										<div className="flex items-center justify-between gap-2 w-full">
+											<div className={cn({ "font-medium": isCurrentConfig })}>{label}</div>
+											<div className="flex items-center gap-1">
+												<Button
+													variant="ghost"
+													size="icon"
+													title={pinned ? t("chat:unpin") : t("chat:pin")}
+													onClick={(e) => {
+														e.stopPropagation()
+														togglePinnedApiConfig(value)
+														vscode.postMessage({ type: "toggleApiConfigPin", text: value })
+													}}
+													className={cn("w-5 h-5", { "bg-accent": pinned })}>
+													<Pin className="size-3 p-0.5 opacity-50" />
+												</Button>
+												{isCurrentConfig && <Check className="size-3" />}
 											</div>
-											{isCurrentConfig && <Check className="size-4 p-0.5 ml-1" />}
 										</div>
 									)
 								}}

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -25,6 +25,7 @@ export interface DropdownOption {
 	label: string
 	disabled?: boolean
 	type?: DropdownOptionType
+	pinned?: boolean
 }
 
 export interface SelectDropdownProps {
@@ -39,6 +40,7 @@ export interface SelectDropdownProps {
 	align?: "start" | "center" | "end"
 	placeholder?: string
 	shortcutText?: string
+	renderItem?: (option: DropdownOption) => React.ReactNode
 }
 
 export const SelectDropdown = React.forwardRef<React.ElementRef<typeof DropdownMenuTrigger>, SelectDropdownProps>(
@@ -55,6 +57,7 @@ export const SelectDropdown = React.forwardRef<React.ElementRef<typeof DropdownM
 			align = "start",
 			placeholder = "",
 			shortcutText = "",
+			renderItem,
 		},
 		ref,
 	) => {
@@ -121,11 +124,17 @@ export const SelectDropdown = React.forwardRef<React.ElementRef<typeof DropdownM
 								key={`item-${option.value}`}
 								disabled={option.disabled}
 								onClick={() => handleSelect(option)}>
-								{option.label}
-								{option.value === value && (
-									<DropdownMenuShortcut>
-										<Check className="size-4 p-0.5" />
-									</DropdownMenuShortcut>
+								{renderItem ? (
+									renderItem(option)
+								) : (
+									<>
+										{option.label}
+										{option.value === value && (
+											<DropdownMenuShortcut>
+												<Check className="size-4 p-0.5" />
+											</DropdownMenuShortcut>
+										)}
+									</>
 								)}
 							</DropdownMenuItem>
 						)

--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -64,8 +64,10 @@ export const SelectDropdown = React.forwardRef<React.ElementRef<typeof DropdownM
 		const [open, setOpen] = React.useState(false)
 		const portalContainer = useRooPortal("roo-portal")
 
+		// If the selected option isn't in the list yet, but we have a placeholder, prioritize showing the placeholder
 		const selectedOption = options.find((option) => option.value === value)
-		const displayText = selectedOption?.label || placeholder || ""
+		const displayText =
+			value && !selectedOption && placeholder ? placeholder : selectedOption?.label || placeholder || ""
 
 		const handleSelect = (option: DropdownOption) => {
 			if (option.type === DropdownOptionType.ACTION) {

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -225,27 +225,6 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 					setListApiConfigMeta(message.listApiConfig ?? [])
 					break
 				}
-				case "toggleApiConfigPin": {
-					if (message.text) {
-						setState((prevState) => {
-							const currentPinned = prevState.pinnedApiConfigs || {}
-							const newPinned = { ...currentPinned }
-
-							// Toggle the pinned state
-							if (currentPinned[message.text!]) {
-								delete newPinned[message.text!]
-							} else {
-								newPinned[message.text!] = true
-							}
-
-							return {
-								...prevState,
-								pinnedApiConfigs: newPinned,
-							}
-						})
-					}
-					break
-				}
 			}
 		},
 		[setListApiConfigMeta],
@@ -333,17 +312,17 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		setRemoteBrowserEnabled: (value) => setState((prevState) => ({ ...prevState, remoteBrowserEnabled: value })),
 		setMaxReadFileLine: (value) => setState((prevState) => ({ ...prevState, maxReadFileLine: value })),
 		setPinnedApiConfigs: (value) => setState((prevState) => ({ ...prevState, pinnedApiConfigs: value })),
-		togglePinnedApiConfig: (configName) =>
+		togglePinnedApiConfig: (configId) =>
 			setState((prevState) => {
 				const currentPinned = prevState.pinnedApiConfigs || {}
 				const newPinned = {
 					...currentPinned,
-					[configName]: !currentPinned[configName],
+					[configId]: !currentPinned[configId],
 				}
 
 				// If the config is now unpinned, remove it from the object
-				if (!newPinned[configName]) {
-					delete newPinned[configName]
+				if (!newPinned[configId]) {
+					delete newPinned[configId]
 				}
 
 				return { ...prevState, pinnedApiConfigs: newPinned }


### PR DESCRIPTION
Added the ability to pin/unpin API configurations, enabling prioritized appearance in dropdown menus.
- modified state management to support storing pinned configurations persistently.
- Updated UI components to display and toggle pin states
- Adjusted backend handling for syncing pinned configuration states across sessions.

## Context

Convenience feature for accessing frequently used API configurations

![CleanShot 2025-03-26 at 12 04 23](https://github.com/user-attachments/assets/438fc363-2153-474f-b6e7-f8b44cf16218)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add pinning and sorting functionality for API configurations in dropdown menus, with state management and UI updates.
> 
>   - **Behavior**:
>     - Add pin/unpin functionality for API configurations in `ClineProvider.ts` and `ChatTextArea.tsx`.
>     - Update `toggleApiConfigPin` case in `ClineProvider.ts` to manage pinned state.
>     - Modify `SelectDropdown` in `select-dropdown.tsx` to render pin icons and handle pinning actions.
>   - **State Management**:
>     - Add `pinnedApiConfigs` to `ExtensionState` in `ExtensionStateContext.tsx`.
>     - Implement `togglePinnedApiConfig` function in `ExtensionStateContext.tsx` to toggle pin state.
>   - **UI Components**:
>     - Update `ChatTextArea.tsx` to display pinned configurations at the top of the dropdown.
>     - Add pin/unpin icons using `Pin` and `Check` from `lucide-react` in `ChatTextArea.tsx`.
>   - **Misc**:
>     - Add `pinnedApiConfigs` to `GlobalStateKey` in `globalState.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 06055c33dcb023c3a70b27aeb82e701fc6d7867a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->