### PR TITLE
fixes image support in bedrock. regression from prompt cache implementation

### DIFF
--- a/src/api/providers/__tests__/bedrock.test.ts
+++ b/src/api/providers/__tests__/bedrock.test.ts
@@ -7,9 +7,23 @@ jest.mock("@aws-sdk/credential-providers", () => {
 	return { fromIni: mockFromIni }
 })
 
+// Mock BedrockRuntimeClient and ConverseStreamCommand
+const mockConverseStreamCommand = jest.fn()
+const mockSend = jest.fn().mockResolvedValue({
+	stream: [],
+})
+
+jest.mock("@aws-sdk/client-bedrock-runtime", () => ({
+	BedrockRuntimeClient: jest.fn().mockImplementation(() => ({
+		send: mockSend,
+	})),
+	ConverseStreamCommand: mockConverseStreamCommand,
+	ConverseCommand: jest.fn(),
+}))
+
 import { AwsBedrockHandler } from "../bedrock"
 import { MessageContent } from "../../../shared/api"
-import { BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime"
+import { BedrockRuntimeClient, ConverseStreamCommand } from "@aws-sdk/client-bedrock-runtime"
 import { Anthropic } from "@anthropic-ai/sdk"
 const { fromIni } = require("@aws-sdk/credential-providers")
 import { logger } from "../../../utils/logging"
@@ -57,7 +71,6 @@ describe("AwsBedrockHandler", () => {
 		})
 
 		it("should handle inference-profile ARN with apne3 region prefix", () => {
-			// Mock the parseArn method before creating the handler
 			const originalParseArn = AwsBedrockHandler.prototype["parseArn"]
 			const parseArnMock = jest.fn().mockImplementation(function (this: any, arn: string, region?: string) {
 				return originalParseArn.call(this, arn, region)
@@ -65,12 +78,11 @@ describe("AwsBedrockHandler", () => {
 			AwsBedrockHandler.prototype["parseArn"] = parseArnMock
 
 			try {
-				// Create a handler with a custom ARN that includes the apne3. region prefix
 				const customArnHandler = new AwsBedrockHandler({
 					apiModelId: "anthropic.claude-3-5-sonnet-20241022-v2:0",
 					awsAccessKey: "test-access-key",
 					awsSecretKey: "test-secret-key",
-					awsRegion: "ap-northeast-3", // Osaka region
+					awsRegion: "ap-northeast-3",
 					awsCustomArn:
 						"arn:aws:bedrock:ap-northeast-3:123456789012:inference-profile/apne3.anthropic.claude-3-5-sonnet-20241022-v2:0",
 				})
@@ -79,23 +91,17 @@ describe("AwsBedrockHandler", () => {
 
 				expect(modelInfo.id).toBe(
 					"arn:aws:bedrock:ap-northeast-3:123456789012:inference-profile/apne3.anthropic.claude-3-5-sonnet-20241022-v2:0",
-				),
-					// Verify the model info is defined
-					expect(modelInfo.info).toBeDefined()
+				)
+				expect(modelInfo.info).toBeDefined()
 
-				// Verify parseArn was called with the correct ARN
 				expect(parseArnMock).toHaveBeenCalledWith(
 					"arn:aws:bedrock:ap-northeast-3:123456789012:inference-profile/apne3.anthropic.claude-3-5-sonnet-20241022-v2:0",
 					"ap-northeast-3",
 				)
 
-				// Verify the model ID was correctly extracted from the ARN (without the region prefix)
 				expect((customArnHandler as any).arnInfo.modelId).toBe("anthropic.claude-3-5-sonnet-20241022-v2:0")
-
-				// Verify cross-region inference flag is false since apne3 is a prefix for a single region
 				expect((customArnHandler as any).arnInfo.crossRegionInference).toBe(false)
 			} finally {
-				// Restore the original method
 				AwsBedrockHandler.prototype["parseArn"] = originalParseArn
 			}
 		})
@@ -109,12 +115,132 @@ describe("AwsBedrockHandler", () => {
 				awsRegion: "us-east-1",
 			})
 			const modelInfo = customArnHandler.getModel()
-			// Should fall back to default prompt router model
 			expect(modelInfo.id).toBe(
 				"arn:aws:bedrock:ap-northeast-3:123456789012:default-prompt-router/my_router_arn_no_model",
-			) // bedrockDefaultPromptRouterModelId
+			)
 			expect(modelInfo.info).toBeDefined()
 			expect(modelInfo.info.maxTokens).toBe(4096)
+		})
+	})
+
+	describe("image handling", () => {
+		const mockImageData = Buffer.from("test-image-data").toString("base64")
+
+		beforeEach(() => {
+			// Reset the mocks before each test
+			mockSend.mockReset()
+			mockConverseStreamCommand.mockReset()
+
+			mockSend.mockResolvedValue({
+				stream: [],
+			})
+		})
+
+		it("should properly convert image content to Bedrock format", async () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								data: mockImageData,
+								media_type: "image/jpeg",
+							},
+						},
+						{
+							type: "text",
+							text: "What's in this image?",
+						},
+					],
+				},
+			]
+
+			const generator = handler.createMessage("", messages)
+			await generator.next() // Start the generator
+
+			// Verify the command was created with the right payload
+			expect(mockConverseStreamCommand).toHaveBeenCalled()
+			const commandArg = mockConverseStreamCommand.mock.calls[0][0]
+
+			// Verify the image was properly formatted
+			const imageBlock = commandArg.messages[0].content[0]
+			expect(imageBlock).toHaveProperty("image")
+			expect(imageBlock.image).toHaveProperty("format", "jpeg")
+			expect(imageBlock.image.source).toHaveProperty("bytes")
+			expect(imageBlock.image.source.bytes).toBeInstanceOf(Uint8Array)
+		})
+
+		it("should reject unsupported image formats", async () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								data: mockImageData,
+								media_type: "image/tiff" as "image/jpeg", // Type assertion to bypass TS
+							},
+						},
+					],
+				},
+			]
+
+			const generator = handler.createMessage("", messages)
+			await expect(generator.next()).rejects.toThrow("Unsupported image format: tiff")
+		})
+
+		it("should handle multiple images in a single message", async () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user",
+					content: [
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								data: mockImageData,
+								media_type: "image/jpeg",
+							},
+						},
+						{
+							type: "text",
+							text: "First image",
+						},
+						{
+							type: "image",
+							source: {
+								type: "base64",
+								data: mockImageData,
+								media_type: "image/png",
+							},
+						},
+						{
+							type: "text",
+							text: "Second image",
+						},
+					],
+				},
+			]
+
+			const generator = handler.createMessage("", messages)
+			await generator.next() // Start the generator
+
+			// Verify the command was created with the right payload
+			expect(mockConverseStreamCommand).toHaveBeenCalled()
+			const commandArg = mockConverseStreamCommand.mock.calls[0][0]
+
+			// Verify both images were properly formatted
+			const firstImage = commandArg.messages[0].content[0]
+			const secondImage = commandArg.messages[0].content[2]
+
+			expect(firstImage).toHaveProperty("image")
+			expect(firstImage.image).toHaveProperty("format", "jpeg")
+			expect(secondImage).toHaveProperty("image")
+			expect(secondImage.image).toHaveProperty("format", "png")
 		})
 	})
 })


