### PR TITLE
Update History Selection Mode button spacing

### DIFF
--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -85,7 +85,7 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 									: `${t("history:enterSelectionMode")}`
 							}>
 							<span
-								className={`codicon ${isSelectionMode ? "codicon-check-all" : "codicon-checklist"}`}
+								className={`codicon ${isSelectionMode ? "codicon-check-all" : "codicon-checklist"} mr-1`}
 							/>
 							{isSelectionMode ? t("history:exitSelection") : t("history:selectionMode")}
 						</VSCodeButton>


### PR DESCRIPTION
## Context

Incredibly exciting change coming to Roo Code: The icon spacing in the Selection Mode button in the History View was inconsistent with other button styling in the project.

## Implementation

Added class mr-1 to the icon in the Selection Mode button.

## Screenshots

![image](https://github.com/user-attachments/assets/833d4a8d-50b2-4404-abed-8da24967797a)
![image](https://github.com/user-attachments/assets/8f4708e2-72a0-42a1-9c26-0753aaba5dd5)


## How to Test

Open the History tab

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `mr-1` class to Selection Mode button icon in `HistoryView.tsx` for consistent spacing.
> 
>   - **UI Update**:
>     - Add `mr-1` class to the icon in the Selection Mode button in `HistoryView.tsx` to ensure consistent spacing with other buttons.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e842785d05df70a1884bde6f7914de7240568621. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->