### PR TITLE
Fix discard changes in settings

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -111,7 +111,7 @@ const App = () => {
 			{tab === "mcp" && <McpView onDone={() => switchTab("chat")} />}
 			{tab === "history" && <HistoryView onDone={() => switchTab("chat")} />}
 			{tab === "settings" && (
-				<SettingsView ref={settingsRef} onDone={() => switchTab("chat")} targetSection={currentSection} />
+				<SettingsView ref={settingsRef} onDone={() => setTab("chat")} targetSection={currentSection} />
 			)}
 			<ChatView
 				isHidden={tab !== "chat"}


### PR DESCRIPTION
#2477, broke in #2355

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes tab switching behavior in `App.tsx` for `SettingsView` to correctly set tab to "chat" on completion.
> 
>   - **Behavior**:
>     - Fixes tab switching behavior in `App.tsx` by changing `onDone` callback in `SettingsView` from `switchTab("chat")` to `setTab("chat")`.
>   - **Misc**:
>     - Addresses issue #2477 related to discarding changes in settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a195b59b39de23dd9643376bccf60bb10cc85089. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->