### PR TITLE
Add telemetry for diff errors

### DIFF
--- a/src/core/tools/applyDiffTool.ts
+++ b/src/core/tools/applyDiffTool.ts
@@ -10,6 +10,7 @@ import { addLineNumbers } from "../../integrations/misc/extract-text"
 import path from "path"
 import fs from "fs/promises"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
+import { telemetryService } from "../../services/telemetry/TelemetryService"
 
 export async function applyDiffTool(
 	cline: Cline,
@@ -88,6 +89,9 @@ export async function applyDiffTool(
 				const currentCount = (cline.consecutiveMistakeCountForApplyDiff.get(relPath) || 0) + 1
 				cline.consecutiveMistakeCountForApplyDiff.set(relPath, currentCount)
 				let formattedError = ""
+
+				telemetryService.captureDiffApplicationError(cline.taskId)
+
 				if (diffResult.failParts && diffResult.failParts.length > 0) {
 					for (const failPart of diffResult.failParts) {
 						if (failPart.success) {

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -30,6 +30,7 @@ class PostHogClient {
 		},
 		ERRORS: {
 			SCHEMA_VALIDATION_ERROR: "Schema Validation Error",
+			DIFF_APPLICATION_ERROR: "Diff Application Error",
 		},
 	}
 
@@ -271,6 +272,12 @@ class TelemetryService {
 			schemaName,
 			// https://zod.dev/ERROR_HANDLING?id=formatting-errors
 			error: error.format(),
+		})
+	}
+
+	public captureDiffApplicationError(taskId: string): void {
+		this.captureEvent(PostHogClient.EVENTS.ERRORS.DIFF_APPLICATION_ERROR, {
+			taskId,
 		})
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds telemetry for diff application errors by logging them in `applyDiffTool` using `TelemetryService`.
> 
>   - **Telemetry**:
>     - Adds `captureDiffApplicationError(taskId: string)` to `TelemetryService` in `TelemetryService.ts` to log diff application errors.
>     - Logs diff application errors in `applyDiffTool` in `applyDiffTool.ts` using `telemetryService.captureDiffApplicationError(cline.taskId)`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 590209ca76ae0a557df83a1d7f50d0cf69c6d66a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->