### PR TITLE
Improve zh-TW Traditional Chinese locale

### DIFF
--- a/locales/zh-TW/README.md
+++ b/locales/zh-TW/README.md
@@ -33,18 +33,18 @@
 
 </div>
 
-**Roo Code** 是一個存在於您編輯器中的 AI 驅動的**自主編碼代理**。它可以：
+**Roo Code** 是一個存在於您編輯器中的 AI 驅動**自主程式開發助手**。它能夠：
 
-- 使用自然語言溝通
-- 直接在您的工作區讀寫文件
-- 執行終端命令
+- 使用自然語言與您溝通
+- 直接讀寫您工作區中的檔案
+- 執行終端機命令
 - 自動化瀏覽器操作
-- 與任何 OpenAI 相容或自定義的 API/模型整合
-- 透過**自定義模式**調整其"個性"和能力
+- 整合任何與 OpenAI 相容或自訂的 API/模型
+- 透過**自訂模式**調整其「個性」與功能
 
-無論您是尋找一個靈活的程式設計夥伴、系統架構師，還是專業角色如 QA 工程師或產品經理，Roo Code 都能幫助您更高效地建構軟體。
+無論您需要的是一位靈活的程式設計夥伴、系統架構師，或是 QA 工程師、產品經理等特定角色，Roo Code 都能協助您更有效率地開發軟體。
 
-檢視 [CHANGELOG](../CHANGELOG.md) 了解詳細更新和修復。
+請檢視 [CHANGELOG](../CHANGELOG.md) 了解詳細的更新與修正內容。
 
 ---
 
@@ -53,21 +53,21 @@
 Roo Code 3.11 帶來顯著的效能提升與全新功能！
 
 - **快速編輯** - 編輯套用速度大幅提升，減少等待時間，讓您專注於功能開發。
-- **API 金鑰餘額** - 現在可在設定中查看您的 OpenRouter 和 Requesty 餘額。
+- **API 金鑰餘額** - 現在可在設定中檢視您的 OpenRouter 和 Requesty 餘額。
 - **專案級 MCP 設定** - 支援依據專案或工作區進行個別設定。
 - **改進的 Gemini 支援** - 更智慧的重試機制，修正轉義問題，並新增至 Vertex 提供者。
 - **匯入/匯出設定** - 輕鬆備份或跨環境分享您的設定。
 
 ---
 
-## Roo Code 能做什麼？
+## Roo Code 可以做什麼？
 
-- 🚀 從自然語言描述**生成程式碼**
-- 🔧 **重構和除錯**現有程式碼
-- 📝 **編寫和更新**文件
-- 🤔 **回答關於**您程式碼庫的問題
-- 🔄 **自動化**重複性任務
-- 🏗️ **建立**新文件和專案
+- 🚀 從自然語言描述**產生程式碼**
+- 🔧 **重構與除錯**現有程式碼
+- 📝 **撰寫與更新**文件
+- 🤔 **回答**關於您的程式碼的問題
+- 🔄 **自動化**重複性工作
+- 🏗️ **建立**新檔案與專案
 
 ## 快速開始
 
