### PR TITLE
Preserve existing provider profiles when importing

### DIFF
--- a/.changeset/honest-walls-search.md
+++ b/.changeset/honest-walls-search.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Preserve existing provider profiles when importing


### PR DESCRIPTION
## Context

When importing a set of provider profiles, don't clobber the existing ones unless there is a name collision.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `importSettings` now preserves existing provider profiles during import, merging them with new profiles unless there's a name collision, with tests updated accordingly.
> 
>   - **Behavior**:
>     - `importSettings` in `importExport.ts` now merges existing and new provider profiles, preserving existing ones unless there's a name collision.
>     - Adds a test case in `importExport.test.ts` to verify that existing profiles are not clobbered during import.
>   - **Tests**:
>     - Updates `importExport.test.ts` to include a test for preserving existing provider profiles during import.
>     - Mocks `vscode`, `fs/promises`, and `os` modules for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4cd92bdf78e178e43bfd466eece9ac1fe7dc9254. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->