### PR TITLE
Display info about partial reads in chat row

### DIFF
--- a/src/i18n/locales/ca/tools.json
+++ b/src/i18n/locales/ca/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (línies {{start}}-{{end}})",
+		"linesFromToEnd": " (línies {{start}}-final)",
+		"linesFromStartTo": " (línies 1-{{end}})",
+		"definitionsOnly": " (només definicions)",
+		"maxLines": " (màxim {{max}} línies)"
+	}
+}

--- a/src/i18n/locales/de/tools.json
+++ b/src/i18n/locales/de/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (Zeilen {{start}}-{{end}})",
+		"linesFromToEnd": " (Zeilen {{start}}-Ende)",
+		"linesFromStartTo": " (Zeilen 1-{{end}})",
+		"definitionsOnly": " (nur Definitionen)",
+		"maxLines": " (maximal {{max}} Zeilen)"
+	}
+}

--- a/src/i18n/locales/en/tools.json
+++ b/src/i18n/locales/en/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (lines {{start}}-{{end}})",
+		"linesFromToEnd": " (lines {{start}}-end)",
+		"linesFromStartTo": " (lines 1-{{end}})",
+		"definitionsOnly": " (definitions only)",
+		"maxLines": " (max {{max}} lines)"
+	}
+}

--- a/src/i18n/locales/es/tools.json
+++ b/src/i18n/locales/es/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (líneas {{start}}-{{end}})",
+		"linesFromToEnd": " (líneas {{start}}-final)",
+		"linesFromStartTo": " (líneas 1-{{end}})",
+		"definitionsOnly": " (solo definiciones)",
+		"maxLines": " (máximo {{max}} líneas)"
+	}
+}

--- a/src/i18n/locales/fr/tools.json
+++ b/src/i18n/locales/fr/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (lignes {{start}}-{{end}})",
+		"linesFromToEnd": " (lignes {{start}}-fin)",
+		"linesFromStartTo": " (lignes 1-{{end}})",
+		"definitionsOnly": " (définitions uniquement)",
+		"maxLines": " (max {{max}} lignes)"
+	}
+}

--- a/src/i18n/locales/hi/tools.json
+++ b/src/i18n/locales/hi/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (पंक्तियाँ {{start}}-{{end}})",
+		"linesFromToEnd": " (पंक्तियाँ {{start}}-अंत)",
+		"linesFromStartTo": " (पंक्तियाँ 1-{{end}})",
+		"definitionsOnly": " (केवल परिभाषाएँ)",
+		"maxLines": " (अधिकतम {{max}} पंक्तियाँ)"
+	}
+}

--- a/src/i18n/locales/it/tools.json
+++ b/src/i18n/locales/it/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (righe {{start}}-{{end}})",
+		"linesFromToEnd": " (righe {{start}}-fine)",
+		"linesFromStartTo": " (righe 1-{{end}})",
+		"definitionsOnly": " (solo definizioni)",
+		"maxLines": " (max {{max}} righe)"
+	}
+}

--- a/src/i18n/locales/ja/tools.json
+++ b/src/i18n/locales/ja/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " ({{start}}-{{end}}行目)",
+		"linesFromToEnd": " ({{start}}行目-最後まで)",
+		"linesFromStartTo": " (1-{{end}}行目)",
+		"definitionsOnly": " (定義のみ)",
+		"maxLines": " (最大{{max}}行)"
+	}
+}

--- a/src/i18n/locales/ko/tools.json
+++ b/src/i18n/locales/ko/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " ({{start}}-{{end}}행)",
+		"linesFromToEnd": " ({{start}}행-끝)",
+		"linesFromStartTo": " (1-{{end}}행)",
+		"definitionsOnly": " (정의만)",
+		"maxLines": " (최대 {{max}}행)"
+	}
+}

