### PR TITLE
fix: copy tree-sitter WASM files to out dir in build

### DIFF
--- a/esbuild.js
+++ b/esbuild.js
@@ -31,12 +31,28 @@ const copyWasmFiles = {
 		build.onEnd(() => {
 			const nodeModulesDir = path.join(__dirname, "node_modules")
 			const distDir = path.join(__dirname, "dist")
+			const outDir = path.join(__dirname, "out") // Define outDir
+
+			// Ensure destination directories exist
+			fs.mkdirSync(distDir, { recursive: true })
+			try {
+				fs.mkdirSync(outDir, { recursive: true })
+			} catch (e) {}
 
 			// tiktoken
 			fs.copyFileSync(
 				path.join(nodeModulesDir, "tiktoken", "tiktoken_bg.wasm"),
 				path.join(distDir, "tiktoken_bg.wasm"),
 			)
+			// Also copy tiktoken wasm to outDir
+			try {
+				fs.copyFileSync(
+					path.join(nodeModulesDir, "tiktoken", "tiktoken_bg.wasm"),
+					path.join(outDir, "tiktoken_bg.wasm"),
+				)
+			} catch (e) {
+				console.warn("Could not copy tiktoken wasm to out directory:", e.message)
+			}
 
 			// Copy language-specific WASM files
 			const languageWasmDir = path.join(__dirname, "node_modules", "tree-sitter-wasms", "out")
@@ -48,8 +64,16 @@ const copyWasmFiles = {
 				console.log(`Copying ${wasmFiles.length} tree-sitter WASM files to dist directory`)
 
 				wasmFiles.forEach((filename) => {
+					// Copy to dist
 					fs.copyFileSync(path.join(languageWasmDir, filename), path.join(distDir, filename))
+					// Also copy to out
+					try {
+						fs.copyFileSync(path.join(languageWasmDir, filename), path.join(outDir, filename))
+					} catch (e) {
+						console.warn(`Could not copy ${filename} to out directory:`, e.message)
+					}
 				})
+				console.log(`Copied tree-sitter WASM files to dist and out directories`)
 			} else {
 				console.warn(`Tree-sitter WASM directory not found: ${languageWasmDir}`)
 			}


### PR DESCRIPTION
## Context

The `listCodeDefinitionNamesTool` was observed to hang indefinitely after recent changes related to tree-sitter (potentially introduced in #2960). The root cause was identified as the necessary tree-sitter language parser WASM files (`tree-sitter-*.wasm`) not being present in the runtime build output directory (`out`). The build script (`esbuild.js`) was only copying these essential files to the `dist` directory.

This PR fixes the build process to ensure the WASM files are available at runtime, resolving the hang in the `listCodeDefinitionNamesTool`.

## Implementation

Modified the `copyWasmFiles` plugin within `esbuild.js`:
- Defined the `outDir` path alongside `distDir`.
- Ensured the `out` directory is created if it doesn't exist.
- Added logic to copy both the `tiktoken_bg.wasm` file and all `tree-sitter-*.wasm` files from `node_modules/tree-sitter-wasms/out` to the `out` directory, mirroring the existing copy operation to the `dist` directory.
- Included basic error handling for the copy operations to the `out` directory.

This ensures that when the extension code executes from the `out` directory, the `languageParser.ts` module can successfully load the required WASM language grammars via `Parser.Language.load()`.

## Screenshots

| before | after |
| ------ | ----- |
| N/A    | N/A   |

*(No visual changes)*

## How to Test

1.  Check out this branch (`fix/tree-sitter-wasm-build`).
2.  Run the extension build command (e.g., `npm run compile` or `npm run watch`).
3.  Verify that the `out` directory now contains the `tree-sitter-*.wasm` files (e.g., `ls out | grep .wasm`).
4.  Launch the VS Code extension (Run -> Start Debugging).
5.  Open a project/folder with source code files (e.g., TypeScript, Python).
6.  Open Roo and use the `list_code_definition_names` tool:
    ```xml

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes hang in `listCodeDefinitionNamesTool` by copying necessary WASM files to `out` directory in `esbuild.js`.
> 
>   - **Behavior**:
>     - Fixes hang in `listCodeDefinitionNamesTool` by ensuring `tree-sitter-*.wasm` files are copied to `out` directory in `esbuild.js`.
>     - Ensures `tiktoken_bg.wasm` and `tree-sitter-*.wasm` files are copied to both `dist` and `out` directories.
>   - **Implementation**:
>     - Modifies `copyWasmFiles` plugin in `esbuild.js` to define `outDir` and ensure its existence.
>     - Adds error handling for file copy operations to `out` directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f67e0031d15dfdf9dbe9f217427e680908111662. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->