### PR TITLE
Fix a type in the listFiles tool

### DIFF
--- a/src/core/tools/listFilesTool.ts
+++ b/src/core/tools/listFilesTool.ts
@@ -5,7 +5,7 @@ import { ToolParamName, ToolUse } from "../assistant-message"
 import { formatResponse } from "../prompts/responses"
 import { listFiles } from "../../services/glob/list-files"
 import { getReadablePath } from "../../utils/path"
-import { AskApproval, HandleError, PushToolResult } from "./types"
+import { AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "./types"
 /**
  * Implements the list_files tool.
  *
@@ -26,7 +26,7 @@ export async function listFilesTool(
 	askApproval: AskApproval,
 	handleError: HandleError,
 	pushToolResult: PushToolResult,
-	removeClosingTag: (tag: ToolParamName, text?: string) => string,
+	removeClosingTag: RemoveClosingTag,
 ) {
 	const relDirPath: string | undefined = block.params.path
 	const recursiveRaw: string | undefined = block.params.recursive


### PR DESCRIPTION
MIssed this in the review
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrected the type of `removeClosingTag` in `listFilesTool` function signature to `RemoveClosingTag`.
> 
>   - **Type Correction**:
>     - Corrected the type of `removeClosingTag` in `listFilesTool` function signature to `RemoveClosingTag` in `listFilesTool.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0fdb047fde8e4c1e6e026cb59697635008dbe23e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->