--- a/src/i18n/locales/pl/tools.json
+++ b/src/i18n/locales/pl/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (linie {{start}}-{{end}})",
+		"linesFromToEnd": " (linie {{start}}-koniec)",
+		"linesFromStartTo": " (linie 1-{{end}})",
+		"definitionsOnly": " (tylko definicje)",
+		"maxLines": " (maks. {{max}} linii)"
+	}
+}

--- a/src/i18n/locales/pt-BR/tools.json
+++ b/src/i18n/locales/pt-BR/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (linhas {{start}}-{{end}})",
+		"linesFromToEnd": " (linhas {{start}}-fim)",
+		"linesFromStartTo": " (linhas 1-{{end}})",
+		"definitionsOnly": " (apenas definições)",
+		"maxLines": " (máx. {{max}} linhas)"
+	}
+}

--- a/src/i18n/locales/tr/tools.json
+++ b/src/i18n/locales/tr/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (satır {{start}}-{{end}})",
+		"linesFromToEnd": " (satır {{start}}-son)",
+		"linesFromStartTo": " (satır 1-{{end}})",
+		"definitionsOnly": " (sadece tanımlar)",
+		"maxLines": " (maks. {{max}} satır)"
+	}
+}

--- a/src/i18n/locales/vi/tools.json
+++ b/src/i18n/locales/vi/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (dòng {{start}}-{{end}})",
+		"linesFromToEnd": " (dòng {{start}}-cuối)",
+		"linesFromStartTo": " (dòng 1-{{end}})",
+		"definitionsOnly": " (chỉ định nghĩa)",
+		"maxLines": " (tối đa {{max}} dòng)"
+	}
+}

--- a/src/i18n/locales/zh-CN/tools.json
+++ b/src/i18n/locales/zh-CN/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (第 {{start}}-{{end}} 行)",
+		"linesFromToEnd": " (第 {{start}} 行至末尾)",
+		"linesFromStartTo": " (第 1-{{end}} 行)",
+		"definitionsOnly": " (仅定义)",
+		"maxLines": " (最多 {{max}} 行)"
+	}
+}

--- a/src/i18n/locales/zh-TW/tools.json
+++ b/src/i18n/locales/zh-TW/tools.json
@@ -1,0 +1,9 @@
+{
+	"readFile": {
+		"linesRange": " (第 {{start}}-{{end}} 行)",
+		"linesFromToEnd": " (第 {{start}} 行至末尾)",
+		"linesFromStartTo": " (第 1-{{end}} 行)",
+		"definitionsOnly": " (僅定義)",
+		"maxLines": " (最多 {{max}} 行)"
+	}
+}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -356,6 +356,7 @@ export const ChatRowContent = ({
 										textAlign: "left",
 									}}>
 									{removeLeadingNonAlphanumeric(tool.path ?? "") + "\u200E"}
+									{tool.reason}
 								</span>
 								<div style={{ flexGrow: 1 }}></div>
 								<span


### PR DESCRIPTION
![Screenshot 2025-03-29 at 2 01 47 AM](https://github.com/user-attachments/assets/79c954b0-0321-4d0a-ac0d-306ad725441e)

![Screenshot 2025-03-29 at 2 01 34 AM](https://github.com/user-attachments/assets/328c9816-6ecf-475b-bb3d-f662f241972e)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds partial read information display in chat row and updates i18n strings for multiple languages.
> 
>   - **Behavior**:
>     - Adds `reason` field to `readFileTool` in `readFileTool.ts` to describe partial read information.
>     - Displays `reason` in `ChatRowContent` in `ChatRow.tsx`.
>   - **i18n**:
>     - Adds new translation strings for partial read descriptions in `tools.json` for multiple languages including `en`, `es`, `fr`, `de`, `hi`, `it`, `ja`, `ko`, `pl`, `pt-BR`, `tr`, `vi`, `zh-CN`, and `zh-TW`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4b69df8cb6186b9e57e4b36a4a7979a05f47d71e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->