### PR TITLE
feat(openai): Add Config Option to Overwrite OpenAI's API Base

### DIFF
--- a/evals/packages/types/src/roo-code.ts
+++ b/evals/packages/types/src/roo-code.ts
@@ -358,6 +358,7 @@ export const providerSettingsSchema = z.object({
 	googleGeminiBaseUrl: z.string().optional(),
 	// OpenAI Native
 	openAiNativeApiKey: z.string().optional(),
+	openAiNativeBaseUrl: z.string().optional(),
 	// XAI
 	xaiApiKey: z.string().optional(),
 	// Mistral
@@ -445,6 +446,7 @@ const providerSettingsRecord: ProviderSettingsRecord = {
 	googleGeminiBaseUrl: undefined,
 	// OpenAI Native
 	openAiNativeApiKey: undefined,
+	openAiNativeBaseUrl: undefined,
 	// Mistral
 	mistralApiKey: undefined,
 	mistralCodestralUrl: undefined,

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -29,7 +29,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 		super()
 		this.options = options
 		const apiKey = this.options.openAiNativeApiKey ?? "not-provided"
-		this.client = new OpenAI({ apiKey })
+		this.client = new OpenAI({ baseURL: this.options.openAiNativeBaseUrl, apiKey })
 	}
 
 	override async *createMessage(systemPrompt: string, messages: Anthropic.Messages.MessageParam[]): ApiStream {

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -105,6 +105,7 @@ type ProviderSettings = {
 	geminiApiKey?: string | undefined
 	googleGeminiBaseUrl?: string | undefined
 	openAiNativeApiKey?: string | undefined
+	openAiNativeBaseUrl?: string | undefined
 	mistralApiKey?: string | undefined
 	mistralCodestralUrl?: string | undefined
 	deepSeekBaseUrl?: string | undefined

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -106,6 +106,7 @@ type ProviderSettings = {
 	geminiApiKey?: string | undefined
 	googleGeminiBaseUrl?: string | undefined
 	openAiNativeApiKey?: string | undefined
+	openAiNativeBaseUrl?: string | undefined
 	mistralApiKey?: string | undefined
 	mistralCodestralUrl?: string | undefined
 	deepSeekBaseUrl?: string | undefined

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -401,6 +401,7 @@ export const providerSettingsSchema = z.object({
 	googleGeminiBaseUrl: z.string().optional(),
 	// OpenAI Native
 	openAiNativeApiKey: z.string().optional(),
+	openAiNativeBaseUrl: z.string().optional(),
 	// Mistral
 	mistralApiKey: z.string().optional(),
 	mistralCodestralUrl: z.string().optional(),
@@ -492,6 +493,7 @@ const providerSettingsRecord: ProviderSettingsRecord = {
 	googleGeminiBaseUrl: undefined,
 	// OpenAI Native
 	openAiNativeApiKey: undefined,
+	openAiNativeBaseUrl: undefined,
 	// Mistral
 	mistralApiKey: undefined,
 	mistralCodestralUrl: undefined,

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -75,6 +75,9 @@ const ApiOptions = ({
 	const [openAiModels, setOpenAiModels] = useState<Record<string, ModelInfo> | null>(null)
 
 	const [anthropicBaseUrlSelected, setAnthropicBaseUrlSelected] = useState(!!apiConfiguration?.anthropicBaseUrl)
+	const [openAiNativeBaseUrlSelected, setOpenAiNativeBaseUrlSelected] = useState(
+		!!apiConfiguration?.openAiNativeBaseUrl,
+	)
 	const [azureApiVersionSelected, setAzureApiVersionSelected] = useState(!!apiConfiguration?.azureApiVersion)
 	const [openRouterBaseUrlSelected, setOpenRouterBaseUrlSelected] = useState(!!apiConfiguration?.openRouterBaseUrl)
 	const [openAiHostHeaderSelected, setOpenAiHostHeaderSelected] = useState(!!apiConfiguration?.openAiHostHeader)
@@ -490,14 +493,28 @@ const ApiOptions = ({
 
 			{selectedProvider === "openai-native" && (
 				<>
-					<VSCodeTextField
-						value={apiConfiguration?.openAiNativeBaseUrl || ""}
-						type="url"
-						onInput={handleInputChange("openAiNativeBaseUrl")}
-						placeholder={t("settings:placeholders.baseUrl")}
-						className="w-full">
-						<label className="block font-medium mb-1">{t("settings:providers.openAiBaseUrl")}</label>
-					</VSCodeTextField>
+					<Checkbox
+						checked={openAiNativeBaseUrlSelected}
+						onChange={(checked: boolean) => {
+							setOpenAiNativeBaseUrlSelected(checked)
+
+							if (!checked) {
+								setApiConfigurationField("openAiNativeBaseUrl", "")
+							}
+						}}>
+						{t("settings:providers.useCustomBaseUrl")}
+					</Checkbox>
+					{openAiNativeBaseUrlSelected && (
+						<>
+							<VSCodeTextField
+								value={apiConfiguration?.openAiNativeBaseUrl || ""}
+								type="url"
+								onInput={handleInputChange("openAiNativeBaseUrl")}
+								placeholder="https://api.openai.com/v1"
+								className="w-full mt-1"
+							/>
+						</>
+					)}
 					<VSCodeTextField
 						value={apiConfiguration?.openAiNativeApiKey || ""}
 						type="password"

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -491,6 +491,14 @@ const ApiOptions = ({
 			{selectedProvider === "openai-native" && (
 				<>
 					<VSCodeTextField
+						value={apiConfiguration?.openAiNativeBaseUrl || ""}
+						type="url"
+						onInput={handleInputChange("openAiNativeBaseUrl")}
+						placeholder={t("settings:placeholders.baseUrl")}
+						className="w-full">
+						<label className="block font-medium mb-1">{t("settings:providers.openAiBaseUrl")}</label>
+					</VSCodeTextField>
+					<VSCodeTextField
 						value={apiConfiguration?.openAiNativeApiKey || ""}
 						type="password"
 						onInput={handleInputChange("openAiNativeApiKey")}


### PR DESCRIPTION
## Context

Add Config Option to Overwrite OpenAI's API Base #3052

## Description:
It would be beneficial to add a configuration option that allows users to overwrite the OpenAI API base.

## Use Case:
Users facing issues with OpenAI's regional restrictions, where the default API base may not be accessible due to geo-blocking or other limitations.

## Screenshots

| before | after |
| ------ | ----- |
|   ![891711a4-2bd3-45e6-a877-eafbf88fe2b2](https://github.com/user-attachments/assets/ddbbbe5a-cc92-4fae-a2e8-25c9e9499b39) |    ![ea607bf2-6103-4d4a-869d-62223996023c](https://github.com/user-attachments/assets/ac264a49-2e51-401b-94f7-533f1725a976)
 |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `openAiNativeBaseUrl` configuration option to overwrite OpenAI's API base URL, updating relevant schemas, models, and UI components.
> 
>   - **Behavior**:
>     - Adds `openAiNativeBaseUrl` to `providerSettingsSchema` in `roo-code.ts` and `schemas/index.ts`.
>     - Updates `OpenAiNativeHandler` in `openai-native.ts` to use `openAiNativeBaseUrl` for API client initialization.
>     - Updates `ApiOptions` in `ApiOptions.tsx` to include a text field for `openAiNativeBaseUrl` when `openai-native` is selected.
>   - **Models**:
>     - Adds `openAiNativeBaseUrl` to `ProviderSettings` in `roo-code.d.ts` and `types.ts`.
>   - **Misc**:
>     - Updates `providerSettingsRecord` in `roo-code.ts` and `schemas/index.ts` to include `openAiNativeBaseUrl`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b3c7be73a284ebb8cedf0991fccabcf3eccbfbfb. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->