### PR TITLE
Improve logic for Gemini free request limits

### DIFF
--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -37,6 +37,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -59,6 +60,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -99,6 +101,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -144,6 +147,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -165,6 +169,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -38,6 +38,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -60,6 +61,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -100,6 +102,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -145,6 +148,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined
@@ -166,6 +170,7 @@ type ProviderSettings = {
 				outputPrice?: number | undefined
 				cacheWritesPrice?: number | undefined
 				cacheReadsPrice?: number | undefined
+				freeRequestsRpm?: number | undefined
 				description?: string | undefined
 				reasoningEffort?: ("low" | "medium" | "high") | undefined
 				thinking?: boolean | undefined

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -109,6 +109,7 @@ export const modelInfoSchema = z.object({
 	outputPrice: z.number().optional(),
 	cacheWritesPrice: z.number().optional(),
 	cacheReadsPrice: z.number().optional(),
+	freeRequestsRpm: z.number().optional(),
 	description: z.string().optional(),
 	reasoningEffort: z.enum(["low", "medium", "high"]).optional(),
 	thinking: z.boolean().optional(),

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -628,6 +628,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 5,
 	},
 	"gemini-2.5-pro-preview-03-25": {
 		maxTokens: 65_535,
@@ -644,6 +645,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 15,
 	},
 	"gemini-2.0-flash-lite-preview-02-05": {
 		maxTokens: 8192,
@@ -652,6 +654,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 30,
 	},
 	"gemini-2.0-pro-exp-02-05": {
 		maxTokens: 8192,
@@ -660,6 +663,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 5,
 	},
 	"gemini-2.0-flash-thinking-exp-01-21": {
 		maxTokens: 65_536,
@@ -668,6 +672,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 10,
 	},
 	"gemini-2.0-flash-thinking-exp-1219": {
 		maxTokens: 8192,
@@ -676,6 +681,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 10,
 	},
 	"gemini-2.0-flash-exp": {
 		maxTokens: 8192,
@@ -684,6 +690,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 10,
 	},
 	"gemini-1.5-flash-002": {
 		maxTokens: 8192,
@@ -692,6 +699,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 15,
 	},
 	"gemini-1.5-flash-exp-0827": {
 		maxTokens: 8192,
@@ -700,6 +708,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 15,
 	},
 	"gemini-1.5-flash-8b-exp-0827": {
 		maxTokens: 8192,
@@ -708,6 +717,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 15,
 	},
 	"gemini-1.5-pro-002": {
 		maxTokens: 8192,
@@ -716,6 +726,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 2,
 	},
 	"gemini-1.5-pro-exp-0827": {
 		maxTokens: 8192,
@@ -724,6 +735,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 2,
 	},
 	"gemini-exp-1206": {
 		maxTokens: 8192,
@@ -732,6 +744,7 @@ export const geminiModels = {
 		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
+		freeRequestsRpm: 5,
 	},
 } as const satisfies Record<string, ModelInfo>
 

--- a/webview-ui/src/components/settings/ModelInfoView.tsx
+++ b/webview-ui/src/components/settings/ModelInfoView.tsx
@@ -77,12 +77,16 @@ export const ModelInfoView = ({
 			<span className="italic">
 				{selectedModelId === "gemini-2.5-pro-preview-03-25"
 					? t("settings:modelInfo.gemini.billingEstimate")
-					: t("settings:modelInfo.gemini.freeRequests", {
-							count: selectedModelId && selectedModelId.includes("flash") ? 15 : 2,
-						})}{" "}
-				<VSCodeLink href="https://ai.google.dev/pricing" className="text-sm">
-					{t("settings:modelInfo.gemini.pricingDetails")}
-				</VSCodeLink>
+					: modelInfo.freeRequestsRpm && modelInfo.freeRequestsRpm > 0
+					? t("settings:modelInfo.gemini.freeRequests", {
+							count: modelInfo.freeRequestsRpm,
+					  })
+					: null}{" "}
+				{(selectedModelId === "gemini-2.5-pro-preview-03-25" || (modelInfo.freeRequestsRpm && modelInfo.freeRequestsRpm > 0)) && (
+					<VSCodeLink href="https://ai.google.dev/pricing" className="text-sm">
+						{t("settings:modelInfo.gemini.pricingDetails")}
+					</VSCodeLink>
+				)}
 			</span>
 		),
 	].filter(Boolean)


### PR DESCRIPTION
## Context

Improve the logic for Gemini free request limits by moving the configuration from the UI to the centralized API. Previously, the limits (15 for flash models, 2 for others) were hardcoded in ModelInfoView, which reduced flexibility.

## Implementation

- Added a new `freeRequestsRPM` property to the ModelInfo schema.
- Updated the `geminiModels` in `src/shared/api.ts` to include the appropriate freeRequestsRPM values (15 for flash models, 2 for others).
- Modified ModelInfoView to read and display the freeRequestsRPM value from modelInfo.
- This change centralizes the configuration logic, supporting easier updates and better handling of multiple Gemini models.

## How to Test

I encountered issues running `npm run build` even for the main branch and could not test the changes. Please review and test the modifications.

My `npm run build` log:

```

> roo-cline@3.11.6 build
> npm run vsix


> roo-cline@3.11.6 vsix
> rimraf bin && mkdirp bin && npx vsce package --out bin

Executing prepublish script 'npm run vscode:prepublish'...

> roo-cline@3.11.6 vscode:prepublish
> npm run package


> roo-cline@3.11.6 package
> npm-run-all -l -p build:webview build:esbuild check-types lint

[check-types  ] 
[check-types  ] > roo-cline@3.11.6 check-types
[check-types  ] > npm-run-all -l -p check-types:*
[check-types  ] 
[build:esbuild] 
[build:esbuild] > roo-cline@3.11.6 build:esbuild
[build:esbuild] > node esbuild.js --production
[build:esbuild] 
[build:webview] 
[build:webview] > roo-cline@3.11.6 build:webview
[build:webview] > cd webview-ui && npm run build
[build:webview] 
[lint         ] 
[lint         ] > roo-cline@3.11.6 lint
[lint         ] > npm-run-all -l -p lint:*
[lint         ] 
[build:esbuild] [watch] build started
[build:webview] 
[build:webview] > webview-ui@0.1.0 build
[build:webview] > npm-run-all -p tsc vite-build
[build:webview] 
[check-types  ] [check-types:webview  ] 
[check-types  ] [check-types:webview  ] > roo-cline@3.11.6 check-types:webview
[check-types  ] [check-types:webview  ] > cd webview-ui && npm run check-types
[check-types  ] [check-types:webview  ] 
[lint         ] [lint:extension] 
[lint         ] [lint:extension] > roo-cline@3.11.6 lint:extension
[lint         ] [lint:extension] > eslint src --ext ts
[lint         ] [lint:extension] 
[check-types  ] [check-types:extension] 
[check-types  ] [check-types:extension] > roo-cline@3.11.6 check-types:extension
[check-types  ] [check-types:extension] > tsc --noEmit
[check-types  ] [check-types:extension] 
[lint         ] [lint:webview  ] 
[lint         ] [lint:webview  ] > roo-cline@3.11.6 lint:webview
[lint         ] [lint:webview  ] > cd webview-ui && npm run lint
[lint         ] [lint:webview  ] 
[lint         ] [lint:e2e      ] 
[lint         ] [lint:e2e      ] > roo-cline@3.11.6 lint:e2e
[lint         ] [lint:e2e      ] > cd e2e && npm run lint
[lint         ] [lint:e2e      ] 
[check-types  ] [check-types:e2e      ] 
[check-types  ] [check-types:e2e      ] > roo-cline@3.11.6 check-types:e2e
[check-types  ] [check-types:e2e      ] > cd e2e && npm run check-types
[check-types  ] [check-types:e2e      ] 
[build:webview] 
[build:webview] > webview-ui@0.1.0 vite-build
[build:webview] > vite build
[build:webview] 
[lint         ] [lint:e2e      ] 
[lint         ] [lint:e2e      ] > e2e@0.1.0 lint
[lint         ] [lint:e2e      ] > eslint src --ext ts
[lint         ] [lint:e2e      ] 
[build:webview] 
[build:webview] > webview-ui@0.1.0 tsc
[build:webview] > tsc -b
[build:webview] 
[lint         ] [lint:webview  ] 
[lint         ] [lint:webview  ] > webview-ui@0.1.0 lint
[lint         ] [lint:webview  ] > eslint src --ext ts,tsx
[lint         ] [lint:webview  ] 
[check-types  ] [check-types:webview  ] 
[check-types  ] [check-types:webview  ] > webview-ui@0.1.0 check-types
[check-types  ] [check-types:webview  ] > tsc
[check-types  ] [check-types:webview  ] 
[check-types  ] [check-types:e2e      ] 
[check-types  ] [check-types:e2e      ] > e2e@0.1.0 check-types
[check-types  ] [check-types:e2e      ] > tsc --noEmit
[check-types  ] [check-types:e2e      ] 
[build:esbuild] Copied locale files to dist/i18n/locales
[build:esbuild] Copied locale files to out/i18n/locales
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/debuggability.js:6:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/errors.js:4:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/finally.js:3:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/generators.js:10:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/join.js:5:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/method.js:4:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/nodeback.js:2:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/nodeify.js:3:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:14:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./async"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:31:20:
[build:esbuild] ✘ [ERROR] Could not resolve "./thenables"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:45:34:
[build:esbuild] ✘ [ERROR] Could not resolve "./context"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:49:22:
[build:esbuild] ✘ [ERROR] Could not resolve "./catch_filter"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:56:26:
[build:esbuild] ✘ [ERROR] Could not resolve "./bind"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:727:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./cancel"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:728:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./synchronous_inspection"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:730:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./map.js"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:735:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./call_get.js"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:736:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./using.js"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:737:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./timers.js"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:738:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./settle.js"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:745:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./some.js"
[build:esbuild]     node_modules/bluebird/js/release/promise.js:746:8:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/promise_array.js:4:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/promisify.js:4:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/props.js:4:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./util"
[build:esbuild]     node_modules/bluebird/js/release/race.js:4:19:
[build:esbuild] ✘ [ERROR] Could not resolve "./pdf.worker.js"
[build:esbuild]     node_modules/pdf-parse/lib/pdf.js/v1.10.100/build/pdf.js:3345:23:
[build:esbuild] [watch] build finished
[build:esbuild] Error: Build failed with 27 errors:
[build:esbuild] node_modules/bluebird/js/release/debuggability.js:6:19: ERROR: Could not resolve "./util"
[build:esbuild] node_modules/bluebird/js/release/errors.js:4:19: ERROR: Could not resolve "./util"
[build:esbuild] node_modules/bluebird/js/release/finally.js:3:19: ERROR: Could not resolve "./util"
[build:esbuild] node_modules/bluebird/js/release/generators.js:10:19: ERROR: Could not resolve "./util"
[build:esbuild] node_modules/bluebird/js/release/join.js:5:19: ERROR: Could not resolve "./util"
[build:esbuild] ...
[build:esbuild]     at failureErrorWithLog (/home/peter/repos/Roo-Code/node_modules/esbuild/lib/main.js:1476:15)
[build:esbuild]     at /home/peter/repos/Roo-Code/node_modules/esbuild/lib/main.js:945:25
[build:esbuild]     at /home/peter/repos/Roo-Code/node_modules/esbuild/lib/main.js:1354:9
[build:esbuild]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
[build:esbuild]   errors: [Getter/Setter],
[build:esbuild]   warnings: [Getter/Setter]
[build:esbuild] }
[build:webview] vite v6.0.11 building for production...
ERROR: "build:esbuild" exited with 1.
 ERROR  npm failed with exit code 1
peter@cleanup ~/repos/Roo-Code $ [04/0
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Centralizes Gemini free request limits by adding `freeRequestsRpm` to the API and updating the UI to use this centralized configuration.
> 
>   - **Behavior**:
>     - Adds `freeRequestsRpm` to `ModelInfo` schema in `index.ts`.
>     - Updates `geminiModels` in `api.ts` to include `freeRequestsRpm` values (15 for flash models, 2 for others).
>     - Modifies `ModelInfoView` in `ModelInfoView.tsx` to display `freeRequestsRpm` from `modelInfo`.
>   - **Types**:
>     - Adds `freeRequestsRpm` to `ProviderSettings` in `roo-code.d.ts` and `types.ts`.
>   - **Misc**:
>     - Centralizes configuration logic for easier updates and better handling of multiple Gemini models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 59538d1ca2e43414522d452e88a50be36446169c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->