### PR TITLE
Add missing awaits on refactored tools

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2255,12 +2255,12 @@ export class Cline extends EventEmitter<ClineEvents> {
 					}
 
 					case "read_file": {
-						readFileTool(this, block, askApproval, handleError, pushToolResult, removeClosingTag)
+						await readFileTool(this, block, askApproval, handleError, pushToolResult, removeClosingTag)
 						break
 					}
 
 					case "fetch_instructions": {
-						fetchInstructionsTool(this, block, askApproval, handleError, pushToolResult)
+						await fetchInstructionsTool(this, block, askApproval, handleError, pushToolResult)
 						break
 					}
 


### PR DESCRIPTION
#2069 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add missing `await` to `readFileTool()` and `fetchInstructionsTool()` calls in `Cline.ts` for proper asynchronous handling.
> 
>   - **Behavior**:
>     - Add missing `await` to `readFileTool()` and `fetchInstructionsTool()` calls in `Cline.ts` to ensure proper asynchronous handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3ea644043146dd7d4a92e13e4a5b9d2990774a45. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->