### PR TITLE
Browser Tool: Implement hover

### DIFF
--- a/src/core/prompts/tools/browser-action.ts
+++ b/src/core/prompts/tools/browser-action.ts
@@ -15,6 +15,9 @@ Parameters:
     * launch: Launch a new Puppeteer-controlled browser instance at the specified URL. This **must always be the first action**.
         - Use with the \`url\` parameter to provide the URL.
         - Ensure the URL is valid and includes the appropriate protocol (e.g. http://localhost:3000/page, file:///path/to/file.html, etc.)
+    * hover: Move the cursor to a specific x,y coordinate.
+        - Use with the \`coordinate\` parameter to specify the location.
+        - Always move to the center of an element (icon, button, link, etc.) based on coordinates derived from a screenshot.
     * click: Click at a specific x,y coordinate.
         - Use with the \`coordinate\` parameter to specify the location.
         - Always click in the center of an element (icon, button, link, etc.) based on coordinates derived from a screenshot.
@@ -26,7 +29,7 @@ Parameters:
         - Example: \`<action>close</action>\`
 - url: (optional) Use this for providing the URL for the \`launch\` action.
     * Example: <url>https://example.com</url>
-- coordinate: (optional) The X and Y coordinates for the \`click\` action. Coordinates should be within the **${args.browserViewportSize}** resolution.
+- coordinate: (optional) The X and Y coordinates for the \`click\` and \`hover\` actions. Coordinates should be within the **${args.browserViewportSize}** resolution.
     * Example: <coordinate>450,300</coordinate>
 - text: (optional) Use this for providing the text for the \`type\` action.
     * Example: <text>Hello, world!</text>

--- a/src/core/tools/browserActionTool.ts
+++ b/src/core/tools/browserActionTool.ts
@@ -72,7 +72,7 @@ export async function browserActionTool(
 				await cline.browserSession.launchBrowser()
 				browserActionResult = await cline.browserSession.navigateToUrl(url)
 			} else {
-				if (action === "click") {
+				if (action === "click" || action === "hover") {
 					if (!coordinate) {
 						cline.consecutiveMistakeCount++
 						pushToolResult(await cline.sayAndCreateMissingParamError("browser_action", "coordinate"))
@@ -103,6 +103,9 @@ export async function browserActionTool(
 					case "click":
 						browserActionResult = await cline.browserSession.click(coordinate!)
 						break
+					case "hover":
+						browserActionResult = await cline.browserSession.hover(coordinate!)
+						break
 					case "type":
 						browserActionResult = await cline.browserSession.type(text!)
 						break
@@ -121,6 +124,7 @@ export async function browserActionTool(
 			switch (action) {
 				case "launch":
 				case "click":
+				case "hover":
 				case "type":
 				case "scroll_down":
 				case "scroll_up":


### PR DESCRIPTION
## Context

Previously, the browser tool could only _click_ on elements, but not simply _move to_ or _hover over_ them. This PR fixes that by providing a dedicated _hover_ action.

## Implementation

Interestingly, the _hover_ action was already implemented for the most part, and was simply missing in the tool description and parameter handling. Took a very small amount of code to implement, and works perfectly.

## Screenshots

This screenshot shows the `hover` action, where Claude hovers over the button without clicking it.
![Code 2025-04-07 14 51 00](https://github.com/user-attachments/assets/edaca988-d213-4b04-87bf-6f34c4228459)

## How to Test

1. Make a small website with any element that has a hover effect
2. Tell Roo Code to open the website and hover over the element
3. ???
4. Profit

## Get in Touch

No Discord, but you can contact me under marco@fivesheep.co, or preferably _right here_.