### PR TITLE
feat: syntax highlighting terminal output with Shiki

### DIFF
--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -1,9 +1,8 @@
-import { HTMLAttributes, forwardRef, useMemo, useState } from "react"
-import { Virtuoso } from "react-virtuoso"
-import { ChevronDown } from "lucide-react"
+import { forwardRef, useState } from "react"
+import { useTranslation } from "react-i18next"
 
 import { useExtensionState } from "@src/context/ExtensionStateContext"
-import { cn } from "@src/lib/utils"
+import CodeBlock, { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 
 interface CommandExecutionProps {
 	command: string
@@ -11,45 +10,47 @@ interface CommandExecutionProps {
 }
 
 export const CommandExecution = forwardRef<HTMLDivElement, CommandExecutionProps>(({ command, output }, ref) => {
+	const { t } = useTranslation()
 	const { terminalShellIntegrationDisabled = false } = useExtensionState()
-
-	// If we aren't opening the VSCode terminal for this command then we default
-	// to expanding the command execution output.
 	const [isExpanded, setIsExpanded] = useState(terminalShellIntegrationDisabled)
 
-	const lines = useMemo(() => output.split("\n"), [output])
+	const onToggleExpand = () => {
+		setIsExpanded(!isExpanded)
+	}
 
 	return (
-		<div ref={ref} className="w-full p-2 rounded-xs bg-vscode-editor-background">
+		<>
 			<div
-				className={cn("flex flex-row justify-between cursor-pointer active:opacity-75", {
-					"opacity-50": isExpanded,
-				})}
-				onClick={() => setIsExpanded(!isExpanded)}>
-				<Line>{command}</Line>
-				<ChevronDown className={cn("size-4 transition-transform duration-300", { "rotate-180": isExpanded })} />
+				ref={ref}
+				style={{
+					borderRadius: 3,
+					border: "1px solid var(--vscode-editorGroup-border)",
+					overflow: "hidden",
+					backgroundColor: CODE_BLOCK_BG_COLOR,
+				}}>
+				<CodeBlock source={command} language="shell" />
+				{output.length > 0 && (
+					<div style={{ width: "100%" }}>
+						<div
+							onClick={onToggleExpand}
+							style={{
+								display: "flex",
+								alignItems: "center",
+								gap: "4px",
+								width: "100%",
+								justifyContent: "flex-start",
+								cursor: "pointer",
+								padding: `2px 8px ${isExpanded ? 0 : 8}px 8px`,
+							}}>
+							<span className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}></span>
+							<span style={{ fontSize: "0.8em" }}>{t("chat:commandOutput")}</span>
+						</div>
+						{isExpanded && <CodeBlock source={output} language="log" />}
+					</div>
+				)}
 			</div>
-			<div className={cn("h-[200px]", { hidden: !isExpanded })}>
-				<Virtuoso
-					className="h-full mt-2"
-					totalCount={lines.length}
-					itemContent={(i) => <Line>{lines[i]}</Line>}
-					followOutput="auto"
-				/>
-			</div>
-		</div>
+		</>
 	)
 })
-
-type LineProps = HTMLAttributes<HTMLDivElement>
-
-const Line = ({ className, ...props }: LineProps) => {
-	return (
-		<div
-			className={cn("font-mono text-vscode-editor-foreground whitespace-pre-wrap break-words", className)}
-			{...props}
-		/>
-	)
-}
 
 CommandExecution.displayName = "CommandExecution"

--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -2,6 +2,7 @@ import { forwardRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { useExtensionState } from "@src/context/ExtensionStateContext"
+import { BaseTerminal } from "../../../../src/integrations/terminal/BaseTerminal"
 import CodeBlock, { CODE_BLOCK_BG_COLOR } from "../common/CodeBlock"
 
 interface CommandExecutionProps {
@@ -11,8 +12,9 @@ interface CommandExecutionProps {
 
 export const CommandExecution = forwardRef<HTMLDivElement, CommandExecutionProps>(({ command, output }, ref) => {
 	const { t } = useTranslation()
-	const { terminalShellIntegrationDisabled = false } = useExtensionState()
+	const { terminalShellIntegrationDisabled = false, terminalOutputLineLimit = 500 } = useExtensionState()
 	const [isExpanded, setIsExpanded] = useState(terminalShellIntegrationDisabled)
+	const compressedOutput = BaseTerminal.compressTerminalOutput(output, terminalOutputLineLimit)
 
 	const onToggleExpand = () => {
 		setIsExpanded(!isExpanded)
@@ -45,7 +47,7 @@ export const CommandExecution = forwardRef<HTMLDivElement, CommandExecutionProps
 							<span className={`codicon codicon-chevron-${isExpanded ? "down" : "right"}`}></span>
 							<span style={{ fontSize: "0.8em" }}>{t("chat:commandOutput")}</span>
 						</div>
-						{isExpanded && <CodeBlock source={output} language="log" />}
+						{isExpanded && <CodeBlock source={compressedOutput} language="log" />}
 					</div>
 				)}
 			</div>

--- a/webview-ui/src/components/chat/__tests__/CommandExecution.test.tsx
+++ b/webview-ui/src/components/chat/__tests__/CommandExecution.test.tsx
@@ -1,31 +1,16 @@
 // npx jest src/components/chat/__tests__/CommandExecution.test.tsx
 
 import React from "react"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent } from "@testing-library/react"
 
 import { ExtensionStateContextProvider } from "@src/context/ExtensionStateContext"
 
 import { CommandExecution } from "../CommandExecution"
 
+jest.mock("../../../components/common/CodeBlock")
+
 jest.mock("@src/lib/utils", () => ({
 	cn: (...inputs: any[]) => inputs.filter(Boolean).join(" "),
-}))
-
-jest.mock("lucide-react", () => ({
-	ChevronDown: () => <div data-testid="chevron-down">ChevronDown</div>,
-}))
-
-jest.mock("react-virtuoso", () => ({
-	Virtuoso: React.forwardRef(({ totalCount, itemContent }: any, ref: any) => (
-		<div ref={ref} data-testid="virtuoso-container">
-			{Array.from({ length: totalCount }).map((_, index) => (
-				<div key={index} data-testid={`virtuoso-item-${index}`}>
-					{itemContent(index)}
-				</div>
-			))}
-		</div>
-	)),
-	VirtuosoHandle: jest.fn(),
 }))
 
 describe("CommandExecution", () => {
@@ -40,24 +25,34 @@ describe("CommandExecution", () => {
 	it("renders command output with virtualized list", () => {
 		const testOutput = "Line 1\nLine 2\nLine 3"
 		renderComponent("ls", testOutput)
-		expect(screen.getByTestId("virtuoso-container")).toBeInTheDocument()
-		expect(screen.getByText("Line 1")).toBeInTheDocument()
-		expect(screen.getByText("Line 2")).toBeInTheDocument()
-		expect(screen.getByText("Line 3")).toBeInTheDocument()
+		const codeBlock = screen.getByTestId("mock-code-block")
+		expect(codeBlock).toHaveTextContent("ls")
+
+		fireEvent.click(screen.getByText("commandOutput"))
+		const outputBlock = screen.getAllByTestId("mock-code-block")[1]
+
+		expect(outputBlock).toHaveTextContent("Line 1")
+		expect(outputBlock).toHaveTextContent("Line 2")
+		expect(outputBlock).toHaveTextContent("Line 3")
 	})
 
 	it("handles empty output", () => {
 		renderComponent("ls", "")
-		expect(screen.getByTestId("virtuoso-container")).toBeInTheDocument()
-		expect(screen.getByTestId("virtuoso-item-0")).toBeInTheDocument()
-		expect(screen.queryByTestId("virtuoso-item-1")).not.toBeInTheDocument()
+		const codeBlock = screen.getByTestId("mock-code-block")
+		expect(codeBlock).toHaveTextContent("ls")
+		expect(screen.queryByText("commandOutput")).not.toBeInTheDocument()
+		expect(screen.queryAllByTestId("mock-code-block")).toHaveLength(1)
 	})
 
 	it("handles large output", () => {
 		const largeOutput = Array.from({ length: 1000 }, (_, i) => `Line ${i + 1}`).join("\n")
 		renderComponent("ls", largeOutput)
-		expect(screen.getByTestId("virtuoso-container")).toBeInTheDocument()
-		expect(screen.getByText("Line 1")).toBeInTheDocument()
-		expect(screen.getByText("Line 1000")).toBeInTheDocument()
+		const codeBlock = screen.getByTestId("mock-code-block")
+		expect(codeBlock).toHaveTextContent("ls")
+
+		fireEvent.click(screen.getByText("commandOutput"))
+		const outputBlock = screen.getAllByTestId("mock-code-block")[1]
+		expect(outputBlock).toHaveTextContent("Line 1")
+		expect(outputBlock).toHaveTextContent("Line 1000")
 	})
 })

--- a/webview-ui/src/components/common/__mocks__/CodeBlock.tsx
+++ b/webview-ui/src/components/common/__mocks__/CodeBlock.tsx
@@ -1,10 +1,10 @@
 import * as React from "react"
 
 interface CodeBlockProps {
-	children?: React.ReactNode
+	source?: string
 	language?: string
 }
 
-const CodeBlock: React.FC<CodeBlockProps> = () => <div data-testid="mock-code-block">Mocked Code Block</div>
+const CodeBlock: React.FC<CodeBlockProps> = ({ source = "" }) => <div data-testid="mock-code-block">{source}</div>
 
 export default CodeBlock


### PR DESCRIPTION
Refactored CommandExecution.tsx to:
- Implement CodeBlock component for terminal display
- Use Shiki for syntax highlighting of shell commands and terminal output
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `CommandExecution.tsx` to use `CodeBlock` for Shiki syntax highlighting and improve output display.
> 
>   - **Component Refactor**:
>     - Refactor `CommandExecution.tsx` to use `CodeBlock` for syntax highlighting of `command` and `output`.
>     - Remove `Virtuoso` and `ChevronDown` imports, replacing with `CodeBlock` and `useTranslation`.
>   - **Behavior**:
>     - Use Shiki for syntax highlighting shell commands and terminal output.
>     - Add expand/collapse functionality for output display with a chevron icon.
>   - **Styling**:
>     - Apply consistent styling using `CODE_BLOCK_BG_COLOR` and inline styles for borders and padding.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b4fd9ee8defbe405f023946eb37629b4cd68d21b. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->