### PR TITLE
feat: persist workspacePath to each task for improved task management

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -133,6 +133,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 	readonly rootTask: Cline | undefined = undefined
 	readonly parentTask: Cline | undefined = undefined
 	readonly taskNumber: number
+	readonly workspacePath: string
 
 	isPaused: boolean = false
 	pausedModeSlug: string = defaultModeSlug
@@ -221,6 +222,10 @@ export class Cline extends EventEmitter<ClineEvents> {
 		}
 
 		this.taskId = historyItem ? historyItem.id : crypto.randomUUID()
+		// normal use-case is usually retry similar history task with new workspace
+		this.workspacePath = parentTask
+			? parentTask.workspacePath
+			: getWorkspacePath(path.join(os.homedir(), "Desktop"))
 		this.instanceId = crypto.randomUUID().slice(0, 8)
 		this.taskNumber = -1
 
@@ -288,7 +293,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 	}
 
 	get cwd() {
-		return getWorkspacePath(path.join(os.homedir(), "Desktop"))
+		return this.workspacePath
 	}
 
 	// Storing task to disk for history


### PR DESCRIPTION
## Context

### Problem
- For multi-root workspaces, the cwd (workspace) path relies on current active editor, or default to the first root.
When a task is running, if user change active editor file, or close all edit file, the cwd point to incorrect directory, causing tool-call and other actions to be mis-behave (eg file not found etc).

### The fix:
- Persist workspace path per task, init its value when a task started.
- The workspace path is passed to sub-task to keep parent/child task workspace consistent

I heavily using multi-root workspace and would love this to be fixed.
Otherwise I must keep same active edit document while running roo task.

### Other consideration:
- When reopen task from history, the workspace should be kept same as history item, or change to new workspace?
The current approach is to config to new workspace, as normal use-case is usually open/retry task in new workspace.

## Implementation

- Add `workspacePath` to Cline class and init its value in constructor

## Screenshots
### Setup
<img width="390" alt="image" src="https://github.com/user-attachments/assets/b2e2b265-f13d-401f-95b2-4e278a995c96" />

### Before
<img width="385" alt="image" src="https://github.com/user-attachments/assets/08b7b512-f104-4839-aee4-f08e8ce6f6b2" />
<img width="318" alt="image" src="https://github.com/user-attachments/assets/ba265806-4341-4959-a4c8-62280fc3736a" />

### After
Correctly using workspace and tool-call when running task while user open file in another workspace
<img width="602" alt="image" src="https://github.com/user-attachments/assets/40f525a4-8591-4b36-8432-b79bacace379" />

## How to Test

- Create multi-root workspaces https://code.visualstudio.com/docs/editing/workspaces/multi-root-workspaces
- Open file in 1 workspace folder and start random roo task, eg `list file in current workspace`, check the prompt being sent and the output to see workspace folder
- Keep same task open, open another file in another workspace folder, continue with other task (eg `list file in current workspace`), check sent prompt and output

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `workspacePath` to `Cline` class to persist workspace paths for tasks, ensuring consistent task management in multi-root workspaces.
> 
>   - **Behavior**:
>     - Adds `workspacePath` to `Cline` class in `Cline.ts`, initialized in the constructor to persist the workspace path for each task.
>     - Updates `get cwd()` to return `workspacePath` instead of recalculating it.
>     - Ensures consistent workspace path for parent and child tasks.
>   - **Implementation**:
>     - Initializes `workspacePath` in `Cline` constructor, using parent task's path or defaulting to the desktop path.
>     - Modifies task resumption to use the new workspace path logic.
>   - **Misc**:
>     - Adjusts logic for reopening tasks from history to use the new workspace path.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 183ec5f2d41772a36d3b3af14a1cd8afcb6d9929. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->