### PR TITLE
Add an activation command for other extensions

### DIFF
--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -50,6 +50,7 @@ export const registerCommands = (options: RegisterCommandOptions) => {
 
 const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOptions) => {
 	return {
+		"roo-cline.activationCompleted": () => {},
 		"roo-cline.plusButtonClicked": async () => {
 			await provider.removeClineFromStack()
 			await provider.postStateToWebview()

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -115,6 +115,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	registerCodeActions(context)
 	registerTerminalActions(context)
 
+	// Allows other extensions to activate once Roo is ready.
+	vscode.commands.executeCommand('roo-cline.activationCompleted');
+
 	// Implements the `RooCodeAPI` interface.
 	return new API(outputChannel, provider)
 }


### PR DESCRIPTION
## Context

Since VS Code provides no actionEvents that trigger when a specific extension activates, extensions can't activate only once Roo is activated and ready. This means that all other extensions have to activate at IDE time and poll for dependent extension(s). This leads to reinvented boilerplate and can also negatively impact VS Code start times.

As some added context, my company is writing a separate extension that manages Roo's configuration. We want to activate this extension once/only if Roo is already activated.

## Implementation

This commit introduces a new roo-cline.activationCompleted command and fires it at the very end of extension activation. Other extensions that use Roo's exported APIs can now activate when they see this event.

Note that I have not added the command to package.json since I don't want it to show up in the command palette. 

## How to Test

* Stick a temporary vscode.window.showWarningMessage into the command definition and start VS Code + Roo in dev mode.
* You should see your warning message
* If you're feeling especially motivated you can go a step further:
  * Create another extension
  * Set it up to activate on `roo-cline.activationCompleted` events
  * Have it fire off a log/print/message when the dependent extension activates


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `roo-cline.activationCompleted` command to signal Roo extension activation completion for dependent extensions.
> 
>   - **Behavior**:
>     - Adds `roo-cline.activationCompleted` command in `registerCommands.ts` to signal Roo extension activation completion.
>     - Executes `roo-cline.activationCompleted` in `activate()` in `extension.ts` to notify dependent extensions.
>   - **Misc**:
>     - Command not added to `package.json` to prevent it from appearing in the command palette.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 08ce78629fcb7b006d1520c46e0582ceb58d244c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->