### PR TITLE
Fix for focus grabbing when follow-up returns + Unit Test

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -140,9 +140,13 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 						case "followup":
 							setTextAreaDisabled(isPartial)
 							setClineAsk("followup")
-							setEnableButtons(isPartial)
-							// setPrimaryButtonText(undefined)
-							// setSecondaryButtonText(undefined)
+							// setting enable buttons to `false` would trigger a focus grab when
+							// the text area is enabled which is undesirable.
+							// We have no buttons for this tool, so no problem having them "enabled"
+							// to workaround this issue.  See #1358.
+							setEnableButtons(true)
+							setPrimaryButtonText(undefined)
+							setSecondaryButtonText(undefined)
 							break
 						case "tool":
 							if (!isAutoApproved(lastMessage)) {


### PR DESCRIPTION
## Context

See issue 1 in this discussion: https://github.com/RooVetGit/Roo-Code/discussions/1358

When "ask followup question" tool is invoked, Roo grabs focus away from whateever the user is doing which is annoying.

## Implementation

A localized fix for the "ask followup question" tool, for reasons explained here: https://github.com/RooVetGit/Roo-Code/discussions/1358#discussioncomment-12712558

Product code change was simple.  Getting a Unit Test that reproduced the failure with the old code change proved rather tricky, but I got there in the end. 

## Screenshots

N/A

## How to Test

Ask Roo to ask you a follow-up question (doesn't matter what).
Move your focus aay from the text area - e.g. start typing into another file.
Observe that when the follow up question is ready, focus does not get grabbed.

A couple of other focus-grabs that remain (I took care not to break these).
- Switching into the Roo extension context from another extension
- Switching to the Roo chat tab from another tab.

-->

## Get in Touch

diarmid/diarmidm on Discord.

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes focus grabbing issue in `ChatView.tsx` for follow-up questions and adds a unit test to verify the behavior.
> 
>   - **Behavior**:
>     - Fixes focus grabbing issue in `ChatView.tsx` when a follow-up question is presented by setting `setEnableButtons(true)` to prevent focus change.
>   - **Testing**:
>     - Adds a unit test in `ChatView.test.tsx` to verify that focus is not grabbed when a follow-up question is presented.
>     - Uses `mockFocus` to track focus calls and ensures it remains unchanged after follow-up questions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cf6bb387bc9d5845f524f9fdbba3cfc9fffdd194. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->