### PR TITLE
Remove hard-coded o3-mini model when streaming is enabled, allowing custom o3-mini-<reasoning> model

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -234,7 +234,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 	): ApiStream {
 		if (this.options.openAiStreamingEnabled ?? true) {
 			const stream = await this.client.chat.completions.create({
-				model: "o3-mini",
+				model: modelId,
 				messages: [
 					{
 						role: "developer",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace hardcoded `"o3-mini"` model with `modelId` in `openai.ts` to allow dynamic model selection when streaming is enabled.
> 
>   - **Behavior**:
>     - In `openai.ts`, replace hardcoded `"o3-mini"` model with `modelId` in `createMessage()` and `handleO3FamilyMessage()` functions.
>     - Allows dynamic selection of `o3-mini-<reasoning>` models when streaming is enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a4ac271ca0861982274d9e6cacbc2e5cda241362. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->