### PR TITLE
Better logic for choosing the view column when opening Roo in a tab

### DIFF
--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -132,7 +132,7 @@ export const openClineInNewTab = async ({ context, outputChannel }: Omit<Registe
 	if (!hasVisibleEditors) {
 		// No editors open, open in first column
 		targetCol = vscode.ViewColumn.One
-	} else if (activeEditor && activeEditor.document.fileName === "" && vscode.window.visibleTextEditors.length === 1) {
+	} else if (activeEditor && activeEditor.document.isUntitled && vscode.window.visibleTextEditors.length === 1) {
 		// Only one editor and it's empty (untitled), reuse it
 		targetCol = activeEditor.viewColumn ?? vscode.ViewColumn.One
 	} else {

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -123,17 +123,25 @@ export const openClineInNewTab = async ({ context, outputChannel }: Omit<Registe
 	// don't need to use that event).
 	// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
 	const tabProvider = new ClineProvider(context, outputChannel, "editor")
-	const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
 
-	// Check if there are any visible text editors, otherwise open a new group
-	// to the right.
+	const activeEditor = vscode.window.activeTextEditor
 	const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
 
-	if (!hasVisibleEditors) {
-		await vscode.commands.executeCommand("workbench.action.newGroupRight")
-	}
+	let targetCol: vscode.ViewColumn
 
-	const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
+	if (!hasVisibleEditors) {
+		// No editors open, open in first column
+		targetCol = vscode.ViewColumn.One
+	} else if (activeEditor && activeEditor.document.fileName === "" && vscode.window.visibleTextEditors.length === 1) {
+		// Only one editor and it's empty (untitled), reuse it
+		targetCol = activeEditor.viewColumn ?? vscode.ViewColumn.One
+	} else {
+		// Otherwise, create a new group to the right
+		await vscode.commands.executeCommand("workbench.action.newGroupRight")
+		// New group becomes the last + 1
+		const lastCol = Math.max(...vscode.window.visibleTextEditors.map((e) => e.viewColumn || 1))
+		targetCol = (lastCol + 1) as vscode.ViewColumn
+	}
 
 	const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Roo Code", targetCol, {
 		enableScripts: true,


### PR DESCRIPTION
Before:
![Screenshot 2025-04-03 at 11 44 45 PM](https://github.com/user-attachments/assets/0e02d9a0-acc6-4d29-9406-b006591119e3)


After:
![Screenshot 2025-04-03 at 11 43 39 PM](https://github.com/user-attachments/assets/ad4d6143-f6e9-428e-acc4-2e4648768600)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves logic in `openClineInNewTab` for selecting view column when opening a new tab in `registerCommands.ts`.
> 
>   - **Behavior**:
>     - Updates `openClineInNewTab` in `registerCommands.ts` to improve logic for selecting view column when opening a new tab.
>     - Opens in first column if no editors are visible.
>     - Reuses the column of a single untitled editor if it's the only one open.
>     - Creates a new group to the right and sets the target column to the last column + 1 if multiple editors are open.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2cd4a28781279fa727139ad4287094cd75daaf88. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->