### PR TITLE
feat: Add 'roo.acceptInput' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,6 +179,11 @@
 				"command": "roo-cline.focusInput",
 				"title": "%command.focusInput.title%",
 				"category": "%extension.displayName%"
+			},
+			{
+				"command": "roo.acceptInput",
+				"title": "%command.acceptInput.title%",
+				"category": "%extension.displayName%"
 			}
 		],
 		"menus": {

--- a/package.nls.ca.json
+++ b/package.nls.ca.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Explicar Aquesta Ordre",
 	"command.terminal.fixCommandInCurrentTask.title": "Corregir Aquesta Ordre (Tasca Actual)",
 	"command.terminal.explainCommandInCurrentTask.title": "Explicar Aquesta Ordre (Tasca Actual)",
+	"command.acceptInput.title": "Acceptar Entrada/Suggeriment",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.de.json
+++ b/package.nls.de.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Diesen Befehl Erklären",
 	"command.terminal.fixCommandInCurrentTask.title": "Diesen Befehl Reparieren (Aktuelle Aufgabe)",
 	"command.terminal.explainCommandInCurrentTask.title": "Diesen Befehl Erklären (Aktuelle Aufgabe)",
+	"command.acceptInput.title": "Eingabe/Vorschlag Akzeptieren",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Explicar Este Comando",
 	"command.terminal.fixCommandInCurrentTask.title": "Corregir Este Comando (Tarea Actual)",
 	"command.terminal.explainCommandInCurrentTask.title": "Explicar Este Comando (Tarea Actual)",
+	"command.acceptInput.title": "Aceptar Entrada/Sugerencia",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.fr.json
+++ b/package.nls.fr.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Expliquer cette Commande",
 	"command.terminal.fixCommandInCurrentTask.title": "Corriger cette Commande (Tâche Actuelle)",
 	"command.terminal.explainCommandInCurrentTask.title": "Expliquer cette Commande (Tâche Actuelle)",
+	"command.acceptInput.title": "Accepter l'Entrée/Suggestion",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.hi.json
+++ b/package.nls.hi.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "यह कमांड समझाएं",
 	"command.terminal.fixCommandInCurrentTask.title": "यह कमांड ठीक करें (वर्तमान कार्य)",
 	"command.terminal.explainCommandInCurrentTask.title": "यह कमांड समझाएं (वर्तमान कार्य)",
+	"command.acceptInput.title": "इनपुट/सुझाव स्वीकारें",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Spiega Questo Comando",
 	"command.terminal.fixCommandInCurrentTask.title": "Correggi Questo Comando (Task Corrente)",
 	"command.terminal.explainCommandInCurrentTask.title": "Spiega Questo Comando (Task Corrente)",
+	"command.acceptInput.title": "Accetta Input/Suggerimento",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.ja.json
+++ b/package.nls.ja.json
@@ -23,6 +23,7 @@
 	"command.terminal.explainCommand.title": "このコマンドを説明",
 	"command.terminal.fixCommandInCurrentTask.title": "このコマンドを修正（現在のタスク）",
 	"command.terminal.explainCommandInCurrentTask.title": "このコマンドを説明（現在のタスク）",
+	"command.acceptInput.title": "入力/提案を承認",
 	"configuration.title": "Roo Code",
 	"commands.allowedCommands.description": "'常に実行操作を承認する'が有効な場合に自動実行できるコマンド",
 	"settings.vsCodeLmModelSelector.description": "VSCode 言語モデル API の設定",

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,7 +23,7 @@
 	"command.terminal.explainCommand.title": "Explain This Command",
 	"command.terminal.fixCommandInCurrentTask.title": "Fix This Command (Current Task)",
 	"command.terminal.explainCommandInCurrentTask.title": "Explain This Command (Current Task)",
-	"command.acceptInput.title": "Roo: Accept Input/Suggestion",
+	"command.acceptInput.title": "Accept Input/Suggestion",
 	"configuration.title": "Roo Code",
 	"commands.allowedCommands.description": "Commands that can be auto-executed when 'Always approve execute operations' is enabled",
 	"settings.vsCodeLmModelSelector.description": "Settings for VSCode Language Model API",

--- a/package.nls.json
+++ b/package.nls.json
@@ -23,6 +23,7 @@
 	"command.terminal.explainCommand.title": "Explain This Command",
 	"command.terminal.fixCommandInCurrentTask.title": "Fix This Command (Current Task)",
 	"command.terminal.explainCommandInCurrentTask.title": "Explain This Command (Current Task)",
+	"command.acceptInput.title": "Roo: Accept Input/Suggestion",
 	"configuration.title": "Roo Code",
 	"commands.allowedCommands.description": "Commands that can be auto-executed when 'Always approve execute operations' is enabled",
 	"settings.vsCodeLmModelSelector.description": "Settings for VSCode Language Model API",

--- a/package.nls.ko.json
+++ b/package.nls.ko.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "이 명령어 설명",
 	"command.terminal.fixCommandInCurrentTask.title": "이 명령어 수정 (현재 작업)",
 	"command.terminal.explainCommandInCurrentTask.title": "이 명령어 설명 (현재 작업)",
+	"command.acceptInput.title": "입력/제안 수락",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.pl.json
+++ b/package.nls.pl.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Wyjaśnij tę Komendę",
 	"command.terminal.fixCommandInCurrentTask.title": "Napraw tę Komendę (Bieżące Zadanie)",
 	"command.terminal.explainCommandInCurrentTask.title": "Wyjaśnij tę Komendę (Bieżące Zadanie)",
+	"command.acceptInput.title": "Akceptuj Wprowadzanie/Sugestię",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.pt-BR.json
+++ b/package.nls.pt-BR.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Explicar Este Comando",
 	"command.terminal.fixCommandInCurrentTask.title": "Corrigir Este Comando (Tarefa Atual)",
 	"command.terminal.explainCommandInCurrentTask.title": "Explicar Este Comando (Tarefa Atual)",
+	"command.acceptInput.title": "Aceitar Entrada/Sugestão",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.tr.json
+++ b/package.nls.tr.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Bu Komutu Açıkla",
 	"command.terminal.fixCommandInCurrentTask.title": "Bu Komutu Düzelt (Mevcut Görev)",
 	"command.terminal.explainCommandInCurrentTask.title": "Bu Komutu Açıkla (Mevcut Görev)",
+	"command.acceptInput.title": "Girişi/Öneriyi Kabul Et",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.vi.json
+++ b/package.nls.vi.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "Giải Thích Lệnh Này",
 	"command.terminal.fixCommandInCurrentTask.title": "Sửa Lệnh Này (Tác Vụ Hiện Tại)",
 	"command.terminal.explainCommandInCurrentTask.title": "Giải Thích Lệnh Này (Tác Vụ Hiện Tại)",
+	"command.acceptInput.title": "Chấp Nhận Đầu Vào/Gợi Ý",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.zh-CN.json
+++ b/package.nls.zh-CN.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "解释此命令",
 	"command.terminal.fixCommandInCurrentTask.title": "修复此命令（当前任务）",
 	"command.terminal.explainCommandInCurrentTask.title": "解释此命令（当前任务）",
+	"command.acceptInput.title": "接受输入/建议",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/package.nls.zh-TW.json
+++ b/package.nls.zh-TW.json
@@ -14,6 +14,7 @@
 	"command.terminal.explainCommand.title": "解釋此命令",
 	"command.terminal.fixCommandInCurrentTask.title": "修復此命令（當前任務）",
 	"command.terminal.explainCommandInCurrentTask.title": "解釋此命令（當前任務）",
+	"command.acceptInput.title": "接受輸入/建議",
 	"views.activitybar.title": "Roo Code",
 	"views.contextMenu.label": "Roo Code",
 	"views.terminalMenu.label": "Roo Code",

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -117,6 +117,11 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 		"roo-cline.focusInput": () => {
 			provider.postMessageToWebview({ type: "action", action: "focusInput" })
 		},
+		"roo.acceptInput": () => {
+			const visibleProvider = getVisibleProviderOrLog(outputChannel)
+			if (!visibleProvider) return
+			visibleProvider.postMessageToWebview({ type: "acceptInput" })
+		},
 	}
 }
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -69,6 +69,7 @@ export interface ExtensionMessage {
 		| "maxReadFileLine"
 		| "fileSearchResults"
 		| "toggleApiConfigPin"
+		| "acceptInput"
 	text?: string
 	action?:
 		| "chatButtonClicked"

--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -8,7 +8,7 @@ import TranslationProvider from "./i18n/TranslationContext"
 import { vscode } from "./utils/vscode"
 import { telemetryClient } from "./utils/TelemetryClient"
 import { ExtensionStateContextProvider, useExtensionState } from "./context/ExtensionStateContext"
-import ChatView from "./components/chat/ChatView"
+import ChatView, { ChatViewRef } from "./components/chat/ChatView"
 import HistoryView from "./components/history/HistoryView"
 import SettingsView, { SettingsViewRef } from "./components/settings/SettingsView"
 import WelcomeView from "./components/welcome/WelcomeView"
@@ -44,6 +44,7 @@ const App = () => {
 	})
 
 	const settingsRef = useRef<SettingsViewRef>(null)
+	const chatViewRef = useRef<ChatViewRef>(null)
 
 	const switchTab = useCallback((newTab: Tab) => {
 		setCurrentSection(undefined)
@@ -74,6 +75,10 @@ const App = () => {
 			if (message.type === "showHumanRelayDialog" && message.requestId && message.promptText) {
 				const { requestId, promptText } = message
 				setHumanRelayDialogState({ isOpen: true, requestId, promptText })
+			}
+
+			if (message.type === "acceptInput") {
+				chatViewRef.current?.acceptInput()
 			}
 		},
 		[switchTab],
@@ -114,6 +119,7 @@ const App = () => {
 				<SettingsView ref={settingsRef} onDone={() => setTab("chat")} targetSection={currentSection} />
 			)}
 			<ChatView
+				ref={chatViewRef}
 				isHidden={tab !== "chat"}
 				showAnnouncement={showAnnouncement}
 				hideAnnouncement={() => setShowAnnouncement(false)}


### PR DESCRIPTION
## Context

Adds a command (`roo.acceptInput`) to allow users to bind a keyboard shortcut for accepting Roo's suggestions or input in the chat view. This improves accessibility and workflow efficiency by providing an alternative to clicking buttons or pressing Enter in the text area.

## Implementation

- Defined the command `roo.acceptInput` in `package.json` and added its title to `package.nls.json`.
- Registered the command handler in `src/activate/registerCommands.ts`. This handler finds the active Roo webview (sidebar or editor tab) and sends an `acceptInput` message to it.
- Updated the `ExtensionMessage` type definition in `src/shared/ExtensionMessage.ts` to include `acceptInput`.
- Modified `webview-ui/src/App.tsx`:
    - Added a `ChatViewRef` to manage the `ChatView` component.
    - Updated the `onMessage` handler to listen for the `acceptInput` message and call the `acceptInput` method on the `ChatView` ref.
- Modified `webview-ui/src/components/chat/ChatView.tsx`:
    - Used `forwardRef` and `useImperativeHandle` to expose an `acceptInput` method.
    - The `acceptInput` method checks the current UI state:
        - If action buttons are visible and enabled, it simulates a click on the primary action button (`handlePrimaryButtonClick`).
        - If the text area is enabled and contains text or images, it simulates sending the message (`handleSendMessage`).

## Screenshots

<img width="742" alt="image" src="https://github.com/user-attachments/assets/dcd3463e-20af-43d6-9143-bda025c77f35" />

## How to Test

1.  Build and run the extension from this branch.
2.  Open the VS Code Keyboard Shortcuts settings (JSON view: `Preferences: Open Keyboard Shortcuts (JSON)`).
3.  Add a keybinding for the command `roo.acceptInput`. Example:
    ```json
    {
        "key": "cmd+enter", // Or your preferred shortcut
        "command": "roo.acceptInput",
        "when": "webviewViewFocus && webviewViewId == 'roo-cline.SidebarProvider'" // Optional: Scope to Roo view
    }
    ```
4.  Open the Roo chat view (sidebar or editor tab).
5.  Interact with Roo until an action button (like "Approve", "Run Command", "Save") appears, OR until you are prompted for text input (e.g., after a `followup` question).
6.  Press the configured hotkey (e.g., `Cmd+Enter`).
7.  **Verify:** The corresponding action should be triggered – the button should appear clicked, or the text input should be sent, just as if you had clicked the button or pressed Enter in the text area.

## Get in Touch
discord: aleks.kirillov_41799
<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `roo.acceptInput` command to allow keyboard shortcuts for accepting input in Roo's chat view, enhancing accessibility and workflow efficiency.
> 
>   - **Behavior**:
>     - Adds `roo.acceptInput` command in `package.json` for accepting input in Roo's chat view via keyboard shortcut.
>     - Command handler in `registerCommands.ts` sends `acceptInput` message to active Roo webview.
>     - `ExtensionMessage` in `ExtensionMessage.ts` updated to include `acceptInput`.
>   - **UI Components**:
>     - `App.tsx` listens for `acceptInput` message and triggers `acceptInput` method on `ChatView` ref.
>     - `ChatView.tsx` uses `forwardRef` and `useImperativeHandle` to expose `acceptInput` method, simulating button click or message send based on UI state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 09f7e2217bbf992c605ba99210faafdd15951f29. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->