### PR TITLE
Fix cache usage tracking for openai-compatible

### DIFF
--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -211,6 +211,8 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 			type: "usage",
 			inputTokens: usage?.prompt_tokens || 0,
 			outputTokens: usage?.completion_tokens || 0,
+			cacheWriteTokens: usage?.cache_creation_input_tokens || undefined,
+			cacheReadTokens: usage?.cache_read_input_tokens || undefined,
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #1587 to track the token usage correctly when caching is enabled.

Before:
![Screenshot 2025-04-08 at 1 15 00 AM](https://github.com/user-attachments/assets/21c8ed42-a587-4803-bcdc-00b14c2e8495)

After:
![Screenshot 2025-04-08 at 1 13 12 AM](https://github.com/user-attachments/assets/f1c44b03-8951-4d98-9857-7c959cb3c917)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds cache usage tracking in `processUsageMetrics` in `openai.ts` for accurate token usage with caching.
> 
>   - **Behavior**:
>     - Updates `processUsageMetrics` in `openai.ts` to include `cacheWriteTokens` and `cacheReadTokens` for tracking cache usage.
>   - **Misc**:
>     - Follow-up to #1587 for correct token usage tracking with caching enabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bc425ba2691170ac1cd5a9e04516a5ff46238c64. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->