### PR TITLE
Copy both error message and content on mermaid error

### DIFF
--- a/webview-ui/src/components/common/MermaidBlock.tsx
+++ b/webview-ui/src/components/common/MermaidBlock.tsx
@@ -186,7 +186,8 @@ export default function MermaidBlock({ code }: MermaidBlockProps) {
 							<CopyButton
 								onClick={(e) => {
 									e.stopPropagation()
-									copyWithFeedback(code, e)
+									const combinedContent = `Error: ${error}\n\n\`\`\`mermaid\n${code}\n\`\`\``
+									copyWithFeedback(combinedContent, e)
 								}}>
 								<span className={`codicon codicon-${showCopyFeedback ? "check" : "copy"}`}></span>
 							</CopyButton>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `CopyButton` in `MermaidBlock.tsx` to copy both error message and Mermaid code on error.
> 
>   - **Behavior**:
>     - In `MermaidBlock.tsx`, the `CopyButton` now copies both the error message and the Mermaid code when an error occurs.
>     - Combines error message and code into a single string formatted with "Error: {error}\n\n```mermaid\n{code}\n```".
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e83bc34d6eb4041de10c7e911ee322fddefc57c3. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->