### PR TITLE
Remove unused ClineSay and -Ask type variants

### DIFF
--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -339,12 +339,10 @@ type ClineMessage = {
 				| "mistake_limit_reached"
 				| "browser_action_launch"
 				| "use_mcp_server"
-				| "finishTask"
 		  )
 		| undefined
 	say?:
 		| (
-				| "task"
 				| "error"
 				| "api_req_started"
 				| "api_req_finished"
@@ -357,15 +355,11 @@ type ClineMessage = {
 				| "user_feedback"
 				| "user_feedback_diff"
 				| "command_output"
-				| "tool"
 				| "shell_integration_warning"
 				| "browser_action"
 				| "browser_action_result"
-				| "command"
 				| "mcp_server_request_started"
 				| "mcp_server_response"
-				| "new_task_started"
-				| "new_task"
 				| "checkpoint_saved"
 				| "rooignore_error"
 		  )

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -344,12 +344,10 @@ type ClineMessage = {
 				| "mistake_limit_reached"
 				| "browser_action_launch"
 				| "use_mcp_server"
-				| "finishTask"
 		  )
 		| undefined
 	say?:
 		| (
-				| "task"
 				| "error"
 				| "api_req_started"
 				| "api_req_finished"
@@ -362,15 +360,11 @@ type ClineMessage = {
 				| "user_feedback"
 				| "user_feedback_diff"
 				| "command_output"
-				| "tool"
 				| "shell_integration_warning"
 				| "browser_action"
 				| "browser_action_result"
-				| "command"
 				| "mcp_server_request_started"
 				| "mcp_server_response"
-				| "new_task_started"
-				| "new_task"
 				| "checkpoint_saved"
 				| "rooignore_error"
 		  )

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -701,7 +701,6 @@ export const clineAsks = [
 	"mistake_limit_reached",
 	"browser_action_launch",
 	"use_mcp_server",
-	"finishTask",
 ] as const
 
 export const clineAskSchema = z.enum(clineAsks)
@@ -711,7 +710,6 @@ export type ClineAsk = z.infer<typeof clineAskSchema>
 // ClineSay
 
 export const clineSays = [
-	"task",
 	"error",
 	"api_req_started",
 	"api_req_finished",
@@ -724,15 +722,11 @@ export const clineSays = [
 	"user_feedback",
 	"user_feedback_diff",
 	"command_output",
-	"tool",
 	"shell_integration_warning",
 	"browser_action",
 	"browser_action_result",
-	"command",
 	"mcp_server_request_started",
 	"mcp_server_response",
-	"new_task_started",
-	"new_task",
 	"checkpoint_saved",
 	"rooignore_error",
 ] as const

--- a/webview-ui/src/__tests__/ContextWindowProgress.test.tsx
+++ b/webview-ui/src/__tests__/ContextWindowProgress.test.tsx
@@ -40,7 +40,7 @@ describe("ContextWindowProgress", () => {
 		const defaultTask = {
 			ts: Date.now(),
 			type: "say" as const,
-			say: "task" as const,
+			say: "text" as const,
 			text: "Test task",
 		}
 

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -245,11 +245,11 @@ export const ChatRowContent = ({
 	}
 
 	const tool = useMemo(() => {
-		if (message.ask === "tool" || message.say === "tool") {
+		if (message.ask === "tool") {
 			return JSON.parse(message.text || "{}") as ClineSayTool
 		}
 		return null
-	}, [message.ask, message.say, message.text])
+	}, [message.ask, message.text])
 
 	const followUpData = useMemo(() => {
 		if (message.type === "ask" && message.ask === "followup" && !message.partial) {

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -247,7 +247,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 							}
 							break
 						case "api_req_finished":
-						case "task":
 						case "error":
 						case "text":
 						case "browser_action":
@@ -256,7 +255,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "mcp_server_request_started":
 						case "mcp_server_response":
 						case "completion_result":
-						case "tool":
 							break
 					}
 					break


### PR DESCRIPTION
## Context

Some variants of `ClineSay` and `ClineAsk` are unused.
During rebasing of https://github.com/RooVetGit/Roo-Code/pull/2003, I decided it would be good to split the PR into two.

## Implementation

Remove them.

## Screenshots

None.

## How to Test

Check if compiles and tests are passing.

## Get in Touch

Discord handle: wkordalski