### PR TITLE
Show menu buttons in tab view

### DIFF
--- a/package.json
+++ b/package.json
@@ -265,6 +265,43 @@
 					"group": "navigation@7",
 					"when": "view == roo-cline.SidebarProvider"
 				}
+			],
+			"editor/title": [
+				{
+					"command": "roo-cline.plusButtonClicked",
+					"group": "navigation@1",
+					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
+				},
+				{
+					"command": "roo-cline.promptsButtonClicked",
+					"group": "navigation@2",
+					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
+				},
+				{
+					"command": "roo-cline.mcpButtonClicked",
+					"group": "navigation@3",
+					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
+				},
+				{
+					"command": "roo-cline.historyButtonClicked",
+					"group": "navigation@4",
+					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
+				},
+				{
+					"command": "roo-cline.popoutButtonClicked",
+					"group": "navigation@5",
+					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
+				},
+				{
+					"command": "roo-cline.settingsButtonClicked",
+					"group": "navigation@6",
+					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
+				},
+				{
+					"command": "roo-cline.helpButtonClicked",
+					"group": "navigation@7",
+					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
+				}
 			]
 		},
 		"configuration": {

--- a/src/activate/__tests__/registerCommands.test.ts
+++ b/src/activate/__tests__/registerCommands.test.ts
@@ -1,0 +1,54 @@
+jest.mock("vscode", () => ({
+	CodeActionKind: {
+		QuickFix: { value: "quickfix" },
+		RefactorRewrite: { value: "refactor.rewrite" },
+	},
+	window: {
+		createTextEditorDecorationType: jest.fn().mockReturnValue({ dispose: jest.fn() }),
+	},
+}))
+
+import * as vscode from "vscode"
+import { ClineProvider } from "../../core/webview/ClineProvider"
+
+// Import the helper function from the actual file
+import { getVisibleProviderOrLog } from "../registerCommands"
+
+jest.mock("../../core/webview/ClineProvider")
+
+describe("getVisibleProviderOrLog", () => {
+	let mockOutputChannel: vscode.OutputChannel
+
+	beforeEach(() => {
+		mockOutputChannel = {
+			appendLine: jest.fn(),
+			append: jest.fn(),
+			clear: jest.fn(),
+			hide: jest.fn(),
+			name: "mock",
+			replace: jest.fn(),
+			show: jest.fn(),
+			dispose: jest.fn(),
+		}
+		jest.clearAllMocks()
+	})
+
+	it("returns the visible provider if found", () => {
+		const mockProvider = {} as ClineProvider
+		;(ClineProvider.getVisibleInstance as jest.Mock).mockReturnValue(mockProvider)
+
+		const result = getVisibleProviderOrLog(mockOutputChannel)
+
+		expect(result).toBe(mockProvider)
+		expect(mockOutputChannel.appendLine).not.toHaveBeenCalled()
+	})
+
+	it("logs and returns undefined if no provider found", () => {
+		;(ClineProvider.getVisibleInstance as jest.Mock).mockReturnValue(undefined)
+
+		const result = getVisibleProviderOrLog(mockOutputChannel)
+
+		expect(result).toBeUndefined()
+		expect(mockOutputChannel.appendLine).toHaveBeenCalledWith("Cannot find any visible Cline instances.")
+	})
+})

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -52,23 +52,48 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 	return {
 		"roo-cline.activationCompleted": () => {},
 		"roo-cline.plusButtonClicked": async () => {
-			await provider.removeClineFromStack()
-			await provider.postStateToWebview()
-			await provider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				outputChannel.appendLine("Cannot find any visible Cline instances.")
+				return
+			}
+			await visibleProvider.removeClineFromStack()
+			await visibleProvider.postStateToWebview()
+			await visibleProvider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
 		},
 		"roo-cline.mcpButtonClicked": () => {
-			provider.postMessageToWebview({ type: "action", action: "mcpButtonClicked" })
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				outputChannel.appendLine("Cannot find any visible Cline instances.")
+				return
+			}
+			visibleProvider.postMessageToWebview({ type: "action", action: "mcpButtonClicked" })
 		},
 		"roo-cline.promptsButtonClicked": () => {
-			provider.postMessageToWebview({ type: "action", action: "promptsButtonClicked" })
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				outputChannel.appendLine("Cannot find any visible Cline instances.")
+				return
+			}
+			visibleProvider.postMessageToWebview({ type: "action", action: "promptsButtonClicked" })
 		},
 		"roo-cline.popoutButtonClicked": () => openClineInNewTab({ context, outputChannel }),
 		"roo-cline.openInNewTab": () => openClineInNewTab({ context, outputChannel }),
 		"roo-cline.settingsButtonClicked": () => {
-			provider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				outputChannel.appendLine("Cannot find any visible Cline instances.")
+				return
+			}
+			visibleProvider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
 		},
 		"roo-cline.historyButtonClicked": () => {
-			provider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
+			const visibleProvider = ClineProvider.getVisibleInstance()
+			if (!visibleProvider) {
+				outputChannel.appendLine("Cannot find any visible Cline instances.")
+				return
+			}
+			visibleProvider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
 		},
 		"roo-cline.helpButtonClicked": () => {
 			vscode.env.openExternal(vscode.Uri.parse("https://docs.roocode.com"))

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -3,6 +3,18 @@ import delay from "delay"
 
 import { ClineProvider } from "../core/webview/ClineProvider"
 
+/**
+ * Helper to get the visible ClineProvider instance or log if not found.
+ */
+export function getVisibleProviderOrLog(outputChannel: vscode.OutputChannel): ClineProvider | undefined {
+	const visibleProvider = ClineProvider.getVisibleInstance()
+	if (!visibleProvider) {
+		outputChannel.appendLine("Cannot find any visible Cline instances.")
+		return undefined
+	}
+	return visibleProvider
+}
+
 import { registerHumanRelayCallback, unregisterHumanRelayCallback, handleHumanRelayResponse } from "./humanRelay"
 import { handleNewTask } from "./handleTask"
 
@@ -52,47 +64,32 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 	return {
 		"roo-cline.activationCompleted": () => {},
 		"roo-cline.plusButtonClicked": async () => {
-			const visibleProvider = ClineProvider.getVisibleInstance()
-			if (!visibleProvider) {
-				outputChannel.appendLine("Cannot find any visible Cline instances.")
-				return
-			}
+			const visibleProvider = getVisibleProviderOrLog(outputChannel)
+			if (!visibleProvider) return
 			await visibleProvider.removeClineFromStack()
 			await visibleProvider.postStateToWebview()
 			await visibleProvider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
 		},
 		"roo-cline.mcpButtonClicked": () => {
-			const visibleProvider = ClineProvider.getVisibleInstance()
-			if (!visibleProvider) {
-				outputChannel.appendLine("Cannot find any visible Cline instances.")
-				return
-			}
+			const visibleProvider = getVisibleProviderOrLog(outputChannel)
+			if (!visibleProvider) return
 			visibleProvider.postMessageToWebview({ type: "action", action: "mcpButtonClicked" })
 		},
 		"roo-cline.promptsButtonClicked": () => {
-			const visibleProvider = ClineProvider.getVisibleInstance()
-			if (!visibleProvider) {
-				outputChannel.appendLine("Cannot find any visible Cline instances.")
-				return
-			}
+			const visibleProvider = getVisibleProviderOrLog(outputChannel)
+			if (!visibleProvider) return
 			visibleProvider.postMessageToWebview({ type: "action", action: "promptsButtonClicked" })
 		},
 		"roo-cline.popoutButtonClicked": () => openClineInNewTab({ context, outputChannel }),
 		"roo-cline.openInNewTab": () => openClineInNewTab({ context, outputChannel }),
 		"roo-cline.settingsButtonClicked": () => {
-			const visibleProvider = ClineProvider.getVisibleInstance()
-			if (!visibleProvider) {
-				outputChannel.appendLine("Cannot find any visible Cline instances.")
-				return
-			}
+			const visibleProvider = getVisibleProviderOrLog(outputChannel)
+			if (!visibleProvider) return
 			visibleProvider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
 		},
 		"roo-cline.historyButtonClicked": () => {
-			const visibleProvider = ClineProvider.getVisibleInstance()
-			if (!visibleProvider) {
-				outputChannel.appendLine("Cannot find any visible Cline instances.")
-				return
-			}
+			const visibleProvider = getVisibleProviderOrLog(outputChannel)
+			if (!visibleProvider) return
 			visibleProvider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
 		},
 		"roo-cline.helpButtonClicked": () => {


### PR DESCRIPTION
Based on https://github.com/cline/cline/pull/2511 - thank you @benny123tw for figuring this out!

![Screenshot 2025-04-03 at 11 16 10 PM](https://github.com/user-attachments/assets/18bddc92-2e15-4426-bd98-cbf53eee3358)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds menu buttons to tab view and tests for visible provider handling in `registerCommands.ts`.
> 
>   - **Behavior**:
>     - Adds menu buttons to `editor/title` in `package.json` for tab view with commands like `plusButtonClicked`, `promptsButtonClicked`, etc.
>     - Uses `getVisibleProviderOrLog` in `registerCommands.ts` to ensure commands operate on the visible provider.
>   - **Testing**:
>     - Adds `registerCommands.test.ts` to test `getVisibleProviderOrLog` function, ensuring it returns the visible provider or logs an error if none is found.
>   - **Functions**:
>     - Adds `getVisibleProviderOrLog` in `registerCommands.ts` to fetch visible `ClineProvider` or log an error.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 98f85468e8fb34ca695c904490045d6638d707b1. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->