### PR TITLE
feat: sync workspace trust setting from vscode

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1250,6 +1250,8 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		const machineId = vscode.env.machineId
 		const allowedCommands = vscode.workspace.getConfiguration("roo-cline").get<string[]>("allowedCommands") || []
 		const cwd = this.cwd
+		const workspaceTrustEnabled =
+			vscode.workspace.getConfiguration("security").get<boolean>("workspace.trust.enabled") ?? false
 
 		return {
 			version: this.context.extension?.packageJSON?.version ?? "",
@@ -1325,6 +1327,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			maxReadFileLine: maxReadFileLine ?? 500,
 			settingsImportedAt: this.settingsImportedAt,
 			showGreeting: showGreeting ?? true, // Ensure showGreeting is included in the returned state
+			workspaceTrustEnabled, // Add the workspace trust setting here
 		}
 	}
 

--- a/src/shared/ExtensionMessage.ts
+++ b/src/shared/ExtensionMessage.ts
@@ -209,6 +209,7 @@ export type ExtensionState = Pick<
 
 	renderContext: "sidebar" | "editor"
 	settingsImportedAt?: number
+	workspaceTrustEnabled?: boolean
 }
 
 export type { ClineMessage, ClineAsk, ClineSay }

--- a/webview-ui/src/components/history/HistoryPreview.tsx
+++ b/webview-ui/src/components/history/HistoryPreview.tsx
@@ -1,8 +1,9 @@
-import { memo } from "react"
+import { memo, useEffect } from "react"
 
 import { vscode } from "@/utils/vscode"
 import { formatLargeNumber, formatDate } from "@/utils/format"
 import { Button, Checkbox } from "@/components/ui"
+import { useExtensionState } from "@/context/ExtensionStateContext" // Import the context hook
 
 import { useAppTranslation } from "../../i18n/TranslationContext"
 import { CopyButton } from "./CopyButton"
@@ -13,7 +14,14 @@ type HistoryPreviewProps = {
 }
 const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 	const { tasks, showAllWorkspaces, setShowAllWorkspaces } = useTaskSearch()
+	const { workspaceTrustEnabled } = useExtensionState()
 	const { t } = useAppTranslation()
+
+	useEffect(() => {
+		if (!workspaceTrustEnabled) {
+			setShowAllWorkspaces(true)
+		}
+	}, [workspaceTrustEnabled, setShowAllWorkspaces])
 
 	return (
 		<div className="flex flex-col gap-3 shrink-0 mx-5">
@@ -26,17 +34,19 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 					{t("history:viewAll")}
 				</Button>
 			</div>
-			<div className="flex items-center gap-2 mb-2">
-				<Checkbox
-					id="show-all-workspaces"
-					checked={showAllWorkspaces}
-					onCheckedChange={(checked) => setShowAllWorkspaces(checked === true)}
-					variant="description"
-				/>
-				<label htmlFor="show-all-workspaces" className="text-xs text-vscode-foreground cursor-pointer">
-					{t("history:showAllWorkspaces")}
-				</label>
-			</div>
+			{workspaceTrustEnabled && (
+				<div className="flex items-center gap-2 mb-2">
+					<Checkbox
+						id="show-all-workspaces"
+						checked={showAllWorkspaces}
+						onCheckedChange={(checked) => setShowAllWorkspaces(checked === true)}
+						variant="description"
+					/>
+					<label htmlFor="show-all-workspaces" className="text-xs text-vscode-foreground cursor-pointer">
+						{t("history:showAllWorkspaces")}
+					</label>
+				</div>
+			)}
 			{tasks.slice(0, 3).map((item) => (
 				<div
 					key={item.id}
@@ -85,7 +95,7 @@ const HistoryPreview = ({ showHistoryView }: HistoryPreviewProps) => {
 								</>
 							)}
 						</div>
-						{showAllWorkspaces && item.workspace && (
+						{showAllWorkspaces && workspaceTrustEnabled && item.workspace && (
 							<div className="flex flex-row gap-1 text-vscode-descriptionForeground text-xs mt-1">
 								<span className="codicon codicon-folder scale-80" />
 								<span>{item.workspace}</span>

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -87,6 +87,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	setPinnedApiConfigs: (value: Record<string, boolean>) => void
 	togglePinnedApiConfig: (configName: string) => void
 	setShowGreeting: (value: boolean) => void
+	workspaceTrustEnabled: boolean
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -165,6 +166,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		terminalZshOhMy: false, // Default Oh My Zsh integration setting
 		terminalZshP10k: false, // Default Powerlevel10k integration setting
 		terminalZdotdir: false, // Default ZDOTDIR handling setting
+		workspaceTrustEnabled: false, // Add default value for the new property
 	})
 
 	const [didHydrateState, setDidHydrateState] = useState(false)
@@ -243,6 +245,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 
 	const contextValue: ExtensionStateContextType = {
 		...state,
+		workspaceTrustEnabled: state.workspaceTrustEnabled ?? false,
 		didHydrateState,
 		showWelcome,
 		theme,


### PR DESCRIPTION
## Context

Enable Roo's workspace-related features only when vscode is in workspace mode, in order to reduce visual and usability overhead for users who are not accustomed to using workspaces.

## Screenshots

| before (workspace enabled) | after (workspace disabled) |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/61da8bbd-1ea1-412f-840f-0cc0bb032055) | ![image](https://github.com/user-attachments/assets/cda452e5-86ec-4bf0-a3df-3c9153998593) |
| ![image](https://github.com/user-attachments/assets/b7f5a437-477f-49c9-a9b3-ae3df647f442) | ![image](https://github.com/user-attachments/assets/568b37a1-2741-44c2-9af8-4f0d92b7a7b1) |

## How to Test

- Run this code.  
- Switch VS Code’s workspace setting (**make sure to save your data first**, as this will immediately restart VS Code).  
- Check the Home and History pages. Workspace-related content should no longer be visible when VS Code is not in workspace mode — the UI should resemble how Roo looked before workspace support was added.

## Get in Touch

Discord: zhangtony239
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Syncs VSCode's workspace trust setting to control workspace-related UI and functionality in the application.
> 
>   - **Behavior**:
>     - Syncs `workspace.trust.enabled` setting from VSCode in `ClineProvider`.
>     - Updates UI in `HistoryPreview.tsx` and `HistoryView.tsx` to hide workspace-related content if workspace trust is disabled.
>   - **State Management**:
>     - Adds `workspaceTrustEnabled` to `ExtensionState` in `ExtensionMessage.ts` and `ExtensionStateContext.tsx`.
>     - Uses `useEffect` in `HistoryPreview.tsx` and `HistoryView.tsx` to set `showAllWorkspaces` based on `workspaceTrustEnabled`.
>   - **Misc**:
>     - Updates `getStateToPostToWebview()` in `ClineProvider.ts` to include `workspaceTrustEnabled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7811af48efdc131475a9d95b2f579c2e39337038. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->