### PR TITLE
UI: Auto-approve toggle styling tweak.

### DIFF
--- a/webview-ui/src/components/settings/AutoApproveToggle.tsx
+++ b/webview-ui/src/components/settings/AutoApproveToggle.tsx
@@ -95,27 +95,23 @@ export const AutoApproveToggle = ({ onToggle, ...props }: AutoApproveToggleProps
 	return (
 		<div
 			className={cn(
-				"grid grid-cols-2",
-				"[@media(min-width:260px)]:grid-cols-3",
-				"[@media(min-width:320px)]:grid-cols-4",
-				"[@media(min-width:480px)]:grid-cols-6",
-				"[@media(min-width:640px)]:grid-cols-8",
-				"gap-2",
+				"flex flex-row flex-wrap justify-center gap-2 max-w-[400px] mx-auto my-2 ",
+				"[@media(min-width:600px)]:gap-4",
+				"[@media(min-width:800px)]:max-w-[800px]",
 			)}>
 			{Object.values(autoApproveSettingsConfig).map(({ key, descriptionKey, labelKey, icon, testId }) => (
-				<div key={key} className="aspect-square">
-					<Button
-						variant="secondary"
-						onClick={() => onToggle(key, !props[key])}
-						title={t(descriptionKey || "")}
-						data-testid={testId}
-						className={cn("w-full h-full", { "opacity-50": !props[key] })}>
-						<span className="flex flex-col items-center gap-1">
-							<span className={`codicon codicon-${icon}`} />
-							<span className="text-sm text-center">{t(labelKey)}</span>
-						</span>
-					</Button>
-				</div>
+				<Button
+					key={key}
+					variant={props[key] ? "default" : "outline"}
+					onClick={() => onToggle(key, !props[key])}
+					title={t(descriptionKey || "")}
+					data-testid={testId}
+					className={cn(" aspect-square h-[80px]")}>
+					<span className={cn("flex flex-col items-center gap-1")}>
+						<span className={`codicon codicon-${icon}`} />
+						<span className="text-sm text-center">{t(labelKey)}</span>
+					</span>
+				</Button>
 			))}
 		</div>
 	)


### PR DESCRIPTION
## Context

Minor tweaks to improve visuals and layout of new auto-approve toggles: 

- Improved theme support and contrast by using `primary|outline` button themes instead of switching to opacity-50 for inactive state. 
- Switch to flex from grid for improved layouts at odd sizes. 

## Screenshots

Improved contrast and theme support: 

https://github.com/user-attachments/assets/38e69fa3-dd4c-44ef-a4a3-31fe286705ca

Improved odd-size layouts: 

![Screenshot 2025-04-18 at 4 07 24 PM](https://github.com/user-attachments/assets/d9ea905b-2b8b-452d-a346-38824a23985d)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> UI improvements in `AutoApproveToggle.tsx` with flex layout and enhanced button themes for better responsiveness and contrast.
> 
>   - **UI Enhancements**:
>     - In `AutoApproveToggle.tsx`, switch from `grid` to `flex` layout for better responsiveness at various screen sizes.
>     - Use `primary|outline` button themes instead of `opacity-50` for inactive state to improve theme support and contrast.
>   - **Styling Adjustments**:
>     - Adjust `gap` and `max-width` properties for different screen sizes to enhance layout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9fe82c5cd2c10b1bbb80b5b4b2e295f94bd32af3. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->