### PR TITLE
Allow Amazon Bedrock Marketplace ARNs

### DIFF
--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -532,7 +532,7 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 		 * match[4] - The resource ID (e.g., "anthropic.claude-3-sonnet-20240229-v1:0")
 		 */
 
-		const arnRegex = /^arn:aws:bedrock:([^:]+):([^:]*):(?:([^\/]+)\/([\w\.\-:]+)|([^\/]+))$/
+		const arnRegex = /^arn:aws:(?:bedrock|sagemaker):([^:]+):([^:]*):(?:([^\/]+)\/([\w\.\-:]+)|([^\/]+))$/
 		let match = arn.match(arnRegex)
 
 		if (match && match[1] && match[3] && match[4]) {

--- a/webview-ui/src/utils/validate.ts
+++ b/webview-ui/src/utils/validate.ts
@@ -89,7 +89,7 @@ export function validateApiConfiguration(apiConfiguration?: ApiConfiguration): s
  */
 export function validateBedrockArn(arn: string, region?: string) {
 	// Validate ARN format
-	const arnRegex = /^arn:aws:bedrock:([^:]+):([^:]*):(?:([^/]+)\/([\w.\-:]+)|([^/]+))$/
+	const arnRegex = /^arn:aws:(?:bedrock|sagemaker):([^:]+):([^:]*):(?:([^/]+)\/([\w.\-:]+)|([^/]+))$/
 	const match = arn.match(arnRegex)
 
 	if (!match) {


### PR DESCRIPTION
## Context

Amazon Bedrock Marketplace lets users deploy LLMs on managed endpoints. Users use it because they want a model which is not available in serverless mode, e.g. Qwen2.5 Coder 32B Instruct or a fine-tuned model. 

The ARNs for Bedrock Marketplace are different from Bedrock serverless because models are deployed using SageMaker Inference behind the scenes, e.g. `arn:aws:sagemaker:us-east-1:123456789:endpoint/endpoint-quick-start-blabla`.

[Bedrock Marketplace Documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-marketplace-deploy-a-model.html)

## Implementation

This PR changes the ARN validation regex to allow these ARNs.

## How to Test

1. Deploy a model from Bedrock Marketplace, e.g. Qwen2.5 Coder 32B Instruct. You might need to request a quota increase for SageMaker: ml.g5.48xlarge for endpoint usage
2. In the Bedrock Marketplace deployments console, retrieve the Endpoint ARN which should look like `arn:aws:sagemaker:us-east-1:123456789:endpoint/endpoint-quick-start-blabla`
3. In Roo Code Settings, pick Amazon Bedrock as the API Provider, "Use custom ARN..." under Model, and copy-paste the Endpoint ARN
4. You should not see the "Invalid ARN format." error message. You should be able to save the settings and use the model

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update ARN validation to support Amazon Bedrock Marketplace ARNs using SageMaker Inference.
> 
>   - **ARN Validation**:
>     - Update regex in `AwsBedrockHandler` in `bedrock.ts` to allow ARNs from both `bedrock` and `sagemaker`.
>     - Update regex in `validateBedrockArn()` in `validate.ts` to support `sagemaker` ARNs.
>   - **Behavior**:
>     - Allows Amazon Bedrock Marketplace ARNs, enabling deployment of models like Qwen2.5 Coder 32B Instruct.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6a0891629d3b5d125472af1d9c3f711ced3aeea4. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->