### PR TITLE
Fix error message not showing after canceling API request

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -936,6 +936,8 @@ export class Cline extends EventEmitter<ClineEvents> {
 		if (this.isStreaming && this.diffViewProvider.isEditing) {
 			await this.diffViewProvider.revertChanges()
 		}
+		// Save the countdown message in the automatic retry or other content
+		await this.saveClineMessages()
 	}
 
 	// Tools

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -591,8 +591,13 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				case "api_req_deleted": // aggregated api_req metrics from deleted messages
 					return false
 				case "api_req_retry_delayed":
-					// Only show the retry message if it's the last message
-					return message === modifiedMessages.at(-1)
+					// Only show the retry message if it's the last message or the last messages is api_req_retry_delayed+resume_task
+					const last1 = modifiedMessages.at(-1)
+					const last2 = modifiedMessages.at(-2)
+					if (last1?.ask === "resume_task" && last2 === message) {
+						return true
+					}
+					return message === last1
 				case "text":
 					// Sometimes cline returns an empty text message, we don't want to render these. (We also use a say text for user messages, so in case they just sent images we still render that)
 					if ((message.text ?? "") === "" && (message.images?.length ?? 0) === 0) {


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->
Fix #2837 
It is now possible to promptly stop API request when an unrecoverable error occurs and view the error message afterwards

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|   ![image](https://github.com/user-attachments/assets/4e065299-d5cf-4904-bc94-fb7a0c1cbe4f)    |    ![image](https://github.com/user-attachments/assets/b98e2a73-0874-4421-8fcb-3ac1b6709820)   |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error message visibility after canceling API requests by saving messages on task abort and updating retry message conditions in `Cline.ts` and `ChatView.tsx`.
> 
>   - **Behavior**:
>     - In `Cline.ts`, `saveClineMessages()` is now called after aborting a task to ensure messages are saved when an API request is canceled.
>     - In `ChatView.tsx`, the condition for displaying `api_req_retry_delayed` messages is updated to show the message if it's the last message or if the last message is `api_req_retry_delayed` followed by `resume_task`.
>   - **Functions**:
>     - `abortTask()` in `Cline.ts` now includes a call to `saveClineMessages()` to save the countdown message or other content.
>     - `visibleMessages` in `ChatView.tsx` filters messages to ensure only relevant retry messages are shown.
>   - **Misc**:
>     - Minor adjustments to message handling logic in `ChatView.tsx` to improve UI responsiveness and message visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 669a28624d2e97694d1c2c0f0ec6e9fc17183646. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->