### PR TITLE
Limits output tokens to 8192 for all models on Unbound

### DIFF
--- a/.changeset/chatty-years-study.md
+++ b/.changeset/chatty-years-study.md
@@ -1,0 +1,6 @@
+---
+"roo-cline": patch
+---
+
+Limits the maximum output tokens for all models to 8192 tokens.
+This is done to improve performance

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -210,15 +210,9 @@ export async function getUnboundModels() {
 					cacheReadsPrice: model?.cacheReadPrice ? parseFloat(model.cacheReadPrice) : undefined,
 				}
 
-				switch (true) {
-					case modelId.startsWith("anthropic/"):
-						// Set max tokens to 8192 for supported Anthropic models
-						if (modelInfo.maxTokens !== 4096) {
-							modelInfo.maxTokens = 8192
-						}
-						break
-					default:
-						break
+				// Restrict max tokens to 8192 for all models
+				if (modelInfo.maxTokens && modelInfo.maxTokens > 8192) {
+					modelInfo.maxTokens = 8192
 				}
 
 				models[modelId] = modelInfo


### PR DESCRIPTION
## Context

The output tokens for all models is being limit to 8192 tokens.
<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

Changes the max output tokens after fetching all models from /models.
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Limits `maxTokens` to 8192 for all models in `getUnboundModels()` in `unbound.ts`, with tests added in `unbound.test.ts`.
> 
>   - **Behavior**:
>     - Limits `maxTokens` to 8192 for all models in `getUnboundModels()` in `unbound.ts`.
>     - Models with `maxTokens` greater than 8192 are restricted to 8192.
>     - Models with `maxTokens` of 4096 or less remain unchanged.
>   - **Tests**:
>     - Added tests in `unbound.test.ts` to verify `maxTokens` restriction to 8192 for models exceeding this limit.
>     - Tests ensure models with `maxTokens` of 4096 or less are unaffected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 13b2304a770b0cb7155a49a714b221862c02f973. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->