### PR TITLE
feat(benchmarks): add mention regex benchmark scripts and results

### DIFF
--- a/src/benchmarks/README.md
+++ b/src/benchmarks/README.md
@@ -1,0 +1,53 @@
+# Regex Benchmarks
+
+This directory contains benchmarking scripts for measuring the performance of regular expressions used in the project.
+
+## Mention Regex Benchmark
+
+The `mention-regex-benchmark.ts` script benchmarks the performance of the `mentionRegexGlobal` regex pattern defined in `src/shared/context-mentions.ts`. This pattern is used to identify mentions in text that start with '@', such as file paths, URLs, or specific words like 'problems', 'git-changes', or 'terminal'.
+
+### Running the Benchmark
+
+To run the benchmark:
+
+```bash
+# Using the convenience script
+./src/benchmarks/run-mention-benchmark.js
+
+# Or directly with tsx
+npx tsx src/benchmarks/mention-regex-benchmark.ts
+```
+
+### Benchmark Test Cases
+
+The benchmark includes the following test cases:
+
+1. **File Paths**: Tests mentions of file paths starting with '@/'
+2. **URLs**: Tests mentions of URLs with various protocols
+3. **Special Words**: Tests mentions of special words like 'problems', 'git-changes', 'terminal'
+4. **Git Hashes**: Tests mentions of git commit hashes
+5. **Mixed Content**: Tests a mix of different mention types
+6. **With Punctuation**: Tests mentions followed by punctuation
+7. **Large Text**: Tests performance on large text with few mentions (worst case scenario)
+8. **Typing Simulation**: Simulates user typing character by character, testing regex performance during interactive typing
+
+### Results
+
+Benchmark results are saved to:
+
+- `src/benchmarks/results/mention-regex-benchmark-[timestamp].md`: A timestamped record of each benchmark run
+- `src/benchmarks/results/mention-regex-benchmark-latest.md`: Always contains the most recent benchmark results
+
+The results include:
+
+- The regex pattern being tested
+- For each test case:
+    - Number of iterations
+    - Number of matches found
+    - Total execution time in milliseconds
+    - Average time per iteration in milliseconds
+    - Matches processed per second
+
+### Purpose
+
+This benchmark serves as a reference for future regex changes. When modifying the regex pattern, you can run this benchmark to compare performance before and after the changes to ensure that performance is maintained or improved.

