### PR TITLE
Capture both stdout and stderr from execa-spawned processes

### DIFF
--- a/.changeset/fifty-pumpkins-wave.md
+++ b/.changeset/fifty-pumpkins-wave.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Capture stderr in execa-spawned processes

--- a/src/integrations/terminal/ExecaTerminalProcess.ts
+++ b/src/integrations/terminal/ExecaTerminalProcess.ts
@@ -38,13 +38,14 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 				shell: true,
 				cwd: this.terminal.getCurrentWorkingDirectory(),
 				cancelSignal: this.controller.signal,
+				all: true,
 			})`${command}`
 
-			this.terminal.setActiveStream(subprocess, subprocess.pid)
-			this.emit("line", "")
+			const stream = subprocess.iterable({ from: "all", preserveNewlines: true })
+			this.terminal.setActiveStream(stream, subprocess.pid)
 
-			for await (const line of subprocess) {
-				this.fullOutput += `${line}\n`
+			for await (const line of stream) {
+				this.fullOutput += line
 
 				const now = Date.now()
 
@@ -62,6 +63,9 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 				console.error(`[ExecaTerminalProcess] shell execution error: ${error.message}`)
 				this.emit("shell_execution_complete", { exitCode: error.exitCode ?? 0, signalName: error.signal })
 			} else {
+				console.error(
+					`[ExecaTerminalProcess] shell execution error: ${error instanceof Error ? error.message : String(error)}`,
+				)
 				this.emit("shell_execution_complete", { exitCode: 1 })
 			}
 		}


### PR DESCRIPTION
## Context

<!-- Brief description of WHAT you’re doing and WHY. -->

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Capture both stdout and stderr in `ExecaTerminalProcess` and improve error logging.
> 
>   - **Behavior**:
>     - Capture both stdout and stderr in `ExecaTerminalProcess` by setting `all: true` in `execa` options.
>     - Use combined stream for output by calling `subprocess.iterable({ from: "all", preserveNewlines: true })`.
>   - **Error Handling**:
>     - Improved error logging in `catch` block to handle non-`ExecaError` cases more gracefully.
>   - **Misc**:
>     - Update changeset file to reflect capturing stderr.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fd0b4e79538e8bf7633862a71d739f4336faf4d4. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->