### PR TITLE
Fix: update parameter names in new task description for consistency

### DIFF
--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -338,18 +338,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 

--- a/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system.test.ts.snap
@@ -805,18 +805,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -1272,18 +1272,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -1792,18 +1792,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -2311,18 +2311,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -2850,18 +2850,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -3410,18 +3410,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -3877,18 +3877,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -4435,18 +4435,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -4908,18 +4908,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -5263,18 +5263,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 
@@ -5812,18 +5812,18 @@ Example: Requesting to switch to code mode
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 

--- a/src/core/prompts/tools/new-task.ts
+++ b/src/core/prompts/tools/new-task.ts
@@ -5,18 +5,18 @@ export function getNewTaskDescription(args: ToolArgs): string {
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 `


### PR DESCRIPTION
## Context

In the MODES section, each mode is listed with:

A display name (e.g., "🧠 Auto-Coder" mode)

A mode_slug in parentheses (e.g., (code))

However, when calling tools:

switch_mode expects the mode_slug (e.g., "code", "ask", "architect").

new_task was previously using a parameter named mode, but it actually expected the mode_slug too — not the display name — leading to unnecessary confusion.

Because of this mismatch, some calls to switch_mode were incorrectly passing display names instead of slugs, resulting in silent failures.

👉 Fix: Standardize all references to use mode_slug across the tools. Ensure only slugs like "code", "ask", and "architect" are passed — never the display name.

## Implementation

----
Version: 3.14.3
default prompt: orchestrator 

## new_task
Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.

Parameters:
- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
- message: (required) The initial user message or instructions for this new task.

Usage:
<new_task>
<mode>your-mode-slug-here</mode>
<message>Your initial instructions here</message>
</new_task>

Example:
<new_task>
<mode>code</mode>
<message>Implement a new feature for the application.</message>
</new_task>

----


## Fix parameter naming inconsistency in new_task tool

This PR changes the parameter name from mode to mode_slug in the new_task tool definition to maintain consistency with other mode-related tools like switch_mode. This change clarifies that the expected value is the internal mode identifier (slug) rather than the display name, reducing potential confusion for users. The functional behavior remains unchanged

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- UI "Prompts" check changes in "Preview"
- Test with sparc new_task which should switch a mode. 

## Get in Touch

discord: d-oit
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Renames `mode` to `mode_slug` in `new_task` tool for consistency with `switch_mode`, ensuring only mode slugs are used.
> 
>   - **Parameter Renaming**:
>     - Change `mode` to `mode_slug` in `getNewTaskDescription()` in `new-task.ts`.
>     - Update usage examples in `system.test.ts.snap` to reflect `mode_slug`.
>   - **Consistency**:
>     - Ensures `new_task` tool uses `mode_slug` consistently with `switch_mode` tool.
>     - Prevents confusion by standardizing on mode slugs (e.g., "code", "ask", "architect").
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bc33ccfb0b9c66e0cd609e5b254ec6af219e56ad. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->