### PR TITLE
Make retries respect the global auto approve checkbox

### DIFF
--- a/src/core/Cline.ts
+++ b/src/core/Cline.ts
@@ -930,7 +930,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 	async *attemptApiRequest(previousApiReqIndex: number, retryAttempt: number = 0): ApiStream {
 		let mcpHub: McpHub | undefined
 
-		const { apiConfiguration, mcpEnabled, alwaysApproveResubmit, requestDelaySeconds } =
+		const { apiConfiguration, mcpEnabled, autoApprovalEnabled, alwaysApproveResubmit, requestDelaySeconds } =
 			(await this.providerRef.deref()?.getState()) ?? {}
 
 		let rateLimitDelay = 0
@@ -1093,7 +1093,7 @@ export class Cline extends EventEmitter<ClineEvents> {
 			this.isWaitingForFirstChunk = false
 		} catch (error) {
 			// note that this api_req_failed ask is unique in that we only present this option if the api hasn't streamed any content yet (ie it fails on the first chunk due), as it would allow them to hit a retry button. However if the api failed mid-stream, it could be in any arbitrary state where some tools may have executed, so that error is handled differently and requires cancelling the task entirely.
-			if (alwaysApproveResubmit) {
+			if (autoApprovalEnabled && alwaysApproveResubmit) {
 				let errorMsg
 
 				if (error.error?.metadata?.raw) {


### PR DESCRIPTION
I noticed that the auto-retry setting wasn't respecting the overall auto approve checkbox like the others did
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure retries in `Cline.ts` respect the global auto-approve setting by checking `autoApprovalEnabled`.
> 
>   - **Behavior**:
>     - Modify `attemptApiRequest()` in `Cline.ts` to check `autoApprovalEnabled` along with `alwaysApproveResubmit` before auto-retrying API requests.
>   - **Variables**:
>     - Add `autoApprovalEnabled` to destructured state variables in `attemptApiRequest()` in `Cline.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d79dfc792d54da03eeb58f424b9cb1c19e010076. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->