### PR TITLE
Revert "Fix empty command bug"

### DIFF
--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -27,7 +27,7 @@ export const CommandExecution = ({ executionId, text }: CommandExecutionProps) =
 
 	const [status, setStatus] = useState<CommandExecutionStatus | null>(null)
 	const [output, setOutput] = useState("")
-	const [command, setCommand] = useState(text)
+	const [command, setCommand] = useState("")
 
 	const lines = useMemo(
 		() => [`$ ${command}`, ...output.split("\n").filter((line) => line.trim() !== "")],
@@ -79,9 +79,7 @@ export const CommandExecution = ({ executionId, text }: CommandExecutionProps) =
 		if (!status && text) {
 			const index = text.indexOf(COMMAND_OUTPUT_STRING)
 
-			if (index === -1) {
-				setCommand(text)
-			} else {
+			if (index !== -1) {
 				setCommand(text.slice(0, index))
 				setOutput(text.slice(index + COMMAND_OUTPUT_STRING.length))
 			}


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#3139
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts initial state and logic changes in `CommandExecution.tsx`, potentially reintroducing the empty command bug.
> 
>   - **Revert Changes**:
>     - Reverts initial state of `command` in `CommandExecution.tsx` from `text` to an empty string.
>     - Modifies logic to set `command` and `output` only if `COMMAND_OUTPUT_STRING` is found in `text`.
>   - **Behavior**:
>     - Affects command processing when no status is set, potentially reintroducing the empty command bug.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 776df1511175ace887f52883cd6e02c595be6954. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->