### PR TITLE
Fix not being able to use specific providers on Openrouter

### DIFF
--- a/src/api/providers/fetchers/openrouter.ts
+++ b/src/api/providers/fetchers/openrouter.ts
@@ -72,7 +72,7 @@ export async function getOpenRouterModels(options?: ApiHandlerOptions): Promise<
 				typeof cacheWritesPrice !== "undefined" && typeof cacheReadsPrice !== "undefined"
 
 			const modelInfo: ModelInfo = {
-				maxTokens: rawModel.top_provider?.max_completion_tokens,
+				maxTokens: 0,
 				contextWindow: rawModel.context_length,
 				supportsImages: rawModel.architecture?.modality?.includes("image"),
 				supportsPromptCache,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -106,7 +106,7 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 		// https://openrouter.ai/docs/transforms
 		const completionParams: OpenRouterChatCompletionParams = {
 			model: modelId,
-			max_tokens: maxTokens,
+			...(maxTokens && maxTokens > 0 && { max_tokens: maxTokens }),
 			temperature,
 			thinking, // OpenRouter is temporarily supporting this.
 			top_p: topP,


### PR DESCRIPTION

Closes: #3353

### Description

- Set default maxTokens to 0 in getOpenRouterModels
- Only include max_tokens in API requests when value > 0

If we omit the maxTokens param, Openrouter will use the max_completion_tokens for the selected provider, this seems to be the intended behavior of the buggy code I replaced. The overrides for some models (like sonnet 3.7 thinking) is kept intact, so this fix doesn't include any breaking changes.

### Test Procedure

Same as the issue I created

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../../CONTRIBUTING.md).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `maxTokens` handling in OpenRouter API requests by setting default to 0 and conditionally including the parameter.
> 
>   - **Behavior**:
>     - Set default `maxTokens` to 0 in `getOpenRouterModels()` in `fetchers/openrouter.ts`.
>     - Include `max_tokens` in API requests in `OpenRouterHandler` in `openrouter.ts` only if `maxTokens > 0`.
>   - **Misc**:
>     - Ensures OpenRouter uses `max_completion_tokens` when `maxTokens` is omitted, maintaining intended behavior without breaking changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a0c2d0d392e29ccc37bc79c67a336dc090e6bb79. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->