### PR TITLE
Bug Fixed: Chinese i18n css error

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -850,7 +850,7 @@ const ApiOptions = ({
 					</div>
 
 					<div className="flex flex-col gap-3">
-						<div className="text-sm text-vscode-descriptionForeground" style={{ whiteSpace: "pre-line" }}>
+						<div className="text-sm text-vscode-descriptionForeground whitespace-pre-line">
 							{t("settings:providers.customModel.capabilities")}
 						</div>
 

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -850,7 +850,7 @@ const ApiOptions = ({
 					</div>
 
 					<div className="flex flex-col gap-3">
-						<div className="text-sm text-vscode-descriptionForeground">
+						<div className="text-sm text-vscode-descriptionForeground" style={{ whiteSpace: "pre-line" }}>
 							{t("settings:providers.customModel.capabilities")}
 						</div>
 

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -180,7 +180,7 @@
 			}
 		},
 		"customModel": {
-			"capabilities": "自定义模型配置注意事项：<br>• 确保兼容OpenAI接口规范<br>• 错误配置可能导致功能异常<br>• 价格参数影响费用统计",
+			"capabilities": "自定义模型配置注意事项：\n• 确保兼容OpenAI接口规范\n• 错误配置可能导致功能异常\n• 价格参数影响费用统计",
 			"maxTokens": {
 				"label": "最大输出Token数",
 				"description": "模型在响应中可以生成的最大Token数。（指定 -1 允许服务器设置最大Token数。）"


### PR DESCRIPTION
## Context

Fixed the abnormality of setting comment display under Simplified Chinese.

## Something unexpected

During husky, it showed that there are some err:
```
src/exports/ipc.ts:5:17 - error TS2307: Cannot find module 'node-ipc' or its corresponding type declarations.

5 import ipc from "node-ipc"
                  ~~~~~~~~~~

src/exports/ipc.ts:41:30 - error TS7006: Parameter 'socket' implicitly has an 'any' type.

41    ipc.server.on("connect", (socket) => this.onConnect(socket))
                                ~~~~~~

src/exports/ipc.ts:42:42 - error TS7006: Parameter 'socket' implicitly has an 'any' type.

42    ipc.server.on("socket.disconnected", (socket) => this.onDisconnect(socket))
                                            ~~~~~~

src/exports/ipc.ts:43:30 - error TS7006: Parameter 'data' implicitly has an 'any' type.

43    ipc.server.on("message", (data) => this.onMessage(data))
                                ~~~~


Found 4 errors in the same file, starting at: src/exports/ipc.ts:5

husky - pre-push script failed (code 2)
error: failed to push some refs to 'https://github.com/zhangtony239/Roo-Code.git'
PS C:\repos\Roo-Code> git push origin zhangtony239 --force   

> roo-cline@3.11.12 compile
> tsc -p . --outDir out && node esbuild.js

src/exports/ipc.ts:5:17 - error TS2307: Cannot find module 'node-ipc' or its corresponding type declarations.

5 import ipc from "node-ipc"
                  ~~~~~~~~~~

src/exports/ipc.ts:41:30 - error TS7006: Parameter 'socket' implicitly has an 'any' type.

41    ipc.server.on("connect", (socket) => this.onConnect(socket))
                                ~~~~~~

src/exports/ipc.ts:42:42 - error TS7006: Parameter 'socket' implicitly has an 'any' type.

42    ipc.server.on("socket.disconnected", (socket) => this.onDisconnect(socket))
                                            ~~~~~~

src/exports/ipc.ts:43:30 - error TS7006: Parameter 'data' implicitly has an 'any' type.

43    ipc.server.on("message", (data) => this.onMessage(data))
                                ~~~~


Found 4 errors in the same file, starting at: src/exports/ipc.ts:5

husky - pre-push script failed (code 2)
error: failed to push some refs to 'https://github.com/zhangtony239/Roo-Code.git'
```
I have skipped this checks as they might not relevant to this PR.

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/547ca70c-45a6-4a13-86b0-a2904f11d091) | ![image](https://github.com/user-attachments/assets/da4e8f46-c5b7-46a0-8fc4-a6d601bf640a) |

## How to Test

- F5 run the code
- open `Settings` button
- language set to 简体中文  (zh-CN)
- you will find what the Screenshots part showed

## Get in Touch
discord: zhangtony239

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes CSS issue in Chinese i18n settings by adjusting text display for line breaks in `ApiOptions.tsx` and `zh-CN/settings.json`.
> 
>   - **CSS Fix**:
>     - In `ApiOptions.tsx`, added `whiteSpace: "pre-line"` to the CSS style of the description text to handle line breaks correctly.
>     - Updated `zh-CN/settings.json` to replace `<br>` with `\n` for line breaks in the `customModel.capabilities` text.
>   - **Misc**:
>     - TypeScript errors in `ipc.ts` were encountered but not addressed in this PR.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 48a2fd6a24195eb9fa27203fd5381a5207f70f9e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->