### PR TITLE
Fix: Correct path handling for dragged files on Windows

### DIFF
--- a/webview-ui/src/utils/path-mentions.ts
+++ b/webview-ui/src/utils/path-mentions.ts
@@ -13,7 +13,18 @@
  */
 export function convertToMentionPath(path: string, cwd?: string): string {
 	// Strip file:// protocol if present
-	const pathWithoutProtocol = path.startsWith("file://") ? path.substring(7) : path
+	let pathWithoutProtocol = path.startsWith("file://") ? path.substring(7) : path
+
+	try {
+		pathWithoutProtocol = decodeURIComponent(pathWithoutProtocol)
+		// Fix: Remove leading slash for Windows paths like /d:/...
+		if (pathWithoutProtocol.startsWith("/") && pathWithoutProtocol[2] === ":") {
+			pathWithoutProtocol = pathWithoutProtocol.substring(1)
+		}
+	} catch (e) {
+		// Log error if decoding fails, but continue with the potentially problematic path
+		console.error("Error decoding URI component in convertToMentionPath:", e, pathWithoutProtocol)
+	}
 
 	const normalizedPath = pathWithoutProtocol.replace(/\\/g, "/")
 	let normalizedCwd = cwd ? cwd.replace(/\\/g, "/") : ""


### PR DESCRIPTION
## Context

Bug:

When dragging and dropping a file from a Windows path (e.g., D:\path\to\file.txt) into the chat text area, the resulting path mention was incorrectly formatted. Instead of generating a relative path mention like @/path/to/file.txt (if within the workspace) or a standard absolute path like D:/path/to/file.txt, it produced a path with a leading slash and URI-encoded characters, such as /d%3A/path/to/file.txt.

Root Cause:

The handleDrop function in ChatTextArea.tsx correctly retrieves the file path as a file:// URI from the dataTransfer object (e.g., file:///d%3A/path/to/file.txt). The convertToMentionPath utility function in path-mentions.ts then performs the following steps:

Strips the file:// prefix, resulting in /d%3A/path/to/file.txt.
Uses decodeURIComponent to decode the URI, resulting in /d:/path/to/file.txt.
The issue arises because step 2 leaves an extraneous leading slash (/) for Windows paths. This incorrect format (/d:/... instead of the standard d:/...) prevents the subsequent logic, which compares the path against the current working directory (cwd) using path.startsWith(cwd), from correctly identifying the path as being inside the workspace. The comparison fails because the cwd (e.g., e:/Project/Roo-Code) does not start with /e:/.

## Implementation

The fix involves modifying the convertToMentionPath function in webview-ui/src/utils/path-mentions.ts. After decoding the URI component, an additional check is introduced:

It specifically looks for paths that start with a slash followed by a drive letter and a colon (regex pattern: ^\/[a-zA-Z]:\/).
If this pattern matches (indicating a Windows path with the extraneous leading slash), the leading slash is removed using pathWithoutProtocol.substring(1).
This ensures that Windows paths are correctly formatted (e.g., d:/path/to/file.txt) before being compared with the cwd or used as absolute paths, resolving the incorrect mention generation.

## Screenshots

| before | after |
| ------ | ----- |
|   |   |


 https://github.com/user-attachments/assets/e42bdbf4-d143-4490-bab1-fcb2a70dd625 

 https://github.com/user-attachments/assets/3226261f-3473-41e2-b8e9-c8fda15a3fff 


## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes path handling for Windows in `convertToMentionPath` by removing extraneous leading slash after URI decoding.
> 
>   - **Behavior**:
>     - Fixes path handling for dragged files on Windows in `convertToMentionPath` in `path-mentions.ts`.
>     - Removes leading slash for Windows paths like `/d:/...` after decoding URI.
>     - Logs error if URI decoding fails but continues with the path.
>   - **Implementation**:
>     - Adds check for Windows path pattern `^\/[a-zA-Z]:\/` and removes leading slash if matched.
>     - Ensures correct path comparison with `cwd` for mention generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e96a9bb5ca0141a3732d73c858f15516b354f9c8. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->