### PR TITLE
fix(diff): Handle line number stripping for deletions in apply_diff

### DIFF
--- a/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
@@ -1486,6 +1486,23 @@ function five() {
 }`)
 				}
 			})
+
+			it("should delete a line when search block has line number prefix and replace is empty", async () => {
+				const originalContent = "line 1\nline to delete\nline 3"
+				const diffContent = `
+<<<<<<< SEARCH
+:start_line:2
+:end_line:2
+-------
+2 | line to delete
+=======
+>>>>>>> REPLACE`
+				const result = await strategy.applyDiff(originalContent, diffContent)
+				expect(result.success).toBe(true)
+				if (result.success) {
+					expect(result.content).toBe("line 1\nline 3")
+				}
+			})
 		})
 
 		describe("insertion", () => {

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -301,7 +301,10 @@ Only use a single line of '=======' between search and replacement content, beca
 			replaceContent = this.unescapeMarkers(replaceContent)
 
 			// Strip line numbers from search and replace content if every line starts with a line number
-			if (everyLineHasLineNumbers(searchContent) && everyLineHasLineNumbers(replaceContent)) {
+			if (
+				(everyLineHasLineNumbers(searchContent) && everyLineHasLineNumbers(replaceContent)) ||
+				(everyLineHasLineNumbers(searchContent) && replaceContent.trim() === "")
+			) {
 				searchContent = stripLineNumbers(searchContent)
 				replaceContent = stripLineNumbers(replaceContent)
 			}


### PR DESCRIPTION
The multi-search-replace diff strategy previously did not correctly strip line numbers (`number | `) from the SEARCH block when the REPLACE block was empty. This occurred because the condition for stripping required both blocks to consistently have line numbers.

This prevented successful deletion operations when the SEARCH block content was copied from `read_file` output (which includes line numbers) and the REPLACE block was empty.

This commit updates the line number stripping condition in `applyDiff` to also trigger if the SEARCH block has line numbers and the REPLACE block is empty or contains only whitespace, resolving the bug.

Additionally, a new test case has been added to `multi-search-replace.test.ts` to specifically verify this deletion scenario. All tests now pass with this updated logic.

![lines](https://github.com/user-attachments/assets/ec401c72-00ac-4655-9366-53cbffd99411)
In this example the removal of line 48 failed. This PR addresses that. 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes line number stripping in `applyDiff` for empty REPLACE blocks in `multi-search-replace.ts`, ensuring successful deletions when SEARCH block has line numbers.
> 
>   - **Behavior**:
>     - Fixes line number stripping in `applyDiff` in `multi-search-replace.ts` when SEARCH block has line numbers and REPLACE block is empty or whitespace.
>     - Ensures successful deletion operations when SEARCH content is from `read_file` output.
>   - **Tests**:
>     - Adds test case in `multi-search-replace.test.ts` to verify deletion when SEARCH block has line numbers and REPLACE is empty.
>     - All tests pass with updated logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 762c7f8f99925bc0fba0e7de43441c9e4622805f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->