### PR TITLE
Limit DropdownMenu height to 80% of viewport

### DIFF
--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -106,7 +106,7 @@ export const SelectDropdown = React.forwardRef<React.ElementRef<typeof DropdownM
 					onEscapeKeyDown={() => setOpen(false)}
 					onInteractOutside={() => setOpen(false)}
 					container={portalContainer}
-					className={contentClassName}>
+					className={cn("overflow-y-auto max-h-[80vh]", contentClassName)}>
 					{options.map((option, index) => {
 						if (option.type === DropdownOptionType.SEPARATOR) {
 							return <DropdownMenuSeparator key={`sep-${index}`} />


### PR DESCRIPTION
## Context

If you have a large number of custom modes (and/or a small screen) The mode-switcher beneath the chat input would become too tall to see all items. This PR fixes that by limiting the DropdownMenu component to 80% of the viewport height. 

## Implementation
- Limit maximum height to 80vh using Tailwind's max-h-[80vh]
- Enable vertical scrolling with overflow-y-auto

## Screenshots

| before | after |
| ------ | ----- |
|    <img width="263" alt="image" src="https://github.com/user-attachments/assets/12fcf294-5968-44e7-a5f7-d15d94404ebd" /> |    <img width="289" alt="image" src="https://github.com/user-attachments/assets/392c0012-b456-4f7a-8cdf-065d913c805c" />   |

## How to Test

- Add a lot of modes (easy method use all items from https://jezweb.github.io/roo-commander/ )
- Open the mode picker menu.

## Get in Touch

Roo Discord: axmo (axmo0929)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Limit `DropdownMenuContent` height to 80% of viewport and enable scrolling in `select-dropdown.tsx`.
> 
>   - **Behavior**:
>     - Limits `DropdownMenuContent` height to 80% of viewport using `max-h-[80vh]` in `select-dropdown.tsx`.
>     - Enables vertical scrolling with `overflow-y-auto` in `select-dropdown.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ba64f175349fae44f233d6fb16ac138440bf1a2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->