### PR TITLE
fixes: 2229 - completePrompt doesn't work for bedrock.

### DIFF
--- a/src/api/providers/__tests__/bedrock-custom-arn.test.ts
+++ b/src/api/providers/__tests__/bedrock-custom-arn.test.ts
@@ -3,10 +3,20 @@ import { ApiHandlerOptions } from "../../../shared/api"
 
 // Mock the AWS SDK
 jest.mock("@aws-sdk/client-bedrock-runtime", () => {
+	const mockResponse = {
+		output: {
+			message: {
+				content: [
+					{
+						text: "Test response",
+					},
+				],
+			},
+		},
+	}
+
 	const mockSend = jest.fn().mockImplementation(() => {
-		return Promise.resolve({
-			output: new TextEncoder().encode(JSON.stringify({ content: "Test response" })),
-		})
+		return Promise.resolve(mockResponse)
 	})
 
 	return {

--- a/src/api/providers/__tests__/bedrock.test.ts
+++ b/src/api/providers/__tests__/bedrock.test.ts
@@ -399,14 +399,20 @@ describe("AwsBedrockHandler", () => {
 		})
 	})
 
+	//response.output.message.content[0].text
+
 	describe("completePrompt", () => {
 		it("should complete prompt successfully", async () => {
 			const mockResponse = {
-				output: new TextEncoder().encode(
-					JSON.stringify({
-						content: "Test response",
-					}),
-				),
+				output: {
+					message: {
+						content: [
+							{
+								text: "Test response",
+							},
+						],
+					},
+				},
 			}
 
 			const mockSend = jest.fn().mockResolvedValue(mockResponse)
@@ -450,7 +456,9 @@ describe("AwsBedrockHandler", () => {
 
 		it("should handle invalid response format", async () => {
 			const mockResponse = {
-				output: new TextEncoder().encode("invalid json"),
+				output: {
+					message: {},
+				},
 			}
 
 			const mockSend = jest.fn().mockResolvedValue(mockResponse)
@@ -464,9 +472,16 @@ describe("AwsBedrockHandler", () => {
 
 		it("should handle empty response", async () => {
 			const mockResponse = {
-				output: new TextEncoder().encode(JSON.stringify({})),
+				output: {
+					message: {
+						content: [
+							{
+								text: "",
+							},
+						],
+					},
+				},
 			}
-
 			const mockSend = jest.fn().mockResolvedValue(mockResponse)
 			handler["client"] = {
 				send: mockSend,
@@ -486,11 +501,15 @@ describe("AwsBedrockHandler", () => {
 			})
 
 			const mockResponse = {
-				output: new TextEncoder().encode(
-					JSON.stringify({
-						content: "Test response",
-					}),
-				),
+				output: {
+					message: {
+						content: [
+							{
+								text: "Test response",
+							},
+						],
+					},
+				},
 			}
 
 			const mockSend = jest.fn().mockResolvedValue(mockResponse)
@@ -519,11 +538,15 @@ describe("AwsBedrockHandler", () => {
 			})
 
 			const mockResponse = {
-				output: new TextEncoder().encode(
-					JSON.stringify({
-						content: "Test response",
-					}),
-				),
+				output: {
+					message: {
+						content: [
+							{
+								text: "Test response",
+							},
+						],
+					},
+				},
 			}
 
 			const mockSend = jest.fn().mockResolvedValue(mockResponse)
@@ -552,13 +575,16 @@ describe("AwsBedrockHandler", () => {
 			})
 
 			const mockResponse = {
-				output: new TextEncoder().encode(
-					JSON.stringify({
-						content: "Test response",
-					}),
-				),
+				output: {
+					message: {
+						content: [
+							{
+								text: "Test response",
+							},
+						],
+					},
+				},
 			}
-
 			const mockSend = jest.fn().mockResolvedValue(mockResponse)
 			handler["client"] = {
 				send: mockSend,
@@ -585,11 +611,15 @@ describe("AwsBedrockHandler", () => {
 			})
 
 			const mockResponse = {
-				output: new TextEncoder().encode(
-					JSON.stringify({
-						content: "Test response",
-					}),
-				),
+				output: {
+					message: {
+						content: [
+							{
+								text: "Test response",
+							},
+						],
+					},
+				},
 			}
 
 			const mockSend = jest.fn().mockResolvedValue(mockResponse)

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -665,13 +665,14 @@ Please check:
 			const command = new ConverseCommand(payload)
 			const response = await this.client.send(command)
 
-			if (response.output && response.output instanceof Uint8Array) {
+			if (
+				response?.output?.message?.content &&
+				response.output.message.content.length > 0 &&
+				response.output.message.content[0].text &&
+				response.output.message.content[0].text.trim().length > 0
+			) {
 				try {
-					const outputStr = new TextDecoder().decode(response.output)
-					const output = JSON.parse(outputStr)
-					if (output.content) {
-						return output.content
-					}
+					return response.output.message.content[0].text
 				} catch (parseError) {
 					logger.error("Failed to parse Bedrock response", {
 						ctx: "bedrock",


### PR DESCRIPTION
Fixes broken complete prompt when using bedrock provider. This PR is a stand-alone for that fix. I've also incorporated the fix into the AWS Prompt Caching PR, so if that one is merged this one can be rejected.

the previous check of `response.output instanceof Uint8Array` was always false because of the Bedrock response format. 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `completePrompt` in `AwsBedrockHandler` to correctly handle Bedrock response format by checking `response.output.message.content[0].text`.
> 
>   - **Behavior**:
>     - Fixes `completePrompt` in `bedrock.ts` to correctly handle Bedrock response format by checking `response.output.message.content[0].text`.
>     - Returns the text content directly if present and non-empty.
>   - **Tests**:
>     - Updates tests in `bedrock.test.ts` to use the new response format for `completePrompt`.
>     - Ensures tests handle cases with valid, invalid, and empty responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3bf3f3829f399d629f15fae0486c87ccae05ebc4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->