### PR TITLE
Fix tree sitter to output 1-based line numbers

### DIFF
--- a/src/services/tree-sitter/__tests__/index.test.ts
+++ b/src/services/tree-sitter/__tests__/index.test.ts
@@ -309,7 +309,7 @@ export const CheckboxExample = () => (
 
 			// Verify function found and correctly parsed
 			expect(result).toContain("jsx-arrow.tsx")
-			expect(result).toContain("4--14 |")
+			expect(result).toContain("5--15 |")
 
 			// Verify line count
 			const capture = mockQuery.captures.mock.results[0].value[0]

--- a/src/services/tree-sitter/__tests__/markdownIntegration.test.ts
+++ b/src/services/tree-sitter/__tests__/markdownIntegration.test.ts
@@ -36,10 +36,10 @@ describe("Markdown Integration Tests", () => {
 		// Check the result
 		expect(result).toBeDefined()
 		expect(result).toContain("# test.md")
-		expect(result).toContain("0--4 | # Main Header")
-		expect(result).toContain("5--9 | ## Section 1")
-		expect(result).toContain("10--14 | ### Subsection 1.1")
-		expect(result).toContain("15--19 | ## Section 2")
+		expect(result).toContain("1--5 | # Main Header")
+		expect(result).toContain("6--10 | ## Section 1")
+		expect(result).toContain("11--15 | ### Subsection 1.1")
+		expect(result).toContain("16--20 | ## Section 2")
 	})
 
 	it("should handle markdown files with no headers", async () => {
@@ -93,7 +93,7 @@ describe("Markdown Integration Tests", () => {
 		// Check the result
 		expect(result).toBeDefined()
 		expect(result).toContain("# mixed-headers.md")
-		expect(result).toContain("0--3 | # ATX Header")
-		expect(result).toContain("4--8 | Setext Header")
+		expect(result).toContain("1--4 | # ATX Header")
+		expect(result).toContain("5--9 | Setext Header")
 	})
 })

--- a/src/services/tree-sitter/index.ts
+++ b/src/services/tree-sitter/index.ts
@@ -275,13 +275,13 @@ function processCaptures(captures: any[], lines: string[], minComponentLines: nu
 
 			// Add component name to output regardless of HTML filtering
 			if (!processedLines.has(lineKey) && componentName) {
-				formattedOutput += `${startLine}--${endLine} | ${lines[startLine]}\n`
+				formattedOutput += `${startLine + 1}--${endLine + 1} | ${lines[startLine]}\n`
 				processedLines.add(lineKey)
 			}
 		}
 		// For other component definitions
 		else if (isNotHtmlElement(startLineContent)) {
-			formattedOutput += `${startLine}--${endLine} | ${lines[startLine]}\n`
+			formattedOutput += `${startLine + 1}--${endLine + 1} | ${lines[startLine]}\n`
 			processedLines.add(lineKey)
 
 			// If this is part of a larger definition, include its non-HTML context
@@ -294,7 +294,7 @@ function processCaptures(captures: any[], lines: string[], minComponentLines: nu
 					// Add the full range first
 					const rangeKey = `${node.parent.startPosition.row}-${contextEnd}`
 					if (!processedLines.has(rangeKey)) {
-						formattedOutput += `${node.parent.startPosition.row}--${contextEnd} | ${lines[node.parent.startPosition.row]}\n`
+						formattedOutput += `${node.parent.startPosition.row + 1}--${contextEnd + 1} | ${lines[node.parent.startPosition.row]}\n`
 						processedLines.add(rangeKey)
 					}
 				}


### PR DESCRIPTION
#2227 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change line number output to 1-based in `processCaptures()` and update tests accordingly.
> 
>   - **Behavior**:
>     - Change line number output to 1-based in `processCaptures()` in `index.ts`.
>     - Update test cases in `index.test.ts` and `markdownIntegration.test.ts` to expect 1-based line numbers.
>   - **Tests**:
>     - Modify expected line numbers in `index.test.ts` and `markdownIntegration.test.ts` to reflect 1-based indexing.
>     - Ensure tests verify correct parsing and line number output for various file types and scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for eb4e2b6b27538509803a8ceb62ee7ebaa2a9b765. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->