### PR TITLE
Add gemini 2.5 flash preview

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -485,6 +485,14 @@ export const vertexModels = {
 		inputPrice: 0.15,
 		outputPrice: 0.6,
 	},
+	"gemini-2.5-flash-preview-04-17": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.6,
+	},
 	"gemini-2.5-pro-preview-03-25": {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,
@@ -632,6 +640,14 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 export type GeminiModelId = keyof typeof geminiModels
 export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-001"
 export const geminiModels = {
+	"gemini-2.5-flash-preview-04-17": {
+		maxTokens: 65_536,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 0.6,
+	},
 	"gemini-2.5-pro-exp-03-25": {
 		maxTokens: 65_536,
 		contextWindow: 1_048_576,


### PR DESCRIPTION
No thinking support yet
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `gemini-2.5-flash-preview-04-17` model to `api.ts` with image support and specific pricing.
> 
>   - **Models**:
>     - Add `gemini-2.5-flash-preview-04-17` to `vertexModels` and `geminiModels` in `api.ts`.
>     - Model supports images, does not support prompt cache, with `maxTokens` 65,536 and `contextWindow` 1,048,576.
>     - Pricing set to `inputPrice` 0.15 and `outputPrice` 0.6.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7d89ec06152c7534be277100b07ef6b52f65b827. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->