### PR DESCRIPTION
## Context

Images in prompts when using bedrock are broken. The image gets replaced with a "Content not Supported" text before sending the prompt to bedrock, and then of course bedrock doesn't have the info needed to do the task being asked.

This a regression I created during prompt caching implementation.

 

## Implementation

Roo reviewed the the SHA before prompt caching and tracked down where images were supported, then compared against main and found the regression... in 2 prompts, then suggested the changes to revert back to the right implementation. Unit tests were added first that failed and then passed after implementation. All in all, about a 20 min task from start to end. 



## How to Test
To manually test the image handling changes in the Bedrock provider, you can:

Set up a test environment:
# Start the extension in development mode
npm run watch
Configure Bedrock in VSCode:

Open VSCode settings
Search for "Roo: AWS"
Configure your AWS credentials and region
Select a Bedrock model that supports images (e.g., "anthropic.claude-3-sonnet-20240229-v1:0")
Test basic image handling:

Create a new conversation
Drag and drop an image into the chat
Ask a question about the image
Verify that the model responds appropriately about the image content
Test with prompt caching:

Enable prompt caching in settings
Start a new conversation with an image
Send multiple messages in the conversation
Verify that cache points are added correctly and the image is still processed properly
Test error cases:

Try uploading an unsupported image format (e.g., .tiff)
Verify you get the proper error message
Try uploading a very large image
Verify the image is properly converted and sent
Test multiple images:

Send a message with multiple images
Verify all images are processed correctly
Check that the order of images and text is maintained
You can monitor the extension's debug console in VSCode to see the actual API payloads being sent to Bedrock and verify that images are being properly formatted in the requests.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes image handling regression in Bedrock provider, ensuring proper image processing and adding relevant tests.
> 
>   - **Behavior**:
>     - Fixes image handling in `AwsBedrockHandler` to prevent images from being replaced with "Content not Supported" text.
>     - Supports JPEG and PNG formats, rejects unsupported formats like TIFF.
>     - Handles multiple images in a single message, maintaining order.
>   - **Testing**:
>     - Adds unit tests in `bedrock.test.ts` for image conversion, unsupported format rejection, and multiple image handling.
>   - **Functions**:
>     - Updates `convertToBedrockConverseMessages()` in `bedrock.ts` to use `sharedConverter` for image handling.
>     - Modifies cache point application logic to work with converted messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 046c2e067521ffdae452ce441e7b71d88132da28. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->