### PR TITLE
Fix list_code_definition_names to support files

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2505,10 +2505,10 @@ export class Cline extends EventEmitter<ClineEvents> {
 						}
 					}
 					case "list_code_definition_names": {
-						const relDirPath: string | undefined = block.params.path
+						const relPath: string | undefined = block.params.path
 						const sharedMessageProps: ClineSayTool = {
 							tool: "listCodeDefinitionNames",
-							path: getReadablePath(this.cwd, removeClosingTag("path", relDirPath)),
+							path: getReadablePath(this.cwd, removeClosingTag("path", relPath)),
 						}
 						try {
 							if (block.partial) {
@@ -2519,7 +2519,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 								await this.ask("tool", partialMessage, block.partial).catch(() => {})
 								break
 							} else {
-								if (!relDirPath) {
+								if (!relPath) {
 									this.consecutiveMistakeCount++
 									pushToolResult(
 										await this.sayAndCreateMissingParamError("list_code_definition_names", "path"),
@@ -2527,11 +2527,27 @@ export class Cline extends EventEmitter<ClineEvents> {
 									break
 								}
 								this.consecutiveMistakeCount = 0
-								const absolutePath = path.resolve(this.cwd, relDirPath)
-								const result = await parseSourceCodeForDefinitionsTopLevel(
-									absolutePath,
-									this.rooIgnoreController,
-								)
+								const absolutePath = path.resolve(this.cwd, relPath)
+								let result: string
+								try {
+									const stats = await fs.stat(absolutePath)
+									if (stats.isFile()) {
+										const fileResult = await parseSourceCodeDefinitionsForFile(
+											absolutePath,
+											this.rooIgnoreController,
+										)
+										result = fileResult ?? "No source code definitions found in this file."
+									} else if (stats.isDirectory()) {
+										result = await parseSourceCodeForDefinitionsTopLevel(
+											absolutePath,
+											this.rooIgnoreController,
+										)
+									} else {
+										result = "The specified path is neither a file nor a directory."
+									}
+								} catch {
+									result = `${absolutePath}: does not exist or cannot be accessed.`
+								}
 								const completeMessage = JSON.stringify({
 									...sharedMessageProps,
 									content: result,

--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -122,17 +122,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -512,17 +519,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -991,17 +1005,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -1434,17 +1455,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -1824,17 +1852,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -2214,17 +2249,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -2604,17 +2646,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -3043,17 +3092,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -3501,17 +3557,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -3940,17 +4003,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## apply_diff
@@ -4392,17 +4462,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -4824,17 +4901,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -5376,17 +5460,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file
@@ -5842,17 +5933,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## ask_followup_question
@@ -6206,17 +6304,24 @@ Example: Requesting to list all files in the current directory
 </list_files>
 
 ## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory /test/path) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory /test/path) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>
 
 ## write_to_file

--- a/src/core/prompts/tools/list-code-definition-names.ts
+++ b/src/core/prompts/tools/list-code-definition-names.ts
@@ -2,16 +2,23 @@ import { ToolArgs } from "./types"
 
 export function getListCodeDefinitionNamesDescription(args: ToolArgs): string {
 	return `## list_code_definition_names
-Description: Request to list definition names (classes, functions, methods, etc.) used in source code files at the top level of the specified directory. This tool provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
+Description: Request to list definition names (classes, functions, methods, etc.) from source code. This tool can analyze either a single file or all files at the top level of a specified directory. It provides insights into the codebase structure and important constructs, encapsulating high-level concepts and relationships that are crucial for understanding the overall architecture.
 Parameters:
-- path: (required) The path of the directory (relative to the current working directory ${args.cwd}) to list top level source code definitions for.
+- path: (required) The path of the file or directory (relative to the current working directory ${args.cwd}) to analyze. When given a directory, it lists definitions from all top-level source files.
 Usage:
 <list_code_definition_names>
 <path>Directory path here</path>
 </list_code_definition_names>
 
-Example: Requesting to list all top level source code definitions in the current directory
+Examples:
+
+1. List definitions from a specific file:
 <list_code_definition_names>
-<path>.</path>
+<path>src/main.ts</path>
+</list_code_definition_names>
+
+2. List definitions from all files in a directory:
+<list_code_definition_names>
+<path>src/</path>
 </list_code_definition_names>`
 }


### PR DESCRIPTION
This PR fixes the 'cwd option must be a path to a directory' error when using list_code_definition_names with file paths.

## Changes
- Add support for analyzing individual source files
- Update tool description to clarify file and directory usage
- Improve error messages for invalid paths

## Before
```xml
<list_code_definition_names>
<path>src/core/Cline.ts</path>
</list_code_definition_names>
```

Would produce an error:

![image](https://github.com/user-attachments/assets/df80de99-2431-4684-b3f8-a0ceb864817e)

```xml
<error>
Error parsing source code definitions: {"name":"Error","message":"The `cwd` option must be a path to a directory","stack":"Error: The `cwd` option must be a path to a directory\n ... "}
</error>
```

## After
```xml
<list_code_definition_names>
<path>src/core/Cline.ts</path>
</list_code_definition_names>
```

Now produces useful code definitions:
```
# Cline.ts
122--4296 | export class Cline extends EventEmitter<ClineEvents> {
125--127 | get cwd() {
181--252 | constructor({
...
```
