### PR TITLE
fix: race in short-running command output capture

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -25,7 +25,7 @@ import { findToolName, formatContentBlockToMarkdown } from "../integrations/misc
 import { fetchInstructionsTool } from "./tools/fetchInstructionsTool"
 import { listFilesTool } from "./tools/listFilesTool"
 import { readFileTool } from "./tools/readFileTool"
-import { ExitCodeDetails } from "../integrations/terminal/TerminalProcess"
+import { ExitCodeDetails, TerminalProcess } from "../integrations/terminal/TerminalProcess"
 import { Terminal } from "../integrations/terminal/Terminal"
 import { TerminalRegistry } from "../integrations/terminal/TerminalRegistry"
 import { UrlContentFetcher } from "../services/browser/UrlContentFetcher"
@@ -969,11 +969,14 @@ export class Cline extends EventEmitter<ClineEvents> {
 
 		const workingDirInfo = workingDir ? ` from '${workingDir.toPosix()}'` : ""
 		terminalInfo.terminal.show() // weird visual bug when creating new terminals (even manually) where there's an empty space at the top.
-		const process = terminalInfo.runCommand(command)
-
 		let userFeedback: { text?: string; images?: string[] } | undefined
 		let didContinue = false
-		const sendCommandOutput = async (line: string): Promise<void> => {
+		let completed = false
+		let result: string = ""
+		let exitDetails: ExitCodeDetails | undefined
+		const { terminalOutputLineLimit = 500 } = (await this.providerRef.deref()?.getState()) ?? {}
+
+		const sendCommandOutput = async (line: string, terminalProcess: TerminalProcess): Promise<void> => {
 			try {
 				const { response, text, images } = await this.ask("command_output", line)
 				if (response === "yesButtonClicked") {
@@ -982,37 +985,30 @@ export class Cline extends EventEmitter<ClineEvents> {
 					userFeedback = { text, images }
 				}
 				didContinue = true
-				process.continue() // continue past the await
+				terminalProcess.continue() // continue past the await
 			} catch {
 				// This can only happen if this ask promise was ignored, so ignore this error
 			}
 		}
 
-		const { terminalOutputLineLimit = 500 } = (await this.providerRef.deref()?.getState()) ?? {}
-
-		process.on("line", (line) => {
-			if (!didContinue) {
-				sendCommandOutput(Terminal.compressTerminalOutput(line, terminalOutputLineLimit))
-			} else {
-				this.say("command_output", Terminal.compressTerminalOutput(line, terminalOutputLineLimit))
-			}
-		})
-
-		let completed = false
-		let result: string = ""
-		let exitDetails: ExitCodeDetails | undefined
-		process.once("completed", (output?: string) => {
-			// Use provided output if available, otherwise keep existing result.
-			result = output ?? ""
-			completed = true
-		})
-
-		process.once("shell_execution_complete", (details: ExitCodeDetails) => {
-			exitDetails = details
-		})
-
-		process.once("no_shell_integration", async (message: string) => {
-			await this.say("shell_integration_warning", message)
+		const process = terminalInfo.runCommand(command, {
+			onLine: (line, process) => {
+				if (!didContinue) {
+					sendCommandOutput(Terminal.compressTerminalOutput(line, terminalOutputLineLimit), process)
+				} else {
+					this.say("command_output", Terminal.compressTerminalOutput(line, terminalOutputLineLimit))
+				}
+			},
+			onCompleted: (output) => {
+				result = output ?? ""
+				completed = true
+			},
+			onShellExecutionComplete: (details) => {
+				exitDetails = details
+			},
+			onNoShellIntegration: async (message) => {
+				await this.say("shell_integration_warning", message)
+			},
 		})
 
 		await process
@@ -1025,6 +1021,25 @@ export class Cline extends EventEmitter<ClineEvents> {
 		await delay(50)
 
 		result = Terminal.compressTerminalOutput(result, terminalOutputLineLimit)
+
+		// keep in case we need it to troubleshoot user issues, but this should be removed in the future
+		// if everything looks good:
+		console.debug(
+			"[execute_command status]",
+			JSON.stringify(
+				{
+					completed,
+					userFeedback,
+					hasResult: result.length > 0,
+					exitDetails,
+					terminalId: terminalInfo.id,
+					workingDir: workingDirInfo,
+					isTerminalBusy: terminalInfo.busy,
+				},
+				null,
+				2,
+			),
+		)
 
 		if (userFeedback) {
 			await this.say("user_feedback", userFeedback.text, userFeedback.images)


### PR DESCRIPTION
## Context

There was a race condition in terminal command handling where fast-executing commands would incorrectly signal to the AI that they were running in background mode. This occurred because:

1. The command would execute and complete before event handlers were registered
2. Due to the timing, the system would mistakenly interpret this as the user choosing to run the command in background mode
3. This caused the AI to wait for background output that would never come, since the command had already completed

The issue specifically manifests when the terminal delay is set to zero, typically appearing after 3-5 command iterations.

## Implementation

- Added a CommandCallbacks interface to define terminal event handlers
- Moved handler registration to happen before process start to ensure accurate command state detection
- Each callback receives the TerminalProcess instance for direct control
- Added debug logging to help diagnose command completion vs background mode confusion

### Before 
![image](https://github.com/user-attachments/assets/e02406bb-9b80-4a56-a990-ff9144668c7d)

### After 
![image](https://github.com/user-attachments/assets/b95ab533-c5f9-406b-b13d-c0e00af476e0)


## How to Test

1. Set terminal delay to zero and give the AI this exact instruction:
   > run `ls` repeatedly until it says that it is running in the background and then stop and ask for instructions. this is a test so it is very important that you use this exact command and do not deviate from my instructions

2. Verify that:
   - Command completion is correctly detected (even after 3-5 iterations)
   - No false background mode is reported to the AI
   - All output is captured

## Get in Touch

Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in terminal command handling by registering event handlers before process start and introducing `CommandCallbacks` for accurate command state detection.
> 
>   - **Behavior**:
>     - Fixes race condition in terminal command handling by registering event handlers before process start in `Cline.ts` and `Terminal.ts`.
>     - Introduces `CommandCallbacks` interface in `Terminal.ts` for handling terminal events like `onLine`, `onCompleted`, etc.
>     - Updates `runCommand` method in `Terminal.ts` to accept `CommandCallbacks` for accurate command state detection.
>   - **Logging**:
>     - Adds debug logging in `Cline.ts` to diagnose command completion vs background mode confusion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 688da6d3a59ba13c76a5d298db2aa27da36013cd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->