### PR TITLE
Fix @ mention triggering mode menu on @/

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -446,8 +446,12 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						const query = newValue.slice(lastAtIndex + 1, newCursorPosition)
 						setSearchQuery(query)
 
-						// Send file search request if query is not empty
-						if (query.length > 0) {
+						// Check if the query is valid for initiating a file search
+						// It should have length > 0 AND not be just '/', '.', or '\' immediately after @
+						const isValidSearchQuery = query.length > 0 && !/^[/.\\\\]$/.test(query) // Removed \ before / and .
+
+						if (isValidSearchQuery) {
+							// Modified condition
 							setSelectedMenuIndex(0)
 							// Don't clear results until we have new ones
 							// This prevents flickering
@@ -471,8 +475,16 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 									requestId: reqId,
 								})
 							}, 200) // 200ms debounce
-						} else {
+						} else if (query.length === 0) {
+							// If query is empty (just @)
 							setSelectedMenuIndex(3) // Set to "File" option by default
+							setFileSearchResults([]) // Clear results for empty query
+							setSelectedType(null) // Reset type for empty query
+						} else {
+							// Query is invalid for search (e.g., "@/", "@.", "@\")
+							setSelectedMenuIndex(3) // Keep default "File" option selected
+							setFileSearchResults([]) // Clear results as the query is invalid
+							setSelectedType(ContextMenuOptionType.File) // Explicitly set type to File
 						}
 					}
 				} else {


### PR DESCRIPTION
# Fix `@/` triggering mode menu instead of file/folder suggestions

**Fixes:** #2660

---

## Bug  
Typing `@/` incorrectly opened the mode selection menu instead of showing file or folder suggestions.

---

## Changes  
- Skip mode selection when context is `File` or `Folder`  
- Normalize paths by adding a leading `/` to improve fuzzy matching  
- Force `File` context when input starts with `@/`

---

## Context  
The `/` in `@/` was misinterpreted as a slash command trigger. This caused the mode menu to appear instead of showing relevant file suggestions. The fix ensures correct behavior by enforcing the appropriate context and improving path handling.

---

## Implementation  
- Explicitly set `selectedType = File` when detecting `@/`  
- Updated `getContextMenuOptions` to bypass mode logic when type is `File` or `Folder`  
- Normalized all paths to start with `/` before fuzzy matching  
- Kept changes scoped to context mention handling only

---

## How to Test  
1. Type `@/` in the mention input field.  
2. Confirm that file/folder suggestions are shown instead of the mode menu.  
3. Test with nested folders and various valid paths.  
4. Ensure mode selection still works in non-file mention contexts.

---



## Contact  
Discord: `@logostone`  
Or comment directly in this pull request.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `@/` triggering mode menu by enforcing `File` context and normalizing paths in `ChatTextArea.tsx` and `context-mentions.ts`.
> 
>   - **Behavior**:
>     - Fix `@/` triggering mode menu instead of file/folder suggestions.
>     - Enforce `File` context when input starts with `@/` in `ChatTextArea.tsx`.
>     - Normalize paths to start with `/` in `context-mentions.ts` for better matching.
>   - **Functions**:
>     - Update `getContextMenuOptions()` to skip mode logic for `File` or `Folder` types.
>     - Modify `shouldShowContextMenu()` to correctly handle `@/` input.
>   - **Misc**:
>     - Adjust `handleInputChange()` in `ChatTextArea.tsx` to validate search queries and set default menu index.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 30c1c86b255a4a794c4a4c8b0a8aa1be9e5640e4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->