### PR TITLE
Update dependencies via `npm audit fix`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7657,44 +7657,75 @@
 			"dev": true
 		},
 		"node_modules/bare-events": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
-			"integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
+			"version": "2.5.4",
+			"resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+			"integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+			"license": "Apache-2.0",
 			"optional": true
 		},
 		"node_modules/bare-fs": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
-			"integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
+			"integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
+			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"bare-events": "^2.0.0",
-				"bare-path": "^2.0.0",
-				"bare-stream": "^2.0.0"
+				"bare-events": "^2.5.4",
+				"bare-path": "^3.0.0",
+				"bare-stream": "^2.6.4"
+			},
+			"engines": {
+				"bare": ">=1.16.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/bare-os": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
-			"integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
-			"optional": true
+			"version": "3.6.1",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+			"integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+			"license": "Apache-2.0",
+			"optional": true,
+			"engines": {
+				"bare": ">=1.14.0"
+			}
 		},
 		"node_modules/bare-path": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
-			"integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"bare-os": "^2.1.0"
+				"bare-os": "^3.0.1"
 			}
 		},
 		"node_modules/bare-stream": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.4.2.tgz",
-			"integrity": "sha512-XZ4ln/KV4KT+PXdIWTKjsLY+quqCaEtqqtgGJVPw9AoM73By03ij64YjepK0aQvHSWDb6AfAZwqKaFu68qkrdA==",
+			"version": "2.6.5",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+			"integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+			"license": "Apache-2.0",
 			"optional": true,
 			"dependencies": {
-				"streamx": "^2.20.0"
+				"streamx": "^2.21.0"
+			},
+			"peerDependencies": {
+				"bare-buffer": "*",
+				"bare-events": "*"
+			},
+			"peerDependenciesMeta": {
+				"bare-buffer": {
+					"optional": true
+				},
+				"bare-events": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/base64-js": {
@@ -15154,84 +15185,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/rimraf/node_modules/glob": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-			"integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
-			"dev": true,
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^4.0.1",
-				"minimatch": "^10.0.0",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^2.0.0"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/jackspeak": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.0.2.tgz",
-			"integrity": "sha512-bZsjR/iRjl1Nk1UkjGpAzLNfQtzuijhn2g+pbZb98HQ1Gk8vM9hfbxeMBP+M2/UUdwj0RqGG3mlvk2MsAqwvEw==",
-			"dev": true,
-			"dependencies": {
-				"@isaacs/cliui": "^8.0.2"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/lru-cache": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
-			"integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
-			"dev": true,
-			"engines": {
-				"node": "20 || >=22"
-			}
-		},
-		"node_modules/rimraf/node_modules/minimatch": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
-			"integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
-			"dev": true,
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/rimraf/node_modules/path-scurry": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^11.0.0",
-				"minipass": "^7.1.2"
-			},
-			"engines": {
-				"node": "20 || >=22"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/rollup": {
 			"version": "4.37.0",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.37.0.tgz",
@@ -16263,16 +16216,17 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-			"integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
+			"integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+			"license": "MIT",
 			"dependencies": {
 				"pump": "^3.0.0",
 				"tar-stream": "^3.1.5"
 			},
 			"optionalDependencies": {
-				"bare-fs": "^2.1.1",
-				"bare-path": "^2.1.0"
+				"bare-fs": "^4.0.1",
+				"bare-path": "^3.0.0"
 			}
 		},
 		"node_modules/tar-stream": {


### PR DESCRIPTION
## Context

npm warns me that there are 2 vulnerabilities (1 moderate, 1 high), so I use `npm audit fix`, and the high severity one was fixed:
- tar-fs 3.0.0-3.0.6 https://github.com/advisories/GHSA-pq67-2wwv-3xjx

There is only one moderate vulnerability now:
- esbuild <=0.24.2 https://github.com/advisories/GHSA-67mh-4wv8-2f99

## Implementation

Run `npm audit` first to check the vulnerabilities, then use `npm audit fix` to resolve them by updating dependencies. Then, run `npm audit` again, plus `git diff` to check the result.

## How to Test

Build the software as it was.