### PR TITLE
fix(icons): use geometricPrecision to avoid blurriness

### DIFF
--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -392,3 +392,11 @@ input[cmdk-input]:focus {
 .custom-markdown > pre {
 	background-color: transparent !important;
 }
+
+/*
+ * Use geometric precision for codicons to avoid blurriness 
+ */
+
+.codicon[class*="codicon-"] {
+	text-rendering: geometricPrecision !important;
+}


### PR DESCRIPTION
## Context

Fixes #2437, the issue explained the context in detail so it's not needed here

## Implementation

Added this css property to force the rendering of the codicons to be geometryPrecision

```css
.codicon[class*="codicon-"] {
	text-rendering: geometricPrecision !important;
}
```

Had to use `!important` here because the css that comes with codicon is setting `text-rendering: auto` and it overrides our global css

## Screenshots

| before | after |
| ------ | ----- |
| ![Screenshot From 2025-04-18 17-16-24](https://github.com/user-attachments/assets/ee7537e5-457a-41a3-9bad-872ec3078547) | ![Screenshot From 2025-04-18 17-16-20](https://github.com/user-attachments/assets/dc5e88a4-d228-4b77-9cbf-ef0a5f499720) |

## How to Test

This is only applicable in Linux. You need to disable stem darkening by setting this value inside `/etc/environment`

```
FREETYPE_PROPERTIES="cff:no-stem-darkening=0 autofitter:no-stem-darkening=0"
```

Restart your session, open vscode, without this PR it should look blurry, with this PR it should look normal

## Get in Touch

@elianiva
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix icon blurriness by setting `text-rendering: geometricPrecision` for `.codicon` in `index.css`.
> 
>   - **CSS Changes**:
>     - Add `text-rendering: geometricPrecision !important;` to `.codicon[class*="codicon-"]` in `index.css` to fix icon blurriness.
>     - Overrides existing `text-rendering: auto` from codicon CSS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d2bdcb89448934f9395db26ef535cd30a8bf73b9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->