### PR TITLE
Exclude demo gif from extension build

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,7 +20,6 @@ vsc-extension-quickstart.md
 **/.vscode-test.*
 
 # Custom
-demo.gif
 .nvmrc
 .gitattributes
 .prettierignore
@@ -51,6 +50,8 @@ webview-ui/node_modules/**
 # Include default themes JSON files used in getTheme
 !src/integrations/theme/default-themes/**
 
+# Ignore doc assets
+assets/docs/**
 # Include icons and images
 !assets/icons/**
 !assets/images/**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Exclude `demo.gif` and `assets/docs/**` from the extension build in `.vscodeignore`.
> 
>   - **Build Exclusions**:
>     - Excludes `demo.gif` from the extension build by removing it from `.vscodeignore`.
>     - Excludes all files in `assets/docs/` from the extension build by adding `assets/docs/**` to `.vscodeignore`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e6581a4bbf3db5338adc648069112464261e3be3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->