### PR TITLE
feat: Add CommandOutputViewer component and integrate it into ChatRow

### DIFF
--- a/webview-ui/src/__tests__/components/common/CommandOutputViewer.test.tsx
+++ b/webview-ui/src/__tests__/components/common/CommandOutputViewer.test.tsx
@@ -1,0 +1,63 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import CommandOutputViewer from "../../../components/common/CommandOutputViewer"
+
+// Mock the cn utility function
+jest.mock("../../../lib/utils", () => ({
+	cn: (...inputs: any[]) => inputs.filter(Boolean).join(" "),
+}))
+
+// Mock the Virtuoso component
+jest.mock("react-virtuoso", () => ({
+	Virtuoso: React.forwardRef(({ totalCount, itemContent }: any, ref: any) => (
+		<div ref={ref} data-testid="virtuoso-container">
+			{Array.from({ length: totalCount }).map((_, index) => (
+				<div key={index} data-testid={`virtuoso-item-${index}`}>
+					{itemContent(index)}
+				</div>
+			))}
+		</div>
+	)),
+	VirtuosoHandle: jest.fn(),
+}))
+
+describe("CommandOutputViewer", () => {
+	it("renders command output with virtualized list", () => {
+		const testOutput = "Line 1\nLine 2\nLine 3"
+
+		render(<CommandOutputViewer output={testOutput} />)
+
+		// Check if Virtuoso container is rendered
+		expect(screen.getByTestId("virtuoso-container")).toBeInTheDocument()
+
+		// Check if all lines are rendered
+		expect(screen.getByText("Line 1")).toBeInTheDocument()
+		expect(screen.getByText("Line 2")).toBeInTheDocument()
+		expect(screen.getByText("Line 3")).toBeInTheDocument()
+	})
+
+	it("handles empty output", () => {
+		render(<CommandOutputViewer output="" />)
+
+		// Should still render the container but with no items
+		expect(screen.getByTestId("virtuoso-container")).toBeInTheDocument()
+
+		// No virtuoso items should be rendered for empty string (which creates one empty line)
+		expect(screen.getByTestId("virtuoso-item-0")).toBeInTheDocument()
+		expect(screen.queryByTestId("virtuoso-item-1")).not.toBeInTheDocument()
+	})
+
+	it("handles large output", () => {
+		// Create a large output with 1000 lines
+		const largeOutput = Array.from({ length: 1000 }, (_, i) => `Line ${i + 1}`).join("\n")
+
+		render(<CommandOutputViewer output={largeOutput} />)
+
+		// Check if Virtuoso container is rendered
+		expect(screen.getByTestId("virtuoso-container")).toBeInTheDocument()
+
+		// Check if first and last lines are rendered
+		expect(screen.getByText("Line 1")).toBeInTheDocument()
+		expect(screen.getByText("Line 1000")).toBeInTheDocument()
+	})
+})

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -16,6 +16,7 @@ import { findMatchingResourceOrTemplate } from "../../utils/mcp"
 import { vscode } from "../../utils/vscode"
 import CodeAccordian, { removeLeadingNonAlphanumeric } from "../common/CodeAccordian"
 import CodeBlock, { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
+import CommandOutputViewer from "../common/CommandOutputViewer"
 import MarkdownBlock from "../common/MarkdownBlock"
 import { ReasoningBlock } from "./ReasoningBlock"
 import Thumbnails from "../common/Thumbnails"
@@ -917,7 +918,7 @@ export const ChatRowContent = ({
 												className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}></span>
 											<span style={{ fontSize: "0.8em" }}>{t("chat:commandOutput")}</span>
 										</div>
-										{isExpanded && <CodeBlock source={`${"```"}shell\n${output}\n${"```"}`} />}
+										{isExpanded && <CommandOutputViewer output={output} />}
 									</div>
 								)}
 							</div>

--- a/webview-ui/src/components/common/CommandOutputViewer.tsx
+++ b/webview-ui/src/components/common/CommandOutputViewer.tsx
@@ -1,0 +1,52 @@
+import { forwardRef, memo, useEffect, useRef } from "react"
+import { Virtuoso, VirtuosoHandle } from "react-virtuoso"
+import { cn } from "../../lib/utils"
+
+interface CommandOutputViewerProps {
+	output: string
+}
+
+const CommandOutputViewer = memo(
+	forwardRef<HTMLDivElement, CommandOutputViewerProps>(({ output }, ref) => {
+		const virtuosoRef = useRef<VirtuosoHandle>(null)
+		const lines = output.split("\n")
+
+		useEffect(() => {
+			// Scroll to the bottom when output changes
+			if (virtuosoRef.current && typeof virtuosoRef.current.scrollToIndex === "function") {
+				virtuosoRef.current.scrollToIndex({
+					index: lines.length - 1,
+					behavior: "auto",
+				})
+			}
+		}, [output, lines.length])
+
+		return (
+			<div ref={ref} className="w-full rounded-b-md bg-[var(--vscode-editor-background)] h-[300px]">
+				<Virtuoso
+					ref={virtuosoRef}
+					className="h-full"
+					totalCount={lines.length}
+					itemContent={(index) => (
+						<div
+							className={cn(
+								"px-3 py-0.5",
+								"font-mono text-vscode-editor-foreground",
+								"text-[var(--vscode-editor-font-size,var(--vscode-font-size,12px))]",
+								"font-[var(--vscode-editor-font-family)]",
+								"whitespace-pre-wrap break-all anywhere",
+							)}>
+							{lines[index]}
+						</div>
+					)}
+					increaseViewportBy={{ top: 300, bottom: 300 }}
+					followOutput="auto"
+				/>
+			</div>
+		)
+	}),
+)
+
+CommandOutputViewer.displayName = "CommandOutputViewer"
+
+export default CommandOutputViewer

--- a/webview-ui/src/components/common/CommandOutputViewer.tsx
+++ b/webview-ui/src/components/common/CommandOutputViewer.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, memo, useEffect, useRef } from "react"
+import { forwardRef, useEffect, useRef } from "react"
 import { Virtuoso, VirtuosoHandle } from "react-virtuoso"
 import { cn } from "../../lib/utils"
 
@@ -6,46 +6,44 @@ interface CommandOutputViewerProps {
 	output: string
 }
 
-const CommandOutputViewer = memo(
-	forwardRef<HTMLDivElement, CommandOutputViewerProps>(({ output }, ref) => {
-		const virtuosoRef = useRef<VirtuosoHandle>(null)
-		const lines = output.split("\n")
+const CommandOutputViewer = forwardRef<HTMLDivElement, CommandOutputViewerProps>(({ output }, ref) => {
+	const virtuosoRef = useRef<VirtuosoHandle>(null)
+	const lines = output.split("\n")
 
-		useEffect(() => {
-			// Scroll to the bottom when output changes
-			if (virtuosoRef.current && typeof virtuosoRef.current.scrollToIndex === "function") {
-				virtuosoRef.current.scrollToIndex({
-					index: lines.length - 1,
-					behavior: "auto",
-				})
-			}
-		}, [output, lines.length])
+	useEffect(() => {
+		// Scroll to the bottom when output changes
+		if (virtuosoRef.current && typeof virtuosoRef.current.scrollToIndex === "function") {
+			virtuosoRef.current.scrollToIndex({
+				index: lines.length - 1,
+				behavior: "auto",
+			})
+		}
+	}, [output, lines.length])
 
-		return (
-			<div ref={ref} className="w-full rounded-b-md bg-[var(--vscode-editor-background)] h-[300px]">
-				<Virtuoso
-					ref={virtuosoRef}
-					className="h-full"
-					totalCount={lines.length}
-					itemContent={(index) => (
-						<div
-							className={cn(
-								"px-3 py-0.5",
-								"font-mono text-vscode-editor-foreground",
-								"text-[var(--vscode-editor-font-size,var(--vscode-font-size,12px))]",
-								"font-[var(--vscode-editor-font-family)]",
-								"whitespace-pre-wrap break-all anywhere",
-							)}>
-							{lines[index]}
-						</div>
-					)}
-					increaseViewportBy={{ top: 300, bottom: 300 }}
-					followOutput="auto"
-				/>
-			</div>
-		)
-	}),
-)
+	return (
+		<div ref={ref} className="w-full rounded-b-md bg-[var(--vscode-editor-background)] h-[300px]">
+			<Virtuoso
+				ref={virtuosoRef}
+				className="h-full"
+				totalCount={lines.length}
+				itemContent={(index) => (
+					<div
+						className={cn(
+							"px-3 py-0.5",
+							"font-mono text-vscode-editor-foreground",
+							"text-[var(--vscode-editor-font-size,var(--vscode-font-size,12px))]",
+							"font-[var(--vscode-editor-font-family)]",
+							"whitespace-pre-wrap break-all anywhere",
+						)}>
+						{lines[index]}
+					</div>
+				)}
+				increaseViewportBy={{ top: 300, bottom: 300 }}
+				followOutput="auto"
+			/>
+		</div>
+	)
+})
 
 CommandOutputViewer.displayName = "CommandOutputViewer"
 


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->
This pr will fix Webview crashed because long running terminal command and has long terminal console output 
https://discord.com/channels/1332146336664915968/1356673356736368893

## Implementation
Implement new Commend for using react-virtuoso then replace it with code-block component
<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Video 

<div> <a href="https://www.loom.com/share/a135bf2b4897483f81d4d0a37b4c7617"> <img style="max-width:300px;" src="https://cdn.loom.com/sessions/thumbnails/a135bf2b4897483f81d4d0a37b4c7617-70932358b35b72c8-full-play.gif"> </a> </div>



## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `CommandOutputViewer` component for virtualized command output rendering and integrates it into `ChatRow.tsx`, replacing `CodeBlock`.
> 
>   - **Component Addition**:
>     - Adds `CommandOutputViewer` in `CommandOutputViewer.tsx` using `react-virtuoso` for virtualized rendering of command outputs.
>     - Automatically scrolls to the bottom on output change.
>   - **Integration**:
>     - Replaces `CodeBlock` with `CommandOutputViewer` in `ChatRow.tsx` for displaying command outputs.
>   - **Testing**:
>     - Adds `CommandOutputViewer.test.tsx` to test rendering with different output sizes, including empty and large outputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 92a91da1ba89f58ba740f4bdf6af62fec2d019b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->