### PR TITLE
feat: add scrollable area to mode selector dropdown

### DIFF
--- a/webview-ui/src/components/ui/select-dropdown.tsx
+++ b/webview-ui/src/components/ui/select-dropdown.tsx
@@ -106,7 +106,7 @@ export const SelectDropdown = React.forwardRef<React.ElementRef<typeof DropdownM
 					onEscapeKeyDown={() => setOpen(false)}
 					onInteractOutside={() => setOpen(false)}
 					container={portalContainer}
-					className={contentClassName}>
+					className={cn("max-h-[300px] overflow-y-auto", contentClassName)}>
 					{options.map((option, index) => {
 						if (option.type === DropdownOptionType.SEPARATOR) {
 							return <DropdownMenuSeparator key={`sep-${index}`} />


### PR DESCRIPTION
## Context

Add max height and vertical scrolling to dropdown menus, ensuring users can access all available modes even when there are too many to display at once.

## Implementation

Simple 1 line change.

## Screenshots

Before:
![image](https://github.com/user-attachments/assets/6cd9e0de-3aba-43a7-8fd2-1d687f8f7580)

After:
![image](https://github.com/user-attachments/assets/5e034ff4-4247-40aa-b96d-6a644cbb8bfc)


## How to Test

- Add more modes
- Check if the area becomes scrollable

## Get in Touch

Discord: murilofp

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add vertical scrolling to `DropdownMenuContent` in `select-dropdown.tsx` for dropdowns exceeding 300px height.
> 
>   - **UI Enhancement**:
>     - Adds `max-h-[300px] overflow-y-auto` to `DropdownMenuContent` in `select-dropdown.tsx` to enable vertical scrolling when dropdown exceeds 300px height.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a4741d93261482fa2ee8fd4f685728d7f39906f3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->