### PR TITLE
refactor(context-menu): handle filename display better

### DIFF
--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -109,21 +109,37 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 			case ContextMenuOptionType.OpenedFile:
 			case ContextMenuOptionType.Folder:
 				if (option.value) {
+					// remove trailing slash
+					const path = removeLeadingNonAlphanumeric(option.value || "").replace(/\/$/, "")
+					const filename = path.split("/").at(-1)
+					const folderPath = path.split("/").slice(0, -1).join("/")
 					return (
-						<>
-							<span>/</span>
-							{option.value?.startsWith("/.") && <span>.</span>}
+						<div
+							style={{
+								flex: 1,
+								overflow: "hidden",
+								display: "flex",
+								gap: "0.5em",
+								whiteSpace: "nowrap",
+								alignItems: "center",
+								justifyContent: "space-between",
+								textAlign: "left",
+							}}>
+							<span>{filename}</span>
 							<span
 								style={{
 									whiteSpace: "nowrap",
 									overflow: "hidden",
 									textOverflow: "ellipsis",
 									direction: "rtl",
-									textAlign: "left",
+									textAlign: "right",
+									flex: 1,
+									opacity: 0.75,
+									fontSize: "0.75em",
 								}}>
-								{removeLeadingNonAlphanumeric(option.value || "") + "\u200E"}
+								{folderPath}
 							</span>
-						</>
+						</div>
 					)
 				} else {
 					return <span>Add {option.type === ContextMenuOptionType.File ? "File" : "Folder"}</span>
@@ -189,10 +205,9 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 							key={`${option.type}-${option.value || index}`}
 							onClick={() => isOptionSelectable(option) && onSelect(option.type, option.value)}
 							style={{
-								padding: "8px 12px",
+								padding: "4px 6px",
 								cursor: isOptionSelectable(option) ? "pointer" : "default",
 								color: "var(--vscode-dropdown-foreground)",
-								borderBottom: "1px solid var(--vscode-editorGroup-border)",
 								display: "flex",
 								alignItems: "center",
 								justifyContent: "space-between",
@@ -232,7 +247,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 								!option.value && (
 									<i
 										className="codicon codicon-chevron-right"
-										style={{ fontSize: "14px", flexShrink: 0, marginLeft: 8 }}
+										style={{ fontSize: "10px", flexShrink: 0, marginLeft: 8 }}
 									/>
 								)}
 							{(option.type === ContextMenuOptionType.Problems ||
@@ -244,7 +259,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 									option.value)) && (
 								<i
 									className="codicon codicon-add"
-									style={{ fontSize: "14px", flexShrink: 0, marginLeft: 8 }}
+									style={{ fontSize: "10px", flexShrink: 0, marginLeft: 8 }}
 								/>
 							)}
 						</div>
@@ -252,7 +267,7 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 				) : (
 					<div
 						style={{
-							padding: "12px",
+							padding: "4px",
 							display: "flex",
 							alignItems: "center",
 							justifyContent: "center",


### PR DESCRIPTION
## Context

I've updated the context menu to have smaller padding and adjusted how the filenames are displayed.
Reason being:
1. Smaller padding means it's less intrusive, it feels like the autocomplete menu that we're used to
2. The filename is now displayed in 2 sections: filename and path. The old one makes it a bit harder to differentiate files with the same name inside different directories (e.g. nextjs, tanstack router, etc)

## Implementation

It's just some css adjustments. 

Although, initially I wanted to mimic cursor where it uses the file icons that vscode uses on its filetree, file picker, etc, but apparently vscode doesn't expose that API.

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/43a55106-e7b0-400d-a633-20ebe242a0c9) | ![image](https://github.com/user-attachments/assets/31d448be-579b-4e4f-8851-34f8a23bb0a2) |
| ![image](https://github.com/user-attachments/assets/176e1639-77cc-4193-90a7-c7d8a28e04d4) | ![image](https://github.com/user-attachments/assets/f935389f-9a26-4a60-80a5-9104cb926300) |

## How to Test

Just pull up the context menu by typing `@`

## Get in Touch

My discord handle is @elianiva