### PR TITLE
Fix openai cache tracking and cost estimates

### DIFF
--- a/src/api/providers/__tests__/openai-native.test.ts
+++ b/src/api/providers/__tests__/openai-native.test.ts
@@ -153,7 +153,12 @@ describe("OpenAiNativeHandler", () => {
 				results.push(result)
 			}
 
-			expect(results).toEqual([{ type: "usage", inputTokens: 0, outputTokens: 0 }])
+			// Verify essential fields directly
+			expect(results.length).toBe(1)
+			expect(results[0].type).toBe("usage")
+			// Use type assertion to avoid TypeScript errors
+			expect((results[0] as any).inputTokens).toBe(0)
+			expect((results[0] as any).outputTokens).toBe(0)
 
 			// Verify developer role is used for system prompt with o1 model
 			expect(mockCreate).toHaveBeenCalledWith({
@@ -221,12 +226,18 @@ describe("OpenAiNativeHandler", () => {
 				results.push(result)
 			}
 
-			expect(results).toEqual([
-				{ type: "text", text: "Hello" },
-				{ type: "text", text: " there" },
-				{ type: "text", text: "!" },
-				{ type: "usage", inputTokens: 10, outputTokens: 5 },
-			])
+			// Verify text responses individually
+			expect(results.length).toBe(4)
+			expect(results[0]).toMatchObject({ type: "text", text: "Hello" })
+			expect(results[1]).toMatchObject({ type: "text", text: " there" })
+			expect(results[2]).toMatchObject({ type: "text", text: "!" })
+
+			// Check usage data fields but use toBeCloseTo for floating point comparison
+			expect(results[3].type).toBe("usage")
+			// Use type assertion to avoid TypeScript errors
+			expect((results[3] as any).inputTokens).toBe(10)
+			expect((results[3] as any).outputTokens).toBe(5)
+			expect((results[3] as any).totalCost).toBeCloseTo(0.00006, 6)
 
 			expect(mockCreate).toHaveBeenCalledWith({
 				model: "gpt-4.1",
@@ -261,10 +272,16 @@ describe("OpenAiNativeHandler", () => {
 				results.push(result)
 			}
 
-			expect(results).toEqual([
-				{ type: "text", text: "Hello" },
-				{ type: "usage", inputTokens: 10, outputTokens: 5 },
-			])
+			// Verify responses individually
+			expect(results.length).toBe(2)
+			expect(results[0]).toMatchObject({ type: "text", text: "Hello" })
+
+			// Check usage data fields but use toBeCloseTo for floating point comparison
+			expect(results[1].type).toBe("usage")
+			// Use type assertion to avoid TypeScript errors
+			expect((results[1] as any).inputTokens).toBe(10)
+			expect((results[1] as any).outputTokens).toBe(5)
+			expect((results[1] as any).totalCost).toBeCloseTo(0.00006, 6)
 		})
 	})
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -754,6 +754,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 2,
 		outputPrice: 8,
+		cacheReadsPrice: 0.5,
 	},
 	"gpt-4.1-mini": {
 		maxTokens: 32_768,
@@ -762,6 +763,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 0.4,
 		outputPrice: 1.6,
+		cacheReadsPrice: 0.1,
 	},
 	"gpt-4.1-nano": {
 		maxTokens: 32_768,
@@ -770,6 +772,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 0.1,
 		outputPrice: 0.4,
+		cacheReadsPrice: 0.025,
 	},
 	"o3-mini": {
 		maxTokens: 100_000,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -781,6 +781,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 1.1,
 		outputPrice: 4.4,
+		cacheReadsPrice: 0.55,
 		reasoningEffort: "medium",
 	},
 	"o3-mini-high": {
@@ -790,6 +791,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 1.1,
 		outputPrice: 4.4,
+		cacheReadsPrice: 0.55,
 		reasoningEffort: "high",
 	},
 	"o3-mini-low": {
@@ -799,6 +801,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 1.1,
 		outputPrice: 4.4,
+		cacheReadsPrice: 0.55,
 		reasoningEffort: "low",
 	},
 	o1: {
@@ -808,6 +811,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 15,
 		outputPrice: 60,
+		cacheReadsPrice: 7.5,
 	},
 	"o1-preview": {
 		maxTokens: 32_768,
@@ -816,6 +820,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 15,
 		outputPrice: 60,
+		cacheReadsPrice: 7.5,
 	},
 	"o1-mini": {
 		maxTokens: 65_536,
@@ -824,6 +829,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 1.1,
 		outputPrice: 4.4,
+		cacheReadsPrice: 0.55,
 	},
 	"gpt-4.5-preview": {
 		maxTokens: 16_384,
@@ -832,6 +838,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 75,
 		outputPrice: 150,
+		cacheReadsPrice: 37.5,
 	},
 	"gpt-4o": {
 		maxTokens: 16_384,
@@ -840,6 +847,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 2.5,
 		outputPrice: 10,
+		cacheReadsPrice: 1.25,
 	},
 	"gpt-4o-mini": {
 		maxTokens: 16_384,
@@ -848,6 +856,7 @@ export const openAiNativeModels = {
 		supportsPromptCache: true,
 		inputPrice: 0.15,
 		outputPrice: 0.6,
+		cacheReadsPrice: 0.075,
 	},
 } as const satisfies Record<string, ModelInfo>
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances OpenAI cache tracking and cost estimation by updating model handling and tests in `openai-native.ts` and `openai-native.test.ts`.
> 
>   - **Behavior**:
>     - Updates `OpenAiNativeHandler` in `openai-native.ts` to include cache read tokens in cost calculation using `calculateApiCostOpenAI`.
>     - Adds `cacheReadsPrice` to `openAiNativeModels` in `api.ts` for cost estimation.
>   - **Tests**:
>     - Modifies tests in `openai-native.test.ts` to verify individual response fields and usage data, including `totalCost`.
>     - Uses type assertions to avoid TypeScript errors in tests.
>   - **Misc**:
>     - Refactors `handleStreamResponse` and related functions in `openai-native.ts` to pass model information for accurate cost calculation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1c814a9ba660700c25c079b8cfcea4fd0ff2eacc. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->