### PR TITLE
fix(action): handle edge case for add to context action

### DIFF
--- a/src/shared/__tests__/support-prompts.test.ts
+++ b/src/shared/__tests__/support-prompts.test.ts
@@ -86,6 +86,123 @@ describe("Code Action Prompts", () => {
 		})
 	})
 
+	describe("ADD_TO_CONTEXT action", () => {
+		it("should format ADD_TO_CONTEXT prompt correctly with all parameters", () => {
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				name: "Roo",
+				place: "Workspace",
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "1",
+				endLine: "1",
+				diagnostics: [],
+			})
+			const expected = `${testFilePath}:1-1\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should format ADD_TO_CONTEXT prompt with diagnostics", () => {
+			const diagnostics = [{ message: "Error 1" }, { source: "Linter", message: "Warning 2" }]
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "10",
+				endLine: "20",
+				diagnostics,
+			})
+			const expected = `${testFilePath}:10-20\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should not replace placeholders within parameter values", () => {
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				value1: "This is ${value2}",
+				value2: "Actual Value 2",
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "5",
+				endLine: "15",
+			})
+			const expected = `${testFilePath}:5-15\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should replace remaining placeholders (not in params) with empty strings", () => {
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				name: "Roo",
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "1",
+				endLine: "1",
+			}) // 'status' is missing
+			const expected = `${testFilePath}:1-1\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should handle placeholders in values that are not in the template", () => {
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				data: "Some data with ${extraInfo}",
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "1",
+				endLine: "1",
+			})
+			const expected = `${testFilePath}:1-1\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should handle minimal params object", () => {
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "1",
+				endLine: "1",
+			})
+			const expected = `${testFilePath}:1-1\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should handle params with non-string values", () => {
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				count: "5",
+				isActive: "true",
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "1",
+				endLine: "1",
+			}) // Convert to strings
+			const expected = `${testFilePath}:1-1\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should handle keys with special regex characters", () => {
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				"key.with.dots": "Dotty",
+				value: "Simple",
+				filePath: testFilePath,
+				selectedText: testCode,
+				startLine: "1",
+				endLine: "1",
+			})
+			const expected = `${testFilePath}:1-1\n\`\`\`\n${testCode}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+
+		it("should handle bash script selection", () => {
+			const bashText =
+				'if [ "${#usecase_deployments[@]}" -gt 0 ] && [ ${{ parameters.single_deployment_per_environment }} = true ]; then'
+			const prompt = supportPrompt.create("ADD_TO_CONTEXT", {
+				selectedText: bashText,
+				filePath: testFilePath,
+				startLine: "1",
+				endLine: "1",
+				diagnostics: [],
+			})
+			const expected = `${testFilePath}:1-1\n\`\`\`\n${bashText}\n\`\`\``
+			expect(prompt).toBe(expected)
+		})
+	})
+
 	describe("get template", () => {
 		it("should return default template when no custom prompts provided", () => {
 			const template = supportPrompt.get(undefined, "EXPLAIN")

--- a/src/shared/support-prompt.ts
+++ b/src/shared/support-prompt.ts
@@ -9,19 +9,23 @@ const generateDiagnosticText = (diagnostics?: any[]) => {
 }
 
 export const createPrompt = (template: string, params: PromptParams): string => {
-	let result = template
-	for (const [key, value] of Object.entries(params)) {
-		if (key === "diagnostics") {
-			result = result.replaceAll("${diagnosticText}", generateDiagnosticText(value as any[]))
+	return template.replace(/\${(.*?)}/g, (_, key) => {
+		if (key === "diagnosticText") {
+			return generateDiagnosticText(params["diagnostics"] as any[])
+		} else if (params.hasOwnProperty(key)) {
+			// Ensure the value is treated as a string for replacement
+			const value = params[key]
+			if (typeof value === "string") {
+				return value
+			} else {
+				// Convert non-string values to string for replacement
+				return String(value)
+			}
 		} else {
-			result = result.replaceAll(`\${${key}}`, value as string)
+			// If the placeholder key is not in params, replace with empty string
+			return ""
 		}
-	}
-
-	// Replace any remaining placeholders with empty strings
-	result = result.replaceAll(/\${[^}]*}/g, "")
-
-	return result
+	})
 }
 
 interface SupportPromptConfig {


### PR DESCRIPTION
## Context

Fixes #2060. This is caused by double replacement so any string that contains `${...}` will get replaced to empty string

## Implementation

I've changed the replace implementation and added some tests. It basically reverses the order of how we replace them. Instead of checking the keys of the params object, we check against the string match and see if it's available in the params object. Otherwise it won't get replaced.

## Screenshots

((sorry for the poor quality))

https://github.com/user-attachments/assets/5a5164ac-a37c-4293-997e-a5c006dc6e45

## How to Test

Select some text like `${foo bar}` for example, go to code action -> add to context, you should see it being inserted correctly now.

## Get in Touch

@elianiva

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes placeholder replacement issue in `ADD_TO_CONTEXT` action by changing replacement logic in `createPrompt()` and adds tests for verification.
> 
>   - **Behavior**:
>     - Fixes edge case in `ADD_TO_CONTEXT` action where placeholders like `${...}` were incorrectly replaced with empty strings.
>     - Changes replacement logic in `createPrompt()` in `support-prompt.ts` to check against string matches instead of param keys.
>     - Ensures placeholders not in params are replaced with empty strings.
>   - **Tests**:
>     - Adds tests in `support-prompts.test.ts` for `ADD_TO_CONTEXT` action to verify correct placeholder handling.
>     - Tests include scenarios with diagnostics, non-string values, special regex characters, and bash script selections.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3877e1acdf6f539da9df0c600d945ba78409a25f. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->