### PR TITLE
Remove auto-approve button useMemo

### DIFF
--- a/.changeset/blue-papayas-clean.md
+++ b/.changeset/blue-papayas-clean.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Remove auto-approve button useMemo

--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -1,5 +1,5 @@
 import { VSCodeCheckbox } from "@vscode/webview-ui-toolkit/react"
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useState } from "react"
 import { Trans } from "react-i18next"
 import { VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 
@@ -56,69 +56,56 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 
 	const { t } = useAppTranslation()
 
-	const actions: AutoApproveAction[] = useMemo(
-		() => [
-			{
-				id: "readFiles",
-				label: t("chat:autoApprove.actions.readFiles.label"),
-				enabled: alwaysAllowReadOnly ?? false,
-				description: t("chat:autoApprove.actions.readFiles.description"),
-			},
-			{
-				id: "editFiles",
-				label: t("chat:autoApprove.actions.editFiles.label"),
-				enabled: alwaysAllowWrite ?? false,
-				description: t("chat:autoApprove.actions.editFiles.description"),
-			},
-			{
-				id: "executeCommands",
-				label: t("chat:autoApprove.actions.executeCommands.label"),
-				enabled: alwaysAllowExecute ?? false,
-				description: t("chat:autoApprove.actions.executeCommands.description"),
-			},
-			{
-				id: "useBrowser",
-				label: t("chat:autoApprove.actions.useBrowser.label"),
-				enabled: alwaysAllowBrowser ?? false,
-				description: t("chat:autoApprove.actions.useBrowser.description"),
-			},
-			{
-				id: "useMcp",
-				label: t("chat:autoApprove.actions.useMcp.label"),
-				enabled: alwaysAllowMcp ?? false,
-				description: t("chat:autoApprove.actions.useMcp.description"),
-			},
-			{
-				id: "switchModes",
-				label: t("chat:autoApprove.actions.switchModes.label"),
-				enabled: alwaysAllowModeSwitch ?? false,
-				description: t("chat:autoApprove.actions.switchModes.description"),
-			},
-			{
-				id: "subtasks",
-				label: t("chat:autoApprove.actions.subtasks.label"),
-				enabled: alwaysAllowSubtasks ?? false,
-				description: t("chat:autoApprove.actions.subtasks.description"),
-			},
-			{
-				id: "retryRequests",
-				label: t("chat:autoApprove.actions.retryRequests.label"),
-				enabled: alwaysApproveResubmit ?? false,
-				description: t("chat:autoApprove.actions.retryRequests.description"),
-			},
-		],
-		[
-			alwaysAllowReadOnly,
-			alwaysAllowWrite,
-			alwaysAllowExecute,
-			alwaysAllowBrowser,
-			alwaysAllowMcp,
-			alwaysAllowModeSwitch,
-			alwaysAllowSubtasks,
-			alwaysApproveResubmit,
-			t,
-		],
-	)
+	const actions: AutoApproveAction[] = [
+		{
+			id: "readFiles",
+			label: t("chat:autoApprove.actions.readFiles.label"),
+			enabled: alwaysAllowReadOnly ?? false,
+			description: t("chat:autoApprove.actions.readFiles.description"),
+		},
+		{
+			id: "editFiles",
+			label: t("chat:autoApprove.actions.editFiles.label"),
+			enabled: alwaysAllowWrite ?? false,
+			description: t("chat:autoApprove.actions.editFiles.description"),
+		},
+		{
+			id: "executeCommands",
+			label: t("chat:autoApprove.actions.executeCommands.label"),
+			enabled: alwaysAllowExecute ?? false,
+			description: t("chat:autoApprove.actions.executeCommands.description"),
+		},
+		{
+			id: "useBrowser",
+			label: t("chat:autoApprove.actions.useBrowser.label"),
+			enabled: alwaysAllowBrowser ?? false,
+			description: t("chat:autoApprove.actions.useBrowser.description"),
+		},
+		{
+			id: "useMcp",
+			label: t("chat:autoApprove.actions.useMcp.label"),
+			enabled: alwaysAllowMcp ?? false,
+			description: t("chat:autoApprove.actions.useMcp.description"),
+		},
+		{
+			id: "switchModes",
+			label: t("chat:autoApprove.actions.switchModes.label"),
+			enabled: alwaysAllowModeSwitch ?? false,
+			description: t("chat:autoApprove.actions.switchModes.description"),
+		},
+		{
+			id: "subtasks",
+			label: t("chat:autoApprove.actions.subtasks.label"),
+			enabled: alwaysAllowSubtasks ?? false,
+			description: t("chat:autoApprove.actions.subtasks.description"),
+		},
+		{
+			id: "retryRequests",
+			label: t("chat:autoApprove.actions.retryRequests.label"),
+			enabled: alwaysApproveResubmit ?? false,
+			description: t("chat:autoApprove.actions.retryRequests.description"),
+		},
+	]
 
 	const toggleExpanded = useCallback(() => {
 		setIsExpanded((prev) => !prev)


### PR DESCRIPTION
## Context

Language changes weren't updating the translations.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `useMemo` from `AutoApproveMenu` to ensure translations update with language changes.
> 
>   - **Behavior**:
>     - Removed `useMemo` from `actions` array in `AutoApproveMenu` in `AutoApproveMenu.tsx` to ensure translations update with language changes.
>   - **Imports**:
>     - Removed `useMemo` import from `AutoApproveMenu.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b1f199b9c6f9052e1734616ffcc0da3cc57aa5b5. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->