### PR TITLE
Remove help button from title bar

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,11 +111,6 @@
 				"icon": "$(settings-gear)"
 			},
 			{
-				"command": "roo-cline.helpButtonClicked",
-				"title": "%command.documentation.title%",
-				"icon": "$(question)"
-			},
-			{
 				"command": "roo-cline.openInNewTab",
 				"title": "%command.openInNewTab.title%",
 				"category": "%configuration.title%"
@@ -247,11 +242,6 @@
 					"command": "roo-cline.settingsButtonClicked",
 					"group": "navigation@6",
 					"when": "view == roo-cline.SidebarProvider"
-				},
-				{
-					"command": "roo-cline.helpButtonClicked",
-					"group": "navigation@7",
-					"when": "view == roo-cline.SidebarProvider"
 				}
 			],
 			"editor/title": [
@@ -283,11 +273,6 @@
 				{
 					"command": "roo-cline.settingsButtonClicked",
 					"group": "navigation@6",
-					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
-				},
-				{
-					"command": "roo-cline.helpButtonClicked",
-					"group": "navigation@7",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				}
 			]

--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -128,11 +128,6 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 
 			visibleProvider.postMessageToWebview({ type: "action", action: "historyButtonClicked" })
 		},
-		"roo-cline.helpButtonClicked": () => {
-			telemetryService.captureTitleButtonClicked("help")
-
-			vscode.env.openExternal(vscode.Uri.parse("https://docs.roocode.com"))
-		},
 		"roo-cline.showHumanRelayDialog": (params: { requestId: string; promptText: string }) => {
 			const panel = getPanel()
 


### PR DESCRIPTION
It's used very little and we have a link to docs in the ChatView now
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `roo-cline.helpButtonClicked` command and help button from title bar in `package.json` and `registerCommands.ts`.
> 
>   - **Behavior**:
>     - Removes `roo-cline.helpButtonClicked` command from `package.json` and `registerCommands.ts`.
>     - Help button functionality is removed from the title bar.
>   - **Commands**:
>     - Deletes `roo-cline.helpButtonClicked` command registration in `registerCommands.ts`.
>     - Removes help button command configuration from `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b00ffd66efb401668eeedd45f92a730cba46f60f. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->