### PR TITLE
Only send environment details in last user message

### DIFF
--- a/src/core/__tests__/Cline.test.ts
+++ b/src/core/__tests__/Cline.test.ts
@@ -721,7 +721,7 @@ describe("Cline", () => {
 				]
 
 				// Trigger API request
-				const iterator = cline.attemptApiRequest(0)
+				const iterator = cline.attemptApiRequest(0, "")
 				await iterator.next()
 
 				// Calculate expected delay for first retry
@@ -845,7 +845,7 @@ describe("Cline", () => {
 				]
 
 				// Trigger API request
-				const iterator = cline.attemptApiRequest(0)
+				const iterator = cline.attemptApiRequest(0, "")
 				await iterator.next()
 
 				// Verify delay is only applied for the countdown


### PR DESCRIPTION
## Context

Inspired by #3082, I decided to try a different variation of environment details de-duplication. I confirmed that it doesn't present cache issues:

<img width="981" alt="Screenshot 2025-05-01 at 2 08 09 PM" src="https://github.com/user-attachments/assets/536d7432-5085-480d-8aeb-318f41664ef5" />
