### PR TITLE
Make Grok3 streaming work with OpenAI Compatible

### DIFF
--- a/src/api/providers/__tests__/openai.test.ts
+++ b/src/api/providers/__tests__/openai.test.ts
@@ -352,4 +352,44 @@ describe("OpenAiHandler", () => {
 			)
 		})
 	})
+
+	describe("Grok xAI Provider", () => {
+		const grokOptions = {
+			...mockOptions,
+			openAiBaseUrl: "https://api.x.ai/v1",
+			openAiModelId: "grok-1",
+		}
+
+		it("should initialize with Grok xAI configuration", () => {
+			const grokHandler = new OpenAiHandler(grokOptions)
+			expect(grokHandler).toBeInstanceOf(OpenAiHandler)
+			expect(grokHandler.getModel().id).toBe(grokOptions.openAiModelId)
+		})
+
+		it("should exclude stream_options when streaming with Grok xAI", async () => {
+			const grokHandler = new OpenAiHandler(grokOptions)
+			const systemPrompt = "You are a helpful assistant."
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: "Hello!",
+				},
+			]
+
+			const stream = grokHandler.createMessage(systemPrompt, messages)
+			await stream.next()
+
+			expect(mockCreate).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: grokOptions.openAiModelId,
+					stream: true,
+				}),
+				{},
+			)
+
+			const mockCalls = mockCreate.mock.calls
+			const lastCall = mockCalls[mockCalls.length - 1]
+			expect(lastCall[0]).not.toHaveProperty("stream_options")
+		})
+	})
 })


### PR DESCRIPTION
## Context

Allow streaming to be used when using Open AI Compatible provider with Grok3 API directly.

## Implementation

If x.ai in base_url remove unsupported stream_options.

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Configure Grok3 API in the Open AI Compatible provider and enable streaming support, observe the 400 error "unsupported option: stream_options". 

After fix streaming works with Grok3 as expected.

## References

https://docs.x.ai/docs/guides/streaming-response#streaming-response
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable Grok3 streaming in `OpenAiHandler` by excluding `stream_options` for x.ai base URLs, with tests added.
> 
>   - **Behavior**:
>     - In `openai.ts`, `OpenAiHandler` now excludes `stream_options` when `base_url` is for x.ai, enabling Grok3 streaming.
>     - Adds `_isGrokXAI()` to check if the base URL is for x.ai.
>   - **Tests**:
>     - In `openai.test.ts`, adds tests for Grok xAI configuration and verifies `stream_options` exclusion during streaming.
>   - **Misc**:
>     - No changes to existing functionality for non-Grok3 providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dc3f06cb31abdd064e73a8f0d1e7ddab8cf1a9b3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->