### PR TITLE
Tweaks to support prompt line number format

### DIFF
--- a/src/shared/__tests__/support-prompts.test.ts
+++ b/src/shared/__tests__/support-prompts.test.ts
@@ -10,8 +10,7 @@ describe("Code Action Prompts", () => {
 				filePath: testFilePath,
 				selectedText: testCode,
 			})
-
-			expect(prompt).toContain(`@/${testFilePath}`)
+			expect(prompt).toContain(testFilePath)
 			expect(prompt).toContain(testCode)
 			expect(prompt).toContain("purpose and functionality")
 			expect(prompt).toContain("Key components")
@@ -25,8 +24,7 @@ describe("Code Action Prompts", () => {
 				filePath: testFilePath,
 				selectedText: testCode,
 			})
-
-			expect(prompt).toContain(`@/${testFilePath}`)
+			expect(prompt).toContain(testFilePath)
 			expect(prompt).toContain(testCode)
 			expect(prompt).toContain("Address all detected problems")
 			expect(prompt).not.toContain("Current problems detected")
@@ -64,8 +62,7 @@ describe("Code Action Prompts", () => {
 				filePath: testFilePath,
 				selectedText: testCode,
 			})
-
-			expect(prompt).toContain(`@/${testFilePath}`)
+			expect(prompt).toContain(testFilePath)
 			expect(prompt).toContain(testCode)
 			expect(prompt).toContain("Code readability")
 			expect(prompt).toContain("Performance optimization")

--- a/src/shared/support-prompt.ts
+++ b/src/shared/support-prompt.ts
@@ -35,7 +35,7 @@ const supportPromptConfigs: Record<string, SupportPromptConfig> = {
 \${userInput}`,
 	},
 	EXPLAIN: {
-		template: `Explain the following code from file path @/\${filePath} \${startLine}:\${endLine}
+		template: `Explain the following code from file path \${filePath}:\${startLine}-\${endLine}
 \${userInput}
 
 \`\`\`
@@ -48,7 +48,7 @@ Please provide a clear and concise explanation of what this code does, including
 3. Important patterns or techniques used`,
 	},
 	FIX: {
-		template: `Fix any issues in the following code from file path @/\${filePath} \${startLine}:\${endLine}
+		template: `Fix any issues in the following code from file path \${filePath}:\${startLine}-\${endLine}
 \${diagnosticText}
 \${userInput}
 
@@ -63,7 +63,7 @@ Please:
 4. Explain what was fixed and why`,
 	},
 	IMPROVE: {
-		template: `Improve the following code from file path @/\${filePath} \${startLine}:\${endLine}
+		template: `Improve the following code from file path \${filePath}:\${startLine}-\${endLine}
 \${userInput}
 
 \`\`\`
@@ -79,7 +79,7 @@ Please suggest improvements for:
 Provide the improved code along with explanations for each enhancement.`,
 	},
 	ADD_TO_CONTEXT: {
-		template: `\${filePath}:\${startLine}:\${endLine}
+		template: `\${filePath}:\${startLine}-\${endLine}
 \`\`\`
 \${selectedText}
 \`\`\``,


### PR DESCRIPTION
I think this format is probably more standard for indicating lines of a file
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update prompt templates and tests to remove `@/` prefix and change line number separator from `:` to `-`.
> 
>   - **Behavior**:
>     - Update prompt templates in `support-prompt.ts` to remove `@/` prefix and change line number separator from `:` to `-`.
>     - Affects `EXPLAIN`, `FIX`, `IMPROVE`, and `ADD_TO_CONTEXT` templates.
>   - **Tests**:
>     - Update `support-prompts.test.ts` to reflect new prompt format by removing `@/` prefix in assertions for `EXPLAIN`, `FIX`, and `IMPROVE` actions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d2b841d5428a43d2750dcbcf21fc8fdfd92c21d0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->