### PR TITLE
Fix: custom modes export import

### DIFF
--- a/src/core/config/ContextProxy.ts
+++ b/src/core/config/ContextProxy.ts
@@ -229,6 +229,10 @@ export class ContextProxy {
 	public async export(): Promise<GlobalSettings | undefined> {
 		try {
 			const globalSettings = globalSettingsExportSchema.parse(this.getValues())
+
+			// Exports should only contain global settings, so this skips project custom modes (those exist in the .roomode folder)
+			globalSettings.customModes = globalSettings.customModes?.filter((mode) => mode.source === "global")
+
 			return Object.fromEntries(Object.entries(globalSettings).filter(([_, value]) => value !== undefined))
 		} catch (error) {
 			if (error instanceof ZodError) {

--- a/src/core/config/__tests__/importExport.test.ts
+++ b/src/core/config/__tests__/importExport.test.ts
@@ -277,8 +277,18 @@ describe("importExport", () => {
 	it("should call updateCustomMode for each custom mode in config", async () => {
 		;(vscode.window.showOpenDialog as jest.Mock).mockResolvedValue([{ fsPath: "/mock/path/settings.json" }])
 		const customModes = [
-			{ slug: "mode1", name: "Mode One" },
-			{ slug: "mode2", name: "Mode Two" },
+			{
+				slug: "mode1",
+				name: "Mode One",
+				roleDefinition: "Custom role one",
+				groups: [],
+			},
+			{
+				slug: "mode2",
+				name: "Mode Two",
+				roleDefinition: "Custom role two",
+				groups: [],
+			},
 		]
 		const mockFileContent = JSON.stringify({
 			providerProfiles: {

--- a/src/core/config/__tests__/importExport.test.ts
+++ b/src/core/config/__tests__/importExport.test.ts
@@ -9,6 +9,7 @@ import { ProviderName } from "../../../schemas"
 import { importSettings, exportSettings } from "../importExport"
 import { ProviderSettingsManager } from "../ProviderSettingsManager"
 import { ContextProxy } from "../ContextProxy"
+import { CustomModesManager } from "../CustomModesManager"
 
 // Mock VSCode modules
 jest.mock("vscode", () => ({
@@ -37,6 +38,7 @@ describe("importExport", () => {
 	let mockProviderSettingsManager: jest.Mocked<ProviderSettingsManager>
 	let mockContextProxy: jest.Mocked<ContextProxy>
 	let mockExtensionContext: jest.Mocked<vscode.ExtensionContext>
+	let mockCustomModesManager: jest.Mocked<CustomModesManager>
 
 	beforeEach(() => {
 		// Reset all mocks
@@ -56,6 +58,11 @@ describe("importExport", () => {
 			export: jest.fn().mockImplementation(() => Promise.resolve({})),
 		} as unknown as jest.Mocked<ContextProxy>
 
+		// Setup customModesManager mock
+		mockCustomModesManager = {
+			updateCustomMode: jest.fn(),
+		} as unknown as jest.Mocked<CustomModesManager>
+
 		const map = new Map<string, string>()
 
 		mockExtensionContext = {
@@ -74,6 +81,7 @@ describe("importExport", () => {
 			const result = await importSettings({
 				providerSettingsManager: mockProviderSettingsManager,
 				contextProxy: mockContextProxy,
+				customModesManager: mockCustomModesManager,
 			})
 
 			expect(result).toEqual({ success: false })
@@ -138,6 +146,7 @@ describe("importExport", () => {
 			const result = await importSettings({
 				providerSettingsManager: mockProviderSettingsManager,
 				contextProxy: mockContextProxy,
+				customModesManager: mockCustomModesManager,
 			})
 
 			expect(result.success).toBe(true)
@@ -181,6 +190,7 @@ describe("importExport", () => {
 			const result = await importSettings({
 				providerSettingsManager: mockProviderSettingsManager,
 				contextProxy: mockContextProxy,
+				customModesManager: mockCustomModesManager,
 			})
 
 			expect(result).toEqual({ success: false })
@@ -202,6 +212,7 @@ describe("importExport", () => {
 			const result = await importSettings({
 				providerSettingsManager: mockProviderSettingsManager,
 				contextProxy: mockContextProxy,
+				customModesManager: mockCustomModesManager,
 			})
 
 			expect(result).toEqual({ success: false })
@@ -220,6 +231,7 @@ describe("importExport", () => {
 			const result = await importSettings({
 				providerSettingsManager: mockProviderSettingsManager,
 				contextProxy: mockContextProxy,
+				customModesManager: mockCustomModesManager,
 			})
 
 			expect(result).toEqual({ success: false })
@@ -252,12 +264,47 @@ describe("importExport", () => {
 			const result = await importSettings({
 				providerSettingsManager,
 				contextProxy: mockContextProxy,
+				customModesManager: mockCustomModesManager,
 			})
 
 			expect(result.success).toBe(true)
 			expect(result.providerProfiles?.apiConfigs["openai"]).toBeDefined()
 			expect(result.providerProfiles?.apiConfigs["default"]).toBeDefined()
 			expect(result.providerProfiles?.apiConfigs["default"].apiProvider).toBe("anthropic")
+		})
+	})
+
+	it("should call updateCustomMode for each custom mode in config", async () => {
+		;(vscode.window.showOpenDialog as jest.Mock).mockResolvedValue([{ fsPath: "/mock/path/settings.json" }])
+		const customModes = [
+			{ slug: "mode1", name: "Mode One" },
+			{ slug: "mode2", name: "Mode Two" },
+		]
+		const mockFileContent = JSON.stringify({
+			providerProfiles: {
+				currentApiConfigName: "test",
+				apiConfigs: {},
+			},
+			globalSettings: {
+				mode: "code",
+				customModes,
+			},
+		})
+		;(fs.readFile as jest.Mock).mockResolvedValue(mockFileContent)
+		mockProviderSettingsManager.export.mockResolvedValue({
+			currentApiConfigName: "test",
+			apiConfigs: {},
+		})
+		mockProviderSettingsManager.listConfig.mockResolvedValue([])
+		const result = await importSettings({
+			providerSettingsManager: mockProviderSettingsManager,
+			contextProxy: mockContextProxy,
+			customModesManager: mockCustomModesManager,
+		})
+		expect(result.success).toBe(true)
+		expect(mockCustomModesManager.updateCustomMode).toHaveBeenCalledTimes(customModes.length)
+		customModes.forEach((mode) => {
+			expect(mockCustomModesManager.updateCustomMode).toHaveBeenCalledWith(mode.slug, mode)
 		})
 	})
 

--- a/src/core/config/importExport.ts
+++ b/src/core/config/importExport.ts
@@ -8,13 +8,20 @@ import { z } from "zod"
 import { globalSettingsSchema } from "../../schemas"
 import { ProviderSettingsManager, providerProfilesSchema } from "./ProviderSettingsManager"
 import { ContextProxy } from "./ContextProxy"
+import { CustomModesManager } from "./CustomModesManager"
 
-type ImportExportOptions = {
+type ImportOptions = {
+	providerSettingsManager: ProviderSettingsManager
+	contextProxy: ContextProxy
+	customModesManager: CustomModesManager
+}
+
+type ExportOptions = {
 	providerSettingsManager: ProviderSettingsManager
 	contextProxy: ContextProxy
 }
 
-export const importSettings = async ({ providerSettingsManager, contextProxy }: ImportExportOptions) => {
+export const importSettings = async ({ providerSettingsManager, contextProxy, customModesManager }: ImportOptions) => {
 	const uris = await vscode.window.showOpenDialog({
 		filters: { JSON: ["json"] },
 		canSelectMany: false,
@@ -31,7 +38,6 @@ export const importSettings = async ({ providerSettingsManager, contextProxy }: 
 
 	try {
 		const previousProviderProfiles = await providerSettingsManager.export()
-
 		const { providerProfiles: newProviderProfiles, globalSettings } = schema.parse(
 			JSON.parse(await fs.readFile(uris[0].fsPath, "utf-8")),
 		)
@@ -48,6 +54,10 @@ export const importSettings = async ({ providerSettingsManager, contextProxy }: 
 			},
 		}
 
+		await Promise.all(
+			(globalSettings.customModes ?? []).map((mode) => customModesManager.updateCustomMode(mode.slug, mode)),
+		)
+
 		await providerSettingsManager.import(newProviderProfiles)
 
 		await contextProxy.setValues(globalSettings)
@@ -60,7 +70,7 @@ export const importSettings = async ({ providerSettingsManager, contextProxy }: 
 	}
 }
 
-export const exportSettings = async ({ providerSettingsManager, contextProxy }: ImportExportOptions) => {
+export const exportSettings = async ({ providerSettingsManager, contextProxy }: ExportOptions) => {
 	const uri = await vscode.window.showSaveDialog({
 		filters: { JSON: ["json"] },
 		defaultUri: vscode.Uri.file(path.join(os.homedir(), "Documents", "roo-code-settings.json")),

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -364,6 +364,7 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 			const { success } = await importSettings({
 				providerSettingsManager: provider.providerSettingsManager,
 				contextProxy: provider.contextProxy,
+				customModesManager: provider.customModesManager,
 			})
 
 			if (success) {


### PR DESCRIPTION
## Context

Import settings was not importing custom modes as mentioned on https://github.com/RooVetGit/Roo-Code/issues/2209

## Implementation

The issue was that the custom modes where loaded into the `ContextProxy` state -- but this is data is actually managed by the `CustomModesManager`. This PR fixes the issue by loading the data into the manager.

In addition to the above, the export feature was updated to NOT export project specific modes since those live in the .roomode folder

## How to Test

### Test Case: Project custom modes are not included in exports
Do a config export in a project that has custom modes (the roo code repo have a couple), then check the export to see that no custom mode with source set to `project` exist. 

### Test Case: Custom modes are loaded
Get an export with custom modes, and import into a clean roocode setup. You should see your custom modes imported.

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

Discor handle: profotium

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix import/export of custom modes by managing them with `CustomModesManager` and excluding project-specific modes from exports.
> 
>   - **Behavior**:
>     - Fix import of custom modes by loading them into `CustomModesManager` instead of `ContextProxy` in `importSettings()` in `importExport.ts`.
>     - Update export in `ContextProxy.ts` to exclude project-specific modes by filtering `customModes` with `source === "global"`.
>   - **Tests**:
>     - Add test in `importExport.test.ts` to verify `updateCustomMode` is called for each custom mode during import.
>     - Add test to ensure project-specific modes are not included in exports.
>   - **Misc**:
>     - Update `webviewMessageHandler.ts` to pass `customModesManager` to `importSettings()` call.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4aaa8d0ba94c1001bce557c24cdb1fd0c4404b58. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->