### PR TITLE
[Bugfix] Await ask during read file

### DIFF
--- a/src/core/tools/readFileTool.ts
+++ b/src/core/tools/readFileTool.ts
@@ -41,7 +41,11 @@ export async function readFileTool(
 						...sharedMessageProps,
 						content: undefined,
 					} satisfies ClineSayTool)
-					await cline.ask("tool", partialMessage, block.partial).catch(() => {})
+					try {
+						await cline.ask("tool", partialMessage, block.partial)
+					} catch (innerError) {
+						pushToolResult(formatResponse.toolError("Failed to send partial message"))
+					}
 					break
 				} else {
 					if (!relPath) {


### PR DESCRIPTION
## Context

Fixes intermittent "Current ask promise was ignored" during file read with new read tool introduced in #2059 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds error handling for `cline.ask` in `readFileTool` to prevent ignored promise errors during file reads.
> 
>   - **Behavior**:
>     - Adds error handling for `cline.ask` in `readFileTool` to prevent 'Current ask promise was ignored' errors.
>     - If `cline.ask` fails, logs error using `pushToolResult` with a formatted tool error message.
>   - **Files**:
>     - Modifies `readFileTool.ts` to include a `try-catch` block around `cline.ask`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2e227e9643f256e0df071442e99fb81bbf2a5a9a. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->