### PR TITLE
Fix select dropdown styling

### DIFF
--- a/.changeset/famous-squids-smile.md
+++ b/.changeset/famous-squids-smile.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix select dropdown styling

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -1037,7 +1037,6 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 										vscode.postMessage({ type: "loadApiConfigurationById", text: value })
 									}
 								}}
-								contentClassName="max-h-[300px]"
 								triggerClassName="w-full text-ellipsis overflow-hidden"
 								itemClassName="group"
 								renderItem={({ type, value, label, pinned }) => {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix select dropdown styling in `ChatTextArea.tsx` by removing `contentClassName` attribute.
> 
>   - **Styling**:
>     - Removed `contentClassName="max-h-[300px]"` from `SelectDropdown` in `ChatTextArea.tsx` to fix dropdown styling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e647696d5c92d562160a859e7ce1973e317769b2. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->