### PR TITLE
Switched Datetime format for <environment_details> to something clearer (ISO)

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2259,21 +2259,18 @@ export class Cline extends EventEmitter<ClineEvents> {
 
 		// Add current time information with timezone
 		const now = new Date()
-		const formatter = new Intl.DateTimeFormat(undefined, {
-			year: "numeric",
-			month: "numeric",
-			day: "numeric",
-			hour: "numeric",
-			minute: "numeric",
-			second: "numeric",
-			hour12: true,
-		})
-		const timeZone = formatter.resolvedOptions().timeZone
-		const timeZoneOffset = -now.getTimezoneOffset() / 60 // Convert to hours and invert sign to match conventional notation
-		const timeZoneOffsetHours = Math.floor(Math.abs(timeZoneOffset))
-		const timeZoneOffsetMinutes = Math.abs(Math.round((Math.abs(timeZoneOffset) - timeZoneOffsetHours) * 60))
-		const timeZoneOffsetStr = `${timeZoneOffset >= 0 ? "+" : "-"}${timeZoneOffsetHours}:${timeZoneOffsetMinutes.toString().padStart(2, "0")}`
-		details += `\n\n# Current Time\n${formatter.format(now)} (${timeZone}, UTC${timeZoneOffsetStr})`
+		// Calculate timezone offset
+		const tzOffset = -now.getTimezoneOffset() // in minutes
+		const sign = tzOffset >= 0 ? "+" : "-"
+		const pad = (num: number) => String(Math.floor(Math.abs(num))).padStart(2, "0")
+		const offsetHours = pad(tzOffset / 60)
+		const offsetMinutes = pad(tzOffset % 60)
+
+		// Remove the trailing 'Z' from ISO string and add the custom offset
+		const isoWithoutZ = now.toISOString().replace("Z", "")
+		const isoString = `${isoWithoutZ}${sign}${offsetHours}:${offsetMinutes}`
+
+		details += `\n\n# Current Time\n${isoString}`
 
 		// Add context tokens information
 		const { contextTokens, totalCost } = getApiMetrics(this.clineMessages)


### PR DESCRIPTION
## Context

The datetime format for <environment_details> was weird and had the potential to confuse LLMs. 

For example it used an international date format that was not defined and fell back to local. In my case (German) todays date output was 6.4.2025 which got confused by LLM for June 4th multiple times (instead of April 6th). 

The forced time format of 12h which is completely not used in germany probably added to that confusion.

## Implementation

I changed the date format to a proper ISO format including the timezone offset to keep the local relation.

## Get in Touch

@helmi on discord.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Changed datetime format in `Cline.ts` to ISO with timezone offset for clarity in `getEnvironmentDetails()`.
> 
>   - **Datetime Format Change**:
>     - In `Cline.ts`, changed datetime format to ISO with timezone offset in `getEnvironmentDetails()`.
>     - Replaced custom formatting logic with `toISOString()` and manual timezone offset calculation.
>     - Removed trailing 'Z' from ISO string and appended custom offset.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d0c725ae4e23d0b0ee54bc8e10639f9c2de5a9be. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->