### PR TITLE
Support mentioning filenames with spaces

### DIFF
--- a/src/core/mentions/__tests__/index.test.ts
+++ b/src/core/mentions/__tests__/index.test.ts
@@ -87,6 +87,24 @@ import * as git from "../../../utils/git"
 import { getWorkspacePath } from "../../../utils/path"
 ;(getWorkspacePath as jest.Mock).mockReturnValue("/test/workspace")
 
+jest.mock("fs/promises", () => ({
+	stat: jest.fn(),
+	readdir: jest.fn(),
+}))
+import fs from "fs/promises"
+import * as path from "path"
+
+jest.mock("../../../integrations/misc/open-file", () => ({
+	openFile: jest.fn(),
+}))
+import { openFile } from "../../../integrations/misc/open-file"
+
+jest.mock("../../../integrations/misc/extract-text", () => ({
+	extractTextFromFile: jest.fn(),
+}))
+
+import * as vscode from "vscode"
+
 describe("mentions", () => {
 	const mockCwd = "/test/workspace"
 	let mockUrlContentFetcher: UrlContentFetcher
@@ -112,6 +130,16 @@ describe("mentions", () => {
 	})
 
 	describe("parseMentions", () => {
+		let mockUrlFetcher: UrlContentFetcher
+
+		beforeEach(() => {
+			mockUrlFetcher = new (UrlContentFetcher as jest.Mock<UrlContentFetcher>)()
+			;(fs.stat as jest.Mock).mockResolvedValue({ isFile: () => true, isDirectory: () => false })
+			;(require("../../../integrations/misc/extract-text").extractTextFromFile as jest.Mock).mockResolvedValue(
+				"Mock file content",
+			)
+		})
+
 		it("should parse git commit mentions", async () => {
 			const commitHash = "abc1234"
 			const commitInfo = `abc1234 Fix bug in parser
@@ -144,35 +172,72 @@ Detailed commit message with multiple lines
 			expect(result).toContain(`<git_commit hash="${commitHash}">`)
 			expect(result).toContain(`Error fetching commit info: ${errorMessage}`)
 		})
+
+		it("should correctly parse mentions with escaped spaces and fetch content", async () => {
+			const text = "Please check the file @/path/to/file\\ with\\ spaces.txt"
+			const expectedUnescaped = "path/to/file with spaces.txt" // Note: leading '/' removed by slice(1) in parseMentions
+			const expectedAbsPath = path.resolve(mockCwd, expectedUnescaped)
+
+			const result = await parseMentions(text, mockCwd, mockUrlFetcher)
+
+			// Check if fs.stat was called with the unescaped path
+			expect(fs.stat).toHaveBeenCalledWith(expectedAbsPath)
+			// Check if extractTextFromFile was called with the unescaped path
+			expect(require("../../../integrations/misc/extract-text").extractTextFromFile).toHaveBeenCalledWith(
+				expectedAbsPath,
+			)
+
+			// Check the output format
+			expect(result).toContain(`'path/to/file\\ with\\ spaces.txt' (see below for file content)`)
+			expect(result).toContain(
+				`<file_content path="path/to/file\\ with\\ spaces.txt">\nMock file content\n</file_content>`,
+			)
+		})
+
+		it("should handle folder mentions with escaped spaces", async () => {
+			const text = "Look in @/my\\ documents/folder\\ name/"
+			const expectedUnescaped = "my documents/folder name/"
+			const expectedAbsPath = path.resolve(mockCwd, expectedUnescaped)
+			;(fs.stat as jest.Mock).mockResolvedValue({ isFile: () => false, isDirectory: () => true })
+			;(fs.readdir as jest.Mock).mockResolvedValue([]) // Empty directory
+
+			const result = await parseMentions(text, mockCwd, mockUrlFetcher)
+
+			expect(fs.stat).toHaveBeenCalledWith(expectedAbsPath)
+			expect(fs.readdir).toHaveBeenCalledWith(expectedAbsPath, { withFileTypes: true })
+			expect(result).toContain(`'my\\ documents/folder\\ name/' (see below for folder content)`)
+			expect(result).toContain(`<folder_content path="my\\ documents/folder\\ name/">`) // Content check might be more complex
+		})
+
+		it("should handle errors when accessing paths with escaped spaces", async () => {
+			const text = "Check @/nonexistent\\ file.txt"
+			const expectedUnescaped = "nonexistent file.txt"
+			const expectedAbsPath = path.resolve(mockCwd, expectedUnescaped)
+			const mockError = new Error("ENOENT: no such file or directory")
+			;(fs.stat as jest.Mock).mockRejectedValue(mockError)
+
+			const result = await parseMentions(text, mockCwd, mockUrlFetcher)
+
+			expect(fs.stat).toHaveBeenCalledWith(expectedAbsPath)
+			expect(result).toContain(
+				`<file_content path="nonexistent\\ file.txt">\nError fetching content: Failed to access path "nonexistent\\ file.txt": ${mockError.message}\n</file_content>`,
+			)
+		})
+
+		// Add more tests for parseMentions if needed (URLs, other mentions combined with escaped paths etc.)
 	})
 
 	describe("openMention", () => {
-		it("should handle file paths and problems", async () => {
-			// Mock stat to simulate file not existing
-			mockVscode.workspace.fs.stat.mockRejectedValueOnce(new Error("File does not exist"))
-
-			// Call openMention and wait for it to complete
-			await openMention("/path/to/file")
-
-			// Verify error handling
-			expect(mockExecuteCommand).not.toHaveBeenCalled()
-			expect(mockOpenExternal).not.toHaveBeenCalled()
-			expect(mockVscode.window.showErrorMessage).toHaveBeenCalledWith("Could not open file: File does not exist")
-
-			// Reset mocks for next test
-			jest.clearAllMocks()
-
-			// Test problems command
-			await openMention("problems")
-			expect(mockExecuteCommand).toHaveBeenCalledWith("workbench.actions.view.problems")
+		beforeEach(() => {
+			;(getWorkspacePath as jest.Mock).mockReturnValue(mockCwd)
 		})
 
 		it("should handle URLs", async () => {
 			const url = "https://example.com"
 			await openMention(url)
-			const mockUri = mockVscode.Uri.parse(url)
-			expect(mockVscode.env.openExternal).toHaveBeenCalled()
-			const calledArg = mockVscode.env.openExternal.mock.calls[0][0]
+			const mockUri = vscode.Uri.parse(url)
+			expect(vscode.env.openExternal).toHaveBeenCalled()
+			const calledArg = (vscode.env.openExternal as jest.Mock).mock.calls[0][0]
 			expect(calledArg).toEqual(
 				expect.objectContaining({
 					scheme: mockUri.scheme,
@@ -182,6 +247,63 @@ Detailed commit message with multiple lines
 					fragment: mockUri.fragment,
 				}),
 			)
+		})
+
+		it("should unescape file path before opening", async () => {
+			const mention = "/file\\ with\\ spaces.txt"
+			const expectedUnescaped = "file with spaces.txt"
+			const expectedAbsPath = path.resolve(mockCwd, expectedUnescaped)
+
+			await openMention(mention)
+
+			expect(openFile).toHaveBeenCalledWith(expectedAbsPath)
+			expect(vscode.commands.executeCommand).not.toHaveBeenCalled()
+		})
+
+		it("should unescape folder path before revealing", async () => {
+			const mention = "/folder\\ with\\ spaces/"
+			const expectedUnescaped = "folder with spaces/"
+			const expectedAbsPath = path.resolve(mockCwd, expectedUnescaped)
+			const expectedUri = { fsPath: expectedAbsPath } // From mock
+			;(vscode.Uri.file as jest.Mock).mockReturnValue(expectedUri)
+
+			await openMention(mention)
+
+			expect(vscode.commands.executeCommand).toHaveBeenCalledWith("revealInExplorer", expectedUri)
+			expect(vscode.Uri.file).toHaveBeenCalledWith(expectedAbsPath)
+			expect(openFile).not.toHaveBeenCalled()
+		})
+
+		it("should handle mentions without paths correctly", async () => {
+			await openMention("problems")
+			expect(vscode.commands.executeCommand).toHaveBeenCalledWith("workbench.actions.view.problems")
+
+			await openMention("terminal")
+			expect(vscode.commands.executeCommand).toHaveBeenCalledWith("workbench.action.terminal.focus")
+
+			await openMention("http://example.com")
+			expect(vscode.env.openExternal).toHaveBeenCalled() // Check if called, specific URI mock might be needed for detailed check
+
+			await openMention("git-changes") // Assuming no specific action for this yet
+			// Add expectations if an action is defined for git-changes
+
+			await openMention("a1b2c3d") // Assuming no specific action for commit hashes yet
+			// Add expectations if an action is defined for commit hashes
+		})
+
+		it("should do nothing if mention is undefined or empty", async () => {
+			await openMention(undefined)
+			await openMention("")
+			expect(openFile).not.toHaveBeenCalled()
+			expect(vscode.commands.executeCommand).not.toHaveBeenCalled()
+			expect(vscode.env.openExternal).not.toHaveBeenCalled()
+		})
+
+		it("should do nothing if cwd is not available", async () => {
+			;(getWorkspacePath as jest.Mock).mockReturnValue(undefined)
+			await openMention("/some\\ path.txt")
+			expect(openFile).not.toHaveBeenCalled()
+			expect(vscode.commands.executeCommand).not.toHaveBeenCalled()
 		})
 	})
 })

--- a/src/core/mentions/index.ts
+++ b/src/core/mentions/index.ts
@@ -6,7 +6,7 @@ import { isBinaryFile } from "isbinaryfile"
 
 import { openFile } from "../../integrations/misc/open-file"
 import { UrlContentFetcher } from "../../services/browser/UrlContentFetcher"
-import { mentionRegexGlobal } from "../../shared/context-mentions"
+import { mentionRegexGlobal, unescapeSpaces } from "../../shared/context-mentions"
 
 import { extractTextFromFile } from "../../integrations/misc/extract-text"
 import { diagnosticsToProblemsString } from "../../integrations/diagnostics"
@@ -25,7 +25,8 @@ export async function openMention(mention?: string): Promise<void> {
 	}
 
 	if (mention.startsWith("/")) {
-		const relPath = mention.slice(1)
+		// Slice off the leading slash and unescape any spaces in the path
+		const relPath = unescapeSpaces(mention.slice(1))
 		const absPath = path.resolve(cwd, relPath)
 		if (mention.endsWith("/")) {
 			vscode.commands.executeCommand("revealInExplorer", vscode.Uri.file(absPath))
@@ -158,7 +159,9 @@ export async function parseMentions(
 }
 
 async function getFileOrFolderContent(mentionPath: string, cwd: string): Promise<string> {
-	const absPath = path.resolve(cwd, mentionPath)
+	// Unescape spaces in the path before resolving it
+	const unescapedPath = unescapeSpaces(mentionPath)
+	const absPath = path.resolve(cwd, unescapedPath)
 
 	try {
 		const stats = await fs.stat(absPath)

--- a/src/shared/__tests__/context-mentions.test.ts
+++ b/src/shared/__tests__/context-mentions.test.ts
@@ -1,0 +1,79 @@
+import { mentionRegex, mentionRegexGlobal } from "../context-mentions"
+
+describe("mentionRegex and mentionRegexGlobal", () => {
+	// Test cases for various mention types
+	const testCases = [
+		// Basic file paths
+		{ input: "@/path/to/file.txt", expected: ["@/path/to/file.txt"] },
+		{ input: "@/file.js", expected: ["@/file.js"] },
+		{ input: "@/folder/", expected: ["@/folder/"] },
+
+		// File paths with escaped spaces
+		{ input: "@/path/to/file\\ with\\ spaces.txt", expected: ["@/path/to/file\\ with\\ spaces.txt"] },
+		{ input: "@/users/my\\ project/report\\ final.pdf", expected: ["@/users/my\\ project/report\\ final.pdf"] },
+		{ input: "@/folder\\ with\\ spaces/", expected: ["@/folder\\ with\\ spaces/"] },
+		{ input: "@/a\\ b\\ c.txt", expected: ["@/a\\ b\\ c.txt"] },
+
+		// URLs
+		{ input: "@http://example.com", expected: ["@http://example.com"] },
+		{ input: "@https://example.com/path?query=1", expected: ["@https://example.com/path?query=1"] },
+
+		// Other mentions
+		{ input: "@problems", expected: ["@problems"] },
+		{ input: "@git-changes", expected: ["@git-changes"] },
+		{ input: "@terminal", expected: ["@terminal"] },
+		{ input: "@a1b2c3d", expected: ["@a1b2c3d"] }, // Git commit hash (short)
+		{ input: "@a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0", expected: ["@a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"] }, // Git commit hash (long)
+
+		// Mentions within text
+		{
+			input: "Check file @/path/to/file\\ with\\ spaces.txt for details.",
+			expected: ["@/path/to/file\\ with\\ spaces.txt"],
+		},
+		{ input: "See @problems and @terminal output.", expected: ["@problems", "@terminal"] },
+		{ input: "URL: @https://example.com.", expected: ["@https://example.com"] }, // Trailing punctuation
+		{ input: "Commit @a1b2c3d, then check @/file.txt", expected: ["@a1b2c3d", "@/file.txt"] },
+
+		// Negative cases (should not match or match partially)
+		{ input: "@/path/with unescaped space.txt", expected: ["@/path/with"] }, // Unescaped space
+		{ input: "@ /path/leading-space.txt", expected: null }, // Space after @
+		{ input: "email@example.com", expected: null }, // Email address
+		{ input: "mention@", expected: null }, // Trailing @
+		{ input: "@/path/trailing\\", expected: null }, // Trailing backslash (invalid escape)
+		{ input: "@/path/to/file\\not-a-space", expected: null }, // Backslash not followed by space
+	]
+
+	testCases.forEach(({ input, expected }) => {
+		it(`should handle input: "${input}"`, () => {
+			// Test mentionRegex (first match)
+			const match = input.match(mentionRegex)
+			const firstExpected = expected ? expected[0] : null
+			if (firstExpected) {
+				expect(match).not.toBeNull()
+				// Check the full match (group 0)
+				expect(match?.[0]).toBe(firstExpected)
+				// Check the captured group (group 1) - remove leading '@'
+				expect(match?.[1]).toBe(firstExpected.slice(1))
+			} else {
+				expect(match).toBeNull()
+			}
+
+			// Test mentionRegexGlobal (all matches)
+			const globalMatches = [...input.matchAll(mentionRegexGlobal)].map((m) => m[0])
+			if (expected) {
+				expect(globalMatches).toEqual(expected)
+			} else {
+				expect(globalMatches).toEqual([])
+			}
+		})
+	})
+
+	it("should correctly capture the mention part (group 1)", () => {
+		const input = "Mention @/path/to/escaped\\ file.txt and @problems"
+		const matches = [...input.matchAll(mentionRegexGlobal)]
+
+		expect(matches.length).toBe(2)
+		expect(matches[0][1]).toBe("/path/to/escaped\\ file.txt") // Group 1 should not include '@'
+		expect(matches[1][1]).toBe("problems")
+	})
+})

--- a/src/shared/__tests__/context-mentions.test.ts
+++ b/src/shared/__tests__/context-mentions.test.ts
@@ -59,7 +59,7 @@ describe("mentionRegex and mentionRegexGlobal", () => {
 			}
 
 			// Test mentionRegexGlobal (all matches)
-			const globalMatches = [...input.matchAll(mentionRegexGlobal)].map((m) => m[0])
+			const globalMatches = Array.from(input.matchAll(mentionRegexGlobal)).map((m) => m[0])
 			if (expected) {
 				expect(globalMatches).toEqual(expected)
 			} else {
@@ -70,7 +70,7 @@ describe("mentionRegex and mentionRegexGlobal", () => {
 
 	it("should correctly capture the mention part (group 1)", () => {
 		const input = "Mention @/path/to/escaped\\ file.txt and @problems"
-		const matches = [...input.matchAll(mentionRegexGlobal)]
+		const matches = Array.from(input.matchAll(mentionRegexGlobal))
 
 		expect(matches.length).toBe(2)
 		expect(matches[0][1]).toBe("/path/to/escaped\\ file.txt") // Group 1 should not include '@'

--- a/src/shared/context-mentions.ts
+++ b/src/shared/context-mentions.ts
@@ -16,10 +16,13 @@ Mention regex:
 	  - `\/`: 
 		- **Slash (`/`)**: Indicates that the mention is a file or folder path starting with a '/'.
 	  - `|`: Logical OR.
-	  - `\w+:\/\/`: 
-		- **Protocol (`\w+://`)**: Matches URLs that start with a word character sequence followed by '://', such as 'http://', 'https://', 'ftp://', etc.
-	- `[^\s]+?`: 
-	  - **Non-Whitespace Characters (`[^\s]+`)**: Matches one or more characters that are not whitespace.
+	  - `\w+:\/\/`:
+	    - **Protocol (`\w+://`)**: Matches URLs that start with a word character sequence followed by '://', such as 'http://', 'https://', 'ftp://', etc.
+	- `(?:[^\s\\]|\\ )+?`:
+	  - **Non-Capturing Group (`(?:...)`)**: Groups the alternatives without capturing them.
+	  - **Non-Whitespace and Non-Backslash (`[^\s\\]`)**: Matches any character that is not whitespace or a backslash.
+	  - **OR (`|`)**: Logical OR.
+	  - **Escaped Space (`\\ `)**: Matches a backslash followed by a space (an escaped space).
 	  - **Non-Greedy (`+?`)**: Ensures the smallest possible match, preventing the inclusion of trailing punctuation.
 	- `|`: Logical OR.
 	- `problems\b`: 
@@ -39,6 +42,7 @@ Mention regex:
 - **Summary**:
   - The regex effectively matches:
 	- Mentions that are file or folder paths starting with '/' and containing any non-whitespace characters (including periods within the path).
+	- File paths can include spaces if they are escaped with a backslash (e.g., `@/path/to/file\ with\ spaces.txt`).
 	- URLs that start with a protocol (like 'http://') followed by any non-whitespace characters (including query parameters).
 	- The exact word 'problems'.
 	- The exact word 'git-changes'.
@@ -50,7 +54,7 @@ Mention regex:
 
 */
 export const mentionRegex =
-	/@((?:\/|\w+:\/\/)[^\s]+?|[a-f0-9]{7,40}\b|problems\b|git-changes\b|terminal\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/
+	/@((?:\/|\w+:\/\/)(?:[^\s\\]|\\ )+?|[a-f0-9]{7,40}\b|problems\b|git-changes\b|terminal\b)(?=[.,;:!?]?(?=[\s\r\n]|$))/
 export const mentionRegexGlobal = new RegExp(mentionRegex.source, "g")
 
 export interface MentionSuggestion {
@@ -89,4 +93,9 @@ export function formatGitSuggestion(commit: {
 		author: commit.author,
 		date: commit.date,
 	}
+}
+
+// Helper function to unescape paths with backslash-escaped spaces
+export function unescapeSpaces(path: string): string {
+	return path.replace(/\\ /g, " ")
 }

--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef, useCallback, useEffect, useLayoutEffect, useMemo, us
 import { useEvent } from "react-use"
 import DynamicTextArea from "react-textarea-autosize"
 
-import { mentionRegex, mentionRegexGlobal } from "@roo/shared/context-mentions"
+import { mentionRegex, mentionRegexGlobal, unescapeSpaces } from "@roo/shared/context-mentions"
 import { WebviewMessage } from "@roo/shared/WebviewMessage"
 import { Mode, getAllModes } from "@roo/shared/modes"
 import { ExtensionMessage } from "@roo/shared/ExtensionMessage"
@@ -470,7 +470,7 @@ const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 								// Send message to extension to search files
 								vscode.postMessage({
 									type: "searchFiles",
-									query: query,
+									query: unescapeSpaces(query),
 									requestId: reqId,
 								})
 							}, 200) // 200ms debounce

--- a/webview-ui/src/utils/__tests__/path-mentions.test.ts
+++ b/webview-ui/src/utils/__tests__/path-mentions.test.ts
@@ -1,60 +1,106 @@
-import { convertToMentionPath } from "../path-mentions"
+import { escapeSpaces, convertToMentionPath } from "../path-mentions"
 
-describe("path-mentions", () => {
+describe("Path Mentions Utilities", () => {
+	describe("escapeSpaces", () => {
+		it("should replace spaces with escaped spaces", () => {
+			expect(escapeSpaces("file with spaces.txt")).toBe("file\\ with\\ spaces.txt")
+			expect(escapeSpaces("/path/to/another file/")).toBe("/path/to/another\\ file/")
+			expect(escapeSpaces("single space")).toBe("single\\ space")
+		})
+
+		it("should handle paths without spaces", () => {
+			expect(escapeSpaces("file_without_spaces.txt")).toBe("file_without_spaces.txt")
+			expect(escapeSpaces("/path/to/normal/file")).toBe("/path/to/normal/file")
+		})
+
+		it("should handle multiple spaces", () => {
+			expect(escapeSpaces("a b c d.txt")).toBe("a\\ b\\ c\\ d.txt")
+		})
+
+		it("should handle leading/trailing spaces", () => {
+			expect(escapeSpaces(" leading space")).toBe("\\ leading\\ space")
+			expect(escapeSpaces("trailing space ")).toBe("trailing\\ space\\ ")
+		})
+
+		it("should handle empty string", () => {
+			expect(escapeSpaces("")).toBe("")
+		})
+
+		it("should not affect already escaped spaces", () => {
+			// This function assumes input spaces are not already escaped
+			// The function will re-escape the backslashes, resulting in double-escaped spaces
+			expect(escapeSpaces("file\\ with\\ spaces.txt")).toBe("file\\\\ with\\\\ spaces.txt")
+		})
+
+		it("should not escape other characters", () => {
+			expect(escapeSpaces("path/with/slashes")).toBe("path/with/slashes")
+			expect(escapeSpaces("file-with-hyphens.txt")).toBe("file-with-hyphens.txt")
+		})
+	})
+
 	describe("convertToMentionPath", () => {
-		it("should convert an absolute path to a mention path when it starts with cwd", () => {
-			// Windows-style paths
-			expect(convertToMentionPath("C:\\Users\\user\\project\\file.txt", "C:\\Users\\user\\project")).toBe(
-				"@/file.txt",
-			)
+		const MOCK_CWD_POSIX = "/Users/test/project"
+		const MOCK_CWD_WIN = "C:\\Users\\test\\project"
 
-			// Unix-style paths
-			expect(convertToMentionPath("/Users/user/project/file.txt", "/Users/user/project")).toBe("@/file.txt")
+		it("should convert absolute posix path within cwd to relative mention path and escape spaces", () => {
+			const absPath = "/Users/test/project/src/file with spaces.ts"
+			expect(convertToMentionPath(absPath, MOCK_CWD_POSIX)).toBe("@/src/file\\ with\\ spaces.ts")
 		})
 
-		it("should handle paths with trailing slashes in cwd", () => {
-			expect(convertToMentionPath("/Users/user/project/file.txt", "/Users/user/project/")).toBe("@/file.txt")
+		it("should convert absolute windows path within cwd to relative mention path and escape spaces", () => {
+			const absPath = "C:\\Users\\test\\project\\src\\file with spaces.ts"
+			expect(convertToMentionPath(absPath, MOCK_CWD_WIN)).toBe("@/src/file\\ with\\ spaces.ts")
 		})
 
-		it("should be case-insensitive when matching paths", () => {
-			expect(convertToMentionPath("/Users/User/Project/file.txt", "/users/user/project")).toBe("@/file.txt")
+		it("should handle paths already relative to cwd (though input is usually absolute)", () => {
+			const relPath = "src/another file.js" // Assuming this might be passed somehow
+			// It won't match startsWith(cwd), so it should return the original path (but normalized)
+			expect(convertToMentionPath(relPath, MOCK_CWD_POSIX)).toBe("src/another file.js")
 		})
 
-		it("should return the original path when cwd is not provided", () => {
-			expect(convertToMentionPath("/Users/user/project/file.txt")).toBe("/Users/user/project/file.txt")
+		it("should handle paths outside cwd by returning the original path (normalized)", () => {
+			const absPath = "/Users/other/file.txt"
+			expect(convertToMentionPath(absPath, MOCK_CWD_POSIX)).toBe("/Users/other/file.txt")
+			// Since we can't control the implementation of path normalization in this test,
+			// let's accept either form of path separators (/ or \) for the Windows path test
+			const winPath = "D:\\another\\folder\\file.txt"
+			const result = convertToMentionPath(winPath, MOCK_CWD_WIN)
+			// Check that the path was returned without being converted to a mention
+			expect(result.startsWith("@")).toBe(false)
+			// Check the path contains the expected components regardless of separator
+			expect(result.toLowerCase()).toContain("d:")
+			expect(result.toLowerCase()).toContain("another")
+			expect(result.toLowerCase()).toContain("folder")
+			expect(result.toLowerCase()).toContain("file.txt")
 		})
 
-		it("should return the original path when it does not start with cwd", () => {
-			expect(convertToMentionPath("/Users/other/project/file.txt", "/Users/user/project")).toBe(
-				"/Users/other/project/file.txt",
-			)
+		it("should handle paths with no spaces correctly", () => {
+			const absPath = "/Users/test/project/src/normal.ts"
+			expect(convertToMentionPath(absPath, MOCK_CWD_POSIX)).toBe("@/src/normal.ts")
 		})
 
-		it("should normalize backslashes to forward slashes", () => {
-			expect(convertToMentionPath("C:\\Users\\user\\project\\subdir\\file.txt", "C:\\Users\\user\\project")).toBe(
-				"@/subdir/file.txt",
-			)
+		it("should add leading slash if missing after cwd removal", () => {
+			const absPath = "/Users/test/projectfile.txt" // Edge case: file directly in project root
+			const cwd = "/Users/test/project"
+			expect(convertToMentionPath(absPath, cwd)).toBe("@/file.txt") // Should still add '/'
 		})
 
-		it("should handle nested paths correctly", () => {
-			expect(convertToMentionPath("/Users/user/project/nested/deeply/file.txt", "/Users/user/project")).toBe(
-				"@/nested/deeply/file.txt",
-			)
+		it("should handle cwd with trailing slash", () => {
+			const absPath = "/Users/test/project/src/file with spaces.ts"
+			const cwdWithSlash = MOCK_CWD_POSIX + "/"
+			expect(convertToMentionPath(absPath, cwdWithSlash)).toBe("@/src/file\\ with\\ spaces.ts")
 		})
 
-		it("should strip file:// protocol from paths if present", () => {
-			// Without cwd
-			expect(convertToMentionPath("file:///Users/user/project/file.txt")).toBe("/Users/user/project/file.txt")
+		it("should handle case-insensitive matching for cwd", () => {
+			const absPath = "/users/test/project/src/file with spaces.ts" // Lowercase path
+			expect(convertToMentionPath(absPath, MOCK_CWD_POSIX)).toBe("@/src/file\\ with\\ spaces.ts") // Should still match uppercase CWD
+			const absPathUpper = "/USERS/TEST/PROJECT/src/file.ts" // Uppercase path
+			expect(convertToMentionPath(absPathUpper, MOCK_CWD_POSIX.toLowerCase())).toBe("@/src/file.ts") // Should match lowercase CWD
+		})
 
-			// With cwd - should strip protocol and then apply mention path logic
-			expect(convertToMentionPath("file:///Users/user/project/file.txt", "/Users/user/project")).toBe(
-				"@/file.txt",
-			)
-
-			// With Windows paths
-			expect(convertToMentionPath("file://C:/Users/user/project/file.txt", "C:/Users/user/project")).toBe(
-				"@/file.txt",
-			)
+		it("should return original path if cwd is not provided", () => {
+			const absPath = "/Users/test/project/src/file with spaces.ts"
+			expect(convertToMentionPath(absPath, undefined)).toBe("/Users/test/project/src/file with spaces.ts")
 		})
 	})
 })

--- a/webview-ui/src/utils/context-mentions.ts
+++ b/webview-ui/src/utils/context-mentions.ts
@@ -2,6 +2,7 @@ import { mentionRegex } from "@roo/shared/context-mentions"
 import { Fzf } from "fzf"
 import { ModeConfig } from "@roo/shared/modes"
 import * as path from "path"
+import { escapeSpaces } from "./path-mentions"
 
 export interface SearchResult {
 	path: string
@@ -27,6 +28,15 @@ export function insertMention(
 	// Find the position of the last '@' symbol before the cursor
 	const lastAtIndex = beforeCursor.lastIndexOf("@")
 
+	// Process the value - escape spaces if it's a file path
+	let processedValue = value
+	if (value && value.startsWith("/")) {
+		// Only escape if the path contains spaces that aren't already escaped
+		if (value.includes(" ") && !value.includes("\\ ")) {
+			processedValue = escapeSpaces(value)
+		}
+	}
+
 	let newValue: string
 	let mentionIndex: number
 
@@ -38,11 +48,11 @@ export function insertMention(
 		const afterCursorContent = /^[a-zA-Z0-9\s]*$/.test(afterCursor)
 			? afterCursor.replace(/^[^\s]*/, "")
 			: afterCursor
-		newValue = beforeMention + "@" + value + " " + afterCursorContent
+		newValue = beforeMention + "@" + processedValue + " " + afterCursorContent
 		mentionIndex = lastAtIndex
 	} else {
 		// If there's no '@' symbol, insert the mention at the cursor position
-		newValue = beforeCursor + "@" + value + " " + afterCursor
+		newValue = beforeCursor + "@" + processedValue + " " + afterCursor
 		mentionIndex = position
 	}
 
@@ -58,8 +68,11 @@ export function removeMention(text: string, position: number): { newText: string
 
 	if (matchEnd) {
 		// If we're at the end of a mention, remove it
-		const newText = text.slice(0, position - matchEnd[0].length) + afterCursor.replace(" ", "") // removes the first space after the mention
-		const newPosition = position - matchEnd[0].length
+		// Remove the mention and the first space that follows it
+		const mentionLength = matchEnd[0].length
+		// Remove the mention and one space after it if it exists
+		const newText = text.slice(0, position - mentionLength) + afterCursor.replace(/^\s/, "")
+		const newPosition = position - mentionLength
 		return { newText, newPosition }
 	}
 
@@ -236,13 +249,21 @@ export function getContextMenuOptions(
 
 	// Convert search results to queryItems format
 	const searchResultItems = dynamicSearchResults.map((result) => {
-		const formattedPath = result.path.startsWith("/") ? result.path : `/${result.path}`
+		// Ensure paths start with / for consistency
+		let formattedPath = result.path.startsWith("/") ? result.path : `/${result.path}`
+
+		// For display purposes, we don't escape spaces in the label or description
+		const displayPath = formattedPath
+		const displayName = result.label || path.basename(result.path)
+
+		// We don't need to escape spaces here because the insertMention function
+		// will handle that when the user selects a suggestion
 
 		return {
 			type: result.type === "folder" ? ContextMenuOptionType.Folder : ContextMenuOptionType.File,
 			value: formattedPath,
-			label: result.label || path.basename(result.path),
-			description: formattedPath,
+			label: displayName,
+			description: displayPath,
 		}
 	})
 
@@ -285,8 +306,11 @@ export function shouldShowContextMenu(text: string, position: number): boolean {
 
 	const textAfterAt = beforeCursor.slice(atIndex + 1)
 
-	// Check if there's any whitespace after the '@'
-	if (/\s/.test(textAfterAt)) return false
+	// Check if there's any unescaped whitespace after the '@'
+	// We need to check for whitespace that isn't preceded by a backslash
+	// Using a negative lookbehind to ensure the space isn't escaped
+	const hasUnescapedSpace = /(?<!\\)\s/.test(textAfterAt)
+	if (hasUnescapedSpace) return false
 
 	// Don't show the menu if it's clearly a URL
 	if (textAfterAt.toLowerCase().startsWith("http")) {

--- a/webview-ui/src/utils/path-mentions.ts
+++ b/webview-ui/src/utils/path-mentions.ts
@@ -3,9 +3,20 @@
  */
 
 /**
+ * Escapes spaces in a path with backslashes
+ *
+ * @param path The path to escape
+ * @returns A path with spaces escaped
+ */
+export function escapeSpaces(path: string): string {
+	return path.replace(/ /g, "\\ ")
+}
+
+/**
  * Converts an absolute path to a mention-friendly path
  * If the provided path starts with the current working directory,
  * it's converted to a relative path prefixed with @
+ * Spaces in the path are escaped with backslashes
  *
  * @param path The path to convert
  * @param cwd The current working directory
@@ -55,9 +66,14 @@ export function convertToMentionPath(path: string, cwd?: string): string {
 	const lowerCwd = normalizedCwd.toLowerCase()
 
 	if (lowerPath.startsWith(lowerCwd)) {
-		const relativePath = normalizedPath.substring(normalizedCwd.length)
+		let relativePath = normalizedPath.substring(normalizedCwd.length)
 		// Ensure there's a slash after the @ symbol when we create the mention path
-		return "@" + (relativePath.startsWith("/") ? relativePath : "/" + relativePath)
+		relativePath = relativePath.startsWith("/") ? relativePath : "/" + relativePath
+
+		// Escape any spaces in the path with backslashes
+		const escapedRelativePath = escapeSpaces(relativePath)
+
+		return "@" + escapedRelativePath
 	}
 
 	return pathWithoutProtocol


### PR DESCRIPTION
Allows spaces to be escaped in mentions with `\\`. Does not attempt more comprehensive escape handling. (IMO a more structured representation or moving to something like `@[something complex]` is probably a better long term approach, but the scope of that seems daunting. 

Adapted from 8955d45708eb78f2754921099a291628203f4069 / #2363.

## Context

Addresses #2361

## Screenshots
before

https://github.com/user-attachments/assets/167568df-2ccb-4b64-a61f-1f7e7f844e7b

after

https://github.com/user-attachments/assets/1dfb8236-3066-4293-a236-4e35ba8e2b2f
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds support for file path mentions with spaces by allowing spaces to be escaped with backslashes, updating regex patterns, and enhancing path handling functions.
> 
>   - **Behavior**:
>     - Supports file path mentions with spaces by allowing spaces to be escaped with `\\` in `parseMentions()` and `openMention()` in `index.ts`.
>     - Updates `mentionRegex` in `context-mentions.ts` to match paths with escaped spaces.
>     - `insertMention()` in `context-mentions.ts` now escapes spaces in file paths.
>   - **Tests**:
>     - Adds tests for escaped spaces in `index.test.ts`, `context-mentions.test.ts`, and `path-mentions.test.ts`.
>     - Verifies correct handling of escaped spaces in mentions and context menu options.
>   - **Utilities**:
>     - Adds `escapeSpaces()` to `path-mentions.ts` to escape spaces in paths.
>     - Updates `convertToMentionPath()` to handle paths with spaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 07bb1f1c34ad19adfc841c03e386c6c2aa0eca78. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->