### PR TITLE
fix: wrap footer buttons in About section on narrow screens

### DIFF
--- a/webview-ui/src/components/settings/About.tsx
+++ b/webview-ui/src/components/settings/About.tsx
@@ -58,16 +58,19 @@ export const About = ({ version, telemetrySetting, setTelemetrySetting, classNam
 					/>
 				</div>
 
-				<div className="flex items-center gap-2 mt-2">
-					<Button onClick={() => vscode.postMessage({ type: "exportSettings" })}>
+				<div className="flex flex-wrap items-center gap-2 mt-2">
+					<Button onClick={() => vscode.postMessage({ type: "exportSettings" })} className="w-28">
 						<Upload className="p-0.5" />
 						{t("settings:footer.settings.export")}
 					</Button>
-					<Button onClick={() => vscode.postMessage({ type: "importSettings" })}>
+					<Button onClick={() => vscode.postMessage({ type: "importSettings" })} className="w-28">
 						<Download className="p-0.5" />
 						{t("settings:footer.settings.import")}
 					</Button>
-					<Button variant="destructive" onClick={() => vscode.postMessage({ type: "resetState" })}>
+					<Button
+						variant="destructive"
+						onClick={() => vscode.postMessage({ type: "resetState" })}
+						className="w-28">
 						<TriangleAlert className="p-0.5" />
 						{t("settings:footer.settings.reset")}
 					</Button>


### PR DESCRIPTION
## Context

In the "About Roo Code" section, the footer buttons (`Export`, `Import`, and `Reset`) did not wrap correctly on narrow screens. As a result, the layout broke and buttons overflowed the container. This PR fixes that issue and improves responsiveness on smaller viewports.

## Implementation

Applied CSS changes to enable proper wrapping of the footer buttons. Adjusted the container styling (e.g., `flex-wrap: wrap`, spacing adjustments) to ensure the buttons stay within bounds and stack gracefully on smaller widths.

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://github.com/user-attachments/assets/761dea2f-f86d-4a76-9e8c-dd0e94b9f661) | ![after](https://github.com/user-attachments/assets/1faac719-9bf5-478d-972c-78616b0e8621) |

## How to Test

- Open the "About Roo Code" section in the extension
- Resize the sidebar or browser window to a narrow width
- Observe the footer buttons — they should now wrap onto a new line instead of overflowing
- Ensure all three buttons (`Export`, `Import`, `Reset`) remain functional

## Get in Touch

I'm in the [Roo Code Discord](https://discord.gg/roocode) — handle: `@yourname`