--- a/src/benchmarks/mention-regex-benchmark.ts
+++ b/src/benchmarks/mention-regex-benchmark.ts
@@ -1,0 +1,309 @@
+import { mentionRegexGlobal } from "../shared/context-mentions"
+import * as fs from "fs"
+import * as path from "path"
+
+/**
+ * Benchmark the performance of the mentionRegexGlobal regex pattern
+ * This script measures execution time for different test cases and saves results
+ * for future reference when making regex changes.
+ */
+
+interface BenchmarkResult {
+	testCase: string
+	description: string
+	iterations: number
+	totalMatches: number
+	executionTimeMs: number
+	timePerIterationMs: number
+	matchesPerSecond: number
+}
+
+// Test cases to benchmark
+const testCases: Array<{ name: string; description: string; text: string; simulateTyping?: boolean }> = [
+	{
+		name: "file_paths",
+		description: "File paths starting with @/",
+		text: generateText(
+			[
+				"@/path/to/file.js",
+				"@/another/path/file.ts",
+				"@/usr/local/bin",
+				"@/home/user/documents/file.txt",
+				"@/var/log/system.log",
+			],
+			100,
+		),
+	},
+	{
+		name: "urls",
+		description: "URLs with protocols",
+		text: generateText(
+			[
+				"@http://example.com",
+				"@https://github.com/user/repo",
+				"@ftp://server.com/file",
+				"@ssh://user@server.com",
+				"@file:///home/user/document.txt",
+			],
+			100,
+		),
+	},
+	{
+		name: "special_words",
+		description: "Special words like problems, git-changes, terminal",
+		text: generateText(
+			[
+				"@problems",
+				"@git-changes",
+				"@terminal",
+				"Check @problems for errors",
+				"View @git-changes for updates",
+				"Open @terminal to run commands",
+			],
+			100,
+		),
+	},
+	{
+		name: "git_hashes",
+		description: "Git commit hashes",
+		text: generateText(
+			[
+				"@1a2b3c4",
+				"@abcdef1234567890",
+				"@1234567890abcdef1234567890abcdef12345678",
+				"Commit @a1b2c3d fixed the bug",
+				"See @1a2b3c4d5e6f7g8h for details",
+			],
+			100,
+		),
+	},
+	{
+		name: "mixed",
+		description: "Mixed content with various mention types",
+		text: generateText(
+			[
+				"Check @/path/to/file.js for implementation",
+				"Visit @https://example.com for more info",
+				"View @problems to see errors",
+				"Commit @1a2b3c4 fixed the issue",
+				"Open @terminal and run the command",
+				"Look at @git-changes for recent updates",
+				"Download from @ftp://server.com/file",
+				"Edit @/usr/local/config.json",
+			],
+			100,
+		),
+	},
+	{
+		name: "with_punctuation",
+		description: "Mentions followed by punctuation",
+		text: generateText(
+			[
+				"Check @/path/to/file.js, it has the implementation",
+				"Visit @https://example.com. It has more info",
+				"View @problems! There are errors",
+				"Commit @1a2b3c4; it fixed the issue",
+				"Open @terminal: run the command",
+				"Look at @git-changes? For recent updates",
+			],
+			100,
+		),
+	},
+	{
+		name: "large_text",
+		description: "Large text with few mentions (worst case scenario)",
+		text: generateLargeText(10000, 50),
+	},
+	{
+		name: "typing_simulation",
+		description: "Simulating user typing character by character",
+		text: generateText(
+			[
+				"User is typing @/path/to/file.js slowly",
+				"Now typing @https://example.com one character at a time",
+				"Typing @problems with pauses between characters",
+				"Slowly typing @1a2b3c4 as a commit reference",
+				"Character by character typing @terminal command",
+				"Typing @git-changes with deliberate keystrokes",
+			],
+			10,
+		),
+		simulateTyping: true,
+	},
+]
+
+// Generate text by repeating the patterns
+function generateText(patterns: string[], repetitions: number): string {
+	const result: string[] = []
+	for (let i = 0; i < repetitions; i++) {
+		for (const pattern of patterns) {
+			result.push(pattern)
+			// Add some random text between patterns
+			result.push(
+				// `This is some random text to separate patterns. Iteration ${i}.`
+				"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n",
+			)
+		}
+	}
+	return result.join("\n")
+}
+
+// Generate large text with few mentions (worst case scenario)
+function generateLargeText(size: number, mentionCount: number): string {
+	const lorem =
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\nExcepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.\n"
+
+	// Generate large text with paragraphs
+	let text = ""
+	while (text.length < size) {
+		text += lorem
+	}
+
+	// Insert mentions at random positions
+	const mentions = ["@/path/to/file.js", "@https://example.com", "@problems", "@1a2b3c4", "@terminal", "@git-changes"]
+
+	// Split by newlines to get paragraphs
+	const lines = text.split("\n")
+	for (let i = 0; i < mentionCount; i++) {
+		const randomLineIndex = Math.floor(Math.random() * lines.length)
+		const randomMention = mentions[Math.floor(Math.random() * mentions.length)]
+		lines[randomLineIndex] += " " + randomMention
+	}
+
+	return lines.join("\n")
+}
+
+// Run benchmark for a single test case
+function runBenchmark(
+	name: string,
+	description: string,
+	text: string,
+	iterations: number = 100,
+	simulateTyping: boolean = false,
+): BenchmarkResult {
+	console.log(`Running benchmark for: ${name}`)
+
+	let totalMatches = 0
+	const startTime = performance.now()
+
+	if (simulateTyping) {
+		// Simulate typing character by character
+		for (let i = 0; i < iterations; i++) {
+			const lines = text.split("\n")
+
+			for (const line of lines) {
+				let currentText = ""
+
+				// Simulate typing each character
+				for (let charIndex = 0; charIndex < line.length; charIndex++) {
+					currentText += line[charIndex]
+
+					// Reset lastIndex to ensure consistent behavior
+					mentionRegexGlobal.lastIndex = 0
+
+					// Check for matches after each keystroke
+					const matches = currentText.match(mentionRegexGlobal) || []
+					totalMatches += matches.length
+				}
+			}
+		}
+	} else {
+		// Standard benchmark (process whole text at once)
+		for (let i = 0; i < iterations; i++) {
+			// Reset lastIndex to ensure consistent behavior across iterations
+			mentionRegexGlobal.lastIndex = 0
+
+			// Count matches
+			const matches = text.match(mentionRegexGlobal) || []
+			totalMatches += matches.length
+		}
+	}
+
+	const endTime = performance.now()
+	const executionTimeMs = endTime - startTime
+	const timePerIterationMs = executionTimeMs / iterations
+	const matchesPerSecond = (totalMatches / executionTimeMs) * 1000
+
+	return {
+		testCase: name,
+		description,
+		iterations,
+		totalMatches: totalMatches / iterations, // Average matches per iteration
+		executionTimeMs,
+		timePerIterationMs,
+		matchesPerSecond,
+	}
+}
+
+// Run all benchmarks and save results
+async function runAllBenchmarks() {
+	console.log("Starting mention regex benchmark...")
+
+	const results: BenchmarkResult[] = []
+	const regexSource = mentionRegexGlobal.toString()
+
+	for (const testCase of testCases) {
+		const result = runBenchmark(
+			testCase.name,
+			testCase.description,
+			testCase.text,
+			100,
+			testCase.simulateTyping || false,
+		)
+		results.push(result)
+	}
+
+	// Format results as markdown
+	const timestamp = new Date().toISOString()
+	const markdownResults = formatResultsAsMarkdown(regexSource, results, timestamp)
+
+	// Save results to file
+	const resultsDir = path.join(__dirname, "results")
+	if (!fs.existsSync(resultsDir)) {
+		fs.mkdirSync(resultsDir, { recursive: true })
+	}
+
+	const filename = path.join(resultsDir, `mention-regex-benchmark-${timestamp.replace(/:/g, "-")}.md`)
+
+	fs.writeFileSync(filename, markdownResults)
+	console.log(`Benchmark results saved to: ${filename}`)
+
+	// Also save to a fixed filename for easy reference
+	const latestFilename = path.join(resultsDir, "mention-regex-benchmark-latest.md")
+	fs.writeFileSync(latestFilename, markdownResults)
+	console.log(`Benchmark results also saved to: ${latestFilename}`)
+
+	return { results, filename }
+}
+
+// Format results as markdown
+function formatResultsAsMarkdown(regexSource: string, results: BenchmarkResult[], timestamp: string): string {
+	let markdown = `# Mention Regex Benchmark Results\n\n`
+	markdown += `Benchmark run on: ${new Date(timestamp).toLocaleString()}\n\n`
+	markdown += `## Regex Pattern\n\n\`\`\`javascript\n${regexSource}\n\`\`\`\n\n`
+
+	markdown += `## Results\n\n`
+	markdown += `| Test Case | Description | Iterations | Matches | Total Time (ms) | Time/Iter (ms) | Matches/sec |\n`
+	markdown += `|-----------|-------------|------------|---------|-----------------|----------------|-------------|\n`
+
+	for (const result of results) {
+		markdown += `| ${result.testCase} | ${result.description} | ${
+			result.iterations
+		} | ${result.totalMatches.toFixed(0)} | ${result.executionTimeMs.toFixed(
+			2,
+		)} | ${result.timePerIterationMs.toFixed(4)} | ${result.matchesPerSecond.toFixed(0)} |\n`
+	}
+
+	return markdown
+}
+
+// Run the benchmarks
+runAllBenchmarks()
+	.then(({ results, filename }) => {
+		console.log("Benchmark completed successfully.")
+		process.exit(0)
+	})
+	.catch((error) => {
+		console.error("Error running benchmark:", error)
+		process.exit(1)
+	})

