### PR TITLE
Updates Claude 3.7 model token limits

### DIFF
--- a/src/api/providers/__tests__/anthropic.test.ts
+++ b/src/api/providers/__tests__/anthropic.test.ts
@@ -255,7 +255,7 @@ describe("AnthropicHandler", () => {
 			})
 
 			const result = handler.getModel()
-			expect(result.maxTokens).toBe(8192)
+			expect(result.maxTokens).toBe(64_000)
 			expect(result.thinking).toBeUndefined()
 			expect(result.temperature).toBe(0)
 		})

--- a/src/api/providers/__tests__/glama.test.ts
+++ b/src/api/providers/__tests__/glama.test.ts
@@ -181,7 +181,7 @@ describe("GlamaHandler", () => {
 					model: mockOptions.apiModelId,
 					messages: [{ role: "user", content: "Test prompt" }],
 					temperature: 0,
-					max_tokens: 8192,
+					max_tokens: 64_000,
 				}),
 			)
 		})
@@ -233,7 +233,7 @@ describe("GlamaHandler", () => {
 			const modelInfo = handler.getModel()
 			expect(modelInfo.id).toBe(mockOptions.apiModelId)
 			expect(modelInfo.info).toBeDefined()
-			expect(modelInfo.info.maxTokens).toBe(8192)
+			expect(modelInfo.info.maxTokens).toBe(64_000)
 			expect(modelInfo.info.contextWindow).toBe(200_000)
 		})
 	})

--- a/src/api/providers/__tests__/requesty.test.ts
+++ b/src/api/providers/__tests__/requesty.test.ts
@@ -18,7 +18,7 @@ describe("RequestyHandler", () => {
 		requestyApiKey: "test-key",
 		requestyModelId: "test-model",
 		requestyModelInfo: {
-			maxTokens: 8192,
+			maxTokens: 64_000,
 			contextWindow: 200_000,
 			supportsImages: true,
 			supportsComputerUse: true,

--- a/src/api/providers/__tests__/vertex.test.ts
+++ b/src/api/providers/__tests__/vertex.test.ts
@@ -309,7 +309,7 @@ describe("VertexHandler", () => {
 					},
 				],
 				generationConfig: {
-					maxOutputTokens: 8192,
+					maxOutputTokens: 64_000,
 					temperature: 0,
 				},
 			})
@@ -914,7 +914,7 @@ describe("VertexHandler", () => {
 			})
 
 			const result = handler.getModel()
-			expect(result.maxTokens).toBe(8192)
+			expect(result.maxTokens).toBe(64_000)
 			expect(result.thinking).toBeUndefined()
 			expect(result.temperature).toBe(0)
 		})

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -27,7 +27,7 @@ export const anthropicModels = {
 		thinking: true,
 	},
 	"claude-3-7-sonnet-20250219": {
-		maxTokens: 8192,
+		maxTokens: 64_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,
@@ -166,7 +166,7 @@ export const bedrockModels = {
 		cachableFields: ["system"],
 	},
 	"anthropic.claude-3-7-sonnet-20250219-v1:0": {
-		maxTokens: 8192,
+		maxTokens: 64_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,
@@ -425,7 +425,7 @@ export const bedrockModels = {
 // https://glama.ai/models
 export const glamaDefaultModelId = "anthropic/claude-3-7-sonnet"
 export const glamaDefaultModelInfo: ModelInfo = {
-	maxTokens: 8192,
+	maxTokens: 64_000,
 	contextWindow: 200_000,
 	supportsImages: true,
 	supportsComputerUse: true,
@@ -442,7 +442,7 @@ export const glamaDefaultModelInfo: ModelInfo = {
 // https://requesty.ai/router-2
 export const requestyDefaultModelId = "anthropic/claude-3-7-sonnet-latest"
 export const requestyDefaultModelInfo: ModelInfo = {
-	maxTokens: 8192,
+	maxTokens: 64_000,
 	contextWindow: 200_000,
 	supportsImages: true,
 	supportsComputerUse: true,
@@ -459,7 +459,7 @@ export const requestyDefaultModelInfo: ModelInfo = {
 // https://openrouter.ai/models?order=newest&supported_parameters=tools
 export const openRouterDefaultModelId = "anthropic/claude-3.7-sonnet"
 export const openRouterDefaultModelInfo: ModelInfo = {
-	maxTokens: 8192,
+	maxTokens: 64_000,
 	contextWindow: 200_000,
 	supportsImages: true,
 	supportsComputerUse: true,
@@ -550,7 +550,7 @@ export const vertexModels = {
 		outputPrice: 5,
 	},
 	"claude-3-7-sonnet@20250219:thinking": {
-		maxTokens: 64_000,
+		maxTokens: 128_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,
@@ -562,7 +562,7 @@ export const vertexModels = {
 		thinking: true,
 	},
 	"claude-3-7-sonnet@20250219": {
-		maxTokens: 8192,
+		maxTokens: 64_000,
 		contextWindow: 200_000,
 		supportsImages: true,
 		supportsComputerUse: true,


### PR DESCRIPTION
## Context

Updates Claude 3.7 model token limits

Increases maxTokens from 8192 to 64000 for Claude 3.7 Sonnet model configurations across various API integrations including Anthropic, Bedrock, Glama, Requesty, and OpenRouter.

Also adjusts Vertex AI thinking model maxTokens to 128000 for improved performance.

## Implementation

Configuration values have been increased to 64K for Claude 3.7

I noticed that they were 64K before, but were downgraded to 8K, any reason for that?

## Get in Touch

Roo Code Discord : vagadiya


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase `maxTokens` for Claude 3.7 model to 64000 across various integrations and adjust Vertex AI thinking model to 128000.
> 
>   - **Behavior**:
>     - Increase `maxTokens` from 8192 to 64000 for `Claude 3.7 Sonnet` in `anthropicModels`, `bedrockModels`, `glamaDefaultModelInfo`, `requestyDefaultModelInfo`, and `openRouterDefaultModelInfo` in `api.ts`.
>     - Adjust `maxTokens` to 128000 for `Vertex AI` thinking model in `vertexModels` in `api.ts`.
>   - **Tests**:
>     - Update expected `maxTokens` to 64000 in `anthropic.test.ts`, `glama.test.ts`, `requesty.test.ts`, and `vertex.test.ts`.
>     - Ensure tests reflect new token limits and verify correct behavior for `Claude 3.7` models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c3e22d53c33ac0cc6017d9c4714ca8dec444049c. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->