### PR TITLE
Fix a bug not to read rule files properly, under nested `.roo/rules` directories

### DIFF
--- a/.changeset/poor-dolphins-brush.md
+++ b/.changeset/poor-dolphins-brush.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix bug where nested .roo/rules directories are not respected properly

--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -39,7 +39,7 @@ async function readTextFilesFromDirectory(dirPath: string): Promise<Array<{ file
 		const files = await fs
 			.readdir(dirPath, { withFileTypes: true, recursive: true })
 			.then((files) => files.filter((file) => file.isFile()))
-			.then((files) => files.map((file) => path.resolve(dirPath, file.name)))
+			.then((files) => files.map((file) => path.resolve(file.parentPath, file.name)))
 
 		const fileContents = await Promise.all(
 			files.map(async (file) => {


### PR DESCRIPTION
## Context

Fix a bug not to resolve nested `.roo/rules` directories properly, such as `.roo/rules/subdir/file1.txt` or `.roo/rules/subdir/subdir2/file` rule files.
It seems to be intended to support nested directory structures, as `recursive` option is marked as `true` in the implementation. 

Sub directories  are quite helpful to organize multiple custom instructions files. It is nicer to support.

## Implementation

Use `Dirent#parentPath` instead of `dirPath` to resolve full path of each rule file.

This is because `dirPath` would be the path of `.roo/rules`, not sub directory path. So current path misses all subdirectories.

>  .then((files) => files.map((file) => path.resolve(dirPath, file.name)))

should be 

>  .then((files) => files.map((file) => path.resolve(file.parentPath, file.name)))

## Screenshots

| before | after |
| ------ | ----- |
|   <img width="441" alt="スクリーンショット 2025-04-08 22 22 02" src="https://github.com/user-attachments/assets/f2c826f9-5166-4e03-9bcb-e11632cf27a3" />   |    ![スクリーンショット 2025-04-08 22 15 52](https://github.com/user-attachments/assets/a2e56416-ab18-4465-9b14-9cd40a6951d6)  |

## How to Test

1. prepare a rule file under subdir
```
echo "This was the missed txt." >> .roo/rules/subdir/missed.txt
```

2. Go to the Prompts tab
2. `Preview System Prompt` and check if `.roo/rules/subdir/missed.txt` is included.

## Get in Touch

I am in the Roo Code Discord server as `@taisukeoe`. Please feel free to ask if any!
