### PR TITLE
Add telemetry for consecutive mistake error

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -1758,6 +1758,9 @@ export class Cline extends EventEmitter<ClineEvents> {
 						...formatResponse.imageBlocks(images),
 					],
 				)
+
+				// Track consecutive mistake errors in telemetry
+				telemetryService.captureConsecutiveMistakeError(this.taskId)
 			}
 			this.consecutiveMistakeCount = 0
 		}

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -31,6 +31,7 @@ class PostHogClient {
 		ERRORS: {
 			SCHEMA_VALIDATION_ERROR: "Schema Validation Error",
 			DIFF_APPLICATION_ERROR: "Diff Application Error",
+			CONSECUTIVE_MISTAKE_ERROR: "Consecutive Mistake Error",
 		},
 	}
 
@@ -277,6 +278,12 @@ class TelemetryService {
 
 	public captureDiffApplicationError(taskId: string): void {
 		this.captureEvent(PostHogClient.EVENTS.ERRORS.DIFF_APPLICATION_ERROR, {
+			taskId,
+		})
+	}
+
+	public captureConsecutiveMistakeError(taskId: string): void {
+		this.captureEvent(PostHogClient.EVENTS.ERRORS.CONSECUTIVE_MISTAKE_ERROR, {
 			taskId,
 		})
 	}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add telemetry tracking for consecutive mistake errors in `Cline` using `TelemetryService`.
> 
>   - **Telemetry**:
>     - Adds `captureConsecutiveMistakeError()` to `TelemetryService` to log consecutive mistake errors.
>     - Updates `PostHogClient.EVENTS.ERRORS` with `CONSECUTIVE_MISTAKE_ERROR`.
>   - **Cline Class**:
>     - In `Cline.ts`, calls `telemetryService.captureConsecutiveMistakeError()` when `consecutiveMistakeCount` reaches `consecutiveMistakeLimit`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for aa3cf253a2115783a9d65f598e60c3647509b7bd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->