### PR TITLE
Set busy flag on ExecaTerminal so it reports in env details when backgrounded

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -2053,15 +2053,15 @@ export class Cline extends EventEmitter<ClineEvents> {
 			...TerminalRegistry.getBackgroundTerminals(false),
 		]
 
-		if (busyTerminals.length > 0 && this.didEditFile) {
-			await delay(300) // delay after saving file to let terminals catch up
-		}
-
 		if (busyTerminals.length > 0) {
+			if (this.didEditFile) {
+				await delay(300) // Delay after saving file to let terminals catch up.
+			}
+
 			// Wait for terminals to cool down.
 			await pWaitFor(() => busyTerminals.every((t) => !TerminalRegistry.isProcessHot(t.id)), {
 				interval: 100,
-				timeout: 15_000,
+				timeout: 5_000,
 			}).catch(() => {})
 		}
 

--- a/src/integrations/terminal/ExecaTerminal.ts
+++ b/src/integrations/terminal/ExecaTerminal.ts
@@ -16,6 +16,8 @@ export class ExecaTerminal extends BaseTerminal {
 	}
 
 	public override runCommand(command: string, callbacks: RooTerminalCallbacks): RooTerminalProcessResultPromise {
+		this.busy = true
+
 		const process = new ExecaTerminalProcess(this)
 		process.command = command
 		this.process = process

--- a/src/integrations/terminal/ExecaTerminalProcess.ts
+++ b/src/integrations/terminal/ExecaTerminalProcess.ts
@@ -11,6 +11,10 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 		super()
 
 		this.terminalRef = new WeakRef(terminal)
+
+		this.once("completed", () => {
+			this.terminal.busy = false
+		})
 	}
 
 	public get terminal(): RooTerminal {

--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -41,9 +41,9 @@ export class Terminal extends BaseTerminal {
 	}
 
 	public override runCommand(command: string, callbacks: RooTerminalCallbacks): RooTerminalProcessResultPromise {
-		// We set busy before the command is running because the terminal may be waiting
-		// on terminal integration, and we must prevent another instance from selecting
-		// the terminal for use during that time.
+		// We set busy before the command is running because the terminal may be
+		// waiting on terminal integration, and we must prevent another instance
+		// from selecting the terminal for use during that time.
 		this.busy = true
 
 		const process = new TerminalProcess(this)

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -18,7 +18,7 @@ import { ShellIntegrationManager } from "./ShellIntegrationManager"
 // benefit of keep track of busy terminals even after a task is closed.
 
 export class TerminalRegistry {
-	private static terminals: RooTerminal[] = []
+	public static terminals: RooTerminal[] = []
 	private static nextTerminalId = 1
 	private static disposables: vscode.Disposable[] = []
 	private static isInitialized = false

--- a/src/integrations/terminal/TerminalRegistry.ts
+++ b/src/integrations/terminal/TerminalRegistry.ts
@@ -18,7 +18,7 @@ import { ShellIntegrationManager } from "./ShellIntegrationManager"
 // benefit of keep track of busy terminals even after a task is closed.
 
 export class TerminalRegistry {
-	public static terminals: RooTerminal[] = []
+	private static terminals: RooTerminal[] = []
 	private static nextTerminalId = 1
 	private static disposables: vscode.Disposable[] = []
 	private static isInitialized = false


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set busy flag on `ExecaTerminal` and `ExecaTerminalProcess` to report terminal activity and adjust terminal cooldown timeout in `Cline.ts`.
> 
>   - **Behavior**:
>     - Set `busy` flag to `true` in `ExecaTerminal.runCommand()` and `ExecaTerminalProcess` constructor to indicate terminal activity.
>     - Reset `busy` flag to `false` in `ExecaTerminalProcess` upon completion of a command.
>     - Reduce timeout for terminal cooldown in `Cline.ts` from 15,000ms to 5,000ms.
>   - **Files**:
>     - `ExecaTerminal.ts`: Modify `runCommand()` to set `busy` flag.
>     - `ExecaTerminalProcess.ts`: Modify constructor to reset `busy` flag on completion.
>     - `Cline.ts`: Adjust terminal cooldown timeout.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for be7098d8489c798036282cf6ad79463d97443393. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->