### PR TITLE
Add reasoning_effort to openai compatible provider for grok-mini

### DIFF
--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -199,6 +199,8 @@ export type ExtensionState = Pick<
 	telemetrySetting: TelemetrySetting
 	telemetryKey?: string
 	machineId?: string
+	reasoningEffort?: "low" | "medium" | "high" // The reasoning effort level for models that support reasoning
+	grokReasoningEffort?: "low" | "high" // The reasoning effort level for Grok 3 Mini models
 
 	renderContext: "sidebar" | "editor"
 	settingsImportedAt?: number

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -120,6 +120,7 @@ export interface WebviewMessage {
 		| "maxReadFileLine"
 		| "searchFiles"
 		| "toggleApiConfigPin"
+		| "reasoningEffort"
 	text?: string
 	disabled?: boolean
 	askResponse?: ClineAskResponse

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -622,6 +622,7 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 	supportsPromptCache: false,
 	inputPrice: 0,
 	outputPrice: 0,
+	reasoningEffort: "low",
 }
 
 // Gemini

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -7,6 +7,7 @@ import { LanguageModelChatSelector } from "vscode"
 import { Checkbox } from "vscrui"
 import { VSCodeLink, VSCodeRadio, VSCodeRadioGroup, VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 import { ExternalLinkIcon } from "@radix-ui/react-icons"
+import { GrokReasoningSettings } from "./GrokReasoningSettings"
 
 import {
 	ApiConfiguration,
@@ -128,6 +129,16 @@ const ApiOptions = ({
 		() => normalizeApiConfiguration(apiConfiguration),
 		[apiConfiguration],
 	)
+
+	// Check if the current model is a Grok 3 Mini model
+	const isGrokMiniModel = useMemo(() => {
+		return selectedModelId?.includes("grok-3-mini-beta") || selectedModelId?.includes("grok-3-mini-fast-beta")
+	}, [selectedModelId])
+
+	// Check if the endpoint is x.ai
+	const isXaiEndpoint = useMemo(() => {
+		return apiConfiguration?.openAiBaseUrl?.includes("x.ai") || false
+	}, [apiConfiguration?.openAiBaseUrl])
 
 	// Debounced refresh model updates, only executed 250ms after the user
 	// stops typing.
@@ -800,6 +811,24 @@ const ApiOptions = ({
 						onChange={handleInputChange("openAiStreamingEnabled", noTransform)}>
 						{t("settings:modelInfo.enableStreaming")}
 					</Checkbox>
+
+					{/* Grok3 Reasoning Settings - Only show for Grok Mini models */}
+					{isGrokMiniModel && isXaiEndpoint && (
+						<GrokReasoningSettings
+							reasoningEffort={
+								(apiConfiguration?.openAiCustomModelInfo?.reasoningEffort === "medium"
+									? "low"
+									: apiConfiguration?.openAiCustomModelInfo?.reasoningEffort) ?? "low"
+							}
+							setReasoningEffort={(value) => {
+								setApiConfigurationField("openAiCustomModelInfo", {
+									...(apiConfiguration?.openAiCustomModelInfo || openAiModelInfoSaneDefaults),
+									reasoningEffort: value,
+								})
+							}}
+						/>
+					)}
+
 					<Checkbox
 						checked={apiConfiguration?.openAiUseAzure ?? false}
 						onChange={handleInputChange("openAiUseAzure", noTransform)}>

--- a/webview-ui/src/components/settings/GrokReasoningSettings.tsx
+++ b/webview-ui/src/components/settings/GrokReasoningSettings.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui"
+
+interface GrokReasoningSettingsProps {
+	reasoningEffort: "low" | "high"
+	setReasoningEffort: (value: "low" | "high") => void
+}
+
+export const GrokReasoningSettings: React.FC<GrokReasoningSettingsProps> = ({
+	reasoningEffort,
+	setReasoningEffort,
+}) => {
+	return (
+		<div className="flex flex-col gap-3">
+			<div>
+				<label className="block font-medium mb-1">Reasoning Effort</label>
+				<Select value={reasoningEffort} onValueChange={(value) => setReasoningEffort(value as "low" | "high")}>
+					<SelectTrigger className="w-full">
+						<SelectValue placeholder="Select reasoning effort" />
+					</SelectTrigger>
+					<SelectContent>
+						<SelectItem value="low">Low (faster responses, less thinking)</SelectItem>
+						<SelectItem value="high">High (more thorough thinking, slower responses)</SelectItem>
+					</SelectContent>
+				</Select>
+			</div>
+		</div>
+	)
+}


### PR DESCRIPTION
## Context

Allows the use of grok3-mini-high-beta and grok3-mini-high-fast-beta using OpenAI compatible provider.

https://www.reddit.com/r/Bard/comments/1jw8lap/grok_3_mini_beta_overtakes_25_pro_in_livebench/

## Implementation

Add support for [reasoning_effort](https://docs.x.ai/docs/guides/reasoning#reasoning) parameter for grok3-mini models.

## Screenshots

| before | after |
| ------ | ----- |
|        |      
<img width="462" alt="image" src="https://github.com/user-attachments/assets/60bf80a4-4f52-411c-8dfd-691da6a39629" />
 |

## How to Test

Set up Grok in the Open AI Compatible provider, choose grok3-mini-beta or grok3-mini-fast-beta. Choose the reason_effort level from the dropdown (default = low). 



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `reasoning_effort` support for Grok 3 Mini models in OpenAI compatible provider with UI and tests.
> 
>   - **Behavior**:
>     - Adds `reasoning_effort` parameter support for Grok 3 Mini models in `OpenAiHandler` in `openai.ts`.
>     - Updates `ExtensionMessage` and `WebviewMessage` to include `reasoningEffort` and `grokReasoningEffort`.
>     - Introduces `GrokReasoningSettings` component in `ApiOptions.tsx` for UI selection of reasoning effort.
>   - **Tests**:
>     - Adds tests in `openai.test.ts` to verify `reasoning_effort` parameter inclusion and processing of `reasoning_content`.
>   - **UI**:
>     - Displays `GrokReasoningSettings` in `ApiOptions.tsx` when Grok 3 Mini models are selected.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fdc8085ed85e69c3ced70ad55aa7cccb04b4cd27. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->