### PR TITLE
Revert "Remove the ask promise error"

### DIFF
--- a/src/services/checkpoints/ShadowCheckpointService.ts
+++ b/src/services/checkpoints/ShadowCheckpointService.ts
@@ -218,7 +218,7 @@ export abstract class ShadowCheckpointService extends EventEmitter {
 			const duration = Date.now() - startTime
 
 			if (isFirst || result.commit) {
-				this.emit("checkpoint", { type: "checkpoint", isFirst, fromHash, toHash, duration, startTime })
+				this.emit("checkpoint", { type: "checkpoint", isFirst, fromHash, toHash, duration })
 			}
 
 			if (result.commit) {

--- a/src/services/checkpoints/types.ts
+++ b/src/services/checkpoints/types.ts
@@ -29,7 +29,6 @@ export interface CheckpointEventMap {
 		fromHash: string
 		toHash: string
 		duration: number
-		startTime: number
 	}
 	restore: { type: "restore"; commitHash: string; duration: number }
 	error: { type: "error"; error: Error }


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#2107

I think this is causing my chats to hang
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts ask promise error handling in `Cline.ts` to fix chat hangs and removes `startTime` from checkpoint events.
> 
>   - **Behavior**:
>     - Reverts changes in `Cline.ts` to reintroduce error handling for ask promises, which were causing chat hangs.
>     - Restores logic to append messages directly to `clineMessages` without timestamp-based sorting.
>     - Reintroduces `lastMessageTs` to track the last message timestamp for ask promise handling.
>   - **Checkpoints**:
>     - Removes `startTime` from `checkpoint` event in `ShadowCheckpointService.ts` and `types.ts`.
>   - **Misc**:
>     - Minor adjustments to error handling and message updates in `Cline.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d9c11aab72d1b964a405aea7a1ed8f8524fe8d66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->