### PR TITLE
Terminal performance improvements

### DIFF
--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -293,8 +293,14 @@ export type CustomSupportPrompts = z.infer<typeof customSupportPromptsSchema>
 export const commandExecutionStatusSchema = z.discriminatedUnion("status", [
 	z.object({
 		executionId: z.string(),
-		status: z.literal("running"),
+		status: z.literal("started"),
 		pid: z.number().optional(),
+		command: z.string(),
+	}),
+	z.object({
+		executionId: z.string(),
+		status: z.literal("output"),
+		output: z.string(),
 	}),
 	z.object({
 		executionId: z.string(),

--- a/src/shared/combineCommandSequences.ts
+++ b/src/shared/combineCommandSequences.ts
@@ -77,35 +77,3 @@ export function combineCommandSequences(messages: ClineMessage[]): ClineMessage[
 			return msg
 		})
 }
-
-export const splitCommandOutput = (text: string) => {
-	const outputIndex = text.indexOf(COMMAND_OUTPUT_STRING)
-
-	if (outputIndex === -1) {
-		return { command: text, output: "" }
-	}
-
-	return {
-		command: text.slice(0, outputIndex).trim(),
-
-		output: text
-			.slice(outputIndex + COMMAND_OUTPUT_STRING.length)
-			.trim()
-			.split("")
-			.map((char) => {
-				switch (char) {
-					case "\t":
-						return "→   "
-					case "\b":
-						return "⌫"
-					case "\f":
-						return "⏏"
-					case "\v":
-						return "⇳"
-					default:
-						return char
-				}
-			})
-			.join(""),
-	}
-}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -5,7 +5,7 @@ import deepEqual from "fast-deep-equal"
 import { VSCodeBadge, VSCodeButton } from "@vscode/webview-ui-toolkit/react"
 
 import { ClineApiReqInfo, ClineAskUseMcpServer, ClineMessage, ClineSayTool } from "@roo/shared/ExtensionMessage"
-import { splitCommandOutput, COMMAND_OUTPUT_STRING } from "@roo/shared/combineCommandSequences"
+import { COMMAND_OUTPUT_STRING } from "@roo/shared/combineCommandSequences"
 import { safeJsonParse } from "@roo/shared/safeJsonParse"
 
 import { useCopyToClipboard } from "@src/utils/clipboard"
@@ -979,19 +979,13 @@ export const ChatRowContent = ({
 						</>
 					)
 				case "command":
-					const { command, output } = splitCommandOutput(message.text || "")
-
 					return (
 						<>
 							<div style={headerStyle}>
 								{icon}
 								{title}
 							</div>
-							<CommandExecution
-								executionId={message.progressStatus?.id}
-								command={command}
-								output={output}
-							/>
+							<CommandExecution executionId={message.progressStatus?.id} text={message.text} />
 						</>
 					)
 				case "use_mcp_server":

--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, forwardRef, useCallback, useMemo, useState } from "react"
+import { HTMLAttributes, useCallback, useEffect, useMemo, useState } from "react"
 import { useEvent } from "react-use"
 import { Virtuoso } from "react-virtuoso"
 import { ChevronDown, Skull } from "lucide-react"
@@ -6,6 +6,7 @@ import { ChevronDown, Skull } from "lucide-react"
 import { CommandExecutionStatus, commandExecutionStatusSchema } from "@roo/schemas"
 import { ExtensionMessage } from "@roo/shared/ExtensionMessage"
 import { safeJsonParse } from "@roo/shared/safeJsonParse"
+import { COMMAND_OUTPUT_STRING } from "@roo/shared/combineCommandSequences"
 
 import { vscode } from "@src/utils/vscode"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
@@ -14,112 +15,134 @@ import { Button } from "@src/components/ui"
 
 interface CommandExecutionProps {
 	executionId?: string
-	command: string
-	output: string
+	text?: string
 }
 
-export const CommandExecution = forwardRef<HTMLDivElement, CommandExecutionProps>(
-	({ executionId, command, output }, ref) => {
-		const { terminalShellIntegrationDisabled = false } = useExtensionState()
+export const CommandExecution = ({ executionId, text }: CommandExecutionProps) => {
+	const { terminalShellIntegrationDisabled = false } = useExtensionState()
 
-		// If we aren't opening the VSCode terminal for this command then we default
-		// to expanding the command execution output.
-		const [isExpanded, setIsExpanded] = useState(terminalShellIntegrationDisabled)
+	// If we aren't opening the VSCode terminal for this command then we default
+	// to expanding the command execution output.
+	const [isExpanded, setIsExpanded] = useState(terminalShellIntegrationDisabled)
 
-		const [status, setStatus] = useState<CommandExecutionStatus | null>(null)
+	const [status, setStatus] = useState<CommandExecutionStatus | null>(null)
+	const [output, setOutput] = useState("")
+	const [command, setCommand] = useState("")
 
-		const lines = useMemo(
-			() => [`$ ${command}`, ...output.split("\n").filter((line) => line.trim() !== "")],
-			[command, output],
-		)
+	const lines = useMemo(
+		() => [`$ ${command}`, ...output.split("\n").filter((line) => line.trim() !== "")],
+		[output, command],
+	)
 
-		const onMessage = useCallback(
-			(event: MessageEvent) => {
-				if (!executionId) {
-					return
-				}
+	const onMessage = useCallback(
+		(event: MessageEvent) => {
+			if (!executionId) {
+				return
+			}
 
-				const message: ExtensionMessage = event.data
+			const message: ExtensionMessage = event.data
 
-				if (message.type === "commandExecutionStatus") {
-					const result = commandExecutionStatusSchema.safeParse(safeJsonParse(message.text, {}))
+			if (message.type === "commandExecutionStatus") {
+				const result = commandExecutionStatusSchema.safeParse(safeJsonParse(message.text, {}))
 
-					if (result.success) {
-						if (result.data.executionId !== executionId) {
-							return
-						}
+				if (result.success) {
+					const data = result.data
 
-						if (result.data.status === "fallback") {
+					if (data.executionId !== executionId) {
+						return
+					}
+
+					switch (data.status) {
+						case "started":
+							setCommand(data.command)
+							setStatus(data)
+							break
+						case "output":
+							setOutput((output) => output + data.output)
+							break
+						case "fallback":
 							setIsExpanded(true)
-						} else {
-							setStatus(result.data)
-						}
+							break
+						default:
+							setStatus(data)
+							break
 					}
 				}
-			},
-			[executionId],
-		)
+			}
+		},
+		[executionId],
+	)
 
-		useEvent("message", onMessage)
+	useEvent("message", onMessage)
 
-		return (
-			<div ref={ref} className="w-full p-2 rounded-xs bg-vscode-editor-background">
-				<div className="flex flex-row items-center justify-between gap-2 px-1">
-					<Line className="text-sm whitespace-nowrap overflow-hidden text-ellipsis">{command}</Line>
-					<div className="flex flex-row items-center gap-1">
-						{status?.status === "running" && (
-							<div className="flex flex-row items-center gap-2 font-mono text-xs">
-								<div className="rounded-full size-1.5 bg-lime-400" />
-								<div>Running</div>
-								{status.pid && <div className="whitespace-nowrap">(PID: {status.pid})</div>}
-								<Button
-									variant="ghost"
-									size="icon"
-									onClick={() =>
-										vscode.postMessage({ type: "terminalOperation", terminalOperation: "abort" })
-									}>
-									<Skull />
-								</Button>
-							</div>
-						)}
-						{status?.status === "exited" && (
-							<div className="flex flex-row items-center gap-2 font-mono text-xs">
-								<div
-									className={cn(
-										"rounded-full size-1.5",
-										status.exitCode === 0 ? "bg-lime-400" : "bg-red-400",
-									)}
-								/>
-								<div className="whitespace-nowrap">Exited ({status.exitCode})</div>
-							</div>
-						)}
-						{lines.length > 0 && (
-							<Button variant="ghost" size="icon" onClick={() => setIsExpanded(!isExpanded)}>
-								<ChevronDown
-									className={cn("size-4 transition-transform duration-300", {
-										"rotate-180": isExpanded,
-									})}
-								/>
+	useEffect(() => {
+		if (!status && text) {
+			const index = text.indexOf(COMMAND_OUTPUT_STRING)
+
+			if (index !== -1) {
+				setCommand(text.slice(0, index))
+				setOutput(text.slice(index + COMMAND_OUTPUT_STRING.length))
+			}
+		}
+	}, [status, text])
+
+	return (
+		<div className="w-full p-2 rounded-xs bg-vscode-editor-background">
+			<div className="flex flex-row items-center justify-between gap-2 px-1">
+				<Line className="text-sm whitespace-nowrap overflow-hidden text-ellipsis">{command}</Line>
+				<div className="flex flex-row items-center gap-1">
+					{status?.status === "started" && (
+						<div className="flex flex-row items-center gap-2 font-mono text-xs">
+							<div className="rounded-full size-1.5 bg-lime-400" />
+							<div>Running</div>
+							{status.pid && <div className="whitespace-nowrap">(PID: {status.pid})</div>}
+							<Button
+								variant="ghost"
+								size="icon"
+								onClick={() =>
+									vscode.postMessage({ type: "terminalOperation", terminalOperation: "abort" })
+								}>
+								<Skull />
 							</Button>
-						)}
-					</div>
-				</div>
-				<div
-					className={cn("mt-1 pt-1 border-t border-border/25", { hidden: !isExpanded })}
-					style={{ height: Math.min((lines.length + 1) * 16, 200) }}>
+						</div>
+					)}
+					{status?.status === "exited" && (
+						<div className="flex flex-row items-center gap-2 font-mono text-xs">
+							<div
+								className={cn(
+									"rounded-full size-1.5",
+									status.exitCode === 0 ? "bg-lime-400" : "bg-red-400",
+								)}
+							/>
+							<div className="whitespace-nowrap">Exited ({status.exitCode})</div>
+						</div>
+					)}
 					{lines.length > 0 && (
-						<Virtuoso
-							className="h-full"
-							totalCount={lines.length}
-							itemContent={(i) => <Line className="text-sm">{lines[i]}</Line>}
-							followOutput="auto"
-						/>
+						<Button variant="ghost" size="icon" onClick={() => setIsExpanded(!isExpanded)}>
+							<ChevronDown
+								className={cn("size-4 transition-transform duration-300", {
+									"rotate-180": isExpanded,
+								})}
+							/>
+						</Button>
 					)}
 				</div>
 			</div>
-		)
-	},
-)
+			<div
+				className={cn("mt-1 pt-1 border-t border-border/25", { hidden: !isExpanded })}
+				style={{ height: Math.min((lines.length + 1) * 16, 200) }}>
+				{lines.length > 0 && (
+					<Virtuoso
+						className="h-full"
+						totalCount={lines.length}
+						itemContent={(i) => <Line className="text-sm">{lines[i]}</Line>}
+						followOutput="auto"
+					/>
+				)}
+			</div>
+		</div>
+	)
+}
 
 type LineProps = HTMLAttributes<HTMLDivElement>
 


### PR DESCRIPTION
## Context

It's very expensive to trigger `postStateToWebView` calls due to the serialization involved. Noisy terminal will trigger this due to the `cline.say("command_output", ...)` calls.

It's much faster to just send an event containing only the new output rather than full state updates.

In testing this was a huge performance win.

## Implementation

<!--

Some description of HOW you achieved it. Perhaps give a high level description of the program flow. Did you need to refactor something? What tradeoffs did you take? Are there things in here which you’d particularly like people to pay close attention to?

-->

## Screenshots

| before | after |
| ------ | ----- |
|        |       |

## How to Test

<!--

A straightforward scenario of how to test your changes will help reviewers that are not familiar with the part of the code that you are changing but want to see it in action. This section can include a description or step-by-step instructions of how to get to the state of v2 that your change affects.

A "How To Test" section can look something like this:

- Sign in with a user with tracks
- Activate `show_awesome_cat_gifs` feature (add `?feature.show_awesome_cat_gifs=1` to your URL)
- You should see a GIF with cats dancing

-->

## Get in Touch

<!-- We'd love to have a way to chat with you about your changes if necessary. If you're in the [Roo Code Discord](https://discord.gg/roocode), please share your handle here. -->
