### PR TITLE
Add workspace filter to historypreview as well

### DIFF
--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -26,13 +26,16 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 					{t("history:viewAll")}
 				</Button>
 			</div>
-			<div className="flex items-center gap-2 mb-2" onClick={() => setShowAllWorkspaces(!showAllWorkspaces)}>
+			<div className="flex items-center gap-2 mb-2">
 				<Checkbox
+					id="show-all-workspaces"
 					checked={showAllWorkspaces}
 					onCheckedChange={(checked) => setShowAllWorkspaces(checked === true)}
 					variant="description"
 				/>
-				<span className="text-xs text-vscode-foreground">{t("history:showAllWorkspaces")}</span>
+				<label htmlFor="show-all-workspaces" className="text-xs text-vscode-foreground cursor-pointer">
+					{t("history:showAllWorkspaces")}
+				</label>
 			</div>
 			{tasks.slice(0, 3).map((item) => (
 				<div

--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -2,7 +2,7 @@ import { memo } from "react"
 
 import { vscode } from "@/utils/vscode"
 import { formatLargeNumber, formatDate } from "@/utils/format"
-import { Button } from "@/components/ui"
+import { Button, Checkbox } from "@/components/ui"
 
 import { useAppTranslation } from "../../i18n/TranslationContext"
 import { CopyButton } from "./CopyButton"
@@ -12,7 +12,7 @@ type HistoryPreviewProps = {
 	showHistoryView: () => void
 }
 const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
-	const { tasks } = useTaskSearch()
+	const { tasks, showAllWorkspaces, setShowAllWorkspaces } = useTaskSearch()
 	const { t } = useAppTranslation()
 
 	return (
@@ -25,6 +25,14 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 				<Button variant="ghost" size="sm" onClick={() => showHistoryView()} className="uppercase">
 					{t("history:viewAll")}
 				</Button>
+			</div>
+			<div className="flex items-center gap-2 mb-2" onClick={() => setShowAllWorkspaces(!showAllWorkspaces)}>
+				<Checkbox
+					checked={showAllWorkspaces}
+					onCheckedChange={(checked) => setShowAllWorkspaces(checked === true)}
+					variant="description"
+				/>
+				<span className="text-xs text-vscode-foreground">{t("history:showAllWorkspaces")}</span>
 			</div>
 			{tasks.slice(0, 3).map((item) => (
 				<div
@@ -74,6 +82,12 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 								</>
 							)}
 						</div>
+						{showAllWorkspaces && item.workspace && (
+							<div className="flex flex-row gap-1 text-vscode-descriptionForeground text-xs mt-1">
+								<span className="codicon codicon-folder scale-80" />
+								<span>{item.workspace}</span>
+							</div>
+						)}
 					</div>
 				</div>
 			))}

--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -156,13 +156,16 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 						</VSCodeRadio>
 					</VSCodeRadioGroup>
 
-					<div className="flex items-center gap-2" onClick={() => setShowAllWorkspaces(!showAllWorkspaces)}>
+					<div className="flex items-center gap-2">
 						<Checkbox
+							id="show-all-workspaces-view"
 							checked={showAllWorkspaces}
 							onCheckedChange={(checked) => setShowAllWorkspaces(checked === true)}
 							variant="description"
 						/>
-						<span className="text-vscode-foreground">{t("history:showAllWorkspaces")}</span>
+						<label htmlFor="show-all-workspaces-view" className="text-vscode-foreground cursor-pointer">
+							{t("history:showAllWorkspaces")}
+						</label>
 					</div>
 
 					{/* Select all control in selection mode */}


### PR DESCRIPTION
Follow-up to #2526 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a workspace filter to `HistoryPreview` with a checkbox to toggle workspace visibility, similar to `HistoryView`.
> 
>   - **Behavior**:
>     - Adds a workspace filter to `HistoryPreview` by introducing a `Checkbox` to toggle `showAllWorkspaces`.
>     - Updates UI in `HistoryPreview` to conditionally display workspace information when `showAllWorkspaces` is true.
>   - **Components**:
>     - Modifies `HistoryPreview` to include `Checkbox` for workspace filtering.
>     - Updates `HistoryView` to use a `label` for the workspace filter `Checkbox` for better accessibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5c7eee2926956c02a05e9fd8f3ec128898c54077. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->