### PR TITLE
Revert changes on omitted line count in write_to_file

### DIFF
--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -115,7 +115,7 @@ export async function writeToFileTool(
 				cline.consecutiveMistakeCount++
 				cline.recordToolError("write_to_file")
 				pushToolResult(await cline.sayAndCreateMissingParamError("write_to_file", "line_count"))
-				await cline.diffViewProvider.reset()
+				await cline.diffViewProvider.revertChanges()
 				return
 			}
 


### PR DESCRIPTION
Fixes a bug where omitted line_count in write_to_file would leave the diff view open and would overwrite content on repeated errors.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `writeToFileTool` by changing `reset()` to `revertChanges()` for omitted `line_count`, preventing open diff view and content overwrite.
> 
>   - **Behavior**:
>     - In `writeToFileTool`, change `cline.diffViewProvider.reset()` to `cline.diffViewProvider.revertChanges()` when `line_count` is omitted.
>     - Fixes bug where omitted `line_count` left diff view open and overwrote content on repeated errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 69f8f6bd32d83722c31ca0681c8a8dfc6acb0011. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->