### PR TITLE
Remove the experimental unified diff

### DIFF
--- a/.changeset/popular-teachers-brush.md
+++ b/.changeset/popular-teachers-brush.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Remove the experimental unified diff

--- a/evals/packages/types/src/roo-code-defaults.ts
+++ b/evals/packages/types/src/roo-code-defaults.ts
@@ -47,9 +47,8 @@ export const rooCodeDefaults: RooCodeSettings = {
 	diffEnabled: true,
 	fuzzyMatchThreshold: 1.0,
 	experiments: {
-		experimentalDiffStrategy: false, // unified diff
-		multi_search_and_replace: false, // multi-line search and replace
-		search_and_replace: true, // single-line search and replace
+		multi_search_and_replace: false,
+		search_and_replace: true,
 		insert_content: false,
 		powerSteering: false,
 	},

--- a/evals/packages/types/src/roo-code.ts
+++ b/evals/packages/types/src/roo-code.ts
@@ -271,7 +271,6 @@ export type CustomSupportPrompts = z.infer<typeof customSupportPromptsSchema>
  */
 
 export const experimentIds = [
-	"experimentalDiffStrategy",
 	"search_and_replace",
 	"insert_content",
 	"powerSteering",
@@ -287,7 +286,6 @@ export type ExperimentId = z.infer<typeof experimentIdsSchema>
  */
 
 const experimentsSchema = z.object({
-	experimentalDiffStrategy: z.boolean(),
 	search_and_replace: z.boolean(),
 	insert_content: z.boolean(),
 	powerSteering: z.boolean(),

--- a/src/core/diff/DiffStrategy.ts
+++ b/src/core/diff/DiffStrategy.ts
@@ -20,6 +20,4 @@ type GetDiffStrategyOptions = {
 }
 
 export const getDiffStrategy = ({ fuzzyMatchThreshold, experiments }: GetDiffStrategyOptions): DiffStrategy =>
-	experiments[EXPERIMENT_IDS.DIFF_STRATEGY_UNIFIED]
-		? new NewUnifiedDiffStrategy(fuzzyMatchThreshold)
-		: new MultiSearchReplaceDiffStrategy(fuzzyMatchThreshold)
+	new MultiSearchReplaceDiffStrategy(fuzzyMatchThreshold)

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -1190,7 +1190,7 @@ describe("ClineProvider", () => {
 				}),
 			}))
 
-			// Mock getState to return experimentalDiffStrategy, diffEnabled and fuzzyMatchThreshold
+			// Mock getState to return diffEnabled and fuzzyMatchThreshold
 			jest.spyOn(provider, "getState").mockResolvedValue({
 				apiConfiguration: {
 					apiProvider: "openrouter",
@@ -1202,7 +1202,6 @@ describe("ClineProvider", () => {
 				enableMcpServerCreation: true,
 				mcpEnabled: false,
 				browserViewportSize: "900x600",
-				experimentalDiffStrategy: true,
 				diffEnabled: true,
 				fuzzyMatchThreshold: 0.8,
 				experiments: experimentDefault,
@@ -1259,7 +1258,6 @@ describe("ClineProvider", () => {
 				mode: "code",
 				mcpEnabled: false,
 				browserViewportSize: "900x600",
-				experimentalDiffStrategy: true,
 				diffEnabled: false,
 				fuzzyMatchThreshold: 0.8,
 				experiments: experimentDefault,

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1253,13 +1253,6 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 
 			await provider.updateGlobalState("experiments", updatedExperiments)
 
-			const currentCline = provider.getCurrentCline()
-
-			// Update diffStrategy in current Cline instance if it exists.
-			if (message.values[EXPERIMENT_IDS.DIFF_STRATEGY_UNIFIED] !== undefined && currentCline) {
-				await currentCline.updateDiffStrategy(updatedExperiments)
-			}
-
 			await provider.postStateToWebview()
 			break
 		}

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -253,7 +253,6 @@ type GlobalSettings = {
 	experiments?:
 		| {
 				search_and_replace: boolean
-				experimentalDiffStrategy: boolean
 				insert_content: boolean
 				powerSteering: boolean
 		  }

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -256,7 +256,6 @@ type GlobalSettings = {
 	experiments?:
 		| {
 				search_and_replace: boolean
-				experimentalDiffStrategy: boolean
 				insert_content: boolean
 				powerSteering: boolean
 		  }

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -274,12 +274,7 @@ export type CustomSupportPrompts = z.infer<typeof customSupportPromptsSchema>
  * ExperimentId
  */
 
-export const experimentIds = [
-	"search_and_replace",
-	"experimentalDiffStrategy",
-	"insert_content",
-	"powerSteering",
-] as const
+export const experimentIds = ["search_and_replace", "insert_content", "powerSteering"] as const
 
 export const experimentIdsSchema = z.enum(experimentIds)
 
@@ -291,7 +286,6 @@ export type ExperimentId = z.infer<typeof experimentIdsSchema>
 
 const experimentsSchema = z.object({
 	search_and_replace: z.boolean(),
-	experimentalDiffStrategy: z.boolean(),
 	insert_content: z.boolean(),
 	powerSteering: z.boolean(),
 })

--- a/src/shared/__tests__/experiments.test.ts
+++ b/src/shared/__tests__/experiments.test.ts
@@ -14,7 +14,6 @@ describe("experiments", () => {
 		it("returns false when experiment is not enabled", () => {
 			const experiments: Record<ExperimentId, boolean> = {
 				powerSteering: false,
-				experimentalDiffStrategy: false,
 				search_and_replace: false,
 				insert_content: false,
 			}
@@ -24,7 +23,6 @@ describe("experiments", () => {
 		it("returns true when experiment is enabled", () => {
 			const experiments: Record<ExperimentId, boolean> = {
 				powerSteering: true,
-				experimentalDiffStrategy: false,
 				search_and_replace: false,
 				insert_content: false,
 			}
@@ -33,7 +31,6 @@ describe("experiments", () => {
 
 		it("returns false when experiment is not present", () => {
 			const experiments: Record<ExperimentId, boolean> = {
-				experimentalDiffStrategy: false,
 				search_and_replace: false,
 				insert_content: false,
 				powerSteering: false,

--- a/src/shared/experiments.ts
+++ b/src/shared/experiments.ts
@@ -4,7 +4,6 @@ import { AssertEqual, Equals, Keys, Values } from "../utils/type-fu"
 export type { ExperimentId }
 
 export const EXPERIMENT_IDS = {
-	DIFF_STRATEGY_UNIFIED: "experimentalDiffStrategy",
 	INSERT_BLOCK: "insert_content",
 	SEARCH_AND_REPLACE: "search_and_replace",
 	POWER_STEERING: "powerSteering",
@@ -19,7 +18,6 @@ interface ExperimentConfig {
 }
 
 export const experimentConfigsMap: Record<ExperimentKey, ExperimentConfig> = {
-	DIFF_STRATEGY_UNIFIED: { enabled: false },
 	INSERT_BLOCK: { enabled: false },
 	SEARCH_AND_REPLACE: { enabled: false },
 	POWER_STEERING: { enabled: false },

--- a/webview-ui/src/components/settings/AdvancedSettings.tsx
+++ b/webview-ui/src/components/settings/AdvancedSettings.tsx
@@ -3,12 +3,10 @@ import { useAppTranslation } from "@/i18n/TranslationContext"
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
 import { Cog } from "lucide-react"
 
-import { EXPERIMENT_IDS, ExperimentId } from "../../../../src/shared/experiments"
-
 import { cn } from "@/lib/utils"
 import { Slider } from "@/components/ui"
 
-import { SetCachedStateField, SetExperimentEnabled } from "./types"
+import { SetCachedStateField } from "./types"
 import { SectionHeader } from "./SectionHeader"
 import { Section } from "./Section"
 
@@ -17,16 +15,12 @@ type AdvancedSettingsProps = HTMLAttributes<HTMLDivElement> & {
 	diffEnabled?: boolean
 	fuzzyMatchThreshold?: number
 	setCachedStateField: SetCachedStateField<"rateLimitSeconds" | "diffEnabled" | "fuzzyMatchThreshold">
-	experiments: Record<ExperimentId, boolean>
-	setExperimentEnabled: SetExperimentEnabled
 }
 export const AdvancedSettings = ({
 	rateLimitSeconds,
 	diffEnabled,
 	fuzzyMatchThreshold,
 	setCachedStateField,
-	experiments,
-	setExperimentEnabled,
 	className,
 	...props
 }: AdvancedSettingsProps) => {
@@ -66,10 +60,6 @@ export const AdvancedSettings = ({
 						checked={diffEnabled}
 						onChange={(e: any) => {
 							setCachedStateField("diffEnabled", e.target.checked)
-							if (!e.target.checked) {
-								// Reset experimental strategies when diffs are disabled.
-								setExperimentEnabled(EXPERIMENT_IDS.DIFF_STRATEGY_UNIFIED, false)
-							}
 						}}>
 						<span className="font-medium">{t("settings:advanced.diff.label")}</span>
 					</VSCodeCheckbox>

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -482,8 +482,6 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone },
 						diffEnabled={diffEnabled}
 						fuzzyMatchThreshold={fuzzyMatchThreshold}
 						setCachedStateField={setCachedStateField}
-						setExperimentEnabled={setExperimentEnabled}
-						experiments={experiments}
 					/>
 				</div>
 

--- a/webview-ui/src/context/__tests__/ExtensionStateContext.test.tsx
+++ b/webview-ui/src/context/__tests__/ExtensionStateContext.test.tsx
@@ -210,7 +210,6 @@ describe("mergeExtensionState", () => {
 			...baseState,
 			apiConfiguration: { modelMaxTokens: 1234, modelMaxThinkingTokens: 123 },
 			experiments: {
-				experimentalDiffStrategy: true,
 				search_and_replace: true,
 				insert_content: true,
 			} as Record<ExperimentId, boolean>,
@@ -232,7 +231,6 @@ describe("mergeExtensionState", () => {
 		})
 
 		expect(result.experiments).toEqual({
-			experimentalDiffStrategy: true,
 			search_and_replace: true,
 			insert_content: true,
 			powerSteering: true,


### PR DESCRIPTION
At this point I think we should just focus our efforts on making the multi-diff great.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove experimental unified diff feature, focusing on multi-diff strategy across codebase.
> 
>   - **Behavior**:
>     - Removed `experimentalDiffStrategy` from `experiments` in `roo-code-defaults.ts` and `roo-code.ts`.
>     - Updated `getDiffStrategy` in `DiffStrategy.ts` to always use `MultiSearchReplaceDiffStrategy`.
>   - **Tests**:
>     - Removed references to `experimentalDiffStrategy` in `ClineProvider.test.ts` and `experiments.test.ts`.
>   - **Settings**:
>     - Removed `experimentalDiffStrategy` handling in `webviewMessageHandler.ts` and `AdvancedSettings.tsx`.
>     - Updated `SettingsView.tsx` to remove `setExperimentEnabled` for `experimentalDiffStrategy`.
>   - **Schemas and Types**:
>     - Removed `experimentalDiffStrategy` from `experiments.ts`, `index.ts`, `roo-code.d.ts`, and `types.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 78fef79e96c5238cb008a4ca25bf242a898d3bb1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->