### PR TITLE
fix: background color for new profile dialog

### DIFF
--- a/webview-ui/src/components/settings/ApiConfigManager.tsx
+++ b/webview-ui/src/components/settings/ApiConfigManager.tsx
@@ -360,7 +360,7 @@ const ApiConfigManager = ({
 					}
 				}}
 				aria-labelledby="new-profile-title">
-				<DialogContent className="p-4 max-w-sm">
+				<DialogContent className="p-4 max-w-sm bg-card">
 					<DialogTitle>{t("settings:providers.newProfile")}</DialogTitle>
 					<Input
 						ref={newProfileInputRef}


### PR DESCRIPTION
## Context

Fixed the color scheme issue in the 'Add Profile' popup.

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/de90b7a3-945d-446f-aecc-8207c2e03231) | ![image](https://github.com/user-attachments/assets/363b6f5e-a7d8-4de3-820a-bc8e3384ac1b) |

_The example color scheme used is VSCode Modern Light theme._

## How to Test

- run the code.
- open the `Settings`.
- create a new profile.
- switch to a different color scheme in VSCode.
- everything should display correctly, as shown in the screenshots.

## Get in Touch
Discord: zhangtony239
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix background color of `DialogContent` in `ApiConfigManager.tsx` for 'Add Profile' dialog.
> 
>   - **UI Fix**:
>     - Change background color of `DialogContent` in `ApiConfigManager.tsx` from default to `bg-card` for the 'Add Profile' dialog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2451ce3d3cbf546efa0a5a55508318bb53ca10d2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->