### PR TITLE
Include inference-profile in Bedrock arnRegex

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -30,7 +30,7 @@ import { logger } from "../../utils/logging"
 function validateBedrockArn(arn: string, region?: string) {
 	// Validate ARN format
 	const arnRegex =
-		/^arn:aws:bedrock:([^:]+):(\d+):(foundation-model|provisioned-model|default-prompt-router|prompt-router|application-inference-profile)\/(.+)$/
+		/^arn:aws:bedrock:([^:]+):(\d+):(foundation-model|provisioned-model|default-prompt-router|prompt-router|inference-profile|application-inference-profile)\/(.+)$/
 	const match = arn.match(arnRegex)
 
 	if (!match) {


### PR DESCRIPTION
#2153
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `arnRegex` in `validateBedrockArn` to include `inference-profile` for correct ARN validation in `bedrock.ts`.
> 
>   - **Behavior**:
>     - Update `arnRegex` in `validateBedrockArn` function in `bedrock.ts` to include `inference-profile` for ARN validation.
>     - Ensures ARNs with `inference-profile` are correctly validated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8feec10f7eed84f53feb470c2f50598a3e285d66. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->