### PR TITLE
Fix bug not to respect symbolic linked rules, if target is a directory or another symbolic link

### DIFF
--- a/.changeset/metal-papayas-think.md
+++ b/.changeset/metal-papayas-think.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix bug not to respect symbolic linked rules, if target is a directory or another symbolic link

--- a/src/core/prompts/sections/__tests__/custom-instructions.test.ts
+++ b/src/core/prompts/sections/__tests__/custom-instructions.test.ts
@@ -615,27 +615,61 @@ describe("Rules directory reading", () => {
 		} as any)
 
 		// Simulate listing files including a symlink
-		readdirMock.mockResolvedValueOnce([
-			{
-				name: "regular.txt",
-				isFile: () => true,
-				isSymbolicLink: () => false,
-				parentPath: "/fake/path/.roo/rules",
-			},
-			{ name: "link.txt", isFile: () => false, isSymbolicLink: () => true, parentPath: "/fake/path/.roo/rules" },
-		] as any)
+		readdirMock
+			.mockResolvedValueOnce([
+				{
+					name: "regular.txt",
+					isFile: () => true,
+					isSymbolicLink: () => false,
+					parentPath: "/fake/path/.roo/rules",
+				},
+				{
+					name: "link.txt",
+					isFile: () => false,
+					isSymbolicLink: () => true,
+					parentPath: "/fake/path/.roo/rules",
+				},
+				{
+					name: "link_dir",
+					isFile: () => false,
+					isSymbolicLink: () => true,
+					parentPath: "/fake/path/.roo/rules",
+				},
+				{
+					name: "nested_link.txt",
+					isFile: () => false,
+					isSymbolicLink: () => true,
+					parentPath: "/fake/path/.roo/rules",
+				},
+			] as any)
+			.mockResolvedValueOnce([
+				{ name: "subdir_link.txt", isFile: () => true, parentPath: "/fake/path/.roo/rules/symlink-target-dir" },
+			] as any)
 
 		// Simulate readlink response
-		readlinkMock.mockResolvedValueOnce("../symlink-target.txt")
+		readlinkMock
+			.mockResolvedValueOnce("../symlink-target.txt")
+			.mockResolvedValueOnce("../symlink-target-dir")
+			.mockResolvedValueOnce("../nested-symlink")
+			.mockResolvedValueOnce("nested-symlink-target.txt")
 
 		// Reset and set up the stat mock with more granular control
 		statMock.mockReset()
 		statMock.mockImplementation((path: string) => {
 			// For directory check
-			if (path === "/fake/path/.roo/rules") {
+			if (path === "/fake/path/.roo/rules" || path.endsWith("dir")) {
 				return Promise.resolve({
 					isDirectory: jest.fn().mockReturnValue(true),
 					isFile: jest.fn().mockReturnValue(false),
+				} as any)
+			}
+
+			// For symlink check
+			if (path.endsWith("symlink")) {
+				return Promise.resolve({
+					isDirectory: jest.fn().mockReturnValue(false),
+					isFile: jest.fn().mockReturnValue(false),
+					isSymbolicLink: jest.fn().mockReturnValue(true),
 				} as any)
 			}
 
@@ -654,6 +688,12 @@ describe("Rules directory reading", () => {
 			if (filePath.toString() === "/fake/path/.roo/rules/../symlink-target.txt") {
 				return Promise.resolve("symlink target content")
 			}
+			if (filePath.toString() === "/fake/path/.roo/rules/symlink-target-dir/subdir_link.txt") {
+				return Promise.resolve("regular file content under symlink target dir")
+			}
+			if (filePath.toString() === "/fake/path/.roo/rules/../nested-symlink-target.txt") {
+				return Promise.resolve("nested symlink target content")
+			}
 			return Promise.reject({ code: "ENOENT" })
 		})
 
@@ -664,13 +704,20 @@ describe("Rules directory reading", () => {
 		expect(result).toContain("regular file content")
 		expect(result).toContain("# Rules from /fake/path/.roo/rules/../symlink-target.txt:")
 		expect(result).toContain("symlink target content")
+		expect(result).toContain("# Rules from /fake/path/.roo/rules/symlink-target-dir/subdir_link.txt:")
+		expect(result).toContain("regular file content under symlink target dir")
+		expect(result).toContain("# Rules from /fake/path/.roo/rules/../nested-symlink-target.txt:")
+		expect(result).toContain("nested symlink target content")
 
 		// Verify readlink was called with the symlink path
 		expect(readlinkMock).toHaveBeenCalledWith("/fake/path/.roo/rules/link.txt")
+		expect(readlinkMock).toHaveBeenCalledWith("/fake/path/.roo/rules/link_dir")
 
 		// Verify both files were read
 		expect(readFileMock).toHaveBeenCalledWith("/fake/path/.roo/rules/regular.txt", "utf-8")
 		expect(readFileMock).toHaveBeenCalledWith("/fake/path/.roo/rules/../symlink-target.txt", "utf-8")
+		expect(readFileMock).toHaveBeenCalledWith("/fake/path/.roo/rules/symlink-target-dir/subdir_link.txt", "utf-8")
+		expect(readFileMock).toHaveBeenCalledWith("/fake/path/.roo/rules/../nested-symlink-target.txt", "utf-8")
 	})
 	beforeEach(() => {
 		jest.clearAllMocks()

--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -32,7 +32,7 @@ async function directoryExists(dirPath: string): Promise<boolean> {
 	}
 }
 
-const MAX_DEPTH = 10
+const MAX_DEPTH = 5
 
 //
 async function resolveDirectoryEntry(

--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -2,6 +2,7 @@ import fs from "fs/promises"
 import path from "path"
 
 import { LANGUAGES, isLanguage } from "../../../shared/language"
+import { Dirent } from "fs"
 
 /**
  * Safely read a file and return its trimmed content
@@ -31,6 +32,63 @@ async function directoryExists(dirPath: string): Promise<boolean> {
 	}
 }
 
+const MAX_DEPTH = 10
+
+//
+async function resolveDirectoryEntry(
+	entry: Dirent,
+	dirPath: string,
+	filePaths: string[],
+	depth: number,
+): Promise<void> {
+	// Avoid cyclic symlinks
+	if (depth > MAX_DEPTH) {
+		return
+	}
+
+	const fullPath = path.resolve(entry.parentPath || dirPath, entry.name)
+	if (entry.isFile()) {
+		// Regular file
+		filePaths.push(fullPath)
+	} else if (entry.isSymbolicLink()) {
+		// Await the resolution of the symbolic link
+		await resolveSymLink(fullPath, filePaths, depth + 1)
+	}
+}
+
+async function resolveSymLink(fullPath: string, filePaths: string[], depth: number): Promise<void> {
+	// Avoid cyclic symlinks
+	if (depth > MAX_DEPTH) {
+		return
+	}
+	try {
+		// Get the symlink target
+		const linkTarget = await fs.readlink(fullPath)
+		// Resolve the target path (relative to the symlink location)
+		const resolvedTarget = path.resolve(path.dirname(fullPath), linkTarget)
+
+		// Check if the target is a file
+		const stats = await fs.stat(resolvedTarget)
+		if (stats.isFile()) {
+			filePaths.push(resolvedTarget)
+		} else if (stats.isDirectory()) {
+			const anotherEntries = await fs.readdir(resolvedTarget, { withFileTypes: true, recursive: true })
+			// Collect promises for recursive calls within the directory
+			const directoryPromises: Promise<void>[] = []
+			for (const anotherEntry of anotherEntries) {
+				directoryPromises.push(resolveDirectoryEntry(anotherEntry, resolvedTarget, filePaths, depth + 1))
+			}
+			// Wait for all entries in the resolved directory to be processed
+			await Promise.all(directoryPromises)
+		} else if (stats.isSymbolicLink()) {
+			// Handle nested symlinks by awaiting the recursive call
+			await resolveSymLink(resolvedTarget, filePaths, depth + 1)
+		}
+	} catch (err) {
+		// Skip invalid symlinks
+	}
+}
+
 /**
  * Read all text files from a directory in alphabetical order
  */
@@ -40,29 +98,15 @@ async function readTextFilesFromDirectory(dirPath: string): Promise<Array<{ file
 
 		// Process all entries - regular files and symlinks that might point to files
 		const filePaths: string[] = []
+		// Collect promises for the initial resolution calls
+		const initialPromises: Promise<void>[] = []
 
 		for (const entry of entries) {
-			const fullPath = path.resolve(entry.parentPath || dirPath, entry.name)
-			if (entry.isFile()) {
-				// Regular file
-				filePaths.push(fullPath)
-			} else if (entry.isSymbolicLink()) {
-				try {
-					// Get the symlink target
-					const linkTarget = await fs.readlink(fullPath)
-					// Resolve the target path (relative to the symlink location)
-					const resolvedTarget = path.resolve(path.dirname(fullPath), linkTarget)
-
-					// Check if the target is a file
-					const stats = await fs.stat(resolvedTarget)
-					if (stats.isFile()) {
-						filePaths.push(resolvedTarget)
-					}
-				} catch (err) {
-					// Skip invalid symlinks
-				}
-			}
+			initialPromises.push(resolveDirectoryEntry(entry, dirPath, filePaths, 0))
 		}
+
+		// Wait for all asynchronous operations (including recursive ones) to complete
+		await Promise.all(initialPromises)
 
 		const fileContents = await Promise.all(
 			filePaths.map(async (file) => {

--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -34,7 +34,9 @@ async function directoryExists(dirPath: string): Promise<boolean> {
 
 const MAX_DEPTH = 5
 
-//
+/**
+ * Recursively resolve directory entries and collect file paths
+ */
 async function resolveDirectoryEntry(
 	entry: Dirent,
 	dirPath: string,
@@ -56,6 +58,9 @@ async function resolveDirectoryEntry(
 	}
 }
 
+/**
+ * Recursively resolve a symbolic link and collect file paths
+ */
 async function resolveSymLink(fullPath: string, filePaths: string[], depth: number): Promise<void> {
 	// Avoid cyclic symlinks
 	if (depth > MAX_DEPTH) {


### PR DESCRIPTION
## Context

This PR fixes a bug not to respect the following symbolic links under `.roo/rules` directory.
- A symbolic link to another symbolic link
- A symbolic link to a directory

## Implementation

Enhance `readTextFilesFromDirectory` function with two helper functions which are called recursively:
- resolveSymLink
- resolveDirectoryEntry

So that recursive symbolic link or directory structure can be respected.
MAX_DEPTH = 5 is also set to avoid cyclic symbolic links and infinite loops.

## Screenshots

Given this rules directory structure

```
.roo % tree
.
├── linked-dir
│   └── missed.txt
├── nested-link.txt
├── nested-symlink -> nested-link.txt
├── rules
│   ├── dir-symlink -> ../linked-dir
│   ├── link-symlink -> ../nested-symlink
```

`Preview System Prompt` in RooCode project will look like:

| before | after |
| ------ | ----- |
|    ![スクリーンショット 2025-04-12 12 00 58](https://github.com/user-attachments/assets/f5268120-426a-4c7d-955c-b070ef8f4a9a)    |    ![スクリーンショット 2025-04-12 12 01 31](https://github.com/user-attachments/assets/f92240ae-5ff0-4e3d-885e-3255a0609841)   |


## How to Test

As described in ScreenShots section.

## Get in Touch

I'm in the RooCode Discord Server as `@taisukeoe`. Please feel free to contact me if any.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `readTextFilesFromDirectory` to handle symbolic links to directories and other symbolic links in `.roo/rules`, with tests added.
> 
>   - **Behavior**:
>     - Fixes bug in `readTextFilesFromDirectory` to handle symbolic links to directories and other symbolic links in `.roo/rules`.
>     - Sets `MAX_DEPTH = 5` to prevent cyclic symbolic links and infinite loops.
>   - **Functions**:
>     - Adds `resolveSymLink` and `resolveDirectoryEntry` to recursively resolve symbolic links and directories in `custom-instructions.ts`.
>   - **Tests**:
>     - Updates `custom-instructions.test.ts` to test new symbolic link handling behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 718c356f2f85bebd784377d438f6c0017fe7de68. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->