### PR TITLE
Fix MCP hub lookup during view transition

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -46,6 +46,7 @@ import { UrlContentFetcher } from "../services/browser/UrlContentFetcher"
 import { listFiles } from "../services/glob/list-files"
 import { BrowserSession } from "../services/browser/BrowserSession"
 import { McpHub } from "../services/mcp/McpHub"
+import { McpServerManager } from "../services/mcp/McpServerManager"
 import { telemetryService } from "../services/telemetry/TelemetryService"
 import { CheckpointServiceOptions, RepoPerTaskCheckpointService } from "../services/checkpoints"
 
@@ -969,12 +970,19 @@ export class Cline extends EventEmitter<ClineEvents> {
 		this.lastApiRequestTime = Date.now()
 
 		if (mcpEnabled ?? true) {
-			mcpHub = this.providerRef.deref()?.getMcpHub()
-			if (!mcpHub) {
-				throw new Error("MCP hub not available")
+			const provider = this.providerRef.deref()
+			if (!provider) {
+				throw new Error("Provider reference lost during view transition")
 			}
+
+			// Wait for MCP hub initialization through McpServerManager
+			mcpHub = await McpServerManager.getInstance(provider.context, provider)
+			if (!mcpHub) {
+				throw new Error("Failed to get MCP hub from server manager")
+			}
+
 			// Wait for MCP servers to be connected before generating system prompt
-			await pWaitFor(() => mcpHub!.isConnecting !== true, { timeout: 10_000 }).catch(() => {
+			await pWaitFor(() => !mcpHub!.isConnecting, { timeout: 10_000 }).catch(() => {
 				console.error("MCP servers failed to connect in time")
 			})
 		}


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/fb07adff-fef7-4e80-950b-438399244126

After:

https://github.com/user-attachments/assets/182caf00-e210-47b2-91f9-f368ba19b2f0


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes MCP hub lookup during view transition in `Cline` by using `McpServerManager` for initialization and connection.
> 
>   - **Behavior**:
>     - Fixes MCP hub lookup during view transition in `Cline` class by using `McpServerManager` to initialize the hub.
>     - Throws error if provider reference is lost or MCP hub retrieval fails.
>     - Ensures MCP servers are connected before proceeding, with a timeout of 10 seconds.
>   - **Imports**:
>     - Adds import for `McpServerManager` in `Cline.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dd528413b1e733e5d23bbd356e86c6fdb101dccf. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->