### PR TITLE
Refactor: relocate eye button to bottom to improve ChatView‘s layout

### DIFF
--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useMemo } from "react" // Removed useState
 import { Trans } from "react-i18next"
 import { VSCodeCheckbox, VSCodeLink } from "@vscode/webview-ui-toolkit/react"
 
@@ -9,10 +9,12 @@ import { AutoApproveToggle, AutoApproveSetting, autoApproveSettingsConfig } from
 
 interface AutoApproveMenuProps {
 	style?: React.CSSProperties
+	isExpanded: boolean
+	onToggleExpanded: () => void
 }
 
-const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
-	const [isExpanded, setIsExpanded] = useState(false)
+const AutoApproveMenu = ({ style, isExpanded, onToggleExpanded }: AutoApproveMenuProps) => {
+	// const [isExpanded, setIsExpanded] = useState(false) // State lifted to parent
 
 	const {
 		autoApprovalEnabled,
@@ -80,7 +82,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 		],
 	)
 
-	const toggleExpanded = useCallback(() => setIsExpanded((prev) => !prev), [])
+	// const toggleExpanded = useCallback(() => setIsExpanded((prev) => !prev), []) // Handler lifted to parent
 
 	const toggles = useMemo(
 		() => ({
@@ -119,7 +121,6 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 	return (
 		<div
 			style={{
-				padding: "0 15px",
 				userSelect: "none",
 				borderTop: isExpanded
 					? `0.5px solid color-mix(in srgb, var(--vscode-titleBar-inactiveForeground) 20%, transparent)`
@@ -135,7 +136,7 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 					padding: isExpanded ? "8px 0" : "8px 0 0 0",
 					cursor: "pointer",
 				}}
-				onClick={toggleExpanded}>
+				onClick={onToggleExpanded}>
 				<div onClick={(e) => e.stopPropagation()}>
 					<VSCodeCheckbox
 						checked={autoApprovalEnabled ?? false}

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -90,8 +90,10 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 	// Initialize expanded state based on the persisted setting (default to expanded if undefined)
 	const [isExpanded, setIsExpanded] = useState(
+		// This is for the history preview
 		historyPreviewCollapsed === undefined ? true : !historyPreviewCollapsed,
 	)
+	const [isAutoApproveMenuExpanded, setIsAutoApproveMenuExpanded] = useState(false) // New state for AutoApproveMenu
 
 	const toggleExpanded = useCallback(() => {
 		const newState = !isExpanded
@@ -99,6 +101,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		// Send message to extension to persist the new collapsed state
 		vscode.postMessage({ type: "setHistoryPreviewCollapsed", bool: !newState })
 	}, [isExpanded])
+
+	const toggleAutoApproveMenuExpanded = useCallback(() => {
+		// New callback for AutoApproveMenu
+		setIsAutoApproveMenuExpanded((prev) => !prev)
+	}, [])
 
 	// Leaving this less safe version here since if the first message is not a
 	// task, then the extension is in a bad state and needs to be debugged (see
@@ -1234,19 +1241,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 				</>
 			) : (
 				<div className="flex-1 min-h-0 overflow-y-auto flex flex-col gap-4">
-					{/* Moved Task Bar Header Here */}
-					{tasks.length !== 0 && (
-						<div className="flex text-vscode-descriptionForeground w-full mx-auto px-5 pt-3">
-							<div className="flex items-center gap-1 cursor-pointer" onClick={toggleExpanded}>
-								{tasks.length < 10 && (
-									<span className={`font-medium text-xs `}>{t("history:recentTasks")}</span>
-								)}
-								<span
-									className={`codicon  ${isExpanded ? "codicon-eye" : "codicon-eye-closed"} scale-90`}
-								/>
-							</div>
-						</div>
-					)}
 					<div
 						className={` w-full flex flex-col gap-4 m-auto ${isExpanded && tasks.length > 0 ? "mt-0" : ""} px-3.5 min-[370px]:px-10 pt-5 transition-all duration-300`}>
 						<RooHero />
@@ -1286,8 +1280,21 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			//    but becomes scrollable when the viewport is too small
 			*/}
 			{!task && (
-				<div className="mb-[-2px] flex-initial min-h-0">
-					<AutoApproveMenu />
+				<div className={`mb-[-2px] flex-initial min-h-0 flex items-end justify-between px-5 pt-3`}>
+					{!isAutoApproveMenuExpanded && (
+						<div className="flex text-vscode-descriptionForeground flex-shrink-0 mb-1 mr-2.5">
+							<div className="flex items-center gap-1 cursor-pointer" onClick={toggleExpanded}>
+								<span
+									className={`codicon  ${isExpanded ? "codicon-eye" : "codicon-eye-closed"} scale-90`}
+								/>
+								<span className={`font-medium text-xs `}>{t("history:recentTasks")}</span>
+							</div>
+						</div>
+					)}
+					<AutoApproveMenu
+						isExpanded={isAutoApproveMenuExpanded}
+						onToggleExpanded={toggleAutoApproveMenuExpanded}
+					/>
 				</div>
 			)}
 
@@ -1316,7 +1323,10 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							initialTopMostItemIndex={groupedMessages.length - 1}
 						/>
 					</div>
-					<AutoApproveMenu />
+					<AutoApproveMenu
+						isExpanded={isAutoApproveMenuExpanded}
+						onToggleExpanded={toggleAutoApproveMenuExpanded}
+					/>
 					{showScrollToBottom ? (
 						<div className="flex px-[15px] pt-[10px]">
 							<div


### PR DESCRIPTION
## Context

Adjusted the position of the eye button for history visibility on the Roo homepage to make the layout more visually balanced, and removed unnecessary variable usage in it before to improve performance.

### Type of Change

🐛 Bug fix (non-breaking change which fixes an issue)
✨ New feature (non-breaking change which adds functionality)
💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
√♻️ Refactor Changes
√💅 Cosmetic Changes
📚 Documentation update
🏃 Workflow Changes

## Screenshots

| before | after |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/3ab688aa-443b-4a28-a08d-5873eaf735f0) | <video src="https://github.com/user-attachments/assets/7a781925-a2df-44fe-9923-750cca9ab99b" /> |

## How to Test

- Run this version.
- Navigate to the Roo homepage.
- You‘ll see the UI adjustment demoed above.

## Get in Touch
Discord: zhangtony239
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `ChatView` and `AutoApproveMenu` components to improve layout and state management, relocating the eye button and lifting state to the parent component.
> 
>   - **UI Adjustments**:
>     - Relocated eye button to bottom in `ChatView.tsx` for better layout balance.
>     - Adjusted `AutoApproveMenu` layout in `ChatView.tsx` to align with new design.
>   - **State Management**:
>     - Lifted `isExpanded` state from `AutoApproveMenu.tsx` to `ChatView.tsx`.
>     - Introduced `isAutoApproveMenuExpanded` state in `ChatView.tsx` for `AutoApproveMenu` visibility control.
>     - Removed `useState` for `isExpanded` in `AutoApproveMenu.tsx`.
>   - **Code Cleanup**:
>     - Removed unused `toggleExpanded` callback in `AutoApproveMenu.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b933710f06dce5059a323496ae2ea10230a51db6. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->