### PR TITLE
Quickfix: Change cloud-download icon to more appropriate desktop-download icon.

### DIFF
--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -212,7 +212,7 @@ const TaskActions = ({ item }: { item: HistoryItem | undefined }) => {
 				size="sm"
 				title={t("chat:task.export")}
 				onClick={() => vscode.postMessage({ type: "exportCurrentTask" })}>
-				<span className="codicon codicon-cloud-download" />
+				<span className="codicon codicon-desktop-download" />
 			</Button>
 			{!!item?.size && item.size > 0 && (
 				<>

--- a/webview-ui/src/components/history/ExportButton.tsx
+++ b/webview-ui/src/components/history/ExportButton.tsx
@@ -15,7 +15,7 @@ export const ExportButton = ({ itemId }: { itemId: string }) => {
 				e.stopPropagation()
 				vscode.postMessage({ type: "exportTaskWithId", text: itemId })
 			}}>
-			<span className="codicon codicon-cloud-download" />
+			<span className="codicon codicon-desktop-download" />
 		</Button>
 	)
 }


### PR DESCRIPTION
## Context

Quick precision strike here: Change the task download icon (currently codicon-cloud-download) to a more appropriate codicon-desktop-download icon — as we're not loading the context from the cloud at all, of course. This applies to both the Task Header in Chat view as well as the Task History list — the two places this icon shows up. 

## Screenshot

Before and after: 

![Screenshot 2025-04-20 at 8 54 33 PM](https://github.com/user-attachments/assets/bd320da3-7600-4314-b01d-fe0a73246d2e)


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change icon from `cloud-download` to `desktop-download` in `TaskHeader.tsx` and `ExportButton.tsx`.
> 
>   - **Icon Change**:
>     - In `TaskHeader.tsx`, change icon from `codicon-cloud-download` to `codicon-desktop-download` in `TaskActions`.
>     - In `ExportButton.tsx`, change icon from `codicon-cloud-download` to `codicon-desktop-download` in `ExportButton`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e3dfbb2bc7f68e321668bb3723bf0e8020ba4e94. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->