### PR TITLE
chore: Add more multi-block tests for apply_diff tool

### DIFF
--- a/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
@@ -76,6 +76,54 @@ function hello() {
 				}
 			})
 
+			it("should replace matching content in multiple blocks", async () => {
+				const originalContent = 'function hello() {\n    console.log("hello")\n}\n'
+				const diffContent = `test.ts
+<<<<<<< SEARCH
+function hello() {
+=======
+function helloWorld() {
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+    console.log("hello")
+=======
+    console.log("hello world")
+>>>>>>> REPLACE`
+
+				const result = await strategy.applyDiff(originalContent, diffContent)
+				expect(result.success).toBe(true)
+				if (result.success) {
+					expect(result.content).toBe('function helloWorld() {\n    console.log("hello world")\n}\n')
+				}
+			})
+
+			it("should replace matching content in multiple blocks with line numbers", async () => {
+				const originalContent = 'function hello() {\n    console.log("hello")\n}\n'
+				const diffContent = `test.ts
+<<<<<<< SEARCH
+:start_line:1
+:end_line:1
+-------
+function hello() {
+=======
+function helloWorld() {
+>>>>>>> REPLACE
+<<<<<<< SEARCH
+:start_line:2
+:end_line:2
+-------
+    console.log("hello")
+=======
+    console.log("hello world")
+>>>>>>> REPLACE`
+
+				const result = await strategy.applyDiff(originalContent, diffContent)
+				expect(result.success).toBe(true)
+				if (result.success) {
+					expect(result.content).toBe('function helloWorld() {\n    console.log("hello world")\n}\n')
+				}
+			})
+
 			it("should match content with different surrounding whitespace", async () => {
 				const originalContent = "\nfunction example() {\n    return 42;\n}\n\n"
 				const diffContent = `test.ts


### PR DESCRIPTION
## Context

While working on https://github.com/RooVetGit/Roo-Code/pull/2260 I noticed lack of multi-block diff tests, so added these.

## Implementation

New tests.

## Screenshots

Not applicable.

## How to Test

`npm test`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tests for multi-block replacements and line number handling in `multi-search-replace.test.ts`.
> 
>   - **Tests**:
>     - Add tests for multi-block replacements in `multi-search-replace.test.ts`.
>     - Include tests for handling line numbers in diffs.
>     - Ensure `applyDiff` handles multiple blocks correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bfac54664434f588be93fc7d78edf9277308607d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->