### PR TITLE
mcp supports cwd config and defaults to workspace cwd

### DIFF
--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -63,6 +63,7 @@ const createServerTypeSchema = () => {
 			type: z.enum(["stdio"]).optional(),
 			command: z.string().min(1, "Command cannot be empty"),
 			args: z.array(z.string()).optional(),
+			cwd: z.string().default(vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath ?? process.cwd()),
 			env: z.record(z.string()).optional(),
 			// Ensure no SSE fields are present
 			url: z.undefined().optional(),
@@ -79,7 +80,7 @@ const createServerTypeSchema = () => {
 			url: z.string().url("URL must be a valid URL format"),
 			headers: z.record(z.string()).optional(),
 			// Ensure no stdio fields are present
-			command: z.undefined().optional(),
+			command: z.undefined(),
 			args: z.undefined().optional(),
 			env: z.undefined().optional(),
 		})
@@ -314,7 +315,7 @@ export class McpHub {
 				mcpSettingsFilePath,
 				`{
   "mcpServers": {
-    
+
   }
 }`,
 			)
@@ -427,6 +428,7 @@ export class McpHub {
 				transport = new StdioClientTransport({
 					command: config.command,
 					args: config.args,
+					cwd: config.cwd,
 					env: {
 						...config.env,
 						...(process.env.PATH ? { PATH: process.env.PATH } : {}),

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -80,7 +80,7 @@ const createServerTypeSchema = () => {
 			url: z.string().url("URL must be a valid URL format"),
 			headers: z.record(z.string()).optional(),
 			// Ensure no stdio fields are present
-			command: z.undefined(),
+			command: z.undefined().optional(),
 			args: z.undefined().optional(),
 			env: z.undefined().optional(),
 		})

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -63,7 +63,7 @@ const createServerTypeSchema = () => {
 			type: z.enum(["stdio"]).optional(),
 			command: z.string().min(1, "Command cannot be empty"),
 			args: z.array(z.string()).optional(),
-			cwd: z.string().default(vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath ?? process.cwd()),
+			cwd: z.string().default(() => vscode.workspace.workspaceFolders?.at(0)?.uri.fsPath ?? process.cwd()),
 			env: z.record(z.string()).optional(),
 			// Ensure no SSE fields are present
 			url: z.undefined().optional(),


### PR DESCRIPTION
## Context

The motivation for this change is to support developing custom mcp servers inside of monorepo 
Allow the user to configure cwd in the mcpServers config file, and setting the default to be the workspace folder

I see that this changes the default behavior but this seems like the right way. adding a project level mcp is somewhat limited without this.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

added to zod schema defaults

## Screenshots

N/A
## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

- add an mcp stidio server
```json
{
  "mcpServers": {
    "tooling": {
      "command": "pnpm",
      "args": [
        "dlx",
        "tsx",
        "./packages/tooling/src/mcp/mcp.ts"
      ],
    }
  }
}

```
- add a debugging line here to see cwd getting set by default, do
https://github.com/shoopapa/Roo-Code/blob/7688aae0b640d9b56118221884429afb024a2a9c/src/services/mcp/McpHub.ts#L209-L210
4. do the same with a custom value in the server for `cwd`
5. ensure the server launcher correctly 

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `cwd` support to MCP server configuration in `McpHub.ts`, defaulting to workspace folder.
> 
>   - **Behavior**:
>     - Adds `cwd` field to server configuration schema in `McpHub.ts`, defaulting to the workspace folder or process cwd.
>     - Updates `StdioClientTransport` in `connectToServer()` to use `cwd` from config.
>   - **Schema**:
>     - Modifies `createServerTypeSchema()` to include `cwd` with default value.
>   - **Misc**:
>     - Minor whitespace change in `McpHub.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7688aae0b640d9b56118221884429afb024a2a9c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->