### PR TITLE
UI: Toggles and border fixes on edge case themes. 

### DIFF
--- a/webview-ui/src/components/settings/AutoApproveToggle.tsx
+++ b/webview-ui/src/components/settings/AutoApproveToggle.tsx
@@ -106,7 +106,7 @@ export const AutoApproveToggle = ({ onToggle, ...props }: AutoApproveToggleProps
 					onClick={() => onToggle(key, !props[key])}
 					title={t(descriptionKey || "")}
 					data-testid={testId}
-					className={cn(" aspect-square h-[80px]")}>
+					className={cn(" aspect-square h-[80px]", !props[key] && "opacity-50")}>
 					<span className={cn("flex flex-col items-center gap-1")}>
 						<span className={`codicon codicon-${icon}`} />
 						<span className="text-sm text-center">{t(labelKey)}</span>

--- a/webview-ui/src/index.css
+++ b/webview-ui/src/index.css
@@ -82,7 +82,10 @@
 
 	--color-vscode-input-foreground: var(--vscode-input-foreground);
 	--color-vscode-input-background: var(--vscode-input-background);
-	--color-vscode-input-border: var(--vscode-input-border);
+	--color-vscode-input-border: var(
+		--vscode-input-border,
+		transparent
+	); /* Some themes don't have a border color, so we can fallback to transparent */
 
 	--color-vscode-focusBorder: var(--vscode-focusBorder);
 
@@ -140,7 +143,7 @@
 		--accent-foreground: var(--vscode-list-hoverForeground);
 		--destructive: var(--vscode-errorForeground);
 		--destructive-foreground: var(--vscode-button-foreground);
-		--border: var(--vscode-input-border);
+		--border: var(--vscode-input-border, transparent); /* --border gets theme value or transparent fallback */
 		--input: var(--vscode-input-background);
 		--ring: var(--vscode-input-border);
 		--chart-1: var(--vscode-charts-red);
@@ -149,6 +152,13 @@
 		--chart-4: var(--vscode-charts-orange);
 		--chart-5: var(--vscode-charts-green);
 		--radius: 0.5rem;
+	}
+
+	/* Higher specififty than VSCode's theme and root. */
+	/* Used for baseline theme overrides, but avoid using for styling. */
+
+	body {
+		--vscode-input-border: var(--border);
 	}
 }
 


### PR DESCRIPTION
## Context

Referenced in #2987 cc @elianiva: 

Some themes don't define border colors, so a white border bleeds through. This PR addresses the issue by setting a transparent fallback if `--vscode-input-border` is undefined: 

Before/After: 

![Screenshot 2025-04-29 at 8 16 19 PM](https://github.com/user-attachments/assets/5753f725-09b2-4fd7-9c1e-08ad19e80b3e)

For the auto-approve toggles specifically, this also addresses some themes which do not have highly differentiated `default` and `outline` button variants by making the falsy state partially-transparent: 

![Screenshot 2025-04-29 at 8 55 22 PM](https://github.com/user-attachments/assets/30e013d4-2108-4468-9a83-d7bc590eac2e)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes border color and toggle button opacity issues in themes with missing definitions by adding transparent fallbacks and adjusting opacity in `index.css` and `AutoApproveToggle.tsx`.
> 
>   - **CSS Changes**:
>     - In `index.css`, set `--color-vscode-input-border` to fallback to `transparent` if `--vscode-input-border` is undefined.
>     - Update `--border` variable to use `transparent` fallback in `index.css`.
>   - **Component Changes**:
>     - In `AutoApproveToggle.tsx`, add `opacity-50` class to toggles in falsy state for better differentiation in themes with similar `default` and `outline` button variants.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 82ddde4a34b299406514f7ffcb42411315af86b6. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->