### PR TITLE
Disable OpenRouter Gemini caching for now

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -290,11 +290,13 @@ export async function getOpenRouterModels(options?: ApiHandlerOptions) {
 					modelInfo.cacheReadsPrice = 0.03
 					modelInfo.maxTokens = 8192
 					break
+				/* TODO: uncomment once we confirm it's working
 				case rawModel.id.startsWith("google/gemini-2.5-pro-preview-03-25"):
 				case rawModel.id.startsWith("google/gemini-2.0-flash-001"):
 				case rawModel.id.startsWith("google/gemini-flash-1.5"):
 					modelInfo.supportsPromptCache = true
 					break
+				*/
 				default:
 					break
 			}


### PR DESCRIPTION
Getting errors like this while testing

![Screenshot 2025-04-23 at 11 52 39 AM](https://github.com/user-attachments/assets/e109a2cc-66ea-429d-8af7-2348bb7354b8)

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Temporarily disable caching for Google Gemini models in `openrouter.ts` due to testing errors.
> 
>   - **Behavior**:
>     - Temporarily disable caching for Google Gemini models in `getOpenRouterModels()` by commenting out cases for `google/gemini-2.5-pro-preview-03-25`, `google/gemini-2.0-flash-001`, and `google/gemini-flash-1.5`.
>     - Caching will be re-enabled once functionality is confirmed.
>   - **Misc**:
>     - Comment added to indicate TODO for re-enabling caching.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 38822d10911ebcfd77719cad4a543f596ee8650c. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->