### PR TITLE
FakeAI "controller" object must not be copied

### DIFF
--- a/src/api/providers/fake-ai.ts
+++ b/src/api/providers/fake-ai.ts
@@ -4,21 +4,52 @@ import { ApiHandlerOptions, ModelInfo } from "../../shared/api"
 import { ApiStream } from "../transform/stream"
 
 interface FakeAI {
+	/**
+	 * The unique identifier for the FakeAI instance.
+	 * It is used to lookup the original FakeAI object in the fakeAiMap
+	 * when the fakeAI object is read from the VSCode global state.
+	 */
+	readonly id: string
+
+	/**
+	 * A function set by the FakeAIHandler on the FakeAI instance, that removes
+	 * the FakeAI instance from the fakeAIMap when the FakeAI instance is
+	 * no longer needed.
+	 */
+	removeFromCache?: () => void
+
 	createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream
 	getModel(): { id: string; info: ModelInfo }
 	countTokens(content: Array<Anthropic.Messages.ContentBlockParam>): Promise<number>
 	completePrompt(prompt: string): Promise<string>
 }
 
+/**
+ * API providers configuration is stored in the VSCode global state.
+ * Therefore, when a new task is created, the FakeAI object in the configuration
+ * is a new object not related to the original one, but with the same ID.
+ *
+ * We use the ID to lookup the original FakeAI object in the mapping.
+ */
+let fakeAiMap: Map<string, FakeAI> = new Map()
+
 export class FakeAIHandler implements ApiHandler, SingleCompletionHandler {
 	private ai: FakeAI
 
 	constructor(options: ApiHandlerOptions) {
-		if (!options.fakeAi) {
+		const optionsFakeAi = options.fakeAi as FakeAI | undefined
+		if (!optionsFakeAi) {
 			throw new Error("Fake AI is not set")
 		}
 
-		this.ai = options.fakeAi as FakeAI
+		const id = optionsFakeAi.id
+		let cachedFakeAi = fakeAiMap.get(id)
+		if (cachedFakeAi === undefined) {
+			cachedFakeAi = optionsFakeAi
+			cachedFakeAi.removeFromCache = () => fakeAiMap.delete(id)
+			fakeAiMap.set(id, cachedFakeAi)
+		}
+		this.ai = cachedFakeAi
 	}
 
 	async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {


### PR DESCRIPTION
## Context

The FakeAI object passed by the user must be exactly the same object that is passed to FakeAIHandler via API configuration. Unfortunatelly, the VSCode global state is used as configuration storage, so the requirement is not met (VSCode global state creates copies of the configuration object). Also the class of the stored object is lost, so methods of the object are unavailable.

## Implementation

Therefore, we store the original (passed by the user) objects in global variable and use ID field of FakeAI object to identify the original object.

## Screenshots

## How to Test

## Get in Touch

Discord handle: wkordalski
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Store original `FakeAI` objects in a global map to prevent copying and ensure method availability, using IDs for retrieval.
> 
>   - **Behavior**:
>     - Introduces `fakeAiMap` to store original `FakeAI` objects globally, identified by `id`.
>     - `FakeAIHandler` constructor retrieves `FakeAI` from `fakeAiMap` using `id`, ensuring the original object is used.
>     - Adds `removeFromCache` method to `FakeAI` to remove itself from `fakeAiMap` when no longer needed.
>   - **Interface**:
>     - Adds `id` and `removeFromCache` to `FakeAI` interface in `fake-ai.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for af838d89ebc223f9c98ea6864d742989b4b879e8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->