### PR TITLE
Fix AWS token expiry issue when cached token expires when using AWS Profile for Bedrock (#2469)

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -169,6 +169,7 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 			// Use profile-based credentials if enabled and profile is set
 			clientConfig.credentials = fromIni({
 				profile: this.options.awsProfile,
+				ignoreCache: true,
 			})
 		} else if (this.options.awsAccessKey && this.options.awsSecretKey) {
 			// Use direct credentials if provided


### PR DESCRIPTION
Fix AWS token expiry issue when cached token expires when using AWS Profile for Bedrock (#2469)

## Context

When using AWS Bedrock profile setup, the cached token expires which even after refreshing results in having to restart the entire VS Code environment for Roo Code to pull the latest token.

## Implementation

The ignoreCache parameter was set to true when creating the clientConfig credentials.

## Screenshots

This is the behaviour whilst the session is working and when the token expires.

![image](https://github.com/user-attachments/assets/7960114f-928f-45b7-9cf7-5e236134e80e)

## How to Test

This fix has been used internally with a custom built version of Roo Code for the past month and has been successful with no token expiry issues.

## Get in Touch

vagadiya
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes AWS token expiry issue by setting `ignoreCache: true` in `fromIni()` for `clientConfig.credentials` in `AwsBedrockHandler`.
> 
>   - **Behavior**:
>     - Fixes AWS token expiry issue by setting `ignoreCache: true` in `fromIni()` for `clientConfig.credentials` in `AwsBedrockHandler`.
>   - **Testing**:
>     - Internally tested with a custom version of Roo Code for a month without token expiry issues.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 156e5b58e4fe31240c2a66640dcba4843b4f571e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->