### PR TITLE
fix: z-index of highlight layer should be under mode/profile dropdowns

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -816,7 +816,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									"leading-vscode-editor-line-height",
 									"py-2",
 									"px-[9px]",
-									"z-[1000]",
+									"z-10",
 								)}
 								style={{
 									color: "transparent",


### PR DESCRIPTION
## Context

change z-index of highlight layer from 1000 to 10, fixes #2386 

## Screenshots

| before | after |
| ------ | ----- |
|<img width="310" alt="image" src="https://github.com/user-attachments/assets/ab2666f1-110e-4ba8-b532-4454c63bda2e" />|<img width="306" alt="image" src="https://github.com/user-attachments/assets/6da46d0b-aa24-4a4f-a425-4ea2599fc584" />|
