### PR TITLE
Fix typo in diff prompt

### DIFF
--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -110,7 +110,7 @@ Search/Replace content with multi edits:
 :start_line:1
 :end_line:2
 -------
-def calculate_sum(items):
+def calculate_total(items):
     sum = 0
 =======
 def calculate_sum(items):

--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -4101,7 +4101,7 @@ Search/Replace content with multi edits:
 :start_line:1
 :end_line:2
 -------
-def calculate_sum(items):
+def calculate_total(items):
     sum = 0
 =======
 def calculate_sum(items):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix typo in diff prompt by renaming `calculate_sum` to `calculate_total` in two files.
> 
>   - Fix typo in diff prompt by renaming `calculate_sum` to `calculate_total` in `multi-search-replace.ts` and `system.test.ts.snap`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 688e3d4906de89ddec350d71c40c19b74b4821d3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->