### PR TITLE
perf: optimize code block rendering performance

### DIFF
--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -604,16 +604,15 @@ const CodeBlock = memo(
 
 		return (
 			<CodeBlockContainer ref={codeBlockRef}>
-				<StyledPre
-					ref={preRef}
+				<MemoizedStyledPre
+					preRef={preRef}
 					preStyle={preStyle}
-					wordwrap={wordWrap ? "true" : "false"}
-					windowshade={windowShade ? "true" : "false"}
+					wordWrap={wordWrap}
+					windowShade={windowShade}
 					collapsedHeight={collapsedHeight}
-					onMouseDown={() => updateCodeBlockButtonPosition(true)}
-					onMouseUp={() => updateCodeBlockButtonPosition(false)}>
-					<div dangerouslySetInnerHTML={{ __html: highlightedCode }} />
-				</StyledPre>
+					highlightedCode={highlightedCode}
+					updateCodeBlockButtonPosition={updateCodeBlockButtonPosition}
+				/>
 				{!isSelecting && (
 					<CodeBlockButtonWrapper
 						ref={copyButtonWrapperRef}
@@ -716,6 +715,41 @@ const CodeBlock = memo(
 			</CodeBlockContainer>
 		)
 	},
+)
+
+// Memoized content component to prevent unnecessary re-renders of highlighted code
+const MemoizedCodeContent = memo(({ html }: { html: string }) => <div dangerouslySetInnerHTML={{ __html: html }} />)
+
+// Memoized StyledPre component
+const MemoizedStyledPre = memo(
+	({
+		preRef,
+		preStyle,
+		wordWrap,
+		windowShade,
+		collapsedHeight,
+		highlightedCode,
+		updateCodeBlockButtonPosition,
+	}: {
+		preRef: React.RefObject<HTMLDivElement>
+		preStyle?: React.CSSProperties
+		wordWrap: boolean
+		windowShade: boolean
+		collapsedHeight?: number
+		highlightedCode: string
+		updateCodeBlockButtonPosition: (forceHide?: boolean) => void
+	}) => (
+		<StyledPre
+			ref={preRef}
+			preStyle={preStyle}
+			wordwrap={wordWrap ? "true" : "false"}
+			windowshade={windowShade ? "true" : "false"}
+			collapsedHeight={collapsedHeight}
+			onMouseDown={() => updateCodeBlockButtonPosition(true)}
+			onMouseUp={() => updateCodeBlockButtonPosition(false)}>
+			<MemoizedCodeContent html={highlightedCode} />
+		</StyledPre>
+	),
 )
 
 export default CodeBlock


### PR DESCRIPTION
## Context

Optimizes CodeBlock component rendering performance by memoizing components to prevent unnecessary re-renders.

Subjectively, this feels smoother when scrolling, but I do not have a way to actually validate render performance.

In any event, I think that memoizing complex content is a best practice, it should reduce rendering overhead, and this is a pretty simple change:

## Implementation

- Added MemoizedCodeContent to prevent re-renders of syntax highlighted HTML content
- Added MemoizedStyledPre to prevent container re-renders when only button states change
- Properly typed all component props
- Reduces React reconciliation work for complex code blocks with syntax highlighting

## How to Test

1. Open a chat with large code blocks
2. Toggle word wrap and window shade buttons
3. Verify smooth performance with no unnecessary re-renders
4. Verify syntax highlighting still works correctly
5. Verify all button functionality remains intact
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimizes `CodeBlock` rendering by memoizing components to reduce unnecessary re-renders and improve performance.
> 
>   - **Performance Optimization**:
>     - Introduced `MemoizedCodeContent` to prevent re-renders of syntax-highlighted HTML content in `CodeBlock.tsx`.
>     - Introduced `MemoizedStyledPre` to prevent container re-renders when button states change in `CodeBlock.tsx`.
>     - Reduced React reconciliation work for complex code blocks with syntax highlighting.
>   - **Type Improvements**:
>     - Properly typed all component props in `CodeBlock.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e159a78533dff95d865e4c0c7f9fe6cbd032363f. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->