### PR TITLE
Fix language select width calculation

### DIFF
--- a/webview-ui/src/components/common/CodeBlock.tsx
+++ b/webview-ui/src/components/common/CodeBlock.tsx
@@ -625,10 +625,7 @@ const CodeBlock = memo(
 							<LanguageSelect
 								value={currentLanguage}
 								style={{
-									alignContent: "middle",
-									width: `${Math.max(3, (currentLanguage?.length || 5) + 1)}ch`,
-									textAlign: "right",
-									marginRight: 0,
+									width: `calc(${currentLanguage?.length || 0}ch + 9px)`,
 								}}
 								onClick={(e) => {
 									e.currentTarget.focus()


### PR DESCRIPTION
## Context

Fix language select width problem reported in #3179.

### Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)
 ✨ New feature (non-breaking change which adds functionality)
 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 ♻️ Refactor Changes
- 💅 Cosmetic Changes
 📚 Documentation update
 🏃 Workflow Changes

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/3ec31a29-df91-4267-8bd9-d3ece33edb76) | ![image](https://github.com/user-attachments/assets/6f4c83d9-6dcb-495a-92a5-174d27a79e01) |

## How to Test

- Run this version.
- Find a code quote Roo sent you.
- The CSS should be fine.

## Get in Touch
Discord: zhangtony239
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes language select width calculation in `CodeBlock.tsx` by updating the `style` property of `LanguageSelect`.
> 
>   - **Bug Fix**:
>     - Fixes language select width calculation in `CodeBlock.tsx` by updating the `style` property of `LanguageSelect` to use `calc(${currentLanguage?.length || 0}ch + 9px)`.
>   - **Testing**:
>     - Run the updated version and verify the CSS for language select is correct.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 391d49af4563ca257bfb671b2d48fdac0f5f12e5. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->