### PR TITLE
fix: clamp negative line numbers when reading files

### DIFF
--- a/src/integrations/misc/__tests__/read-lines.test.ts
+++ b/src/integrations/misc/__tests__/read-lines.test.ts
@@ -33,23 +33,21 @@ describe("nthline", () => {
 
 		it("should throw error for negative to_line", async () => {
 			await expect(readLines(testFile, -3)).rejects.toThrow(
-				"Invalid endLine: -3. Line numbers must be non-negative integers.",
+				"startLine (0) must be less than or equal to endLine (-3)",
 			)
 		})
 
-		it("should throw error for negative from_line", async () => {
-			await expect(readLines(testFile, 3, -1)).rejects.toThrow(
-				"Invalid startLine: -1. Line numbers must be non-negative integers.",
-			)
+		it("should handle negative from_line by clamping to 0", async () => {
+			const lines = await readLines(testFile, 3, -1)
+			expect(lines).toEqual(["Line 1", "Line 2", "Line 3", "Line 4"].join("\n"))
 		})
 
-		it("should throw error for non-integer line numbers", async () => {
-			await expect(readLines(testFile, 3, 1.5)).rejects.toThrow(
-				"Invalid startLine: 1.5. Line numbers must be non-negative integers.",
-			)
-			await expect(readLines(testFile, 3.5)).rejects.toThrow(
-				"Invalid endLine: 3.5. Line numbers must be non-negative integers.",
-			)
+		it("should floor non-integer line numbers", async () => {
+			const linesWithNonIntegerStart = await readLines(testFile, 3, 1.5)
+			expect(linesWithNonIntegerStart).toEqual(["Line 2", "Line 3", "Line 4"].join("\n"))
+
+			const linesWithNonIntegerEnd = await readLines(testFile, 3.5)
+			expect(linesWithNonIntegerEnd).toEqual(["Line 1", "Line 2", "Line 3", "Line 4"].join("\n"))
 		})
 
 		it("should throw error when from_line > to_line", async () => {

--- a/src/integrations/misc/read-lines.ts
+++ b/src/integrations/misc/read-lines.ts
@@ -24,17 +24,24 @@ const outOfRangeError = (filepath: string, n: number) => {
  */
 export function readLines(filepath: string, endLine?: number, startLine?: number): Promise<string> {
 	return new Promise((resolve, reject) => {
-		// Validate input parameters
-		// Check startLine validity if provided
-		if (startLine !== undefined && (startLine < 0 || startLine % 1 !== 0)) {
-			return reject(
-				new RangeError(`Invalid startLine: ${startLine}. Line numbers must be non-negative integers.`),
-			)
+		// Reject if startLine is defined but not a number
+		if (startLine !== undefined && typeof startLine !== "number") {
+			return reject(new RangeError(`Invalid startLine: ${startLine}. Line numbers must be numbers.`))
 		}
 
-		// Check endLine validity if provided
-		if (endLine !== undefined && (endLine < 0 || endLine % 1 !== 0)) {
-			return reject(new RangeError(`Invalid endLine: ${endLine}. Line numbers must be non-negative integers.`))
+		// Force startLine to be an integer and clamp to 0 if negative
+		if (startLine !== undefined) {
+			startLine = Math.max(0, Math.floor(startLine))
+		}
+
+		// Reject if endLine is defined but not a number
+		if (endLine !== undefined && typeof endLine !== "number") {
+			return reject(new RangeError(`Invalid endLine: ${endLine}. Line numbers must be numbers.`))
+		}
+
+		// Force endLine to be an integer
+		if (endLine !== undefined) {
+			endLine = Math.floor(endLine)
 		}
 
 		const effectiveStartLine = startLine === undefined ? 0 : startLine


### PR DESCRIPTION
## Context

This PR improves the handling of line numbers in the readLines function to be more forgiving with AI-generated inputs.

## Implementation

- Clamp negative startLine values to 0 instead of throwing errors
- Convert non-integer line numbers to integers automatically using Math.floor()
- Only reject when line numbers aren't numbers at all
- Update tests to match new behavior

These changes prevent unnecessary model retries by handling imperfect AI-generated line numbers gracefully, making the system more robust when interacting with AI models.

## How to Test

- Run the updated tests which verify the new behavior
- Try using the readLines function with negative or non-integer line numbers

## Get in Touch

Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `readLines` to handle negative and non-integer line numbers by clamping and flooring, updating tests accordingly.
> 
>   - **Behavior**:
>     - `readLines` in `read-lines.ts` now clamps negative `startLine` to 0 and floors non-integer line numbers.
>     - Rejects only if line numbers are not numbers.
>     - Updates error handling to ensure `startLine` is less than or equal to `endLine`.
>   - **Tests**:
>     - Updated tests in `read-lines.test.ts` to reflect new behavior, including clamping and flooring of line numbers.
>     - Added tests for negative and non-integer line numbers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 63659a6f1e46f1e844c06df15ba17f9f5f2cdc58. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->