### PR TITLE
Remove the ask promise error

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -332,7 +332,17 @@ export class Cline extends EventEmitter<ClineEvents> {
 	}
 
 	private async addToClineMessages(message: ClineMessage) {
-		this.clineMessages.push(message)
+		// Find the correct position to insert the message based on timestamp
+		const insertIndex = this.clineMessages.findIndex((existingMsg) => existingMsg.ts > message.ts)
+
+		if (insertIndex === -1) {
+			// If no message with a later timestamp is found, append to the end
+			this.clineMessages.push(message)
+		} else {
+			// Insert the message at the correct position to maintain chronological order
+			this.clineMessages.splice(insertIndex, 0, message)
+		}
+
 		await this.providerRef.deref()?.postStateToWebview()
 		this.emit("message", { action: "created", message })
 		await this.saveClineMessages()
@@ -509,6 +519,8 @@ export class Cline extends EventEmitter<ClineEvents> {
 			throw new Error(`[Cline#say] task ${this.taskId}.${this.instanceId} aborted`)
 		}
 
+		const sayTs = (checkpoint?.startTime as number) ?? Date.now()
+
 		if (partial !== undefined) {
 			const lastMessage = this.clineMessages.at(-1)
 			const isUpdatingPreviousPartial =
@@ -523,7 +535,6 @@ export class Cline extends EventEmitter<ClineEvents> {
 					this.updateClineMessage(lastMessage)
 				} else {
 					// this is a new partial message, so add it with partial state
-					const sayTs = Date.now()
 					await this.addToClineMessages({ ts: sayTs, type: "say", say: type, text, images, partial })
 				}
 			} else {
@@ -542,13 +553,11 @@ export class Cline extends EventEmitter<ClineEvents> {
 					this.updateClineMessage(lastMessage)
 				} else {
 					// This is a new and complete message, so add it like normal.
-					const sayTs = Date.now()
 					await this.addToClineMessages({ ts: sayTs, type: "say", say: type, text, images })
 				}
 			}
 		} else {
 			// this is a new non-partial message, so add it like normal
-			const sayTs = Date.now()
 			await this.addToClineMessages({ ts: sayTs, type: "say", say: type, text, images, checkpoint })
 		}
 	}
@@ -2385,14 +2394,16 @@ export class Cline extends EventEmitter<ClineEvents> {
 				}
 			})
 
-			service.on("checkpoint", ({ isFirst, fromHash: from, toHash: to }) => {
+			service.on("checkpoint", ({ isFirst, fromHash: from, toHash: to, startTime }) => {
 				try {
 					this.providerRef.deref()?.postMessageToWebview({ type: "currentCheckpointUpdated", text: to })
 
-					this.say("checkpoint_saved", to, undefined, undefined, { isFirst, from, to }).catch((err) => {
-						log("[Cline#initializeCheckpoints] caught unexpected error in say('checkpoint_saved')")
-						console.error(err)
-					})
+					this.say("checkpoint_saved", to, undefined, undefined, { isFirst, from, to, startTime }).catch(
+						(err) => {
+							log("[Cline#initializeCheckpoints] caught unexpected error in say('checkpoint_saved')")
+							console.error(err)
+						},
+					)
 				} catch (err) {
 					log(
 						"[Cline#initializeCheckpoints] caught unexpected error in on('checkpoint'), disabling checkpoints",

--- a/src/services/checkpoints/ShadowCheckpointService.ts
+++ b/src/services/checkpoints/ShadowCheckpointService.ts
@@ -218,7 +218,7 @@ export abstract class ShadowCheckpointService extends EventEmitter {
 			const duration = Date.now() - startTime
 
 			if (isFirst || result.commit) {
-				this.emit("checkpoint", { type: "checkpoint", isFirst, fromHash, toHash, duration })
+				this.emit("checkpoint", { type: "checkpoint", isFirst, fromHash, toHash, duration, startTime })
 			}
 
 			if (result.commit) {

--- a/src/services/checkpoints/types.ts
+++ b/src/services/checkpoints/types.ts
@@ -29,6 +29,7 @@ export interface CheckpointEventMap {
 		fromHash: string
 		toHash: string
 		duration: number
+		startTime: number
 	}
 	restore: { type: "restore"; commitHash: string; duration: number }
 	error: { type: "error"; error: Error }


### PR DESCRIPTION
This error is firing a lot when the async checkpoints show up in the middle of an ask. I don't think what they're trying to catch is worth the complexity.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove `ask` promise error handling in `Cline.ts` and update message ordering and checkpoint events.
> 
>   - **Behavior**:
>     - Removed `ask` promise error handling logic in `Cline.ts`, including `lastMessageTs` variable and related checks.
>     - Updated `addToClineMessages()` in `Cline.ts` to insert messages based on timestamp order.
>   - **Checkpoints**:
>     - Added `startTime` to `checkpoint` event in `ShadowCheckpointService.ts` and `types.ts`.
>   - **Misc**:
>     - Removed redundant error handling logic in `ask()` and `say()` methods in `Cline.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7f10b1aae76d55cacefc4b5b612904375b338d47. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->