### PR TITLE
Enable model select when api fails

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -32,6 +32,7 @@ interface ChatTextAreaProps {
 	inputValue: string
 	setInputValue: (value: string) => void
 	textAreaDisabled: boolean
+	selectApiConfigDisabled: boolean
 	placeholderText: string
 	selectedImages: string[]
 	setSelectedImages: React.Dispatch<React.SetStateAction<string[]>>
@@ -50,6 +51,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 			inputValue,
 			setInputValue,
 			textAreaDisabled,
+			selectApiConfigDisabled,
 			placeholderText,
 			selectedImages,
 			setSelectedImages,
@@ -938,6 +940,9 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						<div className="shrink-0">
 							<SelectDropdown
 								value={mode}
+								disabled={
+									false
+								} /* Always enable the model selector regardless of textAreaDisabled state */
 								title={t("chat:selectMode")}
 								options={[
 									{
@@ -975,7 +980,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						<div className={cn("flex-1", "min-w-0", "overflow-hidden")}>
 							<SelectDropdown
 								value={currentConfigId}
-								disabled={textAreaDisabled}
+								disabled={selectApiConfigDisabled}
 								title={t("chat:selectApiConfig")}
 								placeholder={displayName} // Always show the current name
 								options={[

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -940,9 +940,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						<div className="shrink-0">
 							<SelectDropdown
 								value={mode}
-								disabled={
-									false
-								} /* Always enable the model selector regardless of textAreaDisabled state */
 								title={t("chat:selectMode")}
 								options={[
 									{

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1346,6 +1346,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 				inputValue={inputValue}
 				setInputValue={setInputValue}
 				textAreaDisabled={textAreaDisabled}
+				selectApiConfigDisabled={textAreaDisabled && clineAsk !== "api_req_failed"}
 				placeholderText={placeholderText}
 				selectedImages={selectedImages}
 				setSelectedImages={setSelectedImages}

--- a/webview-ui/src/components/chat/__tests__/ChatTextArea.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatTextArea.test.tsx
@@ -47,6 +47,7 @@ describe("ChatTextArea", () => {
 		setInputValue: jest.fn(),
 		onSend: jest.fn(),
 		textAreaDisabled: false,
+		selectApiConfigDisabled: false,
 		onSelectImages: jest.fn(),
 		shouldDisableImages: false,
 		placeholderText: "Type a message...",
@@ -406,6 +407,23 @@ describe("ChatTextArea", () => {
 
 			// Verify setInputValue was not called
 			expect(setInputValue).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("selectApiConfig", () => {
+		// Helper function to get the API config dropdown
+		const getApiConfigDropdown = () => {
+			return screen.getByTitle("chat:selectApiConfig")
+		}
+		it("should be enabled independently of textAreaDisabled", () => {
+			render(<ChatTextArea {...defaultProps} textAreaDisabled={true} selectApiConfigDisabled={false} />)
+			const apiConfigDropdown = getApiConfigDropdown()
+			expect(apiConfigDropdown).not.toHaveAttribute("disabled")
+		})
+		it("should be disabled when selectApiConfigDisabled is true", () => {
+			render(<ChatTextArea {...defaultProps} textAreaDisabled={true} selectApiConfigDisabled={true} />)
+			const apiConfigDropdown = getApiConfigDropdown()
+			expect(apiConfigDropdown).toHaveAttribute("disabled")
 		})
 	})
 })


### PR DESCRIPTION
Bug: Cannot change model selection after API error due to UI state #1657
UI Bug: OpenRouter ran out of credits prevents user from switching models #1206

## Context

Most users have probably experienced having to click "Retry" > "Cancel" when they're reached a rate limit.  This fix allows you to quickly try a different provider.

I recognize that these bugs are labeled as "needs scope", but I'm sure there are plenty of users that would appreciate this fix while we determine the proper scope. (I've seen folks on both reddit and discord report this issue as well as the issues noted above)

## Implementation

I added selectApiConfigDisabled to ChatTextArea to separate the behavior from textAreaDisabled and enabled the model selector when clineAsk == "api_req_failed"

## Screenshots

Before
<img width="498" alt="image" src="https://github.com/user-attachments/assets/e16a6c32-1a71-46b7-80b8-e27331b7d542" />
 After  
<img width="498" alt="image" src="https://github.com/user-attachments/assets/232a625f-8c95-4faa-ba73-8aadcdaaf085" />

## How to Test

Reach an API rate limit and notice that the model selector is enabled.  Notice that it is disabled in all other situations where textAreaDisabled