@@ -85,27 +85,27 @@ Roo Code 提供專業化的[模式](https://docs.roocode.com/basic-usage/using-m
 - **架構師模式：** 規劃架構與技術領導
 - **詢問模式：** 回答問題與提供資訊
 - **除錯模式：** 系統化地診斷問題
-- **[自定義模式](https://docs.roocode.com/advanced-usage/custom-modes)：** 建立無限個專業角色，進行安全性審核、效能優化、文件撰寫或其他任何任務
+- **[客製化模式](https://docs.roocode.com/advanced-usage/custom-modes)：** 建立無限個專業角色，進行安全性審核、效能最佳化、文件撰寫或其他任何任務
 
 ### 智慧工具
 
-Roo Code 配備強大的[工具](https://docs.roocode.com/basic-usage/how-tools-work)，可以：
+Roo Code 內建強大的[工具](https://docs.roocode.com/basic-usage/how-tools-work)，能夠：
 
-- 讀寫您專案中的文件
-- 在您的 VS Code 終端中執行命令
+- 讀寫您專案中的檔案
+- 在您的 VS Code 終端機中執行命令
 - 控制網頁瀏覽器
 - 透過 [MCP (Model Context Protocol)](https://docs.roocode.com/advanced-usage/mcp) 使用外部工具
 
-MCP 擴展了 Roo Code 的能力，允許您新增無限的自定義工具。與外部 API 整合，連接到資料庫，或建立專業開發工具 - MCP 提供了擴展 Roo Code 功能以滿足您特定需求的框架。
+透過 MCP，您可以無限制地新增自訂工具，進一步擴充 Roo Code 的功能。無論是整合外部 API、連接資料庫，或建立專屬的開發工具，MCP 都提供完整的框架，讓您依據自身需求靈活擴充 Roo Code。
 
-### 自定義
+### 客製化
 
-讓 Roo Code 按照您的方式工作：
+Roo Code 可以配合您的需求進行調整：
 
-- [自定義指令](https://docs.roocode.com/advanced-usage/custom-instructions)用於個性化行為
-- [自定義模式](https://docs.roocode.com/advanced-usage/custom-modes)用於專業任務
-- [本機模型](https://docs.roocode.com/advanced-usage/local-models)用於離線使用
-- [自動批准設定](https://docs.roocode.com/advanced-usage/auto-approving-actions)用於更快的工作流程
+- [自訂指令](https://docs.roocode.com/advanced-usage/custom-instructions)：個人化 Roo Code 的行為
+- [自訂模式](https://docs.roocode.com/advanced-usage/custom-modes)：處理特定專業任務
+- [本機模型](https://docs.roocode.com/advanced-usage/local-models)：支援離線使用
+- [自動核准設定](https://docs.roocode.com/advanced-usage/auto-approving-actions)：加快工作流程
 
 ## 資源
 
@@ -123,38 +123,38 @@ MCP 擴展了 Roo Code 的能力，允許您新增無限的自定義工具。與
 
 ---
 
-## 本機設定和開發
+## 開發環境設定
 
-1. **克隆**儲存庫：
+1. **複製**儲存庫：
 
 ```sh
 git clone https://github.com/RooVetGit/Roo-Code.git
 ```
 
-2. **安裝依賴**：
+2. **安裝相依套件**：
 
 ```sh
 npm run install:all
 ```
 
-3. **啟動網頁檢視（帶有 HMR 的 Vite/React 應用）**：
+3. **啟動網頁檢視（Vite/React 應用程式，支援 HMR）**：
 
 ```sh
 npm run dev
 ```
 
 4. **除錯**：
-   在 VSCode 中按 `F5`（或**執行** → **開始除錯**）開啟一個載入了 Roo Code 的新會話。
+   在 VSCode 中按下 `F5`（或選擇**執行** → **開始除錯**）以開啟載入 Roo Code 的新工作階段。
 
-網頁檢視的更改將立即顯示。核心擴展的更改將需要重新啟動擴展主機。
+網頁檢視的變更會立即顯示。核心擴充功能的變更則需要重新啟動擴充主機。
 
-或者，您可以建構一個 .vsix 文件並直接在 VSCode 中安裝：
+或者，您也可以建置 .vsix 檔案並直接在 VSCode 中安裝：
 
 ```sh
 npm run build
 ```
 
-一個 `.vsix` 文件將出現在 `bin/` 目錄中，可以使用以下命令安裝：
+建置完成後，`.vsix` 檔案會出現在 `bin/` 目錄中，可使用以下指令安裝：
 
 ```sh
 code --install-extension bin/roo-cline-<version>.vsix
@@ -164,9 +164,9 @@ code --install-extension bin/roo-cline-<version>.vsix
 
 ---
 
-## 免責宣告
+## 免責聲明
 
-**請注意**，Roo Code, Inc **不**對與 Roo Code 相關的任何程式碼、模型或其他工具，任何相關的第三方工具，或任何產生的輸出做出任何陳述或保證。您承擔使用此類工具或輸出的**所有風險**；這些工具按**"原樣"**和**"可用性"**提供。這些風險可能包括但不限於智慧財產侵權、網路漏洞或攻擊、偏見、不準確、錯誤、缺陷、病毒、停機時間、財產損失或損壞和/或人身傷害。您對這些工具或輸出的使用（包括但不限於其合法性、適當性和結果）完全負責。
+**請注意**，Roo Code, Inc. **不**對與 Roo Code 相關的任何程式碼、模型或其他工具、任何相關的第三方工具，或任何產生的輸出提供任何陳述或保證。您使用這些工具或輸出時，需自行承擔**所有相關風險**；這些工具係以**「現況」**及**「現有」**基礎提供。上述風險包括但不限於智慧財產權侵害、網路安全漏洞或攻擊、偏見、不準確性、錯誤、缺陷、病毒、停機時間、財產損失或損害，以及／或人身傷害。您須自行負責使用這些工具或輸出所產生的任何結果（包括但不限於其合法性、適當性及後果）。
 
 ---
 

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -1,7 +1,7 @@
 {
 	"extension": {
 		"name": "Roo Code",
-		"description": "您編輯器中的完整AI開發團隊。"
+		"description": "您編輯器中的完整 AI 開發團隊。"
 	},
 	"number_format": {
 		"thousand_suffix": "k",
@@ -11,63 +11,63 @@
 	"welcome": "歡迎，{{name}}！您有 {{count}} 條通知。",
 	"items": {
 		"zero": "沒有項目",
-		"one": "1個項目",
+		"one": "1 個項目",
 		"other": "{{count}}個項目"
 	},
 	"confirmation": {
-		"reset_state": "您確定要重置擴展中的所有狀態和密鑰存儲嗎？此操作無法撤消。",
-		"delete_config_profile": "您確定要刪除此配置文件嗎？",
-		"delete_custom_mode": "您確定要刪除此自定義模式嗎？",
-		"delete_message": "您想刪除什麼？",
-		"just_this_message": "僅此消息",
-		"this_and_subsequent": "此消息及所有後續消息"
+		"reset_state": "您確定要重設擴充套件中的所有狀態和金鑰儲存嗎？此操作無法復原。",
+		"delete_config_profile": "您確定要刪除此設定檔案嗎？",
+		"delete_custom_mode": "您確定要刪除此自訂模式嗎？",
+		"delete_message": "您想刪除哪些內容？",
+		"just_this_message": "僅這則訊息",
+		"this_and_subsequent": "這則訊息及所有後續訊息"
 	},
 	"errors": {
-		"invalid_mcp_config": "項目MCP配置格式無效",
-		"invalid_mcp_settings_format": "MCP設置JSON格式無效。請確保您的設置遵循正確的JSON格式。",
-		"invalid_mcp_settings_syntax": "MCP設置JSON格式無效。請檢查您的設置文件是否有語法錯誤。",
-		"invalid_mcp_settings_validation": "MCP設置格式無效：{{errorMessages}}",
-		"failed_initialize_project_mcp": "初始化項目MCP服務器失敗：{{error}}",
-		"invalid_data_uri": "數據URI格式無效",
+		"invalid_mcp_config": "專案 MCP 設定格式無效",
+		"invalid_mcp_settings_format": "MCP 設定 JSON 格式無效。請確保您的設定遵循正確的 JSON 格式。",
+		"invalid_mcp_settings_syntax": "MCP 設定 JSON 格式無效。請檢查您的設定檔案是否有語法錯誤。",
+		"invalid_mcp_settings_validation": "MCP 設定格式無效：{{errorMessages}}",
+		"failed_initialize_project_mcp": "初始化專案 MCP 伺服器失敗：{{error}}",
+		"invalid_data_uri": "資料 URI 格式無效",
 		"checkpoint_timeout": "嘗試恢復檢查點時超時。",
 		"checkpoint_failed": "恢復檢查點失敗。",
-		"no_workspace": "請先打開項目文件夾",
-		"update_support_prompt": "更新支持消息失敗",
-		"reset_support_prompt": "重置支持消息失敗",
-		"enhance_prompt": "增強消息失敗",
-		"get_system_prompt": "獲取系統消息失敗",
-		"search_commits": "搜索提交失敗",
-		"save_api_config": "保存API配置失敗",
-		"create_api_config": "創建API配置失敗",
-		"rename_api_config": "重命名API配置失敗",
-		"load_api_config": "加載API配置失敗",
-		"delete_api_config": "刪除API配置失敗",
-		"list_api_config": "獲取API配置列表失敗",
-		"update_server_timeout": "更新服務器超時設置失敗",
-		"failed_update_project_mcp": "更新項目MCP服務器失敗",
-		"create_mcp_json": "創建或打開 .roo/mcp.json 失敗：{{error}}",
-		"hmr_not_running": "本地開發服務器未運行，HMR將不起作用。請在啟動擴展前運行'npm run dev'以啟用HMR。",
-		"retrieve_current_mode": "從狀態中檢索當前模式失敗。",
+		"no_workspace": "請先開啟專案資料夾",
+		"update_support_prompt": "更新支援訊息失敗",
+		"reset_support_prompt": "重設支援訊息失敗",
+		"enhance_prompt": "增強訊息失敗",
+		"get_system_prompt": "取得系統訊息失敗",
+		"search_commits": "搜尋提交失敗",
+		"save_api_config": "儲存 API 設定失敗",
+		"create_api_config": "建立 API 設定失敗",
+		"rename_api_config": "重新命名 API 設定失敗",
+		"load_api_config": "載入 API 設定失敗",
+		"delete_api_config": "刪除 API 設定失敗",
+		"list_api_config": "取得 API 設定列表失敗",
+		"update_server_timeout": "更新伺服器超時設定失敗",
+		"failed_update_project_mcp": "更新專案 MCP 伺服器失敗",
+		"create_mcp_json": "建立或開啟 .roo/mcp.json 失敗：{{error}}",
+		"hmr_not_running": "本機開發伺服器沒有執行，HMR 將不起作用。請在啟動擴充套件前執行'npm run dev'以啟用 HMR。",
+		"retrieve_current_mode": "從狀態中檢索目前模式失敗。",
 		"failed_delete_repo": "刪除關聯的影子倉庫或分支失敗：{{error}}",
-		"failed_remove_directory": "刪除任務目錄失敗：{{error}}",
-		"custom_storage_path_unusable": "自定義存儲路徑 \"{{path}}\" 不可用，將使用默認路徑",
-		"cannot_access_path": "無法訪問路徑 {{path}}：{{error}}"
+		"failed_remove_directory": "刪除工作目錄失敗：{{error}}",
+		"custom_storage_path_unusable": "自訂儲存路徑 \"{{path}}\" 無法使用，將使用預設路徑",
+		"cannot_access_path": "無法存取路徑 {{path}}：{{error}}"
 	},
 	"warnings": {
-		"no_terminal_content": "沒有選擇終端內容",
-		"missing_task_files": "此任務的文件丟失。您想從任務列表中刪除它嗎？"
+		"no_terminal_content": "沒有選擇終端機內容",
+		"missing_task_files": "此工作的檔案遺失。您想從工作列表中刪除它嗎？"
 	},
 	"info": {
-		"no_changes": "未找到更改。",
-		"clipboard_copy": "系統消息已成功複製到剪貼板",
-		"history_cleanup": "已從歷史記錄中清理{{count}}個缺少文件的任務。",
-		"mcp_server_restarting": "正在重啟{{serverName}}MCP服務器...",
-		"mcp_server_connected": "{{serverName}}MCP服務器已連接",
-		"mcp_server_deleted": "已刪除MCP服務器：{{serverName}}",
-		"mcp_server_not_found": "在配置中未找到服務器\"{{serverName}}\"",
-		"custom_storage_path_set": "自定義存儲路徑已設置：{{path}}",
-		"default_storage_path": "已恢復使用默認存儲路徑",
-		"settings_imported": "設置已成功導入。"
+		"no_changes": "沒有找到更改。",
+		"clipboard_copy": "系統訊息已成功複製到剪貼簿",
+		"history_cleanup": "已從歷史記錄中清理{{count}}個缺少檔案的工作。",
+		"mcp_server_restarting": "正在重啟{{serverName}}MCP 伺服器...",
+		"mcp_server_connected": "{{serverName}}MCP 伺服器已連接",
+		"mcp_server_deleted": "已刪除 MCP 伺服器：{{serverName}}",
+		"mcp_server_not_found": "在設定中沒有找到伺服器\"{{serverName}}\"",
+		"custom_storage_path_set": "自訂儲存路徑已設定：{{path}}",
+		"default_storage_path": "已恢復使用預設儲存路徑",
+		"settings_imported": "設定已成功匯入。"
 	},
 	"answers": {
 		"yes": "是",
@@ -77,17 +77,17 @@
 		"keep": "保留"
 	},
 	"tasks": {
-		"canceled": "任務錯誤：它已被用戶停止並取消。",
-		"deleted": "任務失敗：它已被用戶停止並刪除。"
+		"canceled": "工作錯誤：它已被使用者停止並取消。",
+		"deleted": "工作失敗：它已被使用者停止並刪除。"
 	},
 	"storage": {
-		"prompt_custom_path": "輸入自定義會話歷史存儲路徑，留空以使用默認位置",
+		"prompt_custom_path": "輸入自訂會話歷史儲存路徑，留空以使用預設位置",
 		"path_placeholder": "D:\\RooCodeStorage",
 		"enter_absolute_path": "請輸入絕對路徑（例如 D:\\RooCodeStorage 或 /home/user/storage）",
 		"enter_valid_path": "請輸入有效的路徑"
 	},
 	"input": {
-		"task_prompt": "讓Roo做什麼？",
-		"task_placeholder": "在這裡輸入任務"
+		"task_prompt": "讓 Roo 做什麼？",
+		"task_placeholder": "在這裡輸入工作"
 	}
 }

--- a/src/i18n/locales/zh-TW/tools.json
+++ b/src/i18n/locales/zh-TW/tools.json
@@ -1,7 +1,7 @@
 {
 	"readFile": {
 		"linesRange": " (第 {{start}}-{{end}} 行)",
-		"linesFromToEnd": " (第 {{start}} 行至末尾)",
+		"linesFromToEnd": " (第 {{start}} 行至結尾)",
 		"linesFromStartTo": " (第 1-{{end}} 行)",
 		"definitionsOnly": " (僅定義)",
 		"maxLines": " (最多 {{max}} 行)"

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -119,8 +119,8 @@
 		"wantsToCreate": "Roo 想要建立新檔案："
 	},
 	"directoryOperations": {
-		"wantsToViewTopLevel": "Roo 想要檢視此目錄中的頂層檔案：",
-		"didViewTopLevel": "Roo 已檢視此目錄中的頂層檔案：",
+		"wantsToViewTopLevel": "Roo 想要檢視此目錄中最上層的檔案：",
+		"didViewTopLevel": "Roo 已檢視此目錄中最上層的檔案：",
 		"wantsToViewRecursive": "Roo 想要遞迴檢視此目錄中的所有檔案：",
 		"didViewRecursive": "Roo 已遞迴檢視此目錄中的所有檔案：",
 		"wantsToViewDefinitions": "Roo 想要檢視此目錄中使用的原始碼定義名稱：",


### PR DESCRIPTION
This is a follow-up to #2233, addressing some missing and newly found improvements from the real-use scenario with enough context. I believe this will really help make the zh-TW Traditional Chinese locale sound more natural and professional and less machine- or AI-translated (as I guess this is how the original version came about).

---

Summary from GitHub Copilot for your reference:

This pull request includes several changes to the Traditional Chinese (zh-TW) localization files to improve translations and consistency across the project. The main updates focus on refining terminology, enhancing readability, and ensuring uniformity in the translated content.

### Localization improvements:

* [`locales/zh-TW/README.md`](diffhunk://#diff-7a9d9d02f034dfb7a921ca354ee3690a5d7a7ab79b31aa7c14c9d670ed83fa48L36-R47): Updated various terms and phrases for better clarity and consistency, such as changing "自定義" to "自訂" and "文件" to "檔案". [[1]](diffhunk://#diff-7a9d9d02f034dfb7a921ca354ee3690a5d7a7ab79b31aa7c14c9d670ed83fa48L36-R47) [[2]](diffhunk://#diff-7a9d9d02f034dfb7a921ca354ee3690a5d7a7ab79b31aa7c14c9d670ed83fa48L56-R70) [[3]](diffhunk://#diff-7a9d9d02f034dfb7a921ca354ee3690a5d7a7ab79b31aa7c14c9d670ed83fa48L88-R108) [[4]](diffhunk://#diff-7a9d9d02f034dfb7a921ca354ee3690a5d7a7ab79b31aa7c14c9d670ed83fa48L126-R157) [[5]](diffhunk://#diff-7a9d9d02f034dfb7a921ca354ee3690a5d7a7ab79b31aa7c14c9d670ed83fa48L167-R169)
* [`src/i18n/locales/zh-TW/common.json`](diffhunk://#diff-ce8a8e03bdd4ecb9d977f77c3468febe03b66b530ca40174773961338cb90550L18-R70): Enhanced translation accuracy for confirmation messages, error messages, warnings, and other interface elements. [[1]](diffhunk://#diff-ce8a8e03bdd4ecb9d977f77c3468febe03b66b530ca40174773961338cb90550L18-R70) [[2]](diffhunk://#diff-ce8a8e03bdd4ecb9d977f77c3468febe03b66b530ca40174773961338cb90550L80-R91)
* [`src/i18n/locales/zh-TW/tools.json`](diffhunk://#diff-434975f9c5e1d4db480b45204ca45117cfd53e1d203cc5a779f97084639724ddL4-R4): Improved translation for line range descriptions in the `readFile` tool.
* [`webview-ui/src/i18n/locales/zh-TW/chat.json`](diffhunk://#diff-9bc7e5f324c0c6b940bb1b188095577265c2a7b361d213830a3e1a96c8ad3b8aL122-R123): Refined translations for directory operation messages to ensure better understanding.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves zh-TW Traditional Chinese localization by refining translations for clarity and consistency across multiple files.
> 
>   - **Localization Improvements**:
>     - `README.md`: Updated terms for clarity, e.g., "自定義" to "自訂", "文件" to "檔案".
>     - `common.json`: Enhanced translation accuracy for confirmation, error, and warning messages.
>     - `tools.json`: Improved translation for line range descriptions in `readFile` tool.
>     - `chat.json`: Refined translations for directory operation messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9cb3aa89c35c006aae1760810771fbf9f6aba6bf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->