### PR TITLE
`.direnv` directory should not be packaged

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -31,6 +31,7 @@ cline_docs/**
 coverage/**
 locales/**
 benchmark/**
+.direnv/**
 
 # Ignore all webview-ui files except the build directory (https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/frameworks/hello-world-react-cra/.vscodeignore)
 webview-ui/src/**


### PR DESCRIPTION
## Context & Implementation

If somebody uses direnv tool, the `.direnv` directory is created, that contains some data and especially some symlinks. Symlinks makes `vsce` to fail zipping the built VSIX.

Generally `.direnv` should not be added to the resulting VSIX, therefore I add it to .vscodeignore.

Maybe we should use "whitelist" strategy of defining what should be packaged instead of "blacklist"?

## Screenshots

## How to Test

## Get in Touch

Discord handle: wkordalski
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `.direnv/**` to `.vscodeignore` to prevent packaging issues with `vsce` due to symlinks.
> 
>   - **Behavior**:
>     - Add `.direnv/**` to `.vscodeignore` to exclude `.direnv` directory from VSIX package.
>     - Addresses issue with `vsce` failing due to symlinks in `.direnv`.
>   - **Misc**:
>     - Suggests considering a whitelist strategy for packaging instead of a blacklist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ac0ffeeffc4f65205f1f21f3284eefa6eb110632. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->