### PR TITLE
Add gemini-2.5-pro-preview-05-06 model

### DIFF
--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -502,6 +502,15 @@ export const vertexModels = {
 		inputPrice: 2.5,
 		outputPrice: 15,
 	},
+	"gemini-2.5-pro-preview-05-06": {
+		maxTokens: 65_535,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		isPromptCacheOptional: true,
+		inputPrice: 2.5,
+		outputPrice: 15,
+	},
 	"gemini-2.5-pro-exp-03-25": {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,
@@ -679,6 +688,31 @@ export const geminiModels = {
 		outputPrice: 0,
 	},
 	"gemini-2.5-pro-preview-03-25": {
+		maxTokens: 65_535,
+		contextWindow: 1_048_576,
+		supportsImages: true,
+		supportsPromptCache: true,
+		isPromptCacheOptional: true,
+		inputPrice: 2.5, // This is the pricing for prompts above 200k tokens.
+		outputPrice: 15,
+		cacheReadsPrice: 0.625,
+		cacheWritesPrice: 4.5,
+		tiers: [
+			{
+				contextWindow: 200_000,
+				inputPrice: 1.25,
+				outputPrice: 10,
+				cacheReadsPrice: 0.31,
+			},
+			{
+				contextWindow: Infinity,
+				inputPrice: 2.5,
+				outputPrice: 15,
+				cacheReadsPrice: 0.625,
+			},
+		],
+	},
+	"gemini-2.5-pro-preview-05-06": {
 		maxTokens: 65_535,
 		contextWindow: 1_048_576,
 		supportsImages: true,
@@ -1672,6 +1706,7 @@ export const PROMPT_CACHING_MODELS = new Set([
 	"anthropic/claude-3.7-sonnet:beta",
 	"anthropic/claude-3.7-sonnet:thinking",
 	"google/gemini-2.5-pro-preview-03-25",
+	"google/gemini-2.5-pro-preview-05-06",
 	"google/gemini-2.0-flash-001",
 	"google/gemini-flash-1.5",
 	"google/gemini-flash-1.5-8b",
@@ -1681,6 +1716,7 @@ export const PROMPT_CACHING_MODELS = new Set([
 // in settings).
 export const OPTIONAL_PROMPT_CACHING_MODELS = new Set([
 	"google/gemini-2.5-pro-preview-03-25",
+	"google/gemini-2.5-pro-preview-05-06",
 	"google/gemini-2.0-flash-001",
 	"google/gemini-flash-1.5",
 	"google/gemini-flash-1.5-8b",

--- a/webview-ui/src/components/settings/ModelInfoView.tsx
+++ b/webview-ui/src/components/settings/ModelInfoView.tsx
@@ -73,7 +73,7 @@ export const ModelInfoView = ({
 		),
 		apiProvider === "gemini" && (
 			<span className="italic">
-				{selectedModelId === "gemini-2.5-pro-preview-03-25"
+				{(selectedModelId === "gemini-2.5-pro-preview-03-25" || selectedModelId === "gemini-2.5-pro-preview-05-06")
 					? t("settings:modelInfo.gemini.billingEstimate")
 					: t("settings:modelInfo.gemini.freeRequests", {
 							count: selectedModelId && selectedModelId.includes("flash") ? 15 : 2,


### PR DESCRIPTION
## Context

This PR adds support for the new Gemini model, `gemini-2.5-pro-preview-05-06`, now available in Google AI Studio and Vertex AI. The model has the same configuration as `gemini-2.5-pro-preview-03-25`.

## Implementation

1. **Model Configuration:**
   - Added `gemini-2.5-pro-preview-05-06` to `src/shared/api.ts` with the same settings as `gemini-2.5-pro-preview-03-25`.
   - Included the new model in `PROMPT_CACHING_MODELS` and `OPTIONAL_PROMPT_CACHING_MODELS` sets.

2. **UI Updates:**
   - Updated `webview-ui/src/components/settings/ModelInfoView.tsx` to ensure `gemini-2.5-pro-preview-05-06` displays the same billing estimate text as `gemini-2.5-pro-preview-03-25`.

## How to Test

1. Build and run the extension from this branch.
2. Verify that `gemini-2.5-pro-preview-05-06` appears in the model selection dropdown for both Google Gemini and GCP Vertex AI providers.
3. Confirm that the model’s parameters (e.g., context window, image support, prompt caching, pricing) match those of `gemini-2.5-pro-preview-03-25`.
4. Test API calls with the new model to ensure it functions correctly.

## Get in Touch

zetaloop on Discord.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `gemini-2.5-pro-preview-05-06` model with identical settings to `gemini-2.5-pro-preview-03-25` and update UI for billing display.
> 
>   - **Model Configuration**:
>     - Add `gemini-2.5-pro-preview-05-06` to `src/shared/api.ts` with settings identical to `gemini-2.5-pro-preview-03-25`.
>     - Include in `PROMPT_CACHING_MODELS` and `OPTIONAL_PROMPT_CACHING_MODELS`.
>   - **UI Updates**:
>     - Update `ModelInfoView.tsx` to display billing estimate for `gemini-2.5-pro-preview-05-06` similar to `gemini-2.5-pro-preview-03-25`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 98f90a96fdbfb2d0f74aa8df513f6489368dc52a. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->