### PR TITLE
feat: Add error console to MCP servers - Edited with Roo Code and Anthropic Claude 3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@google-cloud/vertexai": "^1.9.3",
 				"@google/generative-ai": "^0.18.0",
 				"@mistralai/mistralai": "^1.3.6",
-				"@modelcontextprotocol/sdk": "^1.7.0",
+				"@modelcontextprotocol/sdk": "^1.9.0",
 				"@types/clone-deep": "^4.0.4",
 				"@types/pdf-parse": "^1.1.4",
 				"@types/tmp": "^0.2.6",
@@ -6610,23 +6610,33 @@
 			"integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw=="
 		},
 		"node_modules/@modelcontextprotocol/sdk": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.7.0.tgz",
-			"integrity": "sha512-IYPe/FLpvF3IZrd/f5p5ffmWhMc3aEMuM2wGJASDqC2Ge7qatVCdbfPx3n/5xFeb19xN0j/911M2AaFuircsWA==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.9.0.tgz",
+			"integrity": "sha512-Jq2EUCQpe0iyO5FGpzVYDNFR6oR53AIrwph9yWl7uSc7IWUMsrmpmSaTGra5hQNunXpM+9oit85p924jWuHzUA==",
 			"license": "MIT",
 			"dependencies": {
 				"content-type": "^1.0.5",
 				"cors": "^2.8.5",
+				"cross-spawn": "^7.0.3",
 				"eventsource": "^3.0.2",
 				"express": "^5.0.1",
 				"express-rate-limit": "^7.5.0",
-				"pkce-challenge": "^4.1.0",
+				"pkce-challenge": "^5.0.0",
 				"raw-body": "^3.0.0",
 				"zod": "^3.23.8",
 				"zod-to-json-schema": "^3.24.1"
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/@modelcontextprotocol/sdk/node_modules/pkce-challenge": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
+			"integrity": "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.20.0"
 			}
 		},
 		"node_modules/@modelcontextprotocol/sdk/node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -407,7 +407,7 @@
 		"@google-cloud/vertexai": "^1.9.3",
 		"@google/generative-ai": "^0.18.0",
 		"@mistralai/mistralai": "^1.3.6",
-		"@modelcontextprotocol/sdk": "^1.7.0",
+		"@modelcontextprotocol/sdk": "^1.9.0",
 		"@types/clone-deep": "^4.0.4",
 		"@types/pdf-parse": "^1.1.4",
 		"@types/tmp": "^0.2.6",

--- a/src/i18n/setup.ts
+++ b/src/i18n/setup.ts
@@ -9,9 +9,9 @@ const isTestEnv = process.env.NODE_ENV === "test" || process.env.JEST_WORKER_ID 
 // Detect environment - browser vs Node.js
 const isBrowser = typeof window !== "undefined" && typeof window.document !== "undefined"
 
-// Define interface for VSCode extension process
-interface VSCodeProcess extends NodeJS.Process {
-	resourcesPath?: string
+// Type for the VSCode process with optional resourcesPath
+type VSCodeProcess = NodeJS.Process & {
+	resourcesPath?: string | undefined
 }
 
 // Type cast process to custom interface with resourcesPath

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -544,6 +544,7 @@ export class McpHub {
 					disabled: config.disabled,
 					source,
 					projectPath: source === "project" ? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath : undefined,
+					errorHistory: [],
 				},
 				client,
 				transport,
@@ -570,13 +571,31 @@ export class McpHub {
 		}
 	}
 
