### PR TITLE
fix: migrate and persist modeApiConfigs for per-mode API profiles

### DIFF
--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -77,6 +77,18 @@ export class ProviderSettingsManager {
 
 				let isDirty = false
 
+				// Migrate existing installs to have per-mode API config map
+				if (!providerProfiles.modeApiConfigs) {
+					// Use the currently selected config for all modes initially
+					const currentName = providerProfiles.currentApiConfigName
+					const seedId =
+						providerProfiles.apiConfigs[currentName]?.id ??
+						Object.values(providerProfiles.apiConfigs)[0]?.id ??
+						this.defaultConfigId
+					providerProfiles.modeApiConfigs = Object.fromEntries(modes.map((m) => [m.slug, seedId]))
+					isDirty = true
+				}
+
 				// Ensure all configs have IDs.
 				for (const [_name, apiConfig] of Object.entries(providerProfiles.apiConfigs)) {
 					if (!apiConfig.id) {
@@ -307,8 +319,12 @@ export class ProviderSettingsManager {
 		try {
 			return await this.lock(async () => {
 				const providerProfiles = await this.load()
-				const { modeApiConfigs = {} } = providerProfiles
-				modeApiConfigs[mode] = configId
+				// Ensure the per-mode config map exists
+				if (!providerProfiles.modeApiConfigs) {
+					providerProfiles.modeApiConfigs = {}
+				}
+				// Assign the chosen config ID to this mode
+				providerProfiles.modeApiConfigs[mode] = configId
 				await this.store(providerProfiles)
 			})
 		} catch (error) {

--- a/src/core/config/__tests__/ProviderSettingsManager.test.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.test.ts
@@ -53,6 +53,7 @@ describe("ProviderSettingsManager", () => {
 							fuzzyMatchThreshold: 1.0,
 						},
 					},
+					modeApiConfigs: {},
 					migrations: {
 						rateLimitSecondsMigrated: true,
 						diffSettingsMigrated: true,


### PR DESCRIPTION
fix: migrate and persist missing modeApiConfigs for per-mode API profiles

- Backfill `modeApiConfigs` on initialize if absent, seeding with the current profile
- Ensure `setModeConfig()` always mutates and persists the real modeApiConfigs map
- Addresses regression introduced in PR #1997

## Context

Users who upgraded from versions before PR #1997 never had a `modeApiConfigs` map in their stored settings. That caused every mode to fall back to the same “current” profile, so changing a profile in one mode “leaked” into all modes.

For those users, [Sticky Models](https://docs.roocode.com/basic-usage/using-modes) do not work as expected. Changing the profile on a certain mode changes to that profile for ALL modes, prior to this fix.

## Implementation

- In `ProviderSettingsManager.initialize()`, we now detect when `modeApiConfigs` is missing and backfill it by mapping every mode slug to the currently active profile ID. We flag the config as dirty
     so it’s written back exactly once.
- We refactored `ProviderSettingsManager.setModeConfig()` to explicitly create or reuse the real `modeApiConfigs` object on the loaded config before assigning and persisting the new profile ID.

## Screenshots

| before | after |
| ------ | ----- |
| Example: Code Mode + Profile A cannot exist at the same time as Architect Mode + Profile B because changing the profile on either mode will override the other      | Example: Code Mode and Architect Mode can each have different profiles assigned to them      |

## How to Test


1. Check out this branch and build the extension
2. Install it using `cursor --install-extension bin/roo-cline-3.15.0.vsix` (or the resulting .vsix name in bin/)
3. For an existing workspace, open your secret storage (or global state) and remove any `modeApiConfigs` entry.
4. Switch to “Code” mode, select Profile A; switch to “Architect” mode, select Profile B.
5. Go back to “Code” mode and verify it still uses Profile A (not Profile B).
6. Repeat on a fresh workspace—`modeApiConfigs` should appear in storage right after launch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes regression by backfilling and persisting `modeApiConfigs` in `ProviderSettingsManager` to ensure per-mode API profiles work correctly.
> 
>   - **Behavior**:
>     - Backfill `modeApiConfigs` in `ProviderSettingsManager.initialize()` if absent, using the current profile ID.
>     - Ensure `ProviderSettingsManager.setModeConfig()` creates or reuses `modeApiConfigs` before assigning new profile ID.
>   - **Context**:
>     - Fixes regression from PR #1997 where `modeApiConfigs` was missing, causing profile changes to affect all modes.
>   - **Misc**:
>     - Adds migration logic to initialize `modeApiConfigs` for users upgrading from versions before PR #1997.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4cc58c59cce4939d0350b1decad4408a7f71ba7f. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->