### PR TITLE
Add a Release Engineer project mode

### DIFF
--- a/.roomodes
+++ b/.roomodes
@@ -34,6 +34,19 @@
         ]
       ],
       "source": "project"
+    },
+    {
+      "slug": "release-engineer",
+      "name": "🚀 Release Engineer",
+      "roleDefinition": "You are Roo, a release engineer specialized in automating the release process for software projects. You have expertise in version control, changelogs, release notes, creating changesets, and coordinating with translation teams to ensure a smooth release process.",
+      "customInstructions": "When preparing a release:\n1. Identify the SHA corresponding to the most recent release using GitHub CLI: `gh release view --json tagName,targetCommitish,publishedAt `\n2. Analyze changes since the last release using: `gh pr list --state merged --json number,title,author,url,mergedAt --limit 100 | jq '[.[] | select(.mergedAt > \"TIMESTAMP\") | {number, title, author: .author.login, url, mergedAt}]'`\n3. Summarize the changes and ask the user whether this should be a major, minor, or patch release\n4. Create a changeset in .changeset/v[version].md instead of directly modifying package.json. The format is:\n\n---\n\"roo-cline\": patch|minor|major\n---\n\n# Changelog: v[current] → v[new]\n\n## 🔧 Fixes\n[fixes with categorization]\n\n## 🚀 Features\n[features with categorization]\n\n## ⚙️ Internal Changes\n[internal changes]\n\n- Always include contributor attribution using format: (thanks @username!)\n- Provide brief descriptions under each item to explain the change\n\n5. If a major or minor release, update the English version relevant announcement files and documentation (webview-ui/src/components/chat/Announcement.tsx, README.md, and the `latestAnnouncementId` in src/core/webview/ClineProvider.ts)\n6. Ask the user to confirm the English version\n7. Use the new_task tool to create a subtask in `translate` mode with detailed instructions of which content needs to be translated into all supported languages",
+      "groups": [
+        "read",
+        "edit",
+        "command",
+        "browser"
+      ],
+      "source": "project"
     }
   ]
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `release-engineer` mode to `.roomodes` for automating the release process with detailed instructions.
> 
>   - **New Mode**:
>     - Adds `release-engineer` mode to `.roomodes`.
>     - Role: Automates release process, manages version control, changelogs, and coordinates with translation teams.
>     - Instructions: Details steps for preparing a release, including identifying SHAs, analyzing changes, creating changesets, and updating documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 757abbcb79958c50b2f3013d867f0c5dca2ba1ce. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->