### PR TITLE
Move search_files to a tool file

### DIFF
--- a/src/core/tools/searchFilesTool.ts
+++ b/src/core/tools/searchFilesTool.ts
@@ -1,0 +1,69 @@
+import { Cline } from "../Cline"
+import { ToolUse } from "../assistant-message"
+import { AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "./types"
+import { ClineSayTool } from "../../shared/ExtensionMessage"
+import { getReadablePath } from "../../utils/path"
+import path from "path"
+import { regexSearchFiles } from "../../services/ripgrep"
+
+export async function searchFilesTool(
+	cline: Cline,
+	block: ToolUse,
+	askApproval: AskApproval,
+	handleError: HandleError,
+	pushToolResult: PushToolResult,
+	removeClosingTag: RemoveClosingTag,
+) {
+	const relDirPath: string | undefined = block.params.path
+	const regex: string | undefined = block.params.regex
+	const filePattern: string | undefined = block.params.file_pattern
+	const sharedMessageProps: ClineSayTool = {
+		tool: "searchFiles",
+		path: getReadablePath(cline.cwd, removeClosingTag("path", relDirPath)),
+		regex: removeClosingTag("regex", regex),
+		filePattern: removeClosingTag("file_pattern", filePattern),
+	}
+	try {
+		if (block.partial) {
+			const partialMessage = JSON.stringify({
+				...sharedMessageProps,
+				content: "",
+			} satisfies ClineSayTool)
+			await cline.ask("tool", partialMessage, block.partial).catch(() => {})
+			return
+		} else {
+			if (!relDirPath) {
+				cline.consecutiveMistakeCount++
+				pushToolResult(await cline.sayAndCreateMissingParamError("search_files", "path"))
+				return
+			}
+			if (!regex) {
+				cline.consecutiveMistakeCount++
+				pushToolResult(await cline.sayAndCreateMissingParamError("search_files", "regex"))
+				return
+			}
+			cline.consecutiveMistakeCount = 0
+			const absolutePath = path.resolve(cline.cwd, relDirPath)
+			const results = await regexSearchFiles(
+				cline.cwd,
+				absolutePath,
+				regex,
+				filePattern,
+				cline.rooIgnoreController,
+			)
+			const completeMessage = JSON.stringify({
+				...sharedMessageProps,
+				content: results,
+			} satisfies ClineSayTool)
+			const didApprove = await askApproval("tool", completeMessage)
+			if (!didApprove) {
+				return
+			}
+			pushToolResult(results)
+			return
+		}
+	} catch (error) {
+		await handleError("searching files", error)
+		return
+	}
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `search_files` logic from `Cline.ts` to `searchFilesTool.ts` for improved modularity.
> 
>   - **Refactoring**:
>     - Move `search_files` logic from `Cline.ts` to new `searchFilesTool.ts`.
>     - Replace inline `search_files` logic in `Cline.ts` with a call to `searchFilesTool()`.
>   - **Functionality**:
>     - `searchFilesTool()` handles file path resolution, regex search, and error handling.
>     - Maintains existing behavior for handling missing parameters and partial messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1f7276d693b32ffe19255819062904763971c6f0. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->