### PR TITLE
Support dragging and dropping tabs into chat text area

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -612,7 +612,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 				e.preventDefault()
 				setIsDraggingOver(false)
 
-				const text = e.dataTransfer.getData("text")
+				const text = e.dataTransfer.getData("application/vnd.code.uri-list")
 				if (text) {
 					// Split text on newlines to handle multiple files
 					const lines = text.split(/\r?\n/).filter((line) => line.trim() !== "")

--- a/webview-ui/src/utils/__tests__/path-mentions.test.ts
+++ b/webview-ui/src/utils/__tests__/path-mentions.test.ts
@@ -41,5 +41,20 @@ describe("path-mentions", () => {
 				"@/nested/deeply/file.txt",
 			)
 		})
+
+		it("should strip file:// protocol from paths if present", () => {
+			// Without cwd
+			expect(convertToMentionPath("file:///Users/user/project/file.txt")).toBe("/Users/user/project/file.txt")
+
+			// With cwd - should strip protocol and then apply mention path logic
+			expect(convertToMentionPath("file:///Users/user/project/file.txt", "/Users/user/project")).toBe(
+				"@/file.txt",
+			)
+
+			// With Windows paths
+			expect(convertToMentionPath("file://C:/Users/user/project/file.txt", "C:/Users/user/project")).toBe(
+				"@/file.txt",
+			)
+		})
 	})
 })

--- a/webview-ui/src/utils/path-mentions.ts
+++ b/webview-ui/src/utils/path-mentions.ts
@@ -12,11 +12,14 @@
  * @returns A mention-friendly path
  */
 export function convertToMentionPath(path: string, cwd?: string): string {
-	const normalizedPath = path.replace(/\\/g, "/")
+	// Strip file:// protocol if present
+	const pathWithoutProtocol = path.startsWith("file://") ? path.substring(7) : path
+
+	const normalizedPath = pathWithoutProtocol.replace(/\\/g, "/")
 	let normalizedCwd = cwd ? cwd.replace(/\\/g, "/") : ""
 
 	if (!normalizedCwd) {
-		return path
+		return pathWithoutProtocol
 	}
 
 	// Remove trailing slash from cwd if it exists
@@ -34,5 +37,5 @@ export function convertToMentionPath(path: string, cwd?: string): string {
 		return "@" + (relativePath.startsWith("/") ? relativePath : "/" + relativePath)
 	}
 
-	return path
+	return pathWithoutProtocol
 }


### PR DESCRIPTION
Attempt at a simpler version of #2512 
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Support dragging tabs into `ChatTextArea.tsx` and update `convertToMentionPath` to handle `file://` protocol.
> 
>   - **Behavior**:
>     - `ChatTextArea.tsx`: Change drag-and-drop to use `application/vnd.code.uri-list` for tab paths.
>     - `handleDrop`: Converts dropped tab paths to mention-friendly format using `convertToMentionPath()`.
>   - **Utilities**:
>     - `convertToMentionPath`: Strips `file://` protocol from paths.
>   - **Tests**:
>     - `path-mentions.test.ts`: Add tests for `file://` protocol handling in `convertToMentionPath()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0ddaa359eebbb4d39915012e9384276ee16c9012. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->