### PR TITLE
Added Gemini 2.5 Pro model to GCP Vertex AI Provider

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -464,6 +464,14 @@ export const vertexModels = {
 		inputPrice: 0.15,
 		outputPrice: 0.6,
 	},
+	"gemini-2.5-pro-exp-03-25": {
+		maxTokens: 65_535,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+	},
 	"gemini-2.0-pro-exp-02-05": {
 		maxTokens: 8192,
 		contextWindow: 2_097_152,


### PR DESCRIPTION
## Context

Added new Gemini 2.5 Pro Experimental to the GCP Vertex AI Provider

## Implementation

Added the model to the list of Vertex models

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Added `gemini-2.5-pro-exp-03-25` model to Vertex AI provider in `api.ts`.
> 
>   - **Vertex AI Provider**:
>     - Added `gemini-2.5-pro-exp-03-25` model to `vertexModels` in `api.ts`.
>     - Model specifications: `maxTokens` 65,535, `contextWindow` 1,048,576, `supportsImages` true, `supportsPromptCache` false, `inputPrice` 0, `outputPrice` 0.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c98ab69fffd4c515c3dd5abf94f2de27c7d7c195. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->