### PR TITLE
add support for mcp server instructions

### DIFF
--- a/src/core/prompts/sections/mcp-servers.ts
+++ b/src/core/prompts/sections/mcp-servers.ts
@@ -39,6 +39,7 @@ export async function getMcpServersSection(
 
 						return (
 							`## ${server.name} (\`${config.command}${config.args && Array.isArray(config.args) ? ` ${config.args.join(" ")}` : ""}\`)` +
+							(server.instructions ? `\n\n${server.instructions}` : "") +
 							(tools ? `\n\n### Available Tools\n${tools}` : "") +
 							(templates ? `\n\n### Resource Templates\n${templates}` : "") +
 							(resources ? `\n\n### Direct Resources\n${resources}` : "")

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -552,6 +552,7 @@ export class McpHub {
 			await client.connect(transport)
 			connection.server.status = "connected"
 			connection.server.error = ""
+			connection.server.instructions = client.getInstructions()
 
 			// Initial fetch of tools and resources
 			connection.server.tools = await this.fetchToolsList(name, source)

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -17,6 +17,7 @@ export type McpServer = {
 	timeout?: number
 	source?: "global" | "project"
 	projectPath?: string
+	instructions?: string
 }
 
 export type McpTool = {

--- a/webview-ui/src/components/mcp/McpView.tsx
+++ b/webview-ui/src/components/mcp/McpView.tsx
@@ -324,6 +324,16 @@ const ServerRow = ({ server, alwaysAllowMcp }: { server: McpServer; alwaysAllowM
 							fontSize: "13px",
 							borderRadius: "0 0 4px 4px",
 						}}>
+						{server.instructions && (
+							<div
+								style={{
+									paddingTop: "5px 0",
+									opacity: 0.8,
+									fontSize: "12px",
+								}}>
+								{server.instructions}
+							</div>
+						)}
 						<VSCodePanels style={{ marginBottom: "10px" }}>
 							<VSCodePanelTab id="tools">
 								{t("mcp:tabs.tools")} ({server.tools?.length || 0})


### PR DESCRIPTION
## Context

Add support for MCP Server Instructions.
Roo Code can get and display the MCP Server's instructions and add it into the prompts.

## Implementation

- When connecting to the mcp server, use the method `getInstructions` provided by the official sdk to obtain the instructions of the mcp server and save them in the array `connections` of `McpHub`
- Display the instructions in `McpView.tsx`
- When splicing prompts, add the instructions to the mcp-servers segment

## Screenshots

| before | after |
| ------ | ----- |
|   
![截图_选择区域_20250507154118](https://github.com/user-attachments/assets/168894ac-0094-4331-b9d1-f60c7ed74a67)
   |    
![截图_选择区域_20250507150341](https://github.com/user-attachments/assets/55cc5c7d-679a-4cf7-addb-a57f3e0018f6)
   |

## How to Test

- Add a MCP Server that has set instructions
- Check whether the instructions is displayed correctly on the mcp panel
- Check if the mcp-servers segment of the system prompt contains instructions

## Get in Touch

qingyuan1109@gmail.com