--- a/src/benchmarks/results/mention-regex-benchmark-2025-04-05T16-52-57.549Z.md
+++ b/src/benchmarks/results/mention-regex-benchmark-2025-04-05T16-52-57.549Z.md
@@ -1,0 +1,22 @@
+# Mention Regex Benchmark Results
+
+Benchmark run on: 4/5/2025, 11:52:57 PM
+
+## Regex Pattern
+
+```javascript
+;/@((?:\/|\w+:\/\/)[^\s]+?|[a-f0-9]{7,40}\b|problems\b|git-changes\b|terminal\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/g
+```
+
+## Results
+
+| Test Case         | Description                                        | Iterations | Matches | Total Time (ms) | Time/Iter (ms) | Matches/sec |
+| ----------------- | -------------------------------------------------- | ---------- | ------- | --------------- | -------------- | ----------- |
+| file_paths        | File paths starting with @/                        | 100        | 500     | 16.04           | 0.1604         | 3117086     |
+| urls              | URLs with protocols                                | 100        | 500     | 15.05           | 0.1505         | 3321634     |
+| special_words     | Special words like problems, git-changes, terminal | 100        | 600     | 15.56           | 0.1556         | 3855773     |
+| git_hashes        | Git commit hashes                                  | 100        | 400     | 15.09           | 0.1509         | 2651436     |
+| mixed             | Mixed content with various mention types           | 100        | 800     | 22.69           | 0.2269         | 3526054     |
+| with_punctuation  | Mentions followed by punctuation                   | 100        | 600     | 16.48           | 0.1648         | 3640593     |
+| large_text        | Large text with few mentions (worst case scenario) | 100        | 50      | 0.89            | 0.0089         | 5603026     |
+| typing_simulation | Simulating user typing character by character      | 100        | 1490    | 345.67          | 3.4567         | 431051      |

