### PR TITLE
fix(mention): conditionally remove aftercursor content

### DIFF
--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -33,7 +33,12 @@ export function insertMention(
 	if (lastAtIndex !== -1) {
 		// If there's an '@' symbol, replace everything after it with the new mention
 		const beforeMention = text.slice(0, lastAtIndex)
-		newValue = beforeMention + "@" + value + " " + afterCursor.replace(/^[^\s]*/, "")
+		// Only replace if afterCursor is all alphanumerical
+		// This is required to handle languages that don't use space as a word separator (chinese, japanese, korean, etc)
+		const afterCursorContent = /^[a-zA-Z0-9\s]*$/.test(afterCursor)
+			? afterCursor.replace(/^[^\s]*/, "")
+			: afterCursor
+		newValue = beforeMention + "@" + value + " " + afterCursorContent
 		mentionIndex = lastAtIndex
 	} else {
 		// If there's no '@' symbol, insert the mention at the cursor position


### PR DESCRIPTION
## Context

This fixes #2286

Currently we're removing every content after the cursor position, which might be ideal for the case where the cursor is in the middle of mention

```
@/path/to|/foo
         ^ cursor here
```

but this becomes an issue when the content after the cursor is the user's prompt using languages that don't require space for its word boundary (chinese, japanese, korean, etc)
so it removes everything

```
@/path/to/foo|テキスト。。。
             ^ cursor here

// current behaviour
@/path/to/foo.ts

// after this PR
@/path/to/foo.ts テキスト。。。
```

## Implementation

The current implementation simply checks if the content after the cursor is latin alphanumeric using `[a-zA-Z0-9\s]` regex.
If it passes, meaning that it's most likely a path--since using non-latin letters for filename / directory is very uncommon, i think this heuristic is okay--then it will replace everything, otherwise it will just append the content and prepend a space.

## Screenshots

### Before
https://github.com/user-attachments/assets/7ba24551-eb83-4dd0-ad3d-b4193e8afd3a

### After
https://github.com/user-attachments/assets/6958885f-22e2-430e-a947-36b8ace52ba2

## How to Test

Reproduce what I did on the video above.

## Get in Touch

my discord handle is @elianiva on roocode discord server

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #2286 by modifying `insertMention()` in `context-mentions.ts` to conditionally retain non-latin content after the cursor.
> 
>   - **Behavior**:
>     - Modify `insertMention()` in `context-mentions.ts` to conditionally retain content after cursor if non-latin characters are detected.
>     - Uses regex `/^[a-zA-Z0-9\s]*$/` to check if `afterCursor` is alphanumeric.
>     - Appends content with a space if non-alphanumeric, otherwise replaces it.
>   - **Misc**:
>     - Fixes issue #2286 related to handling non-latin scripts in mentions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c26d003bb5b71dd24a38edc5dc84d3af1f54e756. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->