### PR TITLE
Play sound only when action needed from the user

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -181,7 +181,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setSecondaryButtonText(undefined)
 							break
 						case "tool":
-							if (!isAutoApproved(lastMessage)) {
+							if (!isAutoApproved(lastMessage) && !isPartial) {
 								playSound("notification")
 							}
 							setTextAreaDisabled(isPartial)
@@ -207,7 +207,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							}
 							break
 						case "browser_action_launch":
-							if (!isAutoApproved(lastMessage)) {
+							if (!isAutoApproved(lastMessage) && !isPartial) {
 								playSound("notification")
 							}
 							setTextAreaDisabled(isPartial)
@@ -217,7 +217,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setSecondaryButtonText(t("chat:reject.title"))
 							break
 						case "command":
-							if (!isAutoApproved(lastMessage)) {
+							if (!isAutoApproved(lastMessage) && !isPartial) {
 								playSound("notification")
 							}
 							setTextAreaDisabled(isPartial)
@@ -242,7 +242,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							break
 						case "completion_result":
 							// extension waiting for feedback. but we can just present a new task button
-							playSound("celebration")
+							if (!isPartial) {
+								playSound("celebration")
+							}
 							setTextAreaDisabled(isPartial)
 							setClineAsk("completion_result")
 							setEnableButtons(!isPartial)
@@ -822,37 +824,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 						lastTtsRef.current = text
 					} catch (error) {
 						console.error("Failed to execute text-to-speech:", error)
-					}
-				}
-			}
-		}
-
-		// Only execute when isStreaming changes from true to false.
-		if (wasStreaming && !isStreaming && lastMessage) {
-			// Play appropriate sound based on lastMessage content.
-			if (lastMessage.type === "ask") {
-				// Don't play sounds for auto-approved actions
-				if (!isAutoApproved(lastMessage)) {
-					switch (lastMessage.ask) {
-						case "api_req_failed":
-						case "mistake_limit_reached":
-							playSound("progress_loop")
-							break
-						case "followup":
-							if (!lastMessage.partial) {
-								playSound("notification")
-							}
-							break
-						case "tool":
-						case "browser_action_launch":
-						case "resume_task":
-						case "use_mcp_server":
-							playSound("notification")
-							break
-						case "completion_result":
-						case "resume_completed_task":
-							playSound("celebration")
-							break
 					}
 				}
 			}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -170,6 +170,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setSecondaryButtonText(t("chat:startNewTask.title"))
 							break
 						case "followup":
+							if (!isPartial) {
+								playSound("notification")
+							}
 							setTextAreaDisabled(isPartial)
 							setClineAsk("followup")
 							// setting enable buttons to `false` would trigger a focus grab when
@@ -234,6 +237,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setSecondaryButtonText(t("chat:killCommand.title"))
 							break
 						case "use_mcp_server":
+							if (!isAutoApproved(lastMessage) && !isPartial) {
+								playSound("notification")
+							}
 							setTextAreaDisabled(isPartial)
 							setClineAsk("use_mcp_server")
 							setEnableButtons(!isPartial)
@@ -252,6 +258,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setSecondaryButtonText(undefined)
 							break
 						case "resume_task":
+							if (!isAutoApproved(lastMessage) && !isPartial) {
+								playSound("notification")
+							}
 							setTextAreaDisabled(false)
 							setClineAsk("resume_task")
 							setEnableButtons(true)
@@ -260,6 +269,9 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setDidClickCancel(false) // special case where we reset the cancel button state
 							break
 						case "resume_completed_task":
+							if (!isPartial) {
+								playSound("celebration")
+							}
 							setTextAreaDisabled(false)
 							setClineAsk("resume_completed_task")
 							setEnableButtons(true)


### PR DESCRIPTION
## Context

Looking at https://github.com/RooVetGit/Roo-Code/issues/2190 I wanted to make sure that sounds only play when action is needed from the user.

There already was some logic around `!isAutoApproved` but in my testing, I found that to be lacking. Sometimes I would get the same sound played back to back, and there over all was a _lot_ of sounds happening - some of which shouldn't be there.

## Implementation

In looking at `ChatView.tsx` I found that there were two sections where we called `playSound`: 

In the large case statement where we handle the incoming last messages based on type

```
useDeepCompareEffect(() => {
		// if last message is an ask, show user ask UI
		// if user finished a task, then start a new task with a new conversation history since in this moment that the extension is waiting for user response, the user could close the extension and the conversation history would be lost.
		// basically as long as a task is active, the conversation history will be persisted
		if (lastMessage) {
			switch (lastMessage.type) {
```

And then again further down in the streaming section which duplicated some of that case statement. I think this might have been a previous attempt to only play sounds when coming back and needing user input, but this resulted in often getting TWO sounds played

Additionally, most of the statements in the "main" case statement already were properly checking if we needed user input using `!isAutoApproved`.

Thus, I decided to remove that logic, which in my testing got rid of a lot of the double sounds. However, I was still sometimes getting double sounds on tool use or at completion of a task.

I found this to be when we get only a "partial" message back and are waiting for the final message to enable user interaction. Thus, I also added a check for `!isPartial` around these sounds - which is also what handles things like `setTextAreaDisabled` and `setEnableButtons`. Thus, this new sound logic matches how we enable/disable buttons and other user interactions and should more closely mimic that working logic

Closes #2190

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

- Enable sounds in settings
- Disable auto-approve, or approve it only for some actions (say read files but not write)
- Ask Roo to make some modifications to the code
- Observe when sounds are played (should be only when there is a button for the user to press or on API errors and completion)

## Get in Touch

My discord handle is `olearycrew`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refines sound notification logic in `ChatView.tsx` to play sounds only when user action is required, addressing issue #2190.
> 
>   - **Behavior**:
>     - Modify `playSound` logic in `ChatView.tsx` to include `!isPartial` check for `tool`, `browser_action_launch`, `command`, and `completion_result` cases.
>     - Remove redundant sound logic in the streaming section to prevent duplicate sounds.
>   - **Misc**:
>     - Closes issue #2190.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7dd9bdc12e48906dd7162b8cb6ec7bec6e5c0941. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->