--- a/src/benchmarks/results/mention-regex-benchmark-latest.md
+++ b/src/benchmarks/results/mention-regex-benchmark-latest.md
@@ -1,0 +1,22 @@
+# Mention Regex Benchmark Results
+
+Benchmark run on: 4/5/2025, 11:52:57 PM
+
+## Regex Pattern
+
+```javascript
+;/@((?:\/|\w+:\/\/)[^\s]+?|[a-f0-9]{7,40}\b|problems\b|git-changes\b|terminal\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/g
+```
+
+## Results
+
+| Test Case         | Description                                        | Iterations | Matches | Total Time (ms) | Time/Iter (ms) | Matches/sec |
+| ----------------- | -------------------------------------------------- | ---------- | ------- | --------------- | -------------- | ----------- |
+| file_paths        | File paths starting with @/                        | 100        | 500     | 16.04           | 0.1604         | 3117086     |
+| urls              | URLs with protocols                                | 100        | 500     | 15.05           | 0.1505         | 3321634     |
+| special_words     | Special words like problems, git-changes, terminal | 100        | 600     | 15.56           | 0.1556         | 3855773     |
+| git_hashes        | Git commit hashes                                  | 100        | 400     | 15.09           | 0.1509         | 2651436     |
+| mixed             | Mixed content with various mention types           | 100        | 800     | 22.69           | 0.2269         | 3526054     |
+| with_punctuation  | Mentions followed by punctuation                   | 100        | 600     | 16.48           | 0.1648         | 3640593     |
+| large_text        | Large text with few mentions (worst case scenario) | 100        | 50      | 0.89            | 0.0089         | 5603026     |
+| typing_simulation | Simulating user typing character by character      | 100        | 1490    | 345.67          | 3.4567         | 431051      |

--- a/src/benchmarks/run-mention-benchmark.js
+++ b/src/benchmarks/run-mention-benchmark.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+
+/**
+ * Script to run the mention regex benchmark
+ * This allows easy execution of the benchmark from the command line
+ */
+
+const { execSync } = require("child_process")
+const path = require("path")
+
+// Get the project root directory
+const projectRoot = path.resolve(__dirname, "../..")
+
+// Run the benchmark using ts-node
+try {
+	console.log("Running mention regex benchmark...")
+	execSync("npx tsx src/benchmarks/mention-regex-benchmark.ts", {
+		cwd: projectRoot,
+		stdio: "inherit",
+	})
+	console.log("Benchmark completed successfully.")
+} catch (error) {
+	console.error("Error running benchmark:", error.message)
+	process.exit(1)
+}

--- a/src/shared/context-mentions.ts
+++ b/src/shared/context-mentions.ts
@@ -49,8 +49,22 @@ Mention regex:
   - `mentionRegexGlobal`: Creates a global version of the `mentionRegex` to find all matches within a given string.
 
 */
-export const mentionRegex =
-	/@((?:\/|\w+:\/\/)[^\s]+?|[a-f0-9]{7,40}\b|problems\b|git-changes\b|terminal\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/
+// Path or URL pattern: matches file/folder paths starting with '/' or URLs with protocols
+const pathOrUrlPattern = "(?:\\/|\\w+:\\/\\/)[^\\s]+?"
+
+// Git commit hash pattern: matches hexadecimal characters (7-40 chars long)
+const gitHashPattern = "[a-f0-9]{7,40}\\b"
+
+// Special keywords that can be mentioned
+const keywordPatterns = ["problems\\b", "git-changes\\b", "terminal\\b"]
+
+// Combine all patterns with OR operator
+const mentionContentPattern = [pathOrUrlPattern, gitHashPattern, ...keywordPatterns].join("|")
+
+// Lookahead to ensure punctuation (if present) is followed by whitespace or end of string
+const punctuationLookahead = "(?=[.,;:!?]?(?=[\\s\\r\\n]|$))"
+
+export const mentionRegex = new RegExp(`@(${mentionContentPattern})${punctuationLookahead}`)
 export const mentionRegexGlobal = new RegExp(mentionRegex.source, "g")
 
 export interface MentionSuggestion {


### PR DESCRIPTION
## Context

Because we run @-mention's regex every keystroke in chat area, we need tracking the change of regex performance when we add new feature to @-mention

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
