### PR TITLE
Add editor name to telemetry

### DIFF
--- a/.changeset/brave-pigs-judge.md
+++ b/.changeset/brave-pigs-judge.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Add editor name to telemetry

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1476,10 +1476,12 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		const appVersion = this.context.extension?.packageJSON?.version
 		const vscodeVersion = vscode.version
 		const platform = process.platform
+		const editorName = vscode.env.appName // Get the editor name (VS Code, Cursor, etc.)
 
 		const properties: Record<string, any> = {
 			vscodeVersion,
 			platform,
+			editorName,
 		}
 
 		// Add extension version


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add editor name to telemetry properties in `ClineProvider.ts` using `vscode.env.appName`.
> 
>   - **Telemetry Enhancement**:
>     - Add `editorName` to telemetry properties in `getTelemetryProperties()` in `ClineProvider.ts`.
>     - Uses `vscode.env.appName` to retrieve the editor name (e.g., VS Code, Cursor).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a4ac770821a763cbfce12928e3afb4b3e9ee3414. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->