### PR TITLE
Fix configuration titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,32 +118,32 @@
 			{
 				"command": "roo-cline.openInNewTab",
 				"title": "%command.openInNewTab.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo-cline.explainCode",
 				"title": "%command.explainCode.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo-cline.fixCode",
 				"title": "%command.fixCode.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo-cline.improveCode",
 				"title": "%command.improveCode.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo-cline.addToContext",
 				"title": "%command.addToContext.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo-cline.newTask",
 				"title": "%command.newTask.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo-cline.terminalAddToContext",
@@ -173,17 +173,17 @@
 			{
 				"command": "roo-cline.setCustomStoragePath",
 				"title": "%command.setCustomStoragePath.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo-cline.focusInput",
 				"title": "%command.focusInput.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			},
 			{
 				"command": "roo.acceptInput",
 				"title": "%command.acceptInput.title%",
-				"category": "%extension.displayName%"
+				"category": "%configuration.title%"
 			}
 		],
 		"menus": {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change command categories in `package.json` from `%extension.displayName%` to `%configuration.title%`.
> 
>   - **Commands**:
>     - Change `category` from `%extension.displayName%` to `%configuration.title%` for commands: `openInNewTab`, `explainCode`, `fixCode`, `improveCode`, `addToContext`, `newTask`, `setCustomStoragePath`, `focusInput`, `acceptInput` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f5b971035374401b3c3c5155b79652cce4597230. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->