### PR TITLE
Revert "Remove the ask promise error"

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -142,6 +142,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 	private askResponse?: ClineAskResponse
 	private askResponseText?: string
 	private askResponseImages?: string[]
+	private lastMessageTs?: number
 	// Not private since it needs to be accessible by tools
 	consecutiveMistakeCount: number = 0
 	consecutiveMistakeCountForApplyDiff: Map<string, number> = new Map()
@@ -440,6 +441,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 					// This is a new partial message, so add it with partial
 					// state.
 					askTs = Date.now()
+					this.lastMessageTs = askTs
 					await this.addToClineMessages({ ts: askTs, type: "ask", ask: type, text, partial })
 					throw new Error("Current ask promise was ignored (#2)")
 				}
@@ -458,6 +460,8 @@ export class Cline extends EventEmitter<ClineEvents> {
 					So in this case we must make sure that the message ts is never altered after first setting it.
 					*/
 					askTs = lastMessage.ts
+					this.lastMessageTs = askTs
+					// lastMessage.ts = askTs
 					lastMessage.text = text
 					lastMessage.partial = false
 					lastMessage.progressStatus = progressStatus
@@ -469,6 +473,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 					this.askResponseText = undefined
 					this.askResponseImages = undefined
 					askTs = Date.now()
+					this.lastMessageTs = askTs
 					await this.addToClineMessages({ ts: askTs, type: "ask", ask: type, text })
 				}
 			}
@@ -478,10 +483,18 @@ export class Cline extends EventEmitter<ClineEvents> {
 			this.askResponseText = undefined
 			this.askResponseImages = undefined
 			askTs = Date.now()
+			this.lastMessageTs = askTs
 			await this.addToClineMessages({ ts: askTs, type: "ask", ask: type, text })
 		}
 
-		await pWaitFor(() => this.askResponse !== undefined, { interval: 100 })
+		await pWaitFor(() => this.askResponse !== undefined || this.lastMessageTs !== askTs, { interval: 100 })
+
+		if (this.lastMessageTs !== askTs) {
+			// Could happen if we send multiple asks in a row i.e. with
+			// command_output. It's important that when we know an ask could
+			// fail, it is handled gracefully.
+			throw new Error("Current ask promise was ignored")
+		}
 
 		const result = { response: this.askResponse!, text: this.askResponseText, images: this.askResponseImages }
 		this.askResponse = undefined
@@ -524,6 +537,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 				} else {
 					// this is a new partial message, so add it with partial state
 					const sayTs = Date.now()
+					this.lastMessageTs = sayTs
 					await this.addToClineMessages({ ts: sayTs, type: "say", say: type, text, images, partial })
 				}
 			} else {
@@ -531,6 +545,8 @@ export class Cline extends EventEmitter<ClineEvents> {
 				if (isUpdatingPreviousPartial) {
 					// This is the complete version of a previously partial
 					// message, so replace the partial with the complete version.
+					this.lastMessageTs = lastMessage.ts
+					// lastMessage.ts = sayTs
 					lastMessage.text = text
 					lastMessage.images = images
 					lastMessage.partial = false
@@ -543,12 +559,14 @@ export class Cline extends EventEmitter<ClineEvents> {
 				} else {
 					// This is a new and complete message, so add it like normal.
 					const sayTs = Date.now()
+					this.lastMessageTs = sayTs
 					await this.addToClineMessages({ ts: sayTs, type: "say", say: type, text, images })
 				}
 			}
 		} else {
 			// this is a new non-partial message, so add it like normal
 			const sayTs = Date.now()
+			this.lastMessageTs = sayTs
 			await this.addToClineMessages({ ts: sayTs, type: "say", say: type, text, images, checkpoint })
 		}
 	}


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#2123
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts removal of ask promise error handling in `Cline` class, reintroducing logic to track `lastMessageTs` and handle multiple asks gracefully.
> 
>   - **Behavior**:
>     - Reverts removal of ask promise error handling in `Cline` class.
>     - Reintroduces logic to track `lastMessageTs` to handle multiple asks in a row gracefully.
>     - Throws error if `lastMessageTs` does not match current ask timestamp, indicating an ignored ask.
>   - **Functions**:
>     - Modifies `ask()` in `Cline.ts` to include `lastMessageTs` logic and error handling for ignored asks.
>     - Updates `say()` in `Cline.ts` to set `lastMessageTs` for new messages.
>   - **Misc**:
>     - Adds `lastMessageTs` property to `Cline` class to track timestamps of messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bf74cb3b26121762e41a15a82b4f8292844f7bed. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->