-	private appendErrorMessage(connection: McpConnection, error: string) {
+	private appendErrorMessage(connection: McpConnection, error: string, level: "error" | "warn" | "info" = "error") {
 		const MAX_ERROR_LENGTH = 1000
-		const newError = connection.server.error ? `${connection.server.error}\n${error}` : error
-		connection.server.error =
-			newError.length > MAX_ERROR_LENGTH
-				? `${newError.substring(0, MAX_ERROR_LENGTH)}...(error message truncated)`
-				: newError
+		const truncatedError =
+			error.length > MAX_ERROR_LENGTH
+				? `${error.substring(0, MAX_ERROR_LENGTH)}...(error message truncated)`
+				: error
+
+		// Add to error history
+		if (!connection.server.errorHistory) {
+			connection.server.errorHistory = []
+		}
+
+		connection.server.errorHistory.push({
+			message: truncatedError,
+			timestamp: Date.now(),
+			level,
+		})
+
+		// Keep only the last 100 errors
+		if (connection.server.errorHistory.length > 100) {
+			connection.server.errorHistory = connection.server.errorHistory.slice(-100)
+		}
+
+		// Update current error display
+		connection.server.error = truncatedError
 	}
 
 	/**

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -1,8 +1,15 @@
+export type McpErrorEntry = {
+	message: string
+	timestamp: number
+	level: "error" | "warn" | "info"
+}
+
 export type McpServer = {
 	name: string
 	config: string
 	status: "connected" | "connecting" | "disconnected"
 	error?: string
+	errorHistory?: McpErrorEntry[]
 	tools?: McpTool[]
 	resources?: McpResource[]
 	resourceTemplates?: McpResourceTemplate[]
@@ -52,6 +59,11 @@ export type McpToolCallResponse = {
 		  }
 		| {
 				type: "image"
+				data: string
+				mimeType: string
+		  }
+		| {
+				type: "audio"
 				data: string
 				mimeType: string
 		  }

--- a/webview-ui/src/components/mcp/McpErrorRow.tsx
+++ b/webview-ui/src/components/mcp/McpErrorRow.tsx
@@ -1,0 +1,43 @@
+import { formatRelative } from "date-fns"
+import { McpErrorEntry } from "../../../../src/shared/mcp"
+
+type McpErrorRowProps = {
+	error: McpErrorEntry
+}
+
+const McpErrorRow = ({ error }: McpErrorRowProps) => {
+	const getErrorColor = (level: string) => {
+		switch (level) {
+			case "error":
+				return "var(--vscode-testing-iconFailed)"
+			case "warn":
+				return "var(--vscode-charts-yellow)"
+			case "info":
+				return "var(--vscode-testing-iconPassed)"
+			default:
+				return "var(--vscode-testing-iconFailed)"
+		}
+	}
+
+	return (
+		<div
+			style={{
+				padding: "8px",
+				borderLeft: `3px solid ${getErrorColor(error.level)}`,
+				background: "var(--vscode-textCodeBlock-background)",
+				borderRadius: "4px",
+				fontSize: "13px",
+			}}>
+			<div style={{ marginBottom: "4px", color: getErrorColor(error.level) }}>{error.message}</div>
+			<div
+				style={{
+					fontSize: "11px",
+					color: "var(--vscode-descriptionForeground)",
+				}}>
+				{formatRelative(error.timestamp, new Date())}
+			</div>
+		</div>
+	)
+}
+
+export default McpErrorRow

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -20,6 +20,7 @@ import { Tab, TabContent, TabHeader } from "../common/Tab"
 import McpToolRow from "./McpToolRow"
 import McpResourceRow from "./McpResourceRow"
 import McpEnabledToggle from "./McpEnabledToggle"
+import McpErrorRow from "./McpErrorRow"
 
 type McpViewProps = {
 	onDone: () => void
@@ -349,6 +350,9 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 								{t("mcp:tabs.resources")} (
 								{[...(server.resourceTemplates || []), ...(server.resources || [])].length || 0})
 							</VSCodePanelTab>
+							<VSCodePanelTab id="errors">
+								{t("mcp:tabs.errors")} ({server.errorHistory?.length || 0})
+							</VSCodePanelTab>
 
 							<VSCodePanelView id="tools-view">
 								{server.tools && server.tools.length > 0 ? (
@@ -388,6 +392,23 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 								) : (
 									<div style={{ padding: "10px 0", color: "var(--vscode-descriptionForeground)" }}>
 										{t("mcp:emptyState.noResources")}
+									</div>
+								)}
+							</VSCodePanelView>
+
+							<VSCodePanelView id="errors-view">
+								{server.errorHistory && server.errorHistory.length > 0 ? (
+									<div
+										style={{ display: "flex", flexDirection: "column", gap: "8px", width: "100%" }}>
+										{[...server.errorHistory]
+											.sort((a, b) => b.timestamp - a.timestamp)
+											.map((error, index) => (
+												<McpErrorRow key={`${error.timestamp}-${index}`} error={error} />
+											))}
+									</div>
+								) : (
+									<div style={{ padding: "10px 0", color: "var(--vscode-descriptionForeground)" }}>
+										{t("mcp:emptyState.noErrors")}
 									</div>
 								)}
 							</VSCodePanelView>

--- a/webview-ui/src/i18n/locales/en/mcp.json
+++ b/webview-ui/src/i18n/locales/en/mcp.json
@@ -19,11 +19,13 @@
 	},
 	"tabs": {
 		"tools": "Tools",
-		"resources": "Resources"
+		"resources": "Resources",
+		"errors": "Errors"
 	},
 	"emptyState": {
 		"noTools": "No tools found",
-		"noResources": "No resources found"
+		"noResources": "No resources found",
+		"noErrors": "No errors found"
 	},
 	"networkTimeout": {
 		"label": "Network Timeout",


### PR DESCRIPTION
- Add error history tracking with timestamps and error levels
- Create new McpErrorRow component for error display
- Add Errors tab to server view with sortable error history
- Support error/warning/info message levels with different colors
- Maintain up to 100 most recent errors per server
- Update translations for error console UI

## Context

Added error console to Roo's MCP client because currently, if there is an error, it just overides the client display entirely and looks like the MCP is broken, which it may or may not be. 

## Implementation

<!--

Requested that Roo Code using Anthropic Claude 3.5 add an error console. It understood directions, and basically one shot developed it
-->

## Screenshots
The before, is the same as the after, but the error console is not there. I did not realize I needed to take a before screenshot.

![image](https://github.com/user-attachments/assets/e9c9753c-7fbb-4712-8000-7a07daf79fc2) After
## How to Test

I didn't have any issues getting an error because MCP servers tend to constantly push out errors, in this case it is the Github MCP client, though Roo had apparently written a test javascript to push out errors, it wasn't necessary

## Get in Touch

@robertheadley everyone
@robertheadley@gmail.com if you must email
