### PR TITLE
Adds Gemini 2.5 Flash "thinking" model to Vertex AI Provider

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -477,6 +477,16 @@ export const openRouterDefaultModelInfo: ModelInfo = {
 export type VertexModelId = keyof typeof vertexModels
 export const vertexDefaultModelId: VertexModelId = "claude-3-7-sonnet@20250219"
 export const vertexModels = {
+	"gemini-2.5-flash-preview-04-17:thinking": {
+		maxTokens: 65_535,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: false,
+		inputPrice: 0.15,
+		outputPrice: 3.5,
+		thinking: true,
+		maxThinkingTokens: 24_576,
+	},
 	"gemini-2.5-flash-preview-04-17": {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,
@@ -484,6 +494,7 @@ export const vertexModels = {
 		supportsPromptCache: false,
 		inputPrice: 0.15,
 		outputPrice: 0.6,
+		thinking: false,
 	},
 	"gemini-2.5-pro-preview-03-25": {
 		maxTokens: 65_535,


### PR DESCRIPTION
## Context

Vertex AI: Adds a Gemini 2.5 Flash model variant that supports "thinking" mode, with a different output price and token limit during thinking.

## Implementation

Add Gemini Flash 2.5 thinking to api.ts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Gemini 2.5 Flash "thinking" model to Vertex AI provider in `api.ts`, supporting a new mode with specific pricing and token limits.
> 
>   - **Behavior**:
>     - Adds `gemini-2.5-flash-preview-04-17:thinking` model to `vertexModels` in `api.ts`.
>     - Supports "thinking" mode with `maxThinkingTokens` of 24,576.
>     - Different `outputPrice` of 3.5 compared to non-thinking variant.
>   - **Attributes**:
>     - `maxTokens`: 65,535, `contextWindow`: 1,048,576.
>     - `supportsImages`: true, `supportsPromptCache`: false.
>     - `inputPrice`: 0.15, `thinking`: true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c72a2bc4e767c724f8c6dfd3b73e405bbd7e9fa9. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->