### PR TITLE
Update deepseek-chat context window size 64k -> 128k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roo Code Changelog
 
+## [3.11.4] - 2025-03-31
+
+- Update deepseek-chat model config to reflect increased context window size of DeepSeek-V3 model
+
 ## [3.11.3] - 2025-03-31
 
 - Revert mention changes in case they're causing performance issues/crashes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "roo-cline",
-	"version": "3.11.3",
+	"version": "3.11.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "roo-cline",
-			"version": "3.11.3",
+			"version": "3.11.4",
 			"dependencies": {
 				"@anthropic-ai/bedrock-sdk": "^0.10.2",
 				"@anthropic-ai/sdk": "^0.37.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "Roo Code (prev. Roo Cline)",
 	"description": "A whole dev team of AI agents in your editor.",
 	"publisher": "RooVeterinaryInc",
-	"version": "3.11.3",
+	"version": "3.11.4",
 	"icon": "assets/icons/icon.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -799,7 +799,7 @@ export const deepSeekDefaultModelId: DeepSeekModelId = "deepseek-chat"
 export const deepSeekModels = {
 	"deepseek-chat": {
 		maxTokens: 8192,
-		contextWindow: 64_000,
+		contextWindow: 128_000,
 		supportsImages: false,
 		supportsPromptCache: true,
 		inputPrice: 0.27, // $0.27 per million tokens (cache miss)


### PR DESCRIPTION
# Context

Update deepseek-chat model config to reflect increased context window size of DeepSeek-V3 model.

Although the change is not yet reflected in [DeepSeek API docs](https://api-docs.deepseek.com/quick_start/pricing), where it shows 64k, deepseek-chat points at DeepSeek-V3 which has context window 128k,see https://github.com/deepseek-ai/DeepSeek-V3

# Testing
I have built the extension with the change, installed .vsix and continued a previous task so that the context window exceeded past 64k tokens, and then made another request to make sure DeepSeek API does not fail on exceeding the documented but incorrect limit of 64k

![image](https://github.com/user-attachments/assets/ae8f475c-6594-45a2-b8a1-d08a4d46dab9)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `deepseek-chat` model's `contextWindow` in `api.ts` from 64,000 to 128,000 tokens to match DeepSeek-V3 capabilities.
> 
>   - **Behavior**:
>     - Update `contextWindow` for `deepseek-chat` model in `api.ts` from 64,000 to 128,000 tokens.
>     - Ensures compatibility with DeepSeek-V3 model's actual context window size.
>   - **Testing**:
>     - Verified API handles requests exceeding 64,000 tokens without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2f4a129f0f377d56007ab3c9d66112fa354d8396. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->