### PR TITLE
feat: max read file line prompt variables {{maxReadFileLine}}

### DIFF
--- a/src/core/prompts/__tests__/system-prompt-variables.test.ts
+++ b/src/core/prompts/__tests__/system-prompt-variables.test.ts
@@ -1,0 +1,189 @@
+import * as vscode from "vscode"
+import * as os from "os"
+import { ClineProviderStatic, FormatLanguageUtil, PromptVariables } from "./test-types"
+
+// Mock dependencies
+jest.mock("vscode", () => ({
+	env: {
+		language: "en",
+		shell: "/bin/bash",
+	},
+}))
+
+jest.mock("os", () => ({
+	type: jest.fn(),
+}))
+
+// Create mock ClineProvider
+const MockClineProvider = {
+	getInstance: jest.fn(),
+} as unknown as ClineProviderStatic
+
+// Create mock formatLanguage utility
+const formatLanguage = jest.fn() as FormatLanguageUtil
+
+describe("System Prompt Variables", () => {
+	const mockCwd = "/test/workspace"
+	const mockMode = "test-mode"
+	const mockGetState = jest.fn()
+	const mockProvider = {
+		getState: mockGetState,
+	}
+
+	beforeEach(() => {
+		jest.clearAllMocks()
+		jest.resetModules()
+		;(os.type as jest.Mock).mockReturnValue("Linux")
+		;(formatLanguage as jest.Mock).mockReturnValue("en-US")
+		;(MockClineProvider.getInstance as jest.Mock).mockResolvedValue(mockProvider)
+
+		// Set up global variables that would normally be in scope
+		globalThis.cwd = mockCwd
+		globalThis.mode = mockMode
+		globalThis.language = undefined
+	})
+
+	it("should use maxReadFileLine from provider state when available", async () => {
+		// Setup
+		const mockState = { maxReadFileLine: 1000 }
+		mockGetState.mockResolvedValue(mockState)
+
+		// Create test variables
+		const provider = await MockClineProvider.getInstance()
+		const { maxReadFileLine = 500 } = provider ? await provider.getState() : {}
+		const testVariables: PromptVariables = {
+			workspace: mockCwd,
+			mode: mockMode,
+			language: globalThis.language || formatLanguage(vscode.env.language),
+			shell: vscode.env.shell,
+			operatingSystem: os.type(),
+			maxReadFileLine,
+		}
+
+		// Verify
+		expect(testVariables).toEqual({
+			workspace: mockCwd,
+			mode: mockMode,
+			language: "en-US",
+			shell: "/bin/bash",
+			operatingSystem: "Linux",
+			maxReadFileLine: 1000,
+		})
+	})
+
+	it("should default maxReadFileLine to 500 when not in provider state", async () => {
+		// Setup
+		mockGetState.mockResolvedValue({})
+
+		// Create test variables
+		const provider = await MockClineProvider.getInstance()
+		const { maxReadFileLine = 500 } = provider ? await provider.getState() : {}
+		const testVariables: PromptVariables = {
+			workspace: mockCwd,
+			mode: mockMode,
+			language: globalThis.language || formatLanguage(vscode.env.language),
+			shell: vscode.env.shell,
+			operatingSystem: os.type(),
+			maxReadFileLine,
+		}
+
+		// Verify
+		expect(testVariables.maxReadFileLine).toBe(500)
+	})
+
+	it("should default maxReadFileLine to 500 when provider is null", async () => {
+		// Setup
+		;(MockClineProvider.getInstance as jest.Mock).mockResolvedValue(null)
+
+		// Create test variables
+		const provider = await MockClineProvider.getInstance()
+		const { maxReadFileLine = 500 } = provider ? await provider.getState() : {}
+		const testVariables: PromptVariables = {
+			workspace: mockCwd,
+			mode: mockMode,
+			language: globalThis.language || formatLanguage(vscode.env.language),
+			shell: vscode.env.shell,
+			operatingSystem: os.type(),
+			maxReadFileLine,
+		}
+
+		// Verify
+		expect(testVariables.maxReadFileLine).toBe(500)
+	})
+
+	it("should use provided language when available", async () => {
+		// Setup
+		const providedLanguage = "fr"
+		mockGetState.mockResolvedValue({})
+		globalThis.language = providedLanguage
+
+		// Create test variables
+		const provider = await MockClineProvider.getInstance()
+		const { maxReadFileLine = 500 } = provider ? await provider.getState() : {}
+		const testVariables: PromptVariables = {
+			workspace: mockCwd,
+			mode: mockMode,
+			language: globalThis.language || formatLanguage(vscode.env.language),
+			shell: vscode.env.shell,
+			operatingSystem: os.type(),
+			maxReadFileLine,
+		}
+
+		// Verify
+		expect(testVariables.language).toBe(providedLanguage)
+		expect(formatLanguage).not.toHaveBeenCalled()
+	})
+
+	it("should use formatted vscode language when input language is not provided", async () => {
+		// Setup
+		mockGetState.mockResolvedValue({})
+		globalThis.language = undefined
+
+		// Create test variables
+		const provider = await MockClineProvider.getInstance()
+		const { maxReadFileLine = 500 } = provider ? await provider.getState() : {}
+		const testVariables: PromptVariables = {
+			workspace: mockCwd,
+			mode: mockMode,
+			language: globalThis.language || formatLanguage(vscode.env.language),
+			shell: vscode.env.shell,
+			operatingSystem: os.type(),
+			maxReadFileLine,
+		}
+
+		// Verify
+		expect(formatLanguage).toHaveBeenCalledWith("en")
+		expect(testVariables.language).toBe("en-US")
+	})
+
+	it("should correctly populate all variables with mocked inputs", async () => {
+		// Setup
+		mockGetState.mockResolvedValue({ maxReadFileLine: 750 })
+
+		// Create test variables
+		const provider = await MockClineProvider.getInstance()
+		const { maxReadFileLine = 500 } = provider ? await provider.getState() : {}
+		const testVariables: PromptVariables = {
+			workspace: mockCwd,
+			mode: mockMode,
+			language: globalThis.language || formatLanguage(vscode.env.language),
+			shell: vscode.env.shell,
+			operatingSystem: os.type(),
+			maxReadFileLine,
+		}
+
+		// Verify
+		expect(testVariables).toEqual({
+			workspace: mockCwd,
+			mode: mockMode,
+			language: "en-US",
+			shell: "/bin/bash",
+			operatingSystem: "Linux",
+			maxReadFileLine: 750,
+		})
+
+		expect(os.type).toHaveBeenCalled()
+		expect(MockClineProvider.getInstance).toHaveBeenCalled()
+		expect(mockGetState).toHaveBeenCalled()
+	})
+})

