### PR TITLE
Fix overdependence on start/end lines in diff strategy

### DIFF
--- a/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
@@ -1541,7 +1541,7 @@ function five() {
 		})
 	})
 
-	describe("insertion/deletion", () => {
+	describe("deletion", () => {
 		let strategy: MultiSearchReplaceDiffStrategy
 
 		beforeEach(() => {
@@ -1643,218 +1643,6 @@ function five() {
 				expect(result.success).toBe(true)
 				if (result.success) {
 					expect(result.content).toBe("line 1\nline 3")
-				}
-			})
-		})
-
-		describe("insertion", () => {
-			it("should insert code at specified line when search block is empty", async () => {
-				const originalContent = `function test() {
-    const x = 1;
-    return x;
-}`
-				const diffContent = `test.ts
-<<<<<<< SEARCH
-:start_line:2
-:end_line:2
--------
-=======
-    console.log("Adding log");
->>>>>>> REPLACE`
-
-				const result = await strategy.applyDiff(originalContent, diffContent, 2, 2)
-				expect(result.success).toBe(true)
-				if (result.success) {
-					expect(result.content).toBe(`function test() {
-    console.log("Adding log");
-    const x = 1;
-    return x;
-}`)
-				}
-			})
-
-			it("should preserve indentation when inserting at nested location", async () => {
-				const originalContent = `function test() {
-    if (true) {
-        const x = 1;
-    }
-}`
-				const diffContent = `test.ts
-<<<<<<< SEARCH
-:start_line:3
-:end_line:3
--------
-=======
-        console.log("Before");
-        console.log("After");
->>>>>>> REPLACE`
-
-				const result = await strategy.applyDiff(originalContent, diffContent, 3, 3)
-				expect(result.success).toBe(true)
-				if (result.success) {
-					expect(result.content).toBe(`function test() {
-    if (true) {
-        console.log("Before");
-        console.log("After");
-        const x = 1;
-    }
-}`)
-				}
-			})
-
-			it("should handle insertion at start of file", async () => {
-				const originalContent = `function test() {
-    return true;
-}`
-				const diffContent = `test.ts
-<<<<<<< SEARCH
-:start_line:1
-:end_line:1
--------
-=======
-// Copyright 2024
-// License: MIT
-
->>>>>>> REPLACE`
-
-				const result = await strategy.applyDiff(originalContent, diffContent, 1, 1)
-				expect(result.success).toBe(true)
-				if (result.success) {
-					expect(result.content).toBe(`// Copyright 2024
-// License: MIT
-
-function test() {
-    return true;
-}`)
-				}
-			})
-
-			it("should handle insertion at end of file", async () => {
-				const originalContent = `function test() {
-    return true;
-}`
-				const diffContent = `test.ts
-<<<<<<< SEARCH
-:start_line:4
-:end_line:4
--------
-=======
-// End of file
->>>>>>> REPLACE`
-
-				const result = await strategy.applyDiff(originalContent, diffContent, 4, 4)
-				expect(result.success).toBe(true)
-				if (result.success) {
-					expect(result.content).toBe(`function test() {
-    return true;
-}
-// End of file`)
-				}
-			})
-
-			it("should error if no start_line is provided for insertion", async () => {
-				const originalContent = `function test() {
-    return true;
-}`
-				const diffContent = `test.ts
-<<<<<<< SEARCH
-=======
-console.log("test");
->>>>>>> REPLACE`
-
-				const result = await strategy.applyDiff(originalContent, diffContent)
-				expect(result.success).toBe(false)
-			})
-
-			it("should work correctly with line numbers", async () => {
-				const originalContent = `.game-container {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.chess-board-container {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-}
-
-.overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    z-index: 999; /* Ensure it's above the board but below the promotion dialog */
-}
-
-.game-container.promotion-active .chess-board,
-.game-container.promotion-active .game-toolbar,
-.game-container.promotion-active .game-info-container {
-    filter: blur(2px);
-    pointer-events: none; /* Disable clicks on these elements */
-}
-
-.game-container.promotion-active .promotion-dialog {
-    z-index: 1000; /* Ensure it's above the overlay */
-    pointer-events: auto; /* Enable clicks on the promotion dialog */
-}`
-				const diffContent = `test.ts
-<<<<<<< SEARCH
-:start_line:12
-:end_line:13
--------
-.overlay {
-=======
-.piece {
-	will-change: transform;
-}
-
-.overlay {
->>>>>>> REPLACE
-`
-
-				const result = await strategy.applyDiff(originalContent, diffContent)
-				expect(result.success).toBe(true)
-				if (result.success) {
-					expect(result.content).toBe(`.game-container {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-}
-
-.chess-board-container {
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-}
-
-.piece {
-	will-change: transform;
-}
-
-.overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    z-index: 999; /* Ensure it's above the board but below the promotion dialog */
-}
-
-.game-container.promotion-active .chess-board,
-.game-container.promotion-active .game-toolbar,
-.game-container.promotion-active .game-info-container {
-    filter: blur(2px);
-    pointer-events: none; /* Disable clicks on these elements */
-}
-
-.game-container.promotion-active .promotion-dialog {
-    z-index: 1000; /* Ensure it's above the overlay */
-    pointer-events: auto; /* Enable clicks on the promotion dialog */
-}`)
 				}
 			})
 		})
@@ -2037,6 +1825,98 @@ function two() {
 
 function three() {
     return "three";
+}`)
+			}
+		})
+
+		it("should work correctly on this example with line numbers that are slightly off", async () => {
+			const originalContent = `.game-container {
+display: flex;
+flex-direction: column;
+gap: 1rem;
+}
+
+.chess-board-container {
+display: flex;
+gap: 1rem;
+align-items: center;
+}
+
+.overlay {
+position: absolute;
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+background-color: rgba(0, 0, 0, 0.5);
+z-index: 999; /* Ensure it's above the board but below the promotion dialog */
+}
+
+.game-container.promotion-active .chess-board,
+.game-container.promotion-active .game-toolbar,
+.game-container.promotion-active .game-info-container {
+filter: blur(2px);
+pointer-events: none; /* Disable clicks on these elements */
+}
+
+.game-container.promotion-active .promotion-dialog {
+z-index: 1000; /* Ensure it's above the overlay */
+pointer-events: auto; /* Enable clicks on the promotion dialog */
+}`
+			const diffContent = `test.ts
+<<<<<<< SEARCH
+:start_line:12
+:end_line:13
+-------
+.overlay {
+=======
+.piece {
+will-change: transform;
+}
+
+.overlay {
+>>>>>>> REPLACE
+`
+
+			const result = await strategy.applyDiff(originalContent, diffContent)
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.content).toBe(`.game-container {
+display: flex;
+flex-direction: column;
+gap: 1rem;
+}
+
+.chess-board-container {
+display: flex;
+gap: 1rem;
+align-items: center;
+}
+
+.piece {
+will-change: transform;
+}
+
+.overlay {
+position: absolute;
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+background-color: rgba(0, 0, 0, 0.5);
+z-index: 999; /* Ensure it's above the board but below the promotion dialog */
+}
+
+.game-container.promotion-active .chess-board,
+.game-container.promotion-active .game-toolbar,
+.game-container.promotion-active .game-info-container {
+filter: blur(2px);
+pointer-events: none; /* Disable clicks on these elements */
+}
+
+.game-container.promotion-active .promotion-dialog {
+z-index: 1000; /* Ensure it's above the overlay */
+pointer-events: auto; /* Enable clicks on the promotion dialog */
 }`)
 			}
 		})

--- a/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
@@ -1765,6 +1765,98 @@ console.log("test");
 				const result = await strategy.applyDiff(originalContent, diffContent)
 				expect(result.success).toBe(false)
 			})
+
+			it("should work correctly with line numbers", async () => {
+				const originalContent = `.game-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.chess-board-container {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 999; /* Ensure it's above the board but below the promotion dialog */
+}
+
+.game-container.promotion-active .chess-board,
+.game-container.promotion-active .game-toolbar,
+.game-container.promotion-active .game-info-container {
+    filter: blur(2px);
+    pointer-events: none; /* Disable clicks on these elements */
+}
+
+.game-container.promotion-active .promotion-dialog {
+    z-index: 1000; /* Ensure it's above the overlay */
+    pointer-events: auto; /* Enable clicks on the promotion dialog */
+}`
+				const diffContent = `test.ts
+<<<<<<< SEARCH
+:start_line:12
+:end_line:13
+-------
+.overlay {
+=======
+.piece {
+	will-change: transform;
+}
+
+.overlay {
+>>>>>>> REPLACE
+`
+
+				const result = await strategy.applyDiff(originalContent, diffContent)
+				expect(result.success).toBe(true)
+				if (result.success) {
+					expect(result.content).toBe(`.game-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.chess-board-container {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+}
+
+.piece {
+	will-change: transform;
+}
+
+.overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 999; /* Ensure it's above the board but below the promotion dialog */
+}
+
+.game-container.promotion-active .chess-board,
+.game-container.promotion-active .game-toolbar,
+.game-container.promotion-active .game-info-container {
+    filter: blur(2px);
+    pointer-events: none; /* Disable clicks on these elements */
+}
+
+.game-container.promotion-active .promotion-dialog {
+    z-index: 1000; /* Ensure it's above the overlay */
+    pointer-events: auto; /* Enable clicks on the promotion dialog */
+}`)
+				}
+			})
 		})
 	})
 


### PR DESCRIPTION
Fixes #2556 by using start line as a hint for where to start searching for diffs, versus previously looking for the chunk specified by start and end line. I think this could have caused incorrectly applied diffs in lots of cases depending on how the LLM interpreted the end line parameter.

This also removes the ability to pass in an empty search block, since we have no way to verify that the line number from the LLM is correct. The model should always be required to pass in a search block.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disallow empty search content (insertions) in `MultiSearchReplaceDiffStrategy`, remove related tests, and add a fuzzy matching test for issue #2556.
> 
>   - **Behavior change in `multi-search-replace.ts`**:
>     - Disallows empty search content in `MultiSearchReplaceDiffStrategy.applyDiff()`. Now returns an error if search content is empty, removing support for insertions via empty search blocks.
>     - Updates `getSimilarity()` to return 0 for empty search content (was 1).
>   - **Tests in `multi-search-replace.test.ts`**:
>     - Removes all tests for insertions (empty search block with non-empty replace block).
>     - Adds test case for fuzzy matching with slightly off line numbers to reproduce #2556.
>     - Renames test group from "insertion/deletion" to "deletion" to reflect removal of insertion tests.
>   - **No changes to deletion or replacement logic.**
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 842bb2b54324c291c7e6ca1ef1edfe83c650341c. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->