### PR TITLE
fix: persist settings on api.setConfiguration

### DIFF
--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -172,6 +172,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	public async setConfiguration(values: RooCodeSettings) {
 		await this.sidebarProvider.setValues(values)
+		await this.sidebarProvider.providerSettingsManager.saveConfig(values.currentApiConfigName || "default", values)
 		await this.sidebarProvider.postStateToWebview()
 	}
 


### PR DESCRIPTION
## Context

Values weren't being saved to the settings store, preventing switching to newly created profiles. See [this](https://discord.com/channels/1332146336664915968/1353570725432397926/1357963967649288325) Discord thread for screenshots and source code.

## Implementation

See diff. Explicitly call `saveConfig` after changing configurations. I'm not sure that I love taking the name from `currentApiConfigName` but we'd need to rework the API quite a bit to allow for an explicit `name` param.

## How to Test

Create a custom extension that calls these APIs and do something like this:

```
npm run build && code --uninstall-extension rooveterinaryinc.roo-cline && code --install-extension bin/roo-cline-3.11.4.vsix
```

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `api.ts`, `setConfiguration` now persists settings by calling `saveConfig` with `currentApiConfigName` or "default".
> 
>   - **Behavior**:
>     - In `api.ts`, `setConfiguration` now calls `saveConfig` to persist settings using `currentApiConfigName` or "default" if not provided.
>   - **Testing**:
>     - Instructions provided to test the change by creating a custom extension and using specific npm and VS Code commands.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7d2365c2191b0ecb14f035e88b4a719fb6a32d52. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->