### PR TITLE
Fall back on aggressive line number stripping in diffs

### DIFF
--- a/src/integrations/misc/__tests__/extract-text.test.ts
+++ b/src/integrations/misc/__tests__/extract-text.test.ts
@@ -137,6 +137,46 @@ describe("stripLineNumbers", () => {
 		const expected = "line one\nline two\nline three"
 		expect(stripLineNumbers(input)).toBe(expected)
 	})
+
+	describe("aggressive mode", () => {
+		it("should strip content with just a pipe character", () => {
+			const input = "| line one\n| line two\n| line three"
+			const expected = "line one\nline two\nline three"
+			expect(stripLineNumbers(input, true)).toBe(expected)
+		})
+
+		it("should strip content with mixed formats in aggressive mode", () => {
+			const input = "1 | line one\n| line two\n123 | line three"
+			const expected = "line one\nline two\nline three"
+			expect(stripLineNumbers(input, true)).toBe(expected)
+		})
+
+		it("should not strip content with pipe characters not at start in aggressive mode", () => {
+			const input = "text | more text\nx | y"
+			expect(stripLineNumbers(input, true)).toBe(input)
+		})
+
+		it("should handle empty content in aggressive mode", () => {
+			expect(stripLineNumbers("", true)).toBe("")
+		})
+
+		it("should preserve padding after pipe in aggressive mode", () => {
+			const input = "|  line with extra spaces\n1 |  indented content"
+			const expected = " line with extra spaces\n indented content"
+			expect(stripLineNumbers(input, true)).toBe(expected)
+		})
+
+		it("should preserve windows-style line endings in aggressive mode", () => {
+			const input = "| line one\r\n| line two\r\n| line three"
+			const expected = "line one\r\nline two\r\nline three"
+			expect(stripLineNumbers(input, true)).toBe(expected)
+		})
+
+		it("should not affect regular content when using aggressive mode", () => {
+			const input = "regular line\nanother line\nno pipes here"
+			expect(stripLineNumbers(input, true)).toBe(input)
+		})
+	})
 })
 
 describe("truncateOutput", () => {

--- a/src/integrations/misc/extract-text.ts
+++ b/src/integrations/misc/extract-text.ts
@@ -86,17 +86,23 @@ export function everyLineHasLineNumbers(content: string): boolean {
 	return lines.length > 0 && lines.every((line) => /^\s*\d+\s+\|(?!\|)/.test(line))
 }
 
-// Strips line numbers from content while preserving the actual content
-// Handles formats like "1 | content", " 12 | content", "123 | content"
-// Preserves content that naturally starts with pipe characters
-export function stripLineNumbers(content: string): string {
+/**
+ * Strips line numbers from content while preserving the actual content.
+ *
+ * @param content The content to process
+ * @param aggressive When false (default): Only strips lines with clear number patterns like "123 | content"
+ *                   When true: Uses a more lenient pattern that also matches lines with just a pipe character,
+ *                   which can be useful when LLMs don't perfectly format the line numbers in diffs
+ * @returns The content with line numbers removed
+ */
+export function stripLineNumbers(content: string, aggressive: boolean = false): string {
 	// Split into lines to handle each line individually
 	const lines = content.split(/\r?\n/)
 
 	// Process each line
 	const processedLines = lines.map((line) => {
 		// Match line number pattern and capture everything after the pipe
-		const match = line.match(/^\s*\d+\s+\|(?!\|)\s?(.*)$/)
+		const match = aggressive ? line.match(/^\s*(?:\d+\s)?\|\s(.*)$/) : line.match(/^\s*\d+\s+\|(?!\|)\s?(.*)$/)
 		return match ? match[1] : line
 	})
 


### PR DESCRIPTION
## Context

We're seeing a lot of errors applying diffs in the Gemini models. When we look closely, a lot of them are related to not stripping line numbers correctly in the search and replace blocks.

## Implementation

What this change does is add another more aggressive second pass if we fail to apply a diff with the standard approach. This second pass will more aggressively strip leading pipes+spaces from both search and replace, even if there's not a line number before it or not every line has a line number.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add aggressive line number stripping fallback in `applyDiff()` to handle inconsistent line numbers in diffs.
> 
>   - **Behavior**:
>     - Adds aggressive line number stripping fallback in `applyDiff()` in `multi-search-replace.ts`.
>     - Handles cases where line numbers are inconsistent or missing in diffs.
>   - **Functions**:
>     - Updates `stripLineNumbers()` in `extract-text.ts` to support aggressive mode for line number stripping.
>   - **Tests**:
>     - Adds tests for aggressive line number stripping in `multi-search-replace.test.ts` and `extract-text.test.ts`.
>     - Removes a test that expected failure when not all lines had numbers in `multi-search-replace.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 112a1a0315c66faa067dfe072cf354d764f89419. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->