### PR TITLE
feat: Add modelId support when exporting tasks

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2289,6 +2289,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 		const {
 			mode,
 			customModes,
+			apiModelId,
 			customModePrompts,
 			experiments = {} as Record<ExperimentId, boolean>,
 			customInstructions: globalCustomInstructions,
@@ -2303,6 +2304,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 		details += `\n\n# Current Mode\n`
 		details += `<slug>${currentMode}</slug>\n`
 		details += `<name>${modeDetails.name}</name>\n`
+		details += `<model>${apiModelId}</model>\n`
 		if (Experiments.isEnabled(experiments ?? {}, EXPERIMENT_IDS.POWER_STEERING)) {
 			details += `<role>${modeDetails.roleDefinition}</role>\n`
 			if (modeDetails.customInstructions) {

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2691,6 +2691,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			osInfo: os.platform() === "win32" ? "win32" : "unix",
 			lastShownAnnouncementId: stateValues.lastShownAnnouncementId,
 			customInstructions: stateValues.customInstructions,
+			apiModelId: stateValues.apiModelId,
 			alwaysAllowReadOnly: stateValues.alwaysAllowReadOnly ?? false,
 			alwaysAllowReadOnlyOutsideWorkspace: stateValues.alwaysAllowReadOnlyOutsideWorkspace ?? false,
 			alwaysAllowWrite: stateValues.alwaysAllowWrite ?? false,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -126,6 +126,13 @@ const ApiOptions = ({
 		[apiConfiguration],
 	)
 
+	// Update apiConfiguration.aiModelId whenever selectedModelId changes.
+	useEffect(() => {
+		if (selectedModelId) {
+			setApiConfigurationField("apiModelId", selectedModelId)
+		}
+	}, [selectedModelId, setApiConfigurationField])
+
 	// Debounced refresh model updates, only executed 250ms after the user
 	// stops typing.
 	useDebounce(


### PR DESCRIPTION
## Context

- Added modelId to the task export process.
- The same task may switch between different models. When the task is executed abnormally, export the model id to facilitate troubleshooting.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|   <img width="305" alt="image" src="https://github.com/user-attachments/assets/5e9e8d74-82f7-44bd-a3f1-2b940a7059b5" />     |    <img width="473" alt="image" src="https://github.com/user-attachments/assets/06c47e5c-0cdf-4bff-9aff-a0dd4c3ac1cf" />  |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `modelId` support to task export process, updating `Cline`, `ClineProvider`, and `ApiOptions` to handle `modelId` synchronization.
> 
>   - **Behavior**:
>     - Add `modelId` to task export process in `Cline` and `ClineProvider`.
>     - Update `Cline` to include `<model>` tag in task details.
>     - Synchronize `apiModelId` with `selectedModelId` in `ApiOptions`.
>   - **Components**:
>     - Update `ApiOptions` to set `apiModelId` when `selectedModelId` changes.
>   - **Misc**:
>     - Add `apiModelId` to state in `ClineProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8aaec7ce706c1d259697a093b9ad7f9075a73848. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->