### PR TITLE
Fixes to resumeTask and isTaskInHistory

### DIFF
--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -133,14 +133,14 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 	}
 
 	public async resumeTask(taskId: string): Promise<void> {
-		const { historyItem } = await this.provider.getTaskWithId(taskId)
-		await this.provider.initClineWithHistoryItem(historyItem)
-		await this.provider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
+		const { historyItem } = await this.sidebarProvider.getTaskWithId(taskId)
+		await this.sidebarProvider.initClineWithHistoryItem(historyItem)
+		await this.sidebarProvider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
 	}
 
 	public async isTaskInHistory(taskId: string): Promise<boolean> {
 		try {
-			await this.provider.getTaskWithId(taskId)
+			await this.sidebarProvider.getTaskWithId(taskId)
 			return true
 		} catch {
 			return false

--- a/src/exports/interface.ts
+++ b/src/exports/interface.ts
@@ -28,6 +28,20 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	}): Promise<string>
 
 	/**
+	 * Resumes a task with the given ID.
+	 * @param taskId The ID of the task to resume.
+	 * @throws Error if the task is not found in the task history.
+	 */
+	resumeTask(taskId: string): Promise<void>
+
+	/**
+	 * Checks if a task with the given ID is in the task history.
+	 * @param taskId The ID of the task to check.
+	 * @returns True if the task is in the task history, false otherwise.
+	 */
+	isTaskInHistory(taskId: string): Promise<boolean>
+
+	/**
 	 * Returns the current task stack.
 	 * @returns An array of task IDs.
 	 */

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -557,14 +557,12 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 * @throws Error if the task is not found in the task history.
 	 */
 	resumeTask(taskId: string): Promise<void>
-
 	/**
 	 * Checks if a task with the given ID is in the task history.
 	 * @param taskId The ID of the task to check.
 	 * @returns True if the task is in the task history, false otherwise.
 	 */
 	isTaskInHistory(taskId: string): Promise<boolean>
-
 	/**
 	 * Returns the current task stack.
 	 * @returns An array of task IDs.


### PR DESCRIPTION
Cleanup after #1672
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `resumeTask` and `isTaskInHistory` to use `sidebarProvider` and add docstrings for these methods.
> 
>   - **Behavior**:
>     - Update `resumeTask` and `isTaskInHistory` in `api.ts` to use `sidebarProvider` instead of `provider`.
>   - **Documentation**:
>     - Add docstrings for `resumeTask` and `isTaskInHistory` in `interface.ts` and `roo-code.d.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d831ea646bf18f853a7fde5be4892178e8d15cfd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->