### PR TITLE
Parse the retry out of the gemini 429 response

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1221,7 +1221,21 @@ export class Cline extends EventEmitter<ClineEvents> {
 				}
 
 				const baseDelay = requestDelaySeconds || 5
-				const exponentialDelay = Math.ceil(baseDelay * Math.pow(2, retryAttempt))
+				let exponentialDelay = Math.ceil(baseDelay * Math.pow(2, retryAttempt))
+
+				// If the error is a 429, and the error details contain a retry delay, use that delay instead of exponential backoff
+				if (error.status === 429) {
+					const geminiRetryDetails = error.errorDetails?.find(
+						(detail: any) => detail["@type"] === "type.googleapis.com/google.rpc.RetryInfo",
+					)
+					if (geminiRetryDetails) {
+						const match = geminiRetryDetails?.retryDelay?.match(/^(\d+)s$/)
+						if (match) {
+							exponentialDelay = Number(match[1]) + 1
+						}
+					}
+				}
+
 				// Wait for the greater of the exponential delay or the rate limit delay
 				const finalDelay = Math.max(exponentialDelay, rateLimitDelay)
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Parse retry delay from Gemini 429 error responses in `Cline.ts` to override exponential backoff with specified delay.
> 
>   - **Behavior**:
>     - In `Cline.ts`, `attemptApiRequest()` now parses retry delay from Gemini 429 error responses.
>     - Uses `google.rpc.RetryInfo` to extract `retryDelay` and overrides exponential backoff if present.
>   - **Error Handling**:
>     - Handles 429 status code by checking `errorDetails` for retry information.
>     - Adjusts `exponentialDelay` based on parsed `retryDelay` from error details.
>   - **Misc**:
>     - No changes to other error handling or retry logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 46623e5f2212ed32e635fc70d43a7562767f576c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->