### PR TITLE
Fix: word wrapping in Roo message title

### DIFF
--- a/webview-ui/src/components/chat/BrowserSessionRow.tsx
+++ b/webview-ui/src/components/chat/BrowserSessionRow.tsx
@@ -429,6 +429,7 @@ const BrowserSessionRowContent = ({
 		alignItems: "center",
 		gap: "10px",
 		marginBottom: "10px",
+		wordBreak: "break-word",
 	}
 
 	switch (message.type) {

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -242,6 +242,7 @@ export const ChatRowContent = ({
 		alignItems: "center",
 		gap: "10px",
 		marginBottom: "10px",
+		wordBreak: "break-word",
 	}
 
 	const pStyle: React.CSSProperties = {


### PR DESCRIPTION
## Context

Fixed character overflow when Roo's title is too long.

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/7a440ee6-c8a8-4a25-b56f-718a80228d0f) | ![image](https://github.com/user-attachments/assets/83d60c53-b960-493a-86ac-573145b7d8c0) |

## How to Test

- Run this version.
- Let Roo Reply something looong in title.
- You'll see it displays properly now. 

## Get in Touch
Discord: zhangtony239

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes word wrapping issue in Roo message titles by adding `wordBreak: "break-word"` to styles in `BrowserSessionRow.tsx` and `ChatRow.tsx`.
> 
>   - **Behavior**:
>     - Fixes word wrapping issue in Roo message titles by adding `wordBreak: "break-word"` to styles.
>     - Affects long titles in `BrowserSessionRow.tsx` and `ChatRow.tsx`.
>   - **Files**:
>     - `BrowserSessionRow.tsx`: Adds `wordBreak: "break-word"` to `BrowserSessionRowContent` header style.
>     - `ChatRow.tsx`: Adds `wordBreak: "break-word"` to `ChatRowContent` header style.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d026e1f44d298cea862dc1923100f3c21881d1db. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->