### PR TITLE
Prevent duplicate terminal output when combining terminal output messages

### DIFF
--- a/src/shared/__tests__/combineCommandSequences.test.ts
+++ b/src/shared/__tests__/combineCommandSequences.test.ts
@@ -40,6 +40,8 @@ const messages: ClineMessage[] = [
 describe("combineCommandSequences", () => {
 	it("should combine command sequences", () => {
 		const message = combineCommandSequences(messages).at(-1)
-		expect(message!.text!.length).toEqual(131)
+		expect(message!.text).toEqual(
+			"ping www.google.com\nOutput:PING www.google.com (142.251.46.228): 56 data bytes\n",
+		)
 	})
 })


### PR DESCRIPTION
## Context

The "ask" message and the first "say" message for `terminal_output` messages can be duplicates.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
