### PR TITLE
Support all providers in evals settings

### DIFF
--- a/evals/apps/web/src/app/runs/new/new-run.tsx
+++ b/evals/apps/web/src/app/runs/new/new-run.tsx
@@ -158,14 +158,48 @@ export function NewRun() {
 					.parse(JSON.parse(await file.text()))
 
 				const providerSettings = providerProfiles.apiConfigs[providerProfiles.currentApiConfigName] ?? {}
-				const { apiProvider, openRouterModelId, openAiModelId } = providerSettings
+				const {
+					apiProvider,
+					apiModelId,
+					openRouterModelId,
+					glamaModelId,
+					requestyModelId,
+					unboundModelId,
+					ollamaModelId,
+					lmStudioModelId,
+					openAiModelId,
+				} = providerSettings
 
 				switch (apiProvider) {
+					case "anthropic":
+					case "bedrock":
+					case "deepseek":
+					case "gemini":
+					case "mistral":
+					case "openai-native":
+					case "vertex":
+						setValue("model", apiModelId ?? "")
+						break
 					case "openrouter":
 						setValue("model", openRouterModelId ?? "")
 						break
+					case "glama":
+						setValue("model", glamaModelId ?? "")
+						break
+					case "requesty":
+						setValue("model", requestyModelId ?? "")
+						break
+					case "unbound":
+						setValue("model", unboundModelId ?? "")
+						break
 					case "openai":
 						setValue("model", openAiModelId ?? "")
+						break
+					case "ollama":
+						setValue("model", ollamaModelId ?? "")
+						break
+					case "lmstudio":
+						setValue("model", lmStudioModelId ?? "")
 						break
 					default:
 						throw new Error(`Unsupported API provider: ${apiProvider}`)


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `NewRun` component to support multiple API providers for model selection in `new-run.tsx`.
> 
>   - **Behavior**:
>     - `NewRun` component in `new-run.tsx` now supports multiple API providers for model selection.
>     - Adds support for `anthropic`, `bedrock`, `deepseek`, `gemini`, `mistral`, `openai-native`, `vertex`, `glama`, `requesty`, `unbound`, `ollama`, and `lmstudio` providers.
>     - Sets model based on `apiProvider` from imported settings file.
>   - **Error Handling**:
>     - Throws error for unsupported `apiProvider` in `onImportSettings` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9013b72b62e68224cce5d0993a4371f04e495d38. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->