### PR TITLE
Omit reasoning params for non-reasoning models

### DIFF
--- a/.changeset/khaki-months-float.md
+++ b/.changeset/khaki-months-float.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Omit reasoning params for non-reasoning models

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -8,6 +8,7 @@ import {
 	openRouterDefaultModelInfo,
 	PROMPT_CACHING_MODELS,
 	OPTIONAL_PROMPT_CACHING_MODELS,
+	REASONING_MODELS,
 } from "../../shared/api"
 import { convertToOpenAiMessages } from "../transform/openai-format"
 import { ApiStreamChunk } from "../transform/stream"
@@ -138,7 +139,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 				}),
 			// This way, the transforms field will only be included in the parameters when openRouterUseMiddleOutTransform is true.
 			...((this.options.openRouterUseMiddleOutTransform ?? true) && { transforms: ["middle-out"] }),
-			...(reasoningEffort && { reasoning: { effort: reasoningEffort } }),
+			...(REASONING_MODELS.has(modelId) && reasoningEffort && { reasoning: { effort: reasoningEffort } }),
 		}
 
 		const stream = await this.client.chat.completions.create(completionParams)


### PR DESCRIPTION
## Context

I just noticed this when capturing OpenRouter requests in Postman.

When you create a new API profile it copies a bunch of potentially irrelevant settings, so we have to be a bit defensive here.