### PR TITLE
Make sure the slash commands only fire if they're the first character

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -305,6 +305,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 							const direction = event.key === "ArrowUp" ? -1 : 1
 							const options = getContextMenuOptions(
 								searchQuery,
+								inputValue,
 								selectedType,
 								queryItems,
 								fileSearchResults,
@@ -341,6 +342,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 						event.preventDefault()
 						const selectedOption = getContextMenuOptions(
 							searchQuery,
+							inputValue,
 							selectedType,
 							queryItems,
 							fileSearchResults,
@@ -780,6 +782,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								<ContextMenu
 									onSelect={handleMentionSelect}
 									searchQuery={searchQuery}
+									inputValue={inputValue}
 									onMouseDown={handleMenuMouseDown}
 									selectedIndex={selectedMenuIndex}
 									setSelectedIndex={setSelectedMenuIndex}

--- a/webview-ui/src/components/chat/ContextMenu.tsx
+++ b/webview-ui/src/components/chat/ContextMenu.tsx
@@ -11,6 +11,7 @@ import { ModeConfig } from "../../../../src/shared/modes"
 interface ContextMenuProps {
 	onSelect: (type: ContextMenuOptionType, value?: string) => void
 	searchQuery: string
+	inputValue: string
 	onMouseDown: () => void
 	selectedIndex: number
 	setSelectedIndex: (index: number) => void
@@ -24,6 +25,7 @@ interface ContextMenuProps {
 const ContextMenu: React.FC<ContextMenuProps> = ({
 	onSelect,
 	searchQuery,
+	inputValue,
 	onMouseDown,
 	selectedIndex,
 	setSelectedIndex,
@@ -36,8 +38,8 @@ const ContextMenu: React.FC<ContextMenuProps> = ({
 	const menuRef = useRef<HTMLDivElement>(null)
 
 	const filteredOptions = useMemo(() => {
-		return getContextMenuOptions(searchQuery, selectedType, queryItems, dynamicSearchResults, modes)
-	}, [searchQuery, selectedType, queryItems, dynamicSearchResults, modes])
+		return getContextMenuOptions(searchQuery, inputValue, selectedType, queryItems, dynamicSearchResults, modes)
+	}, [searchQuery, inputValue, selectedType, queryItems, dynamicSearchResults, modes])
 
 	useEffect(() => {
 		if (menuRef.current) {

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -84,13 +84,14 @@ export interface ContextMenuQueryItem {
 
 export function getContextMenuOptions(
 	query: string,
+	inputValue: string,
 	selectedType: ContextMenuOptionType | null = null,
 	queryItems: ContextMenuQueryItem[],
 	dynamicSearchResults: SearchResult[] = [],
 	modes?: ModeConfig[],
 ): ContextMenuQueryItem[] {
 	// Handle slash commands for modes
-	if (query.startsWith("/")) {
+	if (query.startsWith("/") && inputValue.startsWith("/")) {
 		const modeQuery = query.slice(1)
 		if (!modes?.length) return [{ type: ContextMenuOptionType.NoResults }]
 


### PR DESCRIPTION
Trying a simpler approach to #2696
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure slash commands only trigger if both query and input value start with a slash in `getContextMenuOptions`.
> 
>   - **Behavior**:
>     - Slash commands now only trigger if both `query` and `inputValue` start with a slash in `getContextMenuOptions` in `context-mentions.ts`.
>     - Added test cases in `context-mentions.test.ts` to verify slash command behavior.
>   - **Code Changes**:
>     - Pass `inputValue` to `getContextMenuOptions` in `ChatTextArea.tsx` and `ContextMenu.tsx` to support new slash command behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0b002fb78ebebb19c7abedf6b00c2f7f31d3d7a1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->