### PR TITLE
Fix redundant 'TASK RESUMPTION' prompts

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -845,8 +845,15 @@ export class Cline extends EventEmitter<ClineEvents> {
 			return "just now"
 		})()
 
-		const wasRecent = lastClineMessage?.ts && Date.now() - lastClineMessage.ts < 30_000
+		const lastTaskResumptionIndex = newUserContent.findIndex(
+			(x) => x.type === "text" && x.text.startsWith("[TASK RESUMPTION]"),
+		)
+		if (lastTaskResumptionIndex !== -1) {
+			newUserContent.splice(lastTaskResumptionIndex, newUserContent.length - lastTaskResumptionIndex)
+		}
 
+		const wasRecent = lastClineMessage?.ts && Date.now() - lastClineMessage.ts < 30_000
+		
 		newUserContent.push({
 			type: "text",
 			text:


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

Fix #2836 
I have tested the case where the user actively sends '[TASK RESUMPTION]'

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes redundant '[TASK RESUMPTION]' prompts in `resumeTaskFromHistory()` in `Cline.ts` by removing existing prompts before adding a new one.
> 
>   - **Behavior**:
>     - Removes redundant '[TASK RESUMPTION]' prompts in `resumeTaskFromHistory()` in `Cline.ts` by clearing existing prompts before adding a new one.
>   - **Implementation**:
>     - Identifies and removes existing '[TASK RESUMPTION]' prompts in `newUserContent` before appending a new prompt.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 201d671533db497aae9199a91dbaf2ae785e0a62. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->