### PR TITLE
Fix node version string when running asdf install nodejs

### DIFF
--- a/evals/scripts/setup.sh
+++ b/evals/scripts/setup.sh
@@ -179,8 +179,8 @@ for i in "${!options[@]}"; do
   case "${plugin}" in
   "nodejs")
     if ! command -v node &>/dev/null; then
-      asdf install nodejs v20.18.1 || exit 1
-      asdf set nodejs v20.18.1 || exit 1
+      asdf install nodejs 20.18.1 || exit 1
+      asdf set nodejs 20.18.1 || exit 1
       NODE_VERSION=$(node --version)
       echo "✅ Node.js is installed ($NODE_VERSION)"
     else


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Node.js version string in `setup.sh` for `asdf install` and `asdf set` commands.
> 
>   - **Behavior**:
>     - Fixes Node.js version string in `setup.sh` from `v20.18.1` to `20.18.1` for `asdf install` and `asdf set` commands.
>   - **Misc**:
>     - Ensures correct Node.js version is installed without the 'v' prefix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5a9b561940698cc0dbfaa5ee48853fbcb5b0edcf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->