### PR TITLE
fix: Prevent unnecessary autoscroll when buttons appear (#1280)

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -421,7 +421,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			setTextAreaDisabled(true)
 			setClineAsk(undefined)
 			setEnableButtons(false)
-			// disableAutoScrollRef.current = false
 		},
 		[clineAsk, startNewTask],
 	)
@@ -468,7 +467,6 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			setTextAreaDisabled(true)
 			setClineAsk(undefined)
 			setEnableButtons(false)
-			// disableAutoScrollRef.current = false
 		},
 		[clineAsk, startNewTask, isStreaming],
 	)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -421,7 +421,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			setTextAreaDisabled(true)
 			setClineAsk(undefined)
 			setEnableButtons(false)
-			disableAutoScrollRef.current = false
+			// disableAutoScrollRef.current = false
 		},
 		[clineAsk, startNewTask],
 	)
@@ -468,7 +468,7 @@ const ChatView = ({ isHidden, showAnnouncement, hideAnnouncement, showHistoryVie
 			setTextAreaDisabled(true)
 			setClineAsk(undefined)
 			setEnableButtons(false)
-			disableAutoScrollRef.current = false
+			// disableAutoScrollRef.current = false
 		},
 		[clineAsk, startNewTask, isStreaming],
 	)


### PR DESCRIPTION
This PR addresses issue #1280.

Previously, when interactive elements like API request or command execution buttons appeared in the chat view, the view would automatically scroll to the bottom, even if the user had manually scrolled up. This could interrupt the user's reading flow.

This change modifies the autoscroll logic to prevent this specific behavior. The chat will no longer automatically scroll down just because new buttons have rendered, unless the user is already scrolled to the bottom.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents unnecessary autoscroll in `ChatView.tsx` when new buttons appear unless user is at the bottom.
> 
>   - **Behavior**:
>     - Prevents autoscroll in `ChatView.tsx` when new buttons appear unless user is at the bottom.
>     - Comments out `disableAutoScrollRef.current = false` in two places to achieve this.
>   - **Misc**:
>     - Addresses issue #1280.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 338c3f7889a5ffa2124c2dad709a5b8d7e5b7272. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->