### PR TITLE
Remove extra colon from rules content

### DIFF
--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -74,7 +74,7 @@ function formatDirectoryContent(dirPath: string, files: Array<{ filename: string
 		"\n\n" +
 		files
 			.map((file) => {
-				return `# Rules from ${file.filename}:\n${file.content}:`
+				return `# Rules from ${file.filename}:\n${file.content}`
 			})
 			.join("\n\n")
 	)


### PR DESCRIPTION
Before:
![Screenshot 2025-04-08 at 11 19 09 AM](https://github.com/user-attachments/assets/0b73e4e0-8744-4c3a-9c8f-34f431c55876)

After:
![Screenshot 2025-04-08 at 11 19 48 AM](https://github.com/user-attachments/assets/d684cf97-f332-4467-90a4-b79481902afd)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove extra colon from rule content in `formatDirectoryContent()` in `custom-instructions.ts`.
> 
>   - **Behavior**:
>     - Removes extra colon from the end of rule content in `formatDirectoryContent()` in `custom-instructions.ts`. This affects the display of rules from files, ensuring no trailing colon after content.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 74c2c29a216cdad302e58ca85e6fae254b01f3fb. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->