### PR TITLE
fix(prompts): revert to vscodetextarea to prevent race condition

### DIFF
--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -431,6 +431,21 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 		})
 	}
 
+	// keep track the state of the textareas locally because we sync them with the backend
+	// on separate event
+	const [roleDefinitionValue, setRoleDefinitionValue] = useState(() => {
+		const customMode = findModeBySlug(visualMode, customModes)
+		const prompt = customModePrompts?.[visualMode] as PromptComponent
+		return customMode?.roleDefinition ?? prompt?.roleDefinition ?? getRoleDefinition(visualMode)
+	})
+	const [customInstructionsValue, setCustomInstructionsValue] = useState(customInstructions || "")
+	const [globalCustomInstructionsValue, setGlobalCustomInstructionsValue] = useState(() => {
+		const customMode = findModeBySlug(visualMode, customModes)
+		const prompt = customModePrompts?.[visualMode] as PromptComponent
+		return customMode?.customInstructions ?? prompt?.customInstructions ?? getCustomInstructions(mode, customModes)
+	})
+	const [supportPromptValue, setSupportPromptValue] = useState(getSupportPromptValue(activeSupportOption) || "")
+
 	return (
 		<Tab>
 			<TabHeader className="flex justify-between items-center">
@@ -667,19 +682,15 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							{t("prompts:roleDefinition.description")}
 						</div>
 						<Textarea
-							value={(() => {
-								const customMode = findModeBySlug(visualMode, customModes)
-								const prompt = customModePrompts?.[visualMode] as PromptComponent
-								return (
-									customMode?.roleDefinition ??
-									prompt?.roleDefinition ??
-									getRoleDefinition(visualMode)
-								)
-							})()}
+							value={roleDefinitionValue}
 							onChange={(e) => {
 								const value =
 									(e as unknown as CustomEvent)?.detail?.target?.value ||
 									((e as any).target as HTMLTextAreaElement).value
+								setRoleDefinitionValue(value)
+							}}
+							onBlur={() => {
+								const value = roleDefinitionValue
 								const customMode = findModeBySlug(visualMode, customModes)
 								if (customMode) {
 									// For custom modes, update the JSON file
@@ -849,19 +860,15 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							})}
 						</div>
 						<Textarea
-							value={(() => {
-								const customMode = findModeBySlug(visualMode, customModes)
-								const prompt = customModePrompts?.[visualMode] as PromptComponent
-								return (
-									customMode?.customInstructions ??
-									prompt?.customInstructions ??
-									getCustomInstructions(mode, customModes)
-								)
-							})()}
+							value={customInstructionsValue}
 							onChange={(e) => {
 								const value =
 									(e as unknown as CustomEvent)?.detail?.target?.value ||
 									((e as any).target as HTMLTextAreaElement).value
+								setCustomInstructionsValue(value)
+							}}
+							onBlur={() => {
+								const value = customInstructionsValue
 								const customMode = findModeBySlug(visualMode, customModes)
 								if (customMode) {
 									// For custom modes, update the JSON file
@@ -1003,11 +1010,15 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						})}
 					</div>
 					<Textarea
-						value={customInstructions}
+						value={globalCustomInstructionsValue}
 						onChange={(e) => {
 							const value =
 								(e as unknown as CustomEvent)?.detail?.target?.value ||
 								((e as any).target as HTMLTextAreaElement).value
+							setGlobalCustomInstructionsValue(value)
+						}}
+						onBlur={() => {
+							const value = globalCustomInstructionsValue
 							setCustomInstructions(value || undefined)
 							vscode.postMessage({
 								type: "customInstructions",
@@ -1081,11 +1092,15 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						</div>
 
 						<Textarea
-							value={getSupportPromptValue(activeSupportOption)}
+							value={supportPromptValue}
 							onChange={(e) => {
 								const value =
 									(e as unknown as CustomEvent)?.detail?.target?.value ||
 									((e as any).target as HTMLTextAreaElement).value
+								setSupportPromptValue(value)
+							}}
+							onBlur={() => {
+								const value = supportPromptValue
 								const trimmedValue = value.trim()
 								updateSupportPrompt(activeSupportOption, trimmedValue || undefined)
 							}}

--- a/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
+++ b/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
@@ -1,3 +1,5 @@
+// npx jest src/components/prompts/__tests__/PromptsView.test.tsx
+
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import PromptsView from "../PromptsView"
 import { ExtensionStateContext } from "@src/context/ExtensionStateContext"
@@ -122,6 +124,7 @@ describe("PromptsView", () => {
 		fireEvent.change(textarea, {
 			target: { value: "New prompt value" },
 		})
+		fireEvent.blur(textarea)
 
 		expect(vscode.postMessage).toHaveBeenCalledWith({
 			type: "updatePrompt",
@@ -203,6 +206,7 @@ describe("PromptsView", () => {
 		fireEvent.change(textarea, {
 			target: { value: "" },
 		})
+		fireEvent.blur(textarea)
 
 		expect(setCustomInstructions).toHaveBeenCalledWith(undefined)
 		expect(vscode.postMessage).toHaveBeenCalledWith({

--- a/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
+++ b/webview-ui/src/components/prompts/__tests__/PromptsView.test.tsx
@@ -124,7 +124,6 @@ describe("PromptsView", () => {
 		fireEvent.change(textarea, {
 			target: { value: "New prompt value" },
 		})
-		fireEvent.blur(textarea)
 
 		expect(vscode.postMessage).toHaveBeenCalledWith({
 			type: "updatePrompt",
@@ -206,7 +205,6 @@ describe("PromptsView", () => {
 		fireEvent.change(textarea, {
 			target: { value: "" },
 		})
-		fireEvent.blur(textarea)
 
 		expect(setCustomInstructions).toHaveBeenCalledWith(undefined)
 		expect(vscode.postMessage).toHaveBeenCalledWith({


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #3239 

### Description

Changed how we sync the state to the backend. Instead of sending them onChange, now it's using onBlur event. It's more consistent than having to rely on the onChange event because the backend might not respond fast enough causing the input state to get 'reset', making it unable to be edited.

### Test Procedure

Go to the prompt settings and edit any of the textarea there, it should work now.

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../../CONTRIBUTING.md).

### Screenshots / Videos

See the before on the issue attached. Here's the after:

https://github.com/user-attachments/assets/3089a747-7580-4d80-b52f-d25f5f42a70a

### Documentation Updates

No documentation changes needed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change textarea sync event from `onChange` to `onBlur` in `PromptsView.tsx` to prevent race conditions, updating tests accordingly.
> 
>   - **Behavior**:
>     - Change textarea sync event from `onChange` to `onBlur` in `PromptsView.tsx` to prevent race conditions with backend.
>     - Affects `roleDefinitionValue`, `customInstructionsValue`, `globalCustomInstructionsValue`, and `supportPromptValue` textareas.
>   - **Tests**:
>     - Update `PromptsView.test.tsx` to include `fireEvent.blur()` after `fireEvent.change()` for textarea tests to match new behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 22f337f659309724a9bd3653f9fa03cc23f5841a. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->