### PR TITLE
Move execute_command to a tool file

### DIFF
--- a/src/core/tools/executeCommandTool.ts
+++ b/src/core/tools/executeCommandTool.ts
@@ -1,0 +1,52 @@
+import { Cline } from "../Cline"
+import { ToolUse } from "../assistant-message"
+import { AskApproval, HandleError, PushToolResult, RemoveClosingTag } from "./types"
+import { formatResponse } from "../prompts/responses"
+
+export async function executeCommandTool(
+	cline: Cline,
+	block: ToolUse,
+	askApproval: AskApproval,
+	handleError: HandleError,
+	pushToolResult: PushToolResult,
+	removeClosingTag: RemoveClosingTag,
+) {
+	const command: string | undefined = block.params.command
+	const customCwd: string | undefined = block.params.cwd
+	try {
+		if (block.partial) {
+			await cline.ask("command", removeClosingTag("command", command), block.partial).catch(() => {})
+			return
+		} else {
+			if (!command) {
+				cline.consecutiveMistakeCount++
+				pushToolResult(await cline.sayAndCreateMissingParamError("execute_command", "command"))
+				return
+			}
+
+			const ignoredFileAttemptedToAccess = cline.rooIgnoreController?.validateCommand(command)
+			if (ignoredFileAttemptedToAccess) {
+				await cline.say("rooignore_error", ignoredFileAttemptedToAccess)
+				pushToolResult(formatResponse.toolError(formatResponse.rooIgnoreError(ignoredFileAttemptedToAccess)))
+
+				return
+			}
+
+			cline.consecutiveMistakeCount = 0
+
+			const didApprove = await askApproval("command", command)
+			if (!didApprove) {
+				return
+			}
+			const [userRejected, result] = await cline.executeCommandTool(command, customCwd)
+			if (userRejected) {
+				cline.didRejectTool = true
+			}
+			pushToolResult(result)
+			return
+		}
+	} catch (error) {
+		await handleError("executing command", error)
+		return
+	}
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `execute_command` logic in `Cline.ts` to a new `executeCommandTool` function in `executeCommandTool.ts` for improved modularity.
> 
>   - **Refactoring**:
>     - Moved `execute_command` logic from `Cline.ts` to new `executeCommandTool` function in `executeCommandTool.ts`.
>     - `executeCommandTool` handles command execution, approval, error handling, and result pushing.
>   - **Cline.ts**:
>     - Replaced `execute_command` case logic with a call to `executeCommandTool`.
>     - Made `didRejectTool` non-private to be accessed by `executeCommandTool`.
>   - **executeCommandTool.ts**:
>     - New file created to encapsulate `execute_command` logic.
>     - Handles command validation, approval, execution, and error management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 36900b96b92dc8a0e4cf51db7fd941ca995c97e3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->