### PR TITLE
Fixes maximum token limit for Gemini provider 2.5 pro exp

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -649,7 +649,7 @@ export const geminiModels = {
 		outputPrice: 0.6,
 	},
 	"gemini-2.5-pro-exp-03-25": {
-		maxTokens: 65_536,
+		maxTokens: 65_535,
 		contextWindow: 1_048_576,
 		supportsImages: true,
 		supportsPromptCache: false,


### PR DESCRIPTION
## Context

Corrects the maximum token limit for the "gemini-2.5-pro-exp-03-25" model, ensuring accurate configuration.

## Implementation

Simply fix the value to maxTokens: 65_535

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects `maxTokens` for `gemini-2.5-pro-exp-03-25` model in `api.ts` from 65,536 to 65,535.
> 
>   - **Behavior**:
>     - Corrects `maxTokens` for `gemini-2.5-pro-exp-03-25` model in `api.ts` from 65,536 to 65,535.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1d055c5a0272e9b57170b42be5f99ce73feca8f7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->