### PR TITLE
Fix: focusInput open roo code panel (#2626)

### DIFF
--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -115,14 +115,18 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			await promptForCustomStoragePath()
 		},
 		"roo-cline.focusInput": async () => {
-			const panel = getPanel()
-			if (!panel) {
-				await vscode.commands.executeCommand("workbench.view.extension.roo-cline-ActivityBar")
-			} else if (panel === tabPanel) {
-				panel.reveal(vscode.ViewColumn.Active, false)
-			} else if (panel === sidebarPanel) {
-				await vscode.commands.executeCommand(`${ClineProvider.sideBarId}.focus`)
-				provider.postMessageToWebview({ type: "action", action: "focusInput" })
+			try {
+				const panel = getPanel()
+				if (!panel) {
+					await vscode.commands.executeCommand("workbench.view.extension.roo-cline-ActivityBar")
+				} else if (panel === tabPanel) {
+					panel.reveal(vscode.ViewColumn.Active, false)
+				} else if (panel === sidebarPanel) {
+					await vscode.commands.executeCommand(`${ClineProvider.sideBarId}.focus`)
+					provider.postMessageToWebview({ type: "action", action: "focusInput" })
+				}
+			} catch (error) {
+				outputChannel.appendLine(`Error focusing input: ${error}`)
 			}
 		},
 		"roo.acceptInput": () => {

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -114,8 +114,16 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			const { promptForCustomStoragePath } = await import("../shared/storagePathManager")
 			await promptForCustomStoragePath()
 		},
-		"roo-cline.focusInput": () => {
-			provider.postMessageToWebview({ type: "action", action: "focusInput" })
+		"roo-cline.focusInput": async () => {
+			const panel = getPanel()
+			if (!panel) {
+				await vscode.commands.executeCommand("workbench.view.extension.roo-cline-ActivityBar")
+			} else if (panel === tabPanel) {
+				panel.reveal(vscode.ViewColumn.Active, false)
+			} else if (panel === sidebarPanel) {
+				await vscode.commands.executeCommand(`${ClineProvider.sideBarId}.focus`)
+				provider.postMessageToWebview({ type: "action", action: "focusInput" })
+			}
 		},
 		"roo.acceptInput": () => {
 			const visibleProvider = getVisibleProviderOrLog(outputChannel)


### PR DESCRIPTION
* Fix: `roo-cline.focusInput` open roo code panel

## Context

This change addresses an issue where the `roo-cline.focusInput` command did not reliably open or focus the Roo Code panel in various scenarios. The goal is to ensure that executing this command consistently brings the Roo Code panel into view and focuses the input field, regardless of the panel's current state (non-existent, closed, inactive tab, or hidden behind other views). This fix ensures the command works correctly when:
1. The Roo Code webview hasn't resolved yet after VS Code starts (panel doesn't exist).
2. The sidebar containing the Roo Code panel is closed, or another panel is active.
3. The Roo Code panel is open in a tab but is hidden behind another active tab.

## Implementation


The implementation modifies the command handler for `roo-cline.focusInput` within `src/activate/registerCommands.ts`.

The updated logic now checks the current state of the Roo Code panel using `getPanel()`:

1.  **Panel Not Found (`!panel`):** If the panel (webview) hasn't resolved or doesn't exist (e.g., shortly after VS Code startup), it executes `workbench.view.extension.roo-cline-ActivityBar` to open the Roo Code view in the activity bar, which subsequently creates and reveals the panel. 
2.  **Panel is a Tab (`panel === tabPanel`):** If the panel exists as a tab but might be inactive (hidden by another tab), it calls `panel.reveal(vscode.ViewColumn.Active, false)` to bring the Roo Code tab to the front. 
3.  **Panel is in Sidebar (`panel === sidebarPanel`):** If the panel is in the sidebar but might be hidden (sidebar closed or another view focused), it first executes `${ClineProvider.sideBarId}.focus` to ensure the Roo Code sidebar view is focused, and *then* sends the `focusInput` action to the webview via `provider.postMessageToWebview` to explicitly focus the input field.

This approach handles the different ways the panel can exist (or not exist) within the VS Code UI, ensuring the `focusInput` command behaves predictably.

## Screenshots

| before                                     | after                                      |
| :----------------------------------------- | :----------------------------------------- |
| N/A (Behavioral change, no UI difference) | N/A (Behavioral change, no UI difference) |


## How to Test


1.  **Scenario 1: Panel not yet resolved**
    *   Restart VS Code with the Roo Code extension enabled.
    *   Immediately after startup (before the Roo Code panel might appear automatically), execute the `Roo Code: Focus Input Field` command from the command palette (`Cmd/Ctrl+Shift+P`).
    *   **Expected:** The Roo Code panel should open (either in the sidebar or as a tab, depending on configuration), and the input field should eventually gain focus as the panel loads.

2.  **Scenario 2: Sidebar closed or different panel visible**
    *   Ensure the Roo Code panel is configured to open in the sidebar.
    *   Close the sidebar entirely, or switch to a different view in the sidebar (e.g., Explorer).
    *   Execute the `Roo Code: Focus Input Field` command.
    *   **Expected:** The sidebar should open (if closed), the Roo Code panel should become visible, and the input field should be focused.

3.  **Scenario 3: Panel open in a tab but hidden**
    *   Ensure the Roo Code panel is configured to open as a tab.
    *   Open the Roo Code panel tab.
    *   Open another file or tab, making it the active tab and hiding the Roo Code tab.
    *   Execute the `Roo Code: Focus Input Field` command.
    *   **Expected:** The Roo Code tab should become the active tab, and the input field should be focused.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `roo-cline.focusInput` command to reliably open and focus the Roo Code panel by handling various panel states in `registerCommands.ts`.
> 
>   - **Behavior**:
>     - Fixes `roo-cline.focusInput` command to reliably open and focus the Roo Code panel.
>     - Handles cases where the panel is non-existent, closed, inactive, or hidden.
>   - **Implementation**:
>     - Modifies `roo-cline.focusInput` in `registerCommands.ts` to check panel state using `getPanel()`.
>     - Executes `workbench.view.extension.roo-cline-ActivityBar` if panel doesn't exist.
>     - Calls `panel.reveal(vscode.ViewColumn.Active, false)` if panel is a hidden tab.
>     - Executes `${ClineProvider.sideBarId}.focus` and sends `focusInput` action if panel is in sidebar.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5c1e7b521eca6108cee7e45a01e6db768fcfe812. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->