### PR TITLE
Add o1-pro to api.ts

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -776,6 +776,14 @@ export const openAiNativeModels = {
 		outputPrice: 4.4,
 		reasoningEffort: "low",
 	},
+	"o1-pro": {
+		maxTokens: 100_000,
+		contextWindow: 200_000,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 150,
+		outputPrice: 600,
+	},
 	o1: {
 		maxTokens: 100_000,
 		contextWindow: 200_000,


### PR DESCRIPTION
Add the o1-pro model to the openai section. Sourced model info from: https://platform.openai.com/docs/models/o1-pro

## Context

Was very disappointed to not find o1 pro in roo!

## Implementation

Added o1-pro in the api.ts file next to the other o1 model entries, following the files format, and including o1-pros specs, [sourced from openai](https://platform.openai.com/docs/models/o1-pro).

## Screenshots

n/a

## How to Test

n/a

## Get in Touch

reply here

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `o1-pro` model to `openAiNativeModels` in `api.ts` with specific attributes.
> 
>   - **Models**:
>     - Add `o1-pro` model to `openAiNativeModels` in `api.ts` with attributes: `maxTokens: 100_000`, `contextWindow: 200_000`, `supportsImages: true`, `supportsPromptCache: false`, `inputPrice: 150`, `outputPrice: 600`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0945a6239dc3b64771093449a7a8c15fcb4e0c3d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->