### PR TITLE
test: verify dist WASM files exist

### DIFF
--- a/src/__tests__/dist_assets.test.ts
+++ b/src/__tests__/dist_assets.test.ts
@@ -1,0 +1,57 @@
+import * as fs from "fs"
+import * as path from "path"
+
+describe("dist assets", () => {
+	const distPath = path.join(__dirname, "../../dist")
+
+	describe("tiktoken", () => {
+		it("should have tiktoken wasm file", () => {
+			expect(fs.existsSync(path.join(distPath, "tiktoken_bg.wasm"))).toBe(true)
+		})
+	})
+
+	describe("tree-sitter", () => {
+		const treeSitterFiles = [
+			"tree-sitter-bash.wasm",
+			"tree-sitter-cpp.wasm",
+			"tree-sitter-c_sharp.wasm",
+			"tree-sitter-css.wasm",
+			"tree-sitter-c.wasm",
+			"tree-sitter-elisp.wasm",
+			"tree-sitter-elixir.wasm",
+			"tree-sitter-elm.wasm",
+			"tree-sitter-embedded_template.wasm",
+			"tree-sitter-go.wasm",
+			"tree-sitter-html.wasm",
+			"tree-sitter-javascript.wasm",
+			"tree-sitter-java.wasm",
+			"tree-sitter-json.wasm",
+			"tree-sitter-kotlin.wasm",
+			"tree-sitter-lua.wasm",
+			"tree-sitter-objc.wasm",
+			"tree-sitter-ocaml.wasm",
+			"tree-sitter-php.wasm",
+			"tree-sitter-python.wasm",
+			"tree-sitter-ql.wasm",
+			"tree-sitter-rescript.wasm",
+			"tree-sitter-ruby.wasm",
+			"tree-sitter-rust.wasm",
+			"tree-sitter-scala.wasm",
+			"tree-sitter-solidity.wasm",
+			"tree-sitter-swift.wasm",
+			"tree-sitter-systemrdl.wasm",
+			"tree-sitter-tlaplus.wasm",
+			"tree-sitter-toml.wasm",
+			"tree-sitter-tsx.wasm",
+			"tree-sitter-typescript.wasm",
+			"tree-sitter-vue.wasm",
+			"tree-sitter.wasm",
+			"tree-sitter-yaml.wasm",
+			"tree-sitter-zig.wasm",
+		]
+
+		test.each(treeSitterFiles)("should have %s file", (filename) => {
+			expect(fs.existsSync(path.join(distPath, filename))).toBe(true)
+		})
+	})
+})


### PR DESCRIPTION
## Context

Add test coverage to verify that all required WASM files are present in the dist directory after build.

## Implementation

Created a new test that checks for:
- tiktoken_bg.wasm for tokenization
- tree-sitter.wasm core parser
- All language-specific tree-sitter WASM files for syntax highlighting

## How to Test

1. Run `npm test src/__tests__/dist_assets.test.ts`
2. All 37 WASM file existence checks should pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add test `dist_assets.test.ts` to verify presence of required WASM files in `dist` directory.
> 
>   - **Tests**:
>     - New test `dist_assets.test.ts` added to verify existence of WASM files in `dist` directory.
>     - Checks for `tiktoken_bg.wasm` for tokenization.
>     - Verifies presence of 36 `tree-sitter` language-specific WASM files for syntax highlighting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ce93ac8c3e97a97ec1a5f844e042be014d352d64. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->