### PR TITLE
Gemini 2.5 Flash Preview fix Max Tokens Count

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -486,7 +486,7 @@ export const vertexModels = {
 		outputPrice: 0.6,
 	},
 	"gemini-2.5-flash-preview-04-17": {
-		maxTokens: 65_536,
+		maxTokens: 65_535,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,
@@ -641,7 +641,7 @@ export type GeminiModelId = keyof typeof geminiModels
 export const geminiDefaultModelId: GeminiModelId = "gemini-2.0-flash-001"
 export const geminiModels = {
 	"gemini-2.5-flash-preview-04-17": {
-		maxTokens: 65_536,
+		maxTokens: 65_535,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,


### PR DESCRIPTION
## Context

Fixing max tokens count for the new Gemini Flash 2.5 model for Gemini and Vertex AI providers

## Implementation

Simply fix the max value in api.ts

## Get in Touch

@nicotexas

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `maxTokens` value for `gemini-2.5-flash-preview-04-17` model in `api.ts` from `65,536` to `65,535`.
> 
>   - **Behavior**:
>     - Fixes `maxTokens` value from `65,536` to `65,535` for `gemini-2.5-flash-preview-04-17` in `vertexModels` and `geminiModels` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 51500c2b87b4ba4eeb97350b39afa8538e315440. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->