### PR TITLE
Add GPT 4.1

### DIFF
--- a/.changeset/selfish-dancers-heal.md
+++ b/.changeset/selfish-dancers-heal.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add gpt 4.1

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -745,9 +745,32 @@ export const geminiModels = {
 // OpenAI Native
 // https://openai.com/api/pricing/
 export type OpenAiNativeModelId = keyof typeof openAiNativeModels
-export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-4o"
+export const openAiNativeDefaultModelId: OpenAiNativeModelId = "gpt-4.1"
 export const openAiNativeModels = {
-	// don't support tool use yet
+	"gpt-4.1": {
+		maxTokens: 32_768,
+		contextWindow: 1_047_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2,
+		outputPrice: 8,
+	},
+	"gpt-4.1-mini": {
+		maxTokens: 32_768,
+		contextWindow: 1_047_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.4,
+		outputPrice: 1.6,
+	},
+	"gpt-4.1-nano": {
+		maxTokens: 32_768,
+		contextWindow: 1_047_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.1,
+		outputPrice: 0.4,
+	},
 	"o3-mini": {
 		maxTokens: 100_000,
 		contextWindow: 200_000,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add GPT 4.1 series models to OpenAI Native in `api.ts` and update default model ID.
> 
>   - **Models**:
>     - Add `gpt-4.1`, `gpt-4.1-mini`, and `gpt-4.1-nano` to `openAiNativeModels` in `api.ts`.
>     - Set `openAiNativeDefaultModelId` to `gpt-4.1` in `api.ts`.
>   - **Misc**:
>     - Add changeset file `selfish-dancers-heal.md` for versioning.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4cdb5e06c6376c6eb3675aa0bffc9cd3ee8f6fd0. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->