### PR TITLE
Add profile management functions to API

### DIFF
--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -40,7 +40,7 @@ export class ProviderSettingsManager {
 		this.initialize().catch(console.error)
 	}
 
-	private generateId() {
+	public generateId() {
 		return Math.random().toString(36).substring(2, 15)
 	}
 

--- a/src/exports/interface.ts
+++ b/src/exports/interface.ts
@@ -73,6 +73,39 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	setConfiguration(values: RooCodeSettings): Promise<void>
 
 	/**
+	 * Creates a new API configuration profile
+	 * @param name The name of the profile
+	 * @returns The ID of the created profile
+	 */
+	createProfile(name: string): Promise<string>
+
+	/**
+	 * Returns a list of all configured profile names
+	 * @returns Array of profile names
+	 */
+	getProfiles(): string[]
+
+	/**
+	 * Changes the active API configuration profile
+	 * @param name The name of the profile to activate
+	 * @throws Error if the profile does not exist
+	 */
+	setActiveProfile(name: string): Promise<void>
+
+	/**
+	 * Returns the name of the currently active profile
+	 * @returns The profile name, or undefined if no profile is active
+	 */
+	getActiveProfile(): string | undefined
+
+	/**
+	 * Deletes a profile by name
+	 * @param name The name of the profile to delete
+	 * @throws Error if the profile does not exist
+	 */
+	deleteProfile(name: string): Promise<void>
+
+	/**
 	 * Returns true if the API is ready to use.
 	 */
 	isReady(): boolean

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -573,6 +573,34 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 */
 	setConfiguration(values: RooCodeSettings): Promise<void>
 	/**
+	 * Creates a new API configuration profile
+	 * @param name The name of the profile
+	 * @returns The ID of the created profile
+	 */
+	createProfile(name: string): Promise<string>
+	/**
+	 * Returns a list of all configured profile names
+	 * @returns Array of profile names
+	 */
+	getProfiles(): string[]
+	/**
+	 * Changes the active API configuration profile
+	 * @param name The name of the profile to activate
+	 * @throws Error if the profile does not exist
+	 */
+	setActiveProfile(name: string): Promise<void>
+	/**
+	 * Returns the name of the currently active profile
+	 * @returns The profile name, or undefined if no profile is active
+	 */
+	getActiveProfile(): string | undefined
+	/**
+	 * Deletes a profile by name
+	 * @param name The name of the profile to delete
+	 * @throws Error if the profile does not exist
+	 */
+	deleteProfile(name: string): Promise<void>
+	/**
 	 * Returns true if the API is ready to use.
 	 */
 	isReady(): boolean


### PR DESCRIPTION
## Context

Continuing the work outlined in the [How to configure Roo from outside of Roo?](https://discord.com/channels/1332146336664915968/1353570725432397926) Discord thread, this PR adds several profile management functions to the Roo extension's exported API: 

* `createProfile(name: string)`
* `getProfiles(): string[]`
* `setActiveProfile(name: string): Promise<void>`
* `getActiveProfile(): string | undefined`
* `deleteProfile(name: string): Promise<void>`

I've tested all of these functions against our WIP Roo Configurator extension.

## Implementation

Most of the changes of substance are in api.ts and build on the recent work to improve the configuration APIs.

I'm using names instead of profile IDs since the settings JSON seems to use them for specifying current active profile.

## How to Test

Create a custom extension that calls these APIs and do something like this:

```
npm run build && code --uninstall-extension rooveterinaryinc.roo-cline && code --install-extension bin/roo-cline-3.11.4.vsix
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds profile management functions to the API, enabling creation, retrieval, activation, and deletion of profiles, with updates to `RooCodeAPI` interface and `generateId` method.
> 
>   - **API Enhancements**:
>     - Adds profile management functions to `API` class in `api.ts`: `createProfile`, `getProfiles`, `setActiveProfile`, `getActiveProfile`, `deleteProfile`.
>     - Functions handle profile creation, retrieval, activation, and deletion by name.
>   - **Interface Updates**:
>     - Updates `RooCodeAPI` interface in `interface.ts` and `roo-code.d.ts` to include new profile management functions.
>   - **Miscellaneous**:
>     - Changes `generateId` method in `ProviderSettingsManager.ts` to public to support profile ID generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d2997399d2a063735cf4fe74873399fea75d47b2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->