### PR TITLE
Telemetry for title button clicks

### DIFF
--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -3,6 +3,7 @@ import delay from "delay"
 
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { ContextProxy } from "../core/config/ContextProxy"
+import { telemetryService } from "../services/telemetry/TelemetryService"
 
 import { registerHumanRelayCallback, unregisterHumanRelayCallback, handleHumanRelayResponse } from "./humanRelay"
 import { handleNewTask } from "./handleTask"
@@ -71,6 +72,8 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 				return
 			}
 
+			telemetryService.captureTitleButtonClicked("plus")
+
 			await visibleProvider.removeClineFromStack()
 			await visibleProvider.postStateToWebview()
 			await visibleProvider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
@@ -82,6 +85,8 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 				return
 			}
 
+			telemetryService.captureTitleButtonClicked("mcp")
+
 			visibleProvider.postMessageToWebview({ type: "action", action: "mcpButtonClicked" })
 		},
 		"roo-cline.promptsButtonClicked": () => {
@@ -91,9 +96,15 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 				return
 			}
 
+			telemetryService.captureTitleButtonClicked("prompts")
+
 			visibleProvider.postMessageToWebview({ type: "action", action: "promptsButtonClicked" })
 		},
-		"roo-cline.popoutButtonClicked": () => openClineInNewTab({ context, outputChannel }),
+		"roo-cline.popoutButtonClicked": () => {
+			telemetryService.captureTitleButtonClicked("popout")
+
+			return openClineInNewTab({ context, outputChannel })
+		},
 		"roo-cline.openInNewTab": () => openClineInNewTab({ context, outputChannel }),
 		"roo-cline.settingsButtonClicked": () => {
 			const visibleProvider = getVisibleProviderOrLog(outputChannel)
@@ -101,6 +112,8 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 			if (!visibleProvider) {
 				return
 			}
+
+			telemetryService.captureTitleButtonClicked("settings")
 
 			visibleProvider.postMessageToWebview({ type: "action", action: "settingsButtonClicked" })
 		},
@@ -111,9 +124,13 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 				return
 			}
 
+			telemetryService.captureTitleButtonClicked("history")
+
 			visibleProvider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
 		},
 		"roo-cline.helpButtonClicked": () => {
+			telemetryService.captureTitleButtonClicked("help")
+
 			vscode.env.openExternal(vscode.Uri.parse("https://docs.roocode.com"))
 		},
 		"roo-cline.showHumanRelayDialog": (params: { requestId: string; promptText: string }) => {

--- a/src/services/telemetry/TelemetryService.ts
+++ b/src/services/telemetry/TelemetryService.ts
@@ -146,6 +146,14 @@ class TelemetryService {
 	}
 
 	/**
+	 * Captures a title button click event
+	 * @param button The button that was clicked
+	 */
+	public captureTitleButtonClicked(button: string): void {
+		this.captureEvent("Title Button Clicked", { button })
+	}
+
+	/**
 	 * Checks if telemetry is currently enabled
 	 * @returns Whether telemetry is enabled
 	 */


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add telemetry tracking for title button clicks in `registerCommands.ts` using `captureTitleButtonClicked()` in `TelemetryService`.
> 
>   - **Telemetry**:
>     - Add `captureTitleButtonClicked()` in `TelemetryService` to log button click events.
>     - Integrate `captureTitleButtonClicked()` in `registerCommands.ts` for buttons: `plus`, `mcp`, `prompts`, `popout`, `settings`, `history`, and `help`.
>   - **Misc**:
>     - Import `telemetryService` in `registerCommands.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 465d120fc6127847b9113340acb63f12e9dfd1b5. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->