### PR TITLE
fix UI/UX: Mode switch performance from 1 sec -> instant

### DIFF
--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -60,6 +60,13 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 		customModes,
 	} = useExtensionState()
 
+	// Use a local state to track the visually active mode
+	// This prevents flickering when switching modes rapidly by:
+	// 1. Updating the UI immediately when a mode is clicked
+	// 2. Not syncing with the backend mode state (which would cause flickering)
+	// 3. Still sending the mode change to the backend for persistence
+	const [visualMode, setVisualMode] = useState(mode)
+
 	// Memoize modes to preserve array order
 	const modes = useMemo(() => getAllModes(customModes), [customModes])
 
@@ -126,22 +133,25 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 	// Handle mode switching with explicit state initialization
 	const handleModeSwitch = useCallback(
 		(modeConfig: ModeConfig) => {
-			if (modeConfig.slug === mode) return // Prevent unnecessary updates
+			if (modeConfig.slug === visualMode) return // Prevent unnecessary updates
 
-			// First switch the mode
+			// Immediately update visual state for instant feedback
+			setVisualMode(modeConfig.slug)
+
+			// Then send the mode change message to the backend
 			switchMode(modeConfig.slug)
 
 			// Exit tools edit mode when switching modes
 			setIsToolsEditMode(false)
 		},
-		[mode, switchMode, setIsToolsEditMode],
+		[visualMode, switchMode, setIsToolsEditMode],
 	)
 
 	// Helper function to get current mode's config
 	const getCurrentMode = useCallback((): ModeConfig | undefined => {
-		const findMode = (m: ModeConfig): boolean => m.slug === mode
+		const findMode = (m: ModeConfig): boolean => m.slug === visualMode
 		return customModes?.find(findMode) || modes.find(findMode)
-	}, [mode, customModes, modes])
+	}, [visualMode, customModes, modes])
 
 	// Helper function to safely access mode properties
 	const getModeProperty = <T extends keyof ModeConfig>(
@@ -472,7 +482,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 
 					<div className="flex gap-2 items-center mb-3 flex-wrap py-1">
 						{modes.map((modeConfig) => {
-							const isActive = mode === modeConfig.slug
+							const isActive = visualMode === modeConfig.slug
 							return (
 								<button
 									key={modeConfig.slug}
@@ -493,20 +503,20 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 
 				<div style={{ marginBottom: "20px" }}>
 					{/* Only show name and delete for custom modes */}
-					{mode && findModeBySlug(mode, customModes) && (
+					{visualMode && findModeBySlug(visualMode, customModes) && (
 						<div className="flex gap-3 mb-4">
 							<div className="flex-1">
 								<div className="font-bold mb-1">{t("prompts:createModeDialog.name.label")}</div>
 								<div className="flex gap-2">
 									<VSCodeTextField
-										value={getModeProperty(findModeBySlug(mode, customModes), "name") ?? ""}
+										value={getModeProperty(findModeBySlug(visualMode, customModes), "name") ?? ""}
 										onChange={(e: Event | React.FormEvent<HTMLElement>) => {
 											const target =
 												(e as CustomEvent)?.detail?.target ||
 												((e as any).target as HTMLInputElement)
-											const customMode = findModeBySlug(mode, customModes)
+											const customMode = findModeBySlug(visualMode, customModes)
 											if (customMode) {
-												updateCustomMode(mode, {
+												updateCustomMode(visualMode, {
 													...customMode,
 													name: target.value,
 													source: customMode.source || "global",
@@ -522,7 +532,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 										onClick={() => {
 											vscode.postMessage({
 												type: "deleteCustomMode",
-												slug: mode,
+												slug: visualMode,
 											})
 										}}>
 										<span className="codicon codicon-trash"></span>
@@ -534,7 +544,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 					<div style={{ marginBottom: "16px" }}>
 						<div className="flex justify-between items-center mb-1">
 							<div className="font-bold">{t("prompts:roleDefinition.title")}</div>
-							{!findModeBySlug(mode, customModes) && (
+							{!findModeBySlug(visualMode, customModes) && (
 								<Button
 									variant="ghost"
 									size="icon"
@@ -555,25 +565,25 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						</div>
 						<VSCodeTextArea
 							value={(() => {
-								const customMode = findModeBySlug(mode, customModes)
-								const prompt = customModePrompts?.[mode] as PromptComponent
+								const customMode = findModeBySlug(visualMode, customModes)
+								const prompt = customModePrompts?.[visualMode] as PromptComponent
 								return customMode?.roleDefinition ?? prompt?.roleDefinition ?? getRoleDefinition(mode)
 							})()}
 							onChange={(e) => {
 								const value =
 									(e as CustomEvent)?.detail?.target?.value ||
 									((e as any).target as HTMLTextAreaElement).value
-								const customMode = findModeBySlug(mode, customModes)
+								const customMode = findModeBySlug(visualMode, customModes)
 								if (customMode) {
 									// For custom modes, update the JSON file
-									updateCustomMode(mode, {
+									updateCustomMode(visualMode, {
 										...customMode,
 										roleDefinition: value.trim() || "",
 										source: customMode.source || "global",
 									})
 								} else {
 									// For built-in modes, update the prompts
-									updateAgentPrompt(mode, {
+									updateAgentPrompt(visualMode, {
 										roleDefinition: value.trim() || undefined,
 									})
 								}
@@ -617,7 +627,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						<div className="mb-4">
 							<div className="flex justify-between items-center mb-1">
 								<div className="font-bold">{t("prompts:tools.title")}</div>
-								{findModeBySlug(mode, customModes) && (
+								{findModeBySlug(visualMode, customModes) && (
 									<Button
 										variant="ghost"
 										size="icon"
@@ -632,16 +642,16 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 									</Button>
 								)}
 							</div>
-							{!findModeBySlug(mode, customModes) && (
+							{!findModeBySlug(visualMode, customModes) && (
 								<div className="text-sm text-vscode-descriptionForeground mb-2">
 									{t("prompts:tools.builtInModesText")}
 								</div>
 							)}
-							{isToolsEditMode && findModeBySlug(mode, customModes) ? (
+							{isToolsEditMode && findModeBySlug(visualMode, customModes) ? (
 								<div className="grid grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-2">
 									{availableGroups.map((group) => {
 										const currentMode = getCurrentMode()
-										const isCustomMode = findModeBySlug(mode, customModes)
+										const isCustomMode = findModeBySlug(visualMode, customModes)
 										const customMode = isCustomMode
 										const isGroupEnabled = isCustomMode
 											? customMode?.groups?.some((g) => getGroupName(g) === group)
@@ -710,7 +720,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 								marginBottom: "4px",
 							}}>
 							<div style={{ fontWeight: "bold" }}>{t("prompts:customInstructions.title")}</div>
-							{!findModeBySlug(mode, customModes) && (
+							{!findModeBySlug(visualMode, customModes) && (
 								<Button
 									variant="ghost"
 									size="icon"
@@ -738,8 +748,8 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						</div>
 						<VSCodeTextArea
 							value={(() => {
-								const customMode = findModeBySlug(mode, customModes)
-								const prompt = customModePrompts?.[mode] as PromptComponent
+								const customMode = findModeBySlug(visualMode, customModes)
+								const prompt = customModePrompts?.[visualMode] as PromptComponent
 								return (
 									customMode?.customInstructions ??
 									prompt?.customInstructions ??
@@ -750,18 +760,18 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 								const value =
 									(e as CustomEvent)?.detail?.target?.value ||
 									((e as any).target as HTMLTextAreaElement).value
-								const customMode = findModeBySlug(mode, customModes)
+								const customMode = findModeBySlug(visualMode, customModes)
 								if (customMode) {
 									// For custom modes, update the JSON file
-									updateCustomMode(mode, {
+									updateCustomMode(visualMode, {
 										...customMode,
 										customInstructions: value.trim() || undefined,
 										source: customMode.source || "global",
 									})
 								} else {
 									// For built-in modes, update the prompts
-									const existingPrompt = customModePrompts?.[mode] as PromptComponent
-									updateAgentPrompt(mode, {
+									const existingPrompt = customModePrompts?.[visualMode] as PromptComponent
+									updateAgentPrompt(visualMode, {
 										...existingPrompt,
 										customInstructions: value.trim(),
 									})

--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -567,7 +567,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							value={(() => {
 								const customMode = findModeBySlug(visualMode, customModes)
 								const prompt = customModePrompts?.[visualMode] as PromptComponent
-								return customMode?.roleDefinition ?? prompt?.roleDefinition ?? getRoleDefinition(mode)
+								return customMode?.roleDefinition ?? prompt?.roleDefinition ?? getRoleDefinition(visualMode)
 							})()}
 							onChange={(e) => {
 								const value =


### PR DESCRIPTION
## Context

Switch mode performance is very bad now (1 sec per change tag) which leads to poor UX. This PR makes it instant.

I looked but can not find any reason to keep it depending on full state update since the data is already loaded for presentation. I may be missing a reason for this architectural choice so please check.

There is also an issue I noticed Settings has a Save button but "Prompts" does not, can we standardize this? I prefer save button for clarity, autosave is OK too but would need user feedback. Either way we should standardize saving behavior across all tabs.

The other thing is, are we sending full convo history because we intend to actually change the mode in conversation or is that a bug? I neither believe users have this expectation nor do they really want that to happen.  It's much better for users to have good UX on the modes page than trade-off bad UX for mode change for feature which user probably do not want. But I'm making a lot of assumptions here and maybe switching Mode here was never intended to influence the chat conversation... In that case we could turn off all backend updates until the user presses the save button which would be optimal from a cursory glance. 

## Screenshot

![mode-performance](https://github.com/user-attachments/assets/52ccf9c1-bf23-4484-9b54-fe5b21c3866d)

## Details

For this PR:

The issue occurs because the UI waits for a complete round-trip:
1. Frontend sends mode change to backend
2. Backend processes it and updates global state
3. Backend sends back a complete state object (including conversation history)
4. Frontend deserializes this large state object and only then updates the UI

## Solution

Implemented an "optimistic UI update" pattern that makes mode switching feel instant:

1. Added a local `visualMode` state that's initialized with the global `mode` state
2. Updated all UI components to use `visualMode` instead of `mode`
3. Updated `visualMode` immediately when a mode is clicked
4. Still sent the mode change to the backend for persistence

This approach provides instant feedback to the user while maintaining proper state synchronization with the backend. The key insight is that we don't need to wait for the backend to update the UI - we can update it immediately and let the backend catch up in the background.

## Implementation Details

The changes are minimal and focused on the frontend only:
- Added a `visualMode` state in `PromptsView.tsx`
- Updated all UI components to reference `visualMode` instead of `mode`
- Modified the `handleModeSwitch` function to update `visualMode` immediately

## Testing

- Manually tested mode switching between all available modes
- Verified that the UI updates instantly when clicking on mode tabs
- Tested rapid mode switching to ensure no flickering occurs

## Impact

This change significantly improves the user experience when switching modes in the PromptsView component. What previously took 1-2 seconds now happens instantly, making the interface go from annoying to usable.

The changes are isolated to the frontend and don't modify any backend code, making this a lower-risk improvement.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes mode switching in `PromptsView.tsx` by implementing an optimistic UI update pattern using a local `visualMode` state.
> 
>   - **Behavior**:
>     - Implements optimistic UI updates for mode switching in `PromptsView.tsx` using a new local state `visualMode`.
>     - Updates `visualMode` immediately on mode click, providing instant feedback.
>     - Backend state update still occurs for persistence.
>   - **Functions**:
>     - Modifies `handleModeSwitch` to update `visualMode` immediately.
>     - Updates all mode-related UI components to use `visualMode` instead of `mode`.
>   - **Testing**:
>     - Manually tested mode switching for instant UI updates and no flickering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d57e64e60ae461b61769aa96a09887f214d8a763. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->