### PR TITLE
Revert "Better logic for choosing the view column when opening Roo in a tab"

### DIFF
--- a/.changeset/hip-pumpkins-mate.md
+++ b/.changeset/hip-pumpkins-mate.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Revert "Better logic for choosing the view column when opening Roo in a tab"

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -123,25 +123,17 @@ export const openClineInNewTab = async ({ context, outputChannel }: Omit<Registe
 	// don't need to use that event).
 	// https://github.com/microsoft/vscode-extension-samples/blob/main/webview-sample/src/extension.ts
 	const tabProvider = new ClineProvider(context, outputChannel, "editor")
+	const lastCol = Math.max(...vscode.window.visibleTextEditors.map((editor) => editor.viewColumn || 0))
 
-	const activeEditor = vscode.window.activeTextEditor
+	// Check if there are any visible text editors, otherwise open a new group
+	// to the right.
 	const hasVisibleEditors = vscode.window.visibleTextEditors.length > 0
 
-	let targetCol: vscode.ViewColumn
-
 	if (!hasVisibleEditors) {
-		// No editors open, open in first column
-		targetCol = vscode.ViewColumn.One
-	} else if (activeEditor && activeEditor.document.isUntitled && vscode.window.visibleTextEditors.length === 1) {
-		// Only one editor and it's empty (untitled), reuse it
-		targetCol = activeEditor.viewColumn ?? vscode.ViewColumn.One
-	} else {
-		// Otherwise, create a new group to the right
 		await vscode.commands.executeCommand("workbench.action.newGroupRight")
-		// New group becomes the last + 1
-		const lastCol = Math.max(...vscode.window.visibleTextEditors.map((e) => e.viewColumn || 1))
-		targetCol = (lastCol + 1) as vscode.ViewColumn
 	}
+
+	const targetCol = hasVisibleEditors ? Math.max(lastCol + 1, 1) : vscode.ViewColumn.Two
 
 	const newPanel = vscode.window.createWebviewPanel(ClineProvider.tabPanelId, "Roo Code", targetCol, {
 		enableScripts: true,


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#2282
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts logic in `openClineInNewTab` to simplify view column selection when opening a new tab in VSCode.
> 
>   - **Behavior**:
>     - Reverts logic in `openClineInNewTab` in `registerCommands.ts` to simplify view column selection.
>     - Opens new tab in a new group to the right if editors are visible, or in `ViewColumn.Two` if none are visible.
>   - **Misc**:
>     - Removes complex conditions for determining `targetCol` based on active editor and untitled documents.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e5005c33e9a97e6cd8825892326288ae51908536. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->