### PR TITLE
Fix: Adjust padding in chat view for better UI

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1256,7 +1256,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						</div>
 					)}
 					<div
-						className={` w-full flex flex-col gap-4 m-auto ${isExpanded && tasks.length > 0 ? "mt-0" : ""} p-10 pt-5`}>
+						className={` w-full flex flex-col gap-4 m-auto ${isExpanded && tasks.length > 0 ? "mt-0" : ""} p-4 pt-5`}>
 						<RooHero />
 						{telemetrySetting === "unset" && <TelemetryBanner />}
 						{/* Show the task history preview if expanded and tasks exist */}


### PR DESCRIPTION
## Context

Adjust minimum padding for history card to accommodate small width layouts.

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/368a6be3-c851-4920-a6bc-1a6dc89d8582) | ![image](https://github.com/user-attachments/assets/e2521517-8114-4416-a502-613f90b36776) |

## How to Test

- Run this version
- You'll notice the changes directly on the Roo Code homepage

## Get in Touch
Discord: zhangtony239
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust padding in `ChatView.tsx` to improve layout on small width screens.
> 
>   - **UI Adjustment**:
>     - In `ChatView.tsx`, change padding from `p-10` to `p-4` in the chat view container to improve layout on small width screens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ad48d48989dc563910e6b8eb11fbe7b00e49f596. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->