### PR TITLE
Remove the strict line bounds check from the diff

### DIFF
--- a/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.test.ts
@@ -2256,6 +2256,85 @@ function two() {
 }`)
 			}
 		})
+
+		it("should fail when line range is far outside file bounds", async () => {
+			const originalContent = `
+function one() {
+		  return 1;
+}
+
+function two() {
+		  return 2;
+}
+
+function three() {
+		  return 3;
+}
+`.trim()
+			const diffContent = `test.ts
+<<<<<<< SEARCH
+:start_line:1000
+-------
+function three() {
+		  return 3;
+}
+=======
+function three() {
+		  return "three";
+}
+>>>>>>> REPLACE`
+
+			// Line 1000 is way outside the bounds of the file (10 lines)
+			// and outside of any reasonable buffer range, so it should fail
+			const result = await strategy.applyDiff(originalContent, diffContent, 1000)
+			expect(result.success).toBe(false)
+		})
+
+		it("should find match when line range is slightly out of bounds but within buffer zone", async () => {
+			const originalContent = `
+function one() {
+		  return 1;
+}
+
+function two() {
+		  return 2;
+}
+
+function three() {
+		  return 3;
+}
+`.trim()
+			const diffContent = `test.ts
+<<<<<<< SEARCH
+:start_line:11
+-------
+function three() {
+		  return 3;
+}
+=======
+function three() {
+		  return "three";
+}
+>>>>>>> REPLACE`
+
+			// File only has 10 lines, but we specify line 11
+			// It should still find the match since it's within the buffer zone (5 lines)
+			const result = await strategy.applyDiff(originalContent, diffContent, 11)
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.content).toBe(`function one() {
+		  return 1;
+}
+
+function two() {
+		  return 2;
+}
+
+function three() {
+		  return "three";
+}`)
+			}
+		})
 	})
 
 	describe("getToolDescription", () => {

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -430,14 +430,6 @@ Only use a single line of '=======' between search and replacement content, beca
 				const searchLen = searchLines.length
 				const exactEndIndex = exactStartIndex + searchLen - 1
 
-				if (exactStartIndex < 0 || exactEndIndex >= resultLines.length) {
-					diffResults.push({
-						success: false,
-						error: `Line range ${startLine}-${startLine + searchLen - 1} is invalid (file has ${resultLines.length} lines)\n\nDebug Info:\n- Requested Range: lines ${startLine}-${startLine + searchLen - 1}\n- File Bounds: lines 1-${resultLines.length}`,
-					})
-					continue
-				}
-
 				// Try exact match first
 				const originalChunk = resultLines.slice(exactStartIndex, exactEndIndex + 1).join("\n")
 				const similarity = getSimilarity(originalChunk, searchChunk)


### PR DESCRIPTION
LLMs aren't great at line numbers. No reason to fail if their estimates are slightly off but still within the buffer range.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes strict line bounds check in `applyDiff()` to allow matches within a buffer zone, with new tests added.
> 
>   - **Behavior**:
>     - Removes strict line bounds check in `applyDiff()` in `multi-search-replace.ts`, allowing matches slightly out of bounds but within a buffer zone.
>     - If line range is far outside file bounds, the operation still fails.
>   - **Tests**:
>     - Adds test `should find match when line range is slightly out of bounds but within buffer zone` in `multi-search-replace.test.ts`.
>     - Adds test `should fail when line range is far outside file bounds` in `multi-search-replace.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 24af7a0c502d7dc2ff7c048dab96d65971b5c22f. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->