### PR TITLE
Add line wrapping to MCP arguments

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1174,6 +1174,7 @@ export const ChatRowContent = ({
 													language="json"
 													isExpanded={true}
 													onToggleExpand={onToggleExpand}
+													forceWrap={true}
 												/>
 											</div>
 										)}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -14,6 +14,7 @@ interface CodeAccordianProps {
 	onToggleExpand: () => void
 	isLoading?: boolean
 	progressStatus?: ToolProgressStatus
+	forceWrap?: boolean
 }
 
 /*
@@ -38,6 +39,7 @@ const CodeAccordian = ({
 	onToggleExpand,
 	isLoading,
 	progressStatus,
+	forceWrap,
 }: CodeAccordianProps) => {
 	const inferredLanguage = useMemo(
 		() => code && (language ?? (path ? getLanguageFromPath(path) : undefined)),
@@ -126,6 +128,7 @@ const CodeAccordian = ({
 							diff ??
 							""
 						).trim()}\n${"```"}`}
+						forceWrap={forceWrap}
 					/>
 				</div>
 			)}


### PR DESCRIPTION
Got some feedback that it was hard to read the MCP arguments.

Before:

![Screenshot 2025-04-22 at 12 09 59 AM](https://github.com/user-attachments/assets/add03b4b-6861-4582-9155-421a5ab8b420)

After:

![Screenshot 2025-04-22 at 12 09 43 AM](https://github.com/user-attachments/assets/b783639c-474a-400f-b813-5866f393fffa)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds line wrapping to MCP arguments in the chat interface by introducing a `forceWrap` prop in `CodeAccordian`.
> 
>   - **Behavior**:
>     - Adds `forceWrap` prop to `CodeAccordian` in `CodeAccordian.tsx` to enable line wrapping.
>     - Updates `ChatRow.tsx` to use `forceWrap` for better readability of MCP arguments.
>   - **Components**:
>     - Modifies `CodeAccordian` component to accept `forceWrap` prop.
>     - Updates `ChatRowContent` in `ChatRow.tsx` to pass `forceWrap` to `CodeAccordian`.
>   - **Misc**:
>     - Improves readability of MCP arguments in the chat interface.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4d978b1b59c854c45671e3b492edf7483ba840bc. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->