### PR TITLE
Revert "Fix: Preserve editor state and prevent tab unpinning during diffs"

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -17,7 +17,6 @@ export class DiffViewProvider {
 	originalContent: string | undefined
 	private createdDirs: string[] = []
 	private documentWasOpen = false
-	private originalViewColumn?: vscode.ViewColumn // Store the original view column
 	private relPath?: string
 	private newContent?: string
 	private activeDiffEditor?: vscode.TextEditor
@@ -66,22 +65,11 @@ export class DiffViewProvider {
 			.filter(
 				(tab) => tab.input instanceof vscode.TabInputText && arePathsEqual(tab.input.uri.fsPath, absolutePath),
 			)
-		// Check if the document is already open and store its state
-		// DO NOT close the original tab to preserve pin status
 		for (const tab of tabs) {
-			if (tab.input instanceof vscode.TabInputText && arePathsEqual(tab.input.uri.fsPath, absolutePath)) {
-				this.originalViewColumn = tab.group.viewColumn
-				this.documentWasOpen = true
-				// Ensure the tab is not dirty before proceeding, but don't close it
-				if (tab.isDirty) {
-					// Find the document associated with the tab and save it
-					const doc = vscode.workspace.textDocuments.find((d) => arePathsEqual(d.uri.fsPath, absolutePath))
-					if (doc) {
-						await doc.save()
-					}
-				}
-				break // Found the relevant tab, no need to check others
+			if (!tab.isDirty) {
+				await vscode.window.tabGroups.close(tab)
 			}
+			this.documentWasOpen = true
 		}
 		this.activeDiffEditor = await this.openDiffEditor()
 		this.fadedOverlayController = new DecorationController("fadedOverlay", this.activeDiffEditor)
@@ -168,30 +156,8 @@ export class DiffViewProvider {
 			await updatedDocument.save()
 		}
 
-		// Close the diff view first
+		await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), { preview: false })
 		await this.closeAllDiffViews()
-
-		// If the original document was open, try to focus it.
-		// VS Code should handle showing the updated content automatically since the file was saved.
-		if (this.documentWasOpen && this.originalViewColumn) {
-			// Find the editor for the original document and reveal it
-			const originalEditor = vscode.window.visibleTextEditors.find(
-				(editor) =>
-					arePathsEqual(editor.document.uri.fsPath, absolutePath) &&
-					editor.viewColumn === this.originalViewColumn,
-			)
-			if (originalEditor) {
-				// Reveal a range (e.g., the start) to ensure focus
-				const position = new vscode.Position(0, 0)
-				originalEditor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.AtTop)
-			} else {
-				// Fallback if editor not found (shouldn't happen often if documentWasOpen is true)
-				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
-					preview: false,
-					viewColumn: this.originalViewColumn,
-				})
-			}
-		}
 
 		/*
 		Getting diagnostics before and after the file edit is a better approach than
@@ -271,28 +237,12 @@ export class DiffViewProvider {
 			await vscode.workspace.applyEdit(edit)
 			await updatedDocument.save()
 			console.log(`File ${absolutePath} has been reverted to its original content.`)
-			// Close the diff view first
-			await this.closeAllDiffViews()
-
-			// If the document was originally open, ensure it's focused.
-			// The revert logic already applied the original content and saved.
-			if (this.documentWasOpen && this.originalViewColumn) {
-				const originalEditor = vscode.window.visibleTextEditors.find(
-					(editor) =>
-						arePathsEqual(editor.document.uri.fsPath, absolutePath) &&
-						editor.viewColumn === this.originalViewColumn,
-				)
-				if (originalEditor) {
-					const position = new vscode.Position(0, 0)
-					originalEditor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.AtTop)
-				} else {
-					// Fallback
-					await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
-						preview: false,
-						viewColumn: this.originalViewColumn,
-					})
-				}
+			if (this.documentWasOpen) {
+				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
+					preview: false,
+				})
 			}
+			await this.closeAllDiffViews()
 		}
 
 		// edit is done
@@ -408,7 +358,6 @@ export class DiffViewProvider {
 		this.originalContent = undefined
 		this.createdDirs = []
 		this.documentWasOpen = false
-		this.originalViewColumn = undefined // Reset stored view column
 		this.activeDiffEditor = undefined
 		this.fadedOverlayController = undefined
 		this.activeLineController = undefined


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#2857

This also led to a behavior change where newly edited files were immediately closed before the error diagnostics had a chance to show up, so I'm reverting this to be safe / give us more time to thoughtfully review and plan next steps.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts changes in `DiffViewProvider.ts` to restore original file handling behavior, removing logic that preserved editor state and prevented tab unpinning.
> 
>   - **Revert Changes**:
>     - Reverts logic in `DiffViewProvider` to preserve editor state and prevent tab unpinning.
>     - Removes handling of `originalViewColumn` and related logic for focusing original documents.
>     - Restores behavior where newly edited files are closed immediately if not dirty.
>   - **Behavior**:
>     - Files are closed immediately if not dirty, potentially before error diagnostics show up.
>     - Removes logic to focus original document after closing diff views.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2675b91a0cf8dc5f360cf206ddbac86580f68e7c. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->