### PR TITLE
Make Databricks models streaming in OpenAI Compatible provider

### DIFF
--- a/src/api/providers/__tests__/openai.test.ts
+++ b/src/api/providers/__tests__/openai.test.ts
@@ -394,43 +394,53 @@ describe("OpenAiHandler", () => {
 	})
 
 	describe("Databricks AI Provider", () => {
-		const databricksOptions = {
+		const baseDatabricksOptions = {
 			...mockOptions,
-			openAiBaseUrl: "https://adb-xxxx.azuredatabricks.net/serving-endpoints",
 			openAiModelId: "databricks-dbrx-instruct",
 		}
 
-		it("should initialize with Databricks AI configuration", () => {
-			const databricksHandler = new OpenAiHandler(databricksOptions)
+		const databricksUrls = [
+			"https://adb-xxxx.azuredatabricks.net/serving-endpoints",
+			"https://myworkspace.cloud.databricks.com/serving-endpoints/myendpoint",
+			"https://anotherworkspace.gcp.databricks.com/serving-endpoints/anotherendpoint",
+		]
+
+		it.each(databricksUrls)("should initialize with Databricks AI configuration for %s", (url) => {
+			const options = { ...baseDatabricksOptions, openAiBaseUrl: url }
+			const databricksHandler = new OpenAiHandler(options)
 			expect(databricksHandler).toBeInstanceOf(OpenAiHandler)
-			expect(databricksHandler.getModel().id).toBe(databricksOptions.openAiModelId)
+			expect(databricksHandler.getModel().id).toBe(options.openAiModelId)
 		})
 
-		it("should exclude stream_options when streaming with Databricks AI", async () => {
-			const databricksHandler = new OpenAiHandler(databricksOptions)
-			const systemPrompt = "You are a helpful assistant."
-			const messages: Anthropic.Messages.MessageParam[] = [
-				{
-					role: "user",
-					content: "Hello!",
-				},
-			]
+		it.each(databricksUrls)(
+			"should exclude stream_options when streaming with Databricks AI for %s",
+			async (url) => {
+				const options = { ...baseDatabricksOptions, openAiBaseUrl: url }
+				const databricksHandler = new OpenAiHandler(options)
+				const systemPrompt = "You are a helpful assistant."
+				const messages: Anthropic.Messages.MessageParam[] = [
+					{
+						role: "user",
+						content: "Hello!",
+					},
+				]
 
-			const stream = databricksHandler.createMessage(systemPrompt, messages)
-			await stream.next() // Consume one item to trigger the mock call
+				const stream = databricksHandler.createMessage(systemPrompt, messages)
+				await stream.next() // Consume one item to trigger the mock call
 
-			expect(mockCreate).toHaveBeenCalledWith(
-				expect.objectContaining({
-					model: databricksOptions.openAiModelId,
-					stream: true,
-				}),
-				{}, // Expecting empty options object as second argument
-			)
+				expect(mockCreate).toHaveBeenCalledWith(
+					expect.objectContaining({
+						model: options.openAiModelId,
+						stream: true,
+					}),
+					{}, // Expecting empty options object as second argument
+				)
 
-			// Verify stream_options is not present in the last call's arguments
-			const mockCalls = mockCreate.mock.calls
-			const lastCallArgs = mockCalls[mockCalls.length - 1][0]
-			expect(lastCallArgs).not.toHaveProperty("stream_options")
-		})
+				// Verify stream_options is not present in the last call's arguments
+				const mockCalls = mockCreate.mock.calls
+				const lastCallArgs = mockCalls[mockCalls.length - 1][0]
+				expect(lastCallArgs).not.toHaveProperty("stream_options")
+			},
+		)
 	})
 })

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -350,7 +350,11 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 
 	private _isDatabricksAI(baseUrl?: string): boolean {
 		const urlHost = this._getUrlHost(baseUrl)
-		return urlHost.includes(".azuredatabricks.net")
+		return (
+			urlHost.endsWith(".azuredatabricks.net") ||
+			urlHost.endsWith(".cloud.databricks.com") ||
+			urlHost.endsWith(".gcp.databricks.com")
+		)
 	}
 
 	private _isAzureAiInference(baseUrl?: string): boolean {


### PR DESCRIPTION
## Context
update the condition to detect the Databrick Azure provider in OpenAI Compatible provider config to make it stream the response.
WHY: The stream option does not work for the Databricks model
![image](https://github.com/user-attachments/assets/971ea44a-1cf7-468d-99d7-0dcd6b2c629e)

## Implementation
Based on #2449 , add condition isDatabricksAI

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

Configure Databricks Azure API endpoint in the Open AI Compatible provider and enable streaming support.
After the fix streaming works with models are provided by Databricks can stream as expected.
I didn't try on Databrick instance on AWS.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add support for streaming Databricks models in OpenAI Compatible provider by excluding `stream_options` for Databricks AI.
> 
>   - **Behavior**:
>     - Update `OpenAiHandler` in `openai.ts` to support streaming for Databricks models by excluding `stream_options` when `isDatabricksAI` is true.
>     - Introduce `_isDatabricksAI()` method to detect Databricks AI based on `openAiBaseUrl`.
>   - **Tests**:
>     - Add tests in `openai.test.ts` to verify Databricks AI configuration and ensure `stream_options` is excluded during streaming.
>     - Test cases include initialization and streaming behavior for Databricks AI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e05d7696193a1833d10c11898d328c7d7dbe5bd8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->