### PR TITLE
Fix mention file name is not fully displayed

### DIFF
--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -17,12 +17,15 @@ interface CodeAccordianProps {
 }
 
 /*
-We need to remove leading non-alphanumeric characters from the path in order for our leading ellipses trick to work.
-^: Anchors the match to the start of the string.
-[^a-zA-Z0-9]+: Matches one or more characters that are not alphanumeric.
-The replace method removes these matched characters, effectively trimming the string up to the first alphanumeric character.
+We need to remove certain leading characters from the path in order for our leading ellipses trick to work.
+However, we want to preserve all language characters (including CJK, Cyrillic, etc.) and only remove specific
+punctuation that might interfere with the ellipsis display.
 */
-export const removeLeadingNonAlphanumeric = (path: string): string => path.replace(/^[^a-zA-Z0-9]+/, "")
+export const removeLeadingNonAlphanumeric = (path: string): string => {
+	// Only remove specific punctuation characters that might interfere with ellipsis display
+	// Keep all language characters (including CJK, Cyrillic, etc.) and numbers
+	return path.replace(/^[/\\:*?"<>|]+/, "")
+}
 
 const CodeAccordian = ({
 	code,


### PR DESCRIPTION

## Context

Fixed path leading character handling to preserve language characters and remove specific punctuation marks

## Implementation

Only remove specific punctuation characters that might interfere with ellipsis display

## Screenshots

| before | after |
| ------ | ----- |
|   ![image](https://github.com/user-attachments/assets/b57bf808-c9bd-4d8c-8ea5-649fa0daa160)     |    ![image](https://github.com/user-attachments/assets/b8c01f4f-7c14-458e-917e-1948d5d8f105)   |

## How to Test

- Create a Chinese file or directory in the root directory.
- `@context` mention file and observe the list

## Get in Touch

aheizi

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves file name display in mentions by preserving language characters and removing specific punctuation in `CodeAccordian.tsx`.
> 
>   - **Behavior**:
>     - `removeLeadingNonAlphanumeric` in `CodeAccordian.tsx` now preserves language characters (CJK, Cyrillic, etc.) and removes only specific punctuation (`/^[/\\:*?"<>|]+/`).
>     - Improves display of file names with leading language characters and specific punctuation.
>   - **Testing**:
>     - Tested with Chinese file or directory names to ensure correct display in mentions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 12da50377da963cb96673fc99ad4be3a8ef2d5c7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->