### PR TITLE
feat: Cost Display in Task Header - Suppress Zero Cost Values and Ensure Visibility for Gemini, OpenAI, LM Studio, and Ollama

### DIFF
--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -122,13 +122,8 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
 	}, [task.text, windowWidth])
 
 	const isCostAvailable = useMemo(() => {
-		return (
-			apiConfiguration?.apiProvider !== "openai" &&
-			apiConfiguration?.apiProvider !== "ollama" &&
-			apiConfiguration?.apiProvider !== "lmstudio" &&
-			apiConfiguration?.apiProvider !== "gemini"
-		)
-	}, [apiConfiguration?.apiProvider])
+		return totalCost !== null && totalCost !== undefined && totalCost > 0 && !isNaN(totalCost)
+	}, [totalCost])
 
 	const shouldShowPromptCacheInfo = doesModelSupportPromptCache && apiConfiguration?.apiProvider !== "openrouter"
 

--- a/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/TaskHeader.test.tsx
@@ -1,0 +1,114 @@
+import React from "react"
+import { render, screen } from "@testing-library/react"
+import TaskHeader from "../TaskHeader"
+import { ApiConfiguration } from "../../../../../src/shared/api"
+
+// Mock the vscode API
+jest.mock("@/utils/vscode", () => ({
+	vscode: {
+		postMessage: jest.fn(),
+	},
+}))
+
+// Mock the ExtensionStateContext
+jest.mock("../../../context/ExtensionStateContext", () => ({
+	useExtensionState: () => ({
+		apiConfiguration: {
+			apiProvider: "anthropic",
+			apiKey: "test-api-key", // Add relevant fields
+			apiModelId: "claude-3-opus-20240229", // Add relevant fields
+		} as ApiConfiguration, // Optional: Add type assertion if ApiConfiguration is imported
+		currentTaskItem: null,
+	}),
+}))
+
+describe("TaskHeader", () => {
+	const defaultProps = {
+		task: { text: "Test task", images: [] },
+		tokensIn: 100,
+		tokensOut: 50,
+		doesModelSupportPromptCache: true,
+		totalCost: 0.05,
+		contextTokens: 200,
+		onClose: jest.fn(),
+	}
+
+	it("should display cost when totalCost is greater than 0", () => {
+		render(
+			<TaskHeader
+				{...defaultProps}
+				task={{
+					type: "say",
+					ts: Date.now(),
+					text: "Test task",
+					images: [],
+				}}
+			/>,
+		)
+		expect(screen.getByText("$0.0500")).toBeInTheDocument()
+	})
+
+	it("should not display cost when totalCost is 0", () => {
+		render(
+			<TaskHeader
+				{...defaultProps}
+				totalCost={0}
+				task={{
+					type: "say",
+					ts: Date.now(),
+					text: "Test task",
+					images: [],
+				}}
+			/>,
+		)
+		expect(screen.queryByText("$0.0000")).not.toBeInTheDocument()
+	})
+
+	it("should not display cost when totalCost is null", () => {
+		render(
+			<TaskHeader
+				{...defaultProps}
+				totalCost={null as any}
+				task={{
+					type: "say",
+					ts: Date.now(),
+					text: "Test task",
+					images: [],
+				}}
+			/>,
+		)
+		expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
+	})
+
+	it("should not display cost when totalCost is undefined", () => {
+		render(
+			<TaskHeader
+				{...defaultProps}
+				totalCost={undefined as any}
+				task={{
+					type: "say",
+					ts: Date.now(),
+					text: "Test task",
+					images: [],
+				}}
+			/>,
+		)
+		expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
+	})
+
+	it("should not display cost when totalCost is NaN", () => {
+		render(
+			<TaskHeader
+				{...defaultProps}
+				totalCost={NaN}
+				task={{
+					type: "say",
+					ts: Date.now(),
+					text: "Test task",
+					images: [],
+				}}
+			/>,
+		)
+		expect(screen.queryByText(/\$/)).not.toBeInTheDocument()
+	})
+})


### PR DESCRIPTION
## Context

Update cost display logic to only show costs when they are greater than zero. This improves the user interface by hiding the cost display when there are no costs to report, reducing visual clutter in the task header. 

## Implementation



## Screenshots

| before | after |
| ------ | ----- |
|        |   ![image](https://github.com/user-attachments/assets/7f872b07-9bf1-4b7a-a928-4428183a4cc4)    |

## How to Test

Use any Google Gemini API Provider - model and ask  

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `TaskHeader.tsx` to suppress zero cost values and add tests in `TaskHeader.test.tsx` to verify cost display logic.
> 
>   - **Behavior**:
>     - Update `isCostAvailable` in `TaskHeader.tsx` to only show costs when `totalCost` is greater than zero.
>     - Removes specific API provider checks for cost display.
>   - **Tests**:
>     - Add `TaskHeader.test.tsx` to test cost display logic for `totalCost` values of 0, null, undefined, and NaN.
>     - Ensure cost is displayed only when `totalCost` is greater than zero.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 743b939a6c2af555e3f02f1e45134be88a6a1af3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->