### PR TITLE
fix: Restore focus ring for VSCodeButton component

### DIFF
--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -183,10 +183,6 @@ textarea:focus {
 	outline: 0 !important; /* Allow tailwind to override the `textarea:focus` rule */
 }
 
-vscode-button::part(control):focus {
-	outline: none;
-}
-
 /**
  * Use vscode native scrollbar styles
  * https://github.com/gitkraken/vscode-gitlens/blob/b1d71d4844523e8b2ef16f9e007068e91f46fd88/src/webviews/apps/home/home.scss


### PR DESCRIPTION
## Context

Resolves #2571

This PR fixes the main action buttons (like "Start New Task", "Resume Task", "Terminate", and other buttons) that did not show a visual focus outline when navigated to using the keyboard.

This style was added in this commit during the initial implementation of `WelcomeView` and `SettingsView`:
https://github.com/RooVetGit/Roo-Code/commit/8ba1be1167df0810bc9a0094a561418052c2ef32

This style was added very early in the claude-dev project, and I think it's no longer necessary (though this may be a matter of preference).
I'm adding a screenshot of the current WelcomeView. Perhaps it would be good to have rings around the buttons?

<img width="725" alt="スクリーンショット 2025-04-14 1 52 23" src="https://github.com/user-attachments/assets/238077ef-c295-487a-abee-0f9c5899a156" />

#### Related Issue

There are no other issues about button focus styles besides the one this PR resolves.

This fix supports usability improvements like the focus shortcuts added in #2369, making it easier to reliably move focus to these buttons.

## Implementation

This PR removes the following style:

https://github.com/RooVetGit/Roo-Code/blob/8bb3839b4d5b52803c97941e316a51d402bc6556/webview-ui/src/index.css#L186-L188

This allows the default focus ring to appear on `VSCodeButton` components.


## Screenshots

| before | after |
| ------ | ----- |
|   <video src="https://github.com/user-attachments/assets/1c3ede97-a059-45ae-bd7c-484d8bed8473" />     |   <video src="https://github.com/user-attachments/assets/b2967903-d83c-4a8b-b46f-d404618965b5" />    |

## How to Test

1.  Run this PR's version of the Roo extension.
2.  Open the Roo view/panel in VS Code.
3.  Click the chat input text area.
4.  Press `Shift+Tab` repeatedly. Focus should cycle through the action buttons above the textarea.
5.  When a button has focus, it should now display the focus outline provided by VS Code.
6.  Use `Tab` and `Shift+Tab` to navigate other elements and confirm the focus ring appears on the buttons when they are focused.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores focus ring for `VSCodeButton` components to improve keyboard navigation by removing a CSS rule in `index.css`.
> 
>   - **Behavior**:
>     - Restores focus ring for `VSCodeButton` components by removing `outline: none;` style in `index.css`.
>     - Improves keyboard navigation for action buttons like "Start New Task", "Resume Task", etc.
>   - **Testing**:
>     - Focus ring now appears when navigating buttons using `Tab` and `Shift+Tab` in the Roo extension panel.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8a87f8c2d6fe5f87933d02fc9b3f800b51901ecf. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->