### PR TITLE
Fix to Bedrock ARN validation

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -515,7 +515,7 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 		 * match[4] - The resource ID (e.g., "anthropic.claude-3-sonnet-20240229-v1:0")
 		 */
 
-		const arnRegex = /^arn:aws:bedrock:([^:]+):([^:]*):(?:([^\/]+)\/(.+)|([^\/]+))$/
+		const arnRegex = /^arn:aws:bedrock:([^:]+):([^:]*):(?:([^\/]+)\/([\w\.\-:]+)|([^\/]+))$/
 		let match = arn.match(arnRegex)
 
 		if (match && match[1] && match[3] && match[4]) {

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -89,7 +89,7 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
  */
 export function validateBedrockArn(arn: string, region?: string) {
 	// Validate ARN format
-	const arnRegex = /^arn:aws:bedrock:([^:]+):(\d+):(foundation-model|provisioned-model|default-prompt-router)\/(.+)$/
+	const arnRegex = /^arn:aws:bedrock:([^:]+):([^:]*):(?:([^/]+)\/([\w.\-:]+)|([^/]+))$/
 	const match = arn.match(arnRegex)
 
 	if (!match) {


### PR DESCRIPTION
## Context

Updates the Bedrock ARN regex to allow alphanumeric characters, dots, hyphens, and colons in the resource ID.

This prevents validation errors when using ARNs containing those characters.
## Implementation

Change to the regex used

## Screenshots

![image](https://github.com/user-attachments/assets/d1b5babe-1f9a-4853-a64c-8ab0b6c6a685)

## How to Test

Input an ARN such as

arn:aws:bedrock:us-east-1:696926768285:application-inference-profile/7f6boiz8ouih

## Get in Touch

vagadiya

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update Bedrock ARN regex to allow more characters in resource ID, preventing validation errors.
> 
>   - **Regex Update**:
>     - In `bedrock.ts` and `validate.ts`, updated ARN regex to allow alphanumeric characters, dots, hyphens, and colons in the resource ID.
>   - **Behavior**:
>     - Prevents validation errors for ARNs with these characters in `AwsBedrockHandler` and `validateBedrockArn()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ab770f1bb65047683ec22690e56c07312730e3e8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->