### PR TITLE
Fix: Remove 'v' prefix from Node.js version in .tool-versions file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-nodejs v20.18.1
+nodejs 20.18.1


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you're doing and WHY. -->
I'm fixing the Node.js version format in the `.tool-versions` file by removing the 'v' prefix. This is needed because asdf doesn't recognize Node.js versions with the 'v' prefix, which was preventing `npm install` from working properly.

## Implementation

The fix was super simple - just removed the 'v' prefix from the Node.js version in the `.tool-versions` file:

Before:
```
nodejs v20.18.1
```

After:
```
nodejs 20.18.1
```

Note that the `.nvmrc` file still has `v20.18.1` with the 'v' prefix, which is correct for nvm. Only the `.tool-versions` file needed the update for asdf compatibility.

## How to Test

1. Check out this branch: `fix/tool-versions-nodejs-format`
2. Run `asdf install nodejs 20.18.1` (should work without errors)
3. Run `npm install` (should work without errors)
4. Verify that the development setup works by following the steps in `SETUP_DEV.md`

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

I'm on the Roo Discord as @bgdn2608

Thanks guys! ❤️ 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove 'v' prefix from Node.js version in `.tool-versions` for asdf compatibility.
> 
>   - **Behavior**:
>     - Removed 'v' prefix from Node.js version in `.tool-versions` for asdf compatibility.
>     - `.nvmrc` file remains unchanged with 'v' prefix for nvm compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cbe3a7112726aa73a5908a97cc6a250f2ff31dea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->