--- a/src/core/prompts/__tests__/test-types.ts
+++ b/src/core/prompts/__tests__/test-types.ts
@@ -1,0 +1,35 @@
+// Test types
+
+// Provider types
+export interface ClineState {
+	maxReadFileLine?: number
+}
+
+export interface ClineProvider {
+	getState(): Promise<ClineState>
+}
+
+export interface ClineProviderStatic {
+	getInstance(): Promise<ClineProvider | null>
+}
+
+// Utility types
+export interface FormatLanguageUtil {
+	(lang: string): string
+}
+
+// Global declarations
+declare global {
+	var cwd: string
+	var mode: string
+	var language: string | undefined
+}
+
+export interface PromptVariables {
+	workspace: string
+	mode: string
+	language: string
+	shell: string
+	operatingSystem: string
+	maxReadFileLine: number
+}

--- a/src/core/prompts/sections/custom-system-prompt.ts
+++ b/src/core/prompts/sections/custom-system-prompt.ts
@@ -9,6 +9,7 @@ export type PromptVariables = {
 	language?: string
 	shell?: string
 	operatingSystem?: string
+	maxReadFileLine?: number
 }
 
 function interpolatePromptContent(content: string, variables: PromptVariables): string {
@@ -19,7 +20,10 @@ function interpolatePromptContent(content: string, variables: PromptVariables): 
 			variables[key as keyof PromptVariables] !== undefined
 		) {
 			const placeholder = new RegExp(`\\{\\{${key}\\}\\}`, "g")
-			interpolatedContent = interpolatedContent.replace(placeholder, variables[key as keyof PromptVariables]!)
+			interpolatedContent = interpolatedContent.replace(
+				placeholder,
+				String(variables[key as keyof PromptVariables]!),
+			)
 		}
 	}
 	return interpolatedContent

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -3,12 +3,12 @@ import {
 	modes,
 	CustomModePrompts,
 	PromptComponent,
-	getRoleDefinition,
 	defaultModeSlug,
 	ModeConfig,
 	getModeBySlug,
 	getGroupName,
 } from "../../shared/modes"
+import { ClineProvider } from "../webview/ClineProvider"
 import { PromptVariables } from "./sections/custom-system-prompt"
 import { DiffStrategy } from "../../shared/tools"
 import { McpHub } from "../../services/mcp/McpHub"
@@ -126,13 +126,15 @@ export const SYSTEM_PROMPT = async (
 		return undefined
 	}
 
-	// Try to load custom system prompt from file
+	const provider = await ClineProvider.getInstance()
+	const { maxReadFileLine = 500 } = provider ? await provider.getState() : {}
 	const variablesForPrompt: PromptVariables = {
 		workspace: cwd,
 		mode: mode,
 		language: language ?? formatLanguage(vscode.env.language),
 		shell: vscode.env.shell,
 		operatingSystem: os.type(),
+		maxReadFileLine,
 	}
 	const fileCustomSystemPrompt = await loadSystemPromptFile(cwd, mode, variablesForPrompt)
 

--- a/src/core/prompts/tools/new-task.ts
+++ b/src/core/prompts/tools/new-task.ts
@@ -5,18 +5,18 @@ export function getNewTaskDescription(args: ToolArgs): string {
 Description: Create a new task with a specified starting mode and initial message. This tool instructs the system to create a new Cline instance in the given mode with the provided message.
 
 Parameters:
-- mode: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
+- mode_slug: (required) The slug of the mode to start the new task in (e.g., "code", "ask", "architect").
 - message: (required) The initial user message or instructions for this new task.
 
 Usage:
 <new_task>
-<mode>your-mode-slug-here</mode>
+<mode_slug>your-mode-slug-here</mode_slug>
 <message>Your initial instructions here</message>
 </new_task>
 
 Example:
 <new_task>
-<mode>code</mode>
+<mode_slug>code</mode_slug>
 <message>Implement a new feature for the application.</message>
 </new_task>
 `


### PR DESCRIPTION
## Context

New context variable {{maxReadFileLine}} for the maxReadFileLine setting:

TODO: add to
https://docs.roocode.com/features/footgun-prompting#using-context-variables


## Implementation

created a new test \src\core\prompts\__tests__\custom-system-prompt.test.ts 

the existing looks old and not update to date with the current codebase before my changes:
 FAIL  src/core/prompts/__tests__/custom-system-prompt.test.ts
  ● Test suite failed to run

## Screenshots

![image](https://github.com/user-attachments/assets/86febe81-7be6-4afd-8ee6-4882ca11eaa2)

## How to Test

See screenshot

## Get in Touch

discord: d_oit
