### PR TITLE
Add isSubtask to telemetry

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1517,6 +1517,11 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			properties.diffStrategy = currentCline.diffStrategy.getName()
 		}
 
+		// Add isSubtask property that indicates whether this task is a subtask
+		if (currentCline) {
+			properties.isSubtask = !!currentCline.parentTask
+		}
+
 		return properties
 	}
 }


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `isSubtask` property to telemetry in `ClineProvider.ts` to indicate if a task is a subtask.
> 
>   - **Telemetry**:
>     - Add `isSubtask` property in `getTelemetryProperties()` in `ClineProvider.ts` to indicate if a task is a subtask based on the presence of `parentTask`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c66133ca3d8649378b1fd7ba3ac1abb41c95e2c5. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->