### PR TITLE
feat: Add total API cost calculation to HistoryView component

### DIFF
--- a/webview-ui/src/components/history/HistoryView.tsx
+++ b/webview-ui/src/components/history/HistoryView.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useState } from "react"
+import React, { memo, useState, useMemo } from "react"
 import { DeleteTaskDialog } from "./DeleteTaskDialog"
 import { BatchDeleteTaskDialog } from "./BatchDeleteTaskDialog"
 import prettyBytes from "pretty-bytes"
@@ -74,6 +74,14 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 		}
 	}
 
+	// Calculate total API cost for current tasks
+	const totalApiCost = useMemo(() => {
+		return tasks.reduce((sum, task) => {
+			const cost = typeof task.totalCost === "string" ? parseFloat(task.totalCost) : task.totalCost
+			return sum + (isNaN(cost) ? 0 : cost)
+		}, 0)
+	}, [tasks])
+
 	return (
 		<Tab>
 			<TabHeader className="flex flex-col gap-2">
@@ -95,6 +103,9 @@ const HistoryView = ({ onDone }: HistoryViewProps) => {
 						</Button>
 						<Button onClick={onDone}>{t("history:done")}</Button>
 					</div>
+				</div>
+				<div className="text-vscode-descriptionForeground text-sm font-semibold">
+					{`Total ${t("history:apiCostLabel")}`} ${totalApiCost.toFixed(4)}
 				</div>
 				<div className="flex flex-col gap-2">
 					<VSCodeTextField


### PR DESCRIPTION
## Context

Adds a Total API Cost to the history view, makes it easy to quickly see how much is spent on a project. 
Can view totals for both current project and all projects.

## Implementation

It uses a React useMemo hook to compute the sum of the totalCost field from the filtered task list. The total is shown above the task list.

## Screenshots

Before:
![CleanShot 2025-04-17 at 03 35 31](https://github.com/user-attachments/assets/c2f975dd-1dd4-498f-89b5-3ad3b82b1016)

After:
![CleanShot 2025-04-17 at 03 43 09](https://github.com/user-attachments/assets/2087f59a-6ab2-4e66-b061-0d7bd889ef7a)


## Get in Touch

Discord: dondaws

