### PR TITLE
Add consecutive mistake count to diff error telemetry

### DIFF
--- a/.changeset/fair-donuts-wash.md
+++ b/.changeset/fair-donuts-wash.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add consecutive mistake count to diff error telemetry

--- a/src/core/tools/applyDiffTool.ts
+++ b/src/core/tools/applyDiffTool.ts
@@ -90,7 +90,7 @@ export async function applyDiffTool(
 				cline.consecutiveMistakeCountForApplyDiff.set(relPath, currentCount)
 				let formattedError = ""
 
-				telemetryService.captureDiffApplicationError(cline.taskId)
+				telemetryService.captureDiffApplicationError(cline.taskId, currentCount)
 
 				if (diffResult.failParts && diffResult.failParts.length > 0) {
 					for (const failPart of diffResult.failParts) {

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -290,9 +290,10 @@ class TelemetryService {
 		})
 	}
 
-	public captureDiffApplicationError(taskId: string): void {
+	public captureDiffApplicationError(taskId: string, consecutiveMistakeCount: number): void {
 		this.captureEvent(PostHogClient.EVENTS.ERRORS.DIFF_APPLICATION_ERROR, {
 			taskId,
+			consecutiveMistakeCount,
 		})
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add consecutive mistake count tracking to diff error telemetry in `applyDiffTool` and `TelemetryService.ts`.
> 
>   - **Behavior**:
>     - `applyDiffTool` in `applyDiffTool.ts` now tracks consecutive mistake counts for diff application errors and passes this count to `captureDiffApplicationError`.
>   - **Telemetry**:
>     - `captureDiffApplicationError` in `TelemetryService.ts` updated to accept `consecutiveMistakeCount` parameter.
>   - **Misc**:
>     - Adds changeset `fair-donuts-wash.md` to document the patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 59960b92f6b44d59254752683f33d9f5ad9d0a5e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->