### PR TITLE
refactor(mcp): Implement reference counting for McpHub lifecycle

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -115,6 +115,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		McpServerManager.getInstance(this.context, this)
 			.then((hub) => {
 				this.mcpHub = hub
+				this.mcpHub.registerClient()
 			})
 			.catch((error) => {
 				this.outputChannel.appendLine(`Failed to initialize MCP Hub: ${error}`)
@@ -221,7 +222,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 
 		this.workspaceTracker?.dispose()
 		this.workspaceTracker = undefined
-		this.mcpHub?.dispose()
+		await this.mcpHub?.unregisterClient()
 		this.mcpHub = undefined
 		this.customModesManager?.dispose()
 		this.outputChannel.appendLine("Disposed all disposables")


### PR DESCRIPTION
Problem:
Closing auxiliary windows (e.g., from "open in editor") could prematurely dispose the shared singleton McpHub instance, shutting down MCP servers unexpectedly while other panels (like the sidebar) might still be active.

Solution:
Implemented reference counting directly within the McpHub class to manage its own lifecycle based on active clients (ClineProvider instances).
- Added `refCount`, `registerClient()`, and `unregisterClient()` methods to McpHub.
- McpHub now disposes itself only when the last registered client unregisters (`refCount` reaches 0).
- ClineProvider instances now call `mcpHub.registerClient()` upon initialization and `mcpHub.unregisterClient()` upon disposal.
- Removed the direct `mcpHub.dispose()` call from ClineProvider.dispose.

Benefit:
This ensures the shared McpHub instance remains active as long as at least one ClineProvider instance is using it. Cleanup now correctly occurs only when the last provider is closed or during full extension deactivation. This centralizes the resource's lifecycle logic within the resource class itself.

Files Changed:
- src/services/mcp/McpHub.ts
- src/core/webview/ClineProvider.ts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements reference counting in `McpHub` to manage its lifecycle based on active `ClineProvider` instances, preventing premature disposal.
> 
>   - **Behavior**:
>     - Implements reference counting in `McpHub` to manage lifecycle based on active `ClineProvider` instances.
>     - `McpHub` disposes itself only when `refCount` reaches 0.
>     - `ClineProvider` calls `registerClient()` on initialization and `unregisterClient()` on disposal.
>     - Removes direct `dispose()` call from `ClineProvider.dispose()`.
>   - **Methods**:
>     - Adds `registerClient()` and `unregisterClient()` to `McpHub`.
>   - **Files**:
>     - Changes in `McpHub.ts` and `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0c51f384b4df62540e95a3c552202b42eac66799. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->