### PR TITLE
test: run linting during npm test

### DIFF
--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -2,7 +2,7 @@
 const { execSync } = require("child_process")
 
 if (process.platform === "win32") {
-	execSync("npm-run-all test:*", { stdio: "inherit" })
+	execSync("npm-run-all test:* lint:*", { stdio: "inherit" })
 } else {
-	execSync("npm-run-all -p test:*", { stdio: "inherit" })
+	execSync("npm-run-all -p test:* lint:*", { stdio: "inherit" })
 }


### PR DESCRIPTION
## Context

Run linting checks alongside tests to catch style and formatting issues before pushing code or creating PRs. This helps developers identify and fix issues earlier in their workflow.

## Implementation

Modified scripts/run-tests.js to:
- Add lint:* to npm test command execution
- Maintain parallel execution on non-Windows systems

## How to Test

1. Make a change that would fail linting (e.g. add trailing whitespace)
2. Run `npm test`
3. Verify that linting errors are reported alongside test results

## Get in Touch

Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Include linting in `npm test` command in `scripts/run-tests.js` to catch style issues early.
> 
>   - **Behavior**:
>     - Modifies `scripts/run-tests.js` to include `lint:*` in `npm test` command.
>     - Ensures linting errors are reported alongside test results.
>     - Maintains parallel execution on non-Windows systems.
>   - **Testing**:
>     - To test, introduce a linting error and run `npm test` to verify error reporting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dcf7bc73951d6d81c5229ac9ebc6c04b783196f7. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->