### PR TITLE
fix: preserve content integrity in VS Code LM provider

### DIFF
--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -289,36 +289,36 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 
 		return (
 			text
-				// Нормализуем переносы строк
+				// Normalize line breaks
 				.replace(/\r\n/g, "\n")
 				.replace(/\r/g, "\n")
 
-				// Удаляем ANSI escape sequences
-				.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "") // Полный набор ANSI sequences
+				// Remove ANSI escape sequences
+				.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "") // Complete set of ANSI sequences
 				.replace(/\x9B[0-?]*[ -/]*[@-~]/g, "") // CSI sequences
 
-				// Удаляем последовательности установки заголовка терминала и прочие OSC sequences
+				// Remove terminal title setting sequences and other OSC sequences
 				.replace(/\x1B\][0-9;]*(?:\x07|\x1B\\)/g, "")
 
-				// Удаляем управляющие символы
+				// Remove control characters
 				.replace(/[\x00-\x09\x0B-\x0C\x0E-\x1F\x7F]/g, "")
 
-				// Удаляем escape-последовательности VS Code
+				// Remove VS Code escape sequences
 				.replace(/\x1B[PD].*?\x1B\\/g, "") // DCS sequences
 				.replace(/\x1B_.*?\x1B\\/g, "") // APC sequences
 				.replace(/\x1B\^.*?\x1B\\/g, "") // PM sequences
 				.replace(/\x1B\[[\d;]*[HfABCDEFGJKST]/g, "") // Cursor movement and clear screen
 
-				// Удаляем пути Windows и служебную информацию
+				// Remove Windows paths and service information
 				.replace(/^(?:PS )?[A-Z]:\\[^\n]*$/gm, "")
 				.replace(/^;?Cwd=.*$/gm, "")
 
-				// Очищаем экранированные последовательности
+				// Clean escaped sequences
 				.replace(/\\x[0-9a-fA-F]{2}/g, "")
 				.replace(/\\u[0-9a-fA-F]{4}/g, "")
 
-				// Финальная очистка
-				.replace(/\n{3,}/g, "\n\n") // Убираем множественные пустые строки
+				// Final cleanup
+				.replace(/\n{3,}/g, "\n\n") // Remove multiple empty lines
 				.trim()
 		)
 	}


### PR DESCRIPTION
## Context

The VS Code LM provider was modifying system information and model responses by stripping escape sequences and performing other transformations.

The issue was discovered when attempting to use escape sequences like '\x1b' in text, which were being removed by the cleanTerminalOutput method. This caused problems in scenarios where escape sequences needed to be preserved, such as when working with terminal control codes.

## Implementation

- Removed the cleanTerminalOutput method that was stripping escape sequences
- Modified the code to use the system prompt directly without any cleaning or transformation

It is not the responsibility of the provider to modify input/output to and from the model. Roo expects all communication through different providers to be clean so that it can manage transformation centrally.

## How to Test

1. Use the VS Code LM provider
2. Ask the model to reply with '\x1b'
3. Prior to this patch, it would respond with an empty string ''
4. After this patch, it will successfully respond with '\x1b'

**Note:** This PR is submitted as a draft because I plan to test it locally to see if there are any unexpected side effects from removing the content cleaning functionality.

## Get in Touch

Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `cleanTerminalOutput` from `vscode-lm.ts` to preserve escape sequences in VS Code LM provider responses.
> 
>   - **Behavior**:
>     - Removed `cleanTerminalOutput` method from `vscode-lm.ts`, which stripped escape sequences and transformed text.
>     - Updated `cleanMessageContent` to return content directly without cleaning.
>   - **Testing**:
>     - Ensures that escape sequences like `\x1b` are preserved in model responses.
>     - Prior to this change, such sequences were removed, resulting in empty responses.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7538e12aef48cc5aa69b3c743b6a93087a373747. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->