### PR TITLE
Improve evals settings import

### DIFF
--- a/evals/apps/web/src/app/runs/new/new-run.tsx
+++ b/evals/apps/web/src/app/runs/new/new-run.tsx
@@ -9,7 +9,7 @@ import fuzzysort from "fuzzysort"
 import { toast } from "sonner"
 import { X, Rocket, Check, ChevronsUpDown, HardDriveUpload, CircleCheck } from "lucide-react"
 
-import { globalSettingsSchema, rooCodeDefaults } from "@evals/types"
+import { globalSettingsSchema, providerSettingsSchema, rooCodeDefaults } from "@evals/types"
 
 import { createRun } from "@/lib/server/runs"
 import { createRunSchema as formSchema, type CreateRun as FormValues } from "@/lib/schemas"
@@ -73,7 +73,6 @@ export function NewRun() {
 
 	const {
 		setValue,
-		setError,
 		clearErrors,
 		watch,
 		formState: { isSubmitting },
@@ -147,14 +146,51 @@ export function NewRun() {
 			clearErrors("settings")
 
 			try {
-				const result = z.object({ globalSettings: globalSettingsSchema }).parse(JSON.parse(await file.text()))
-				setValue("settings", result.globalSettings)
+				const { providerProfiles, globalSettings } = z
+					.object({
+						providerProfiles: z.object({
+							currentApiConfigName: z.string(),
+							apiConfigs: z.record(z.string(), providerSettingsSchema),
+						}),
+						globalSettings: globalSettingsSchema,
+					})
+					.parse(JSON.parse(await file.text()))
+
+				const providerSettings = providerProfiles.apiConfigs[providerProfiles.currentApiConfigName] ?? {}
+
+				if (providerSettings.apiProvider === "openrouter" && providerSettings.openRouterModelId) {
+					const {
+						openRouterModelId,
+						modelMaxTokens,
+						modelMaxThinkingTokens,
+						modelTemperature,
+						includeMaxTokens,
+					} = providerSettings
+
+					const model = openRouterModelId
+
+					const settings = {
+						...rooCodeDefaults,
+						openRouterModelId,
+						modelMaxTokens,
+						modelMaxThinkingTokens,
+						modelTemperature,
+						includeMaxTokens,
+						...globalSettings,
+					}
+
+					setValue("model", model)
+					setValue("settings", settings)
+				} else {
+					setValue("settings", globalSettings)
+				}
+
 				event.target.value = ""
-			} catch (_error) {
-				setError("settings", { message: "Error parsing JSON file. Please check the file format." })
+			} catch (e) {
+				toast.error(e instanceof Error ? e.message : "An unknown error occurred.")
 			}
 		},
-		[clearErrors, setError, setValue],
+		[clearErrors, setValue],
 	)
 
 	return (

--- a/evals/apps/web/src/app/runs/new/settings-diff.tsx
+++ b/evals/apps/web/src/app/runs/new/settings-diff.tsx
@@ -1,6 +1,6 @@
 import { Fragment, HTMLAttributes } from "react"
 
-import { RooCodeSettings } from "@evals/types"
+import { RooCodeSettings, ROO_CODE_SETTINGS_KEYS } from "@evals/types"
 
 import { cn } from "@/lib/utils"
 
@@ -23,7 +23,8 @@ export function SettingsDiff({
 			<div className="font-medium text-muted-foreground">Setting</div>
 			<div className="font-medium text-muted-foreground">Default</div>
 			<div className="font-medium text-muted-foreground">Custom</div>
-			{Object.entries(defaults).flatMap(([key, defaultValue]) => {
+			{ROO_CODE_SETTINGS_KEYS.map((key) => {
+				const defaultValue = defaults[key as keyof typeof defaults]
 				const customValue = custom[key as keyof typeof custom]
 				const isDefault = JSON.stringify(defaultValue) === JSON.stringify(customValue)
 
@@ -49,9 +50,15 @@ type SettingDiffProps = HTMLAttributes<HTMLDivElement> & {
 export function SettingDiff({ name, defaultValue, customValue, ...props }: SettingDiffProps) {
 	return (
 		<Fragment {...props}>
-			<div className="overflow-hidden font-mono">{name}</div>
-			<pre className="inline text-rose-500 line-through">{defaultValue}</pre>
-			<pre className="inline text-teal-500">{customValue}</pre>
+			<div className="overflow-hidden font-mono" title={name}>
+				{name}
+			</div>
+			<pre className="overflow-hidden inline text-rose-500 line-through" title={defaultValue}>
+				{defaultValue}
+			</pre>
+			<pre className="overflow-hidden inline text-teal-500" title={customValue}>
+				{customValue}
+			</pre>
 		</Fragment>
 	)
 }

--- a/evals/packages/types/src/roo-code.ts
+++ b/evals/packages/types/src/roo-code.ts
@@ -373,11 +373,10 @@ export const providerSettingsSchema = z.object({
 	requestyApiKey: z.string().optional(),
 	requestyModelId: z.string().optional(),
 	requestyModelInfo: modelInfoSchema.optional(),
-	// Claude 3.7 Sonnet Thinking
-	modelTemperature: z.number().nullish(),
-	modelMaxTokens: z.number().optional(),
-	modelMaxThinkingTokens: z.number().optional(),
 	// Generic
+	modelMaxTokens: z.number().optional(), // Currently only used by Anthropic hybrid thinking models.
+	modelMaxThinkingTokens: z.number().optional(), // Currently only used by Anthropic hybrid thinking models.
+	modelTemperature: z.number().nullish(),
 	includeMaxTokens: z.boolean().optional(),
 	// Fake AI
 	fakeAi: z.unknown().optional(),
@@ -618,6 +617,8 @@ export const GLOBAL_SETTINGS_KEYS = Object.keys(globalSettingsRecord) as Keys<Gl
 export const rooCodeSettingsSchema = providerSettingsSchema.merge(globalSettingsSchema)
 
 export type RooCodeSettings = GlobalSettings & ProviderSettings
+
+export const ROO_CODE_SETTINGS_KEYS = [...GLOBAL_SETTINGS_KEYS, ...PROVIDER_SETTINGS_KEYS] as Keys<RooCodeSettings>[]
 
 /**
  * SecretState


### PR DESCRIPTION
## Context

<img width="734" alt="Screenshot 2025-04-04 at 9 31 58 AM" src="https://github.com/user-attachments/assets/9cf2be05-4374-4da3-b875-6639ea98edd5" />

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves settings import in `NewRun` by handling provider-specific settings and enhances `SettingsDiff` with unified settings key management.
> 
>   - **Behavior**:
>     - `NewRun` component in `new-run.tsx` now imports `providerSettingsSchema` and handles provider-specific settings when importing JSON files.
>     - Improved error handling in `onImportSettings` by using `toast.error()` instead of `setError()`.
>   - **Components**:
>     - `SettingsDiff` in `settings-diff.tsx` now uses `ROO_CODE_SETTINGS_KEYS` to iterate over settings keys.
>     - Adds `title` attribute to `SettingDiff` elements for better accessibility.
>   - **Schemas**:
>     - Reorganizes `providerSettingsSchema` in `roo-code.ts` to clarify usage of settings like `modelMaxTokens` and `modelTemperature`.
>     - Introduces `ROO_CODE_SETTINGS_KEYS` in `roo-code.ts` for unified settings key management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0f81c1c553c76412149ca46a25379a4e9dda3f4f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->