### PR TITLE
fix: handle unsupported language errors gracefully in read_file tool

### DIFF
--- a/src/core/tools/readFileTool.ts
+++ b/src/core/tools/readFileTool.ts
@@ -164,7 +164,21 @@ export async function readFileTool(
 
 				const res = await Promise.all([
 					maxReadFileLine > 0 ? readLines(absolutePath, maxReadFileLine - 1, 0) : "",
-					parseSourceCodeDefinitionsForFile(absolutePath, cline.rooIgnoreController),
+					(async () => {
+						try {
+							return await parseSourceCodeDefinitionsForFile(absolutePath, cline.rooIgnoreController)
+						} catch (error) {
+							if (error instanceof Error && error.message.startsWith("Unsupported language:")) {
+								console.warn(`[read_file] Warning: ${error.message}`)
+								return undefined
+							} else {
+								console.error(
+									`[read_file] Unhandled error: ${error instanceof Error ? error.message : String(error)}`,
+								)
+								return undefined
+							}
+						}
+					})(),
 				])
 
 				content = res[0].length > 0 ? addLineNumbers(res[0]) : ""


### PR DESCRIPTION
Instead of failing with an error when encountering an unsupported language, now logs a warning and continues with file reading. This provides a better user experience by still showing the file contents even if syntax highlighting is not available.

fixes #3269
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `readFileTool.ts`, handle unsupported language errors by logging a warning and continuing file reading, improving user experience.
> 
>   - **Behavior**:
>     - In `readFileTool` in `readFileTool.ts`, handle unsupported language errors by logging a warning and continuing file reading.
>     - If an unsupported language is encountered in `parseSourceCodeDefinitionsForFile`, logs a warning instead of failing.
>     - Continues to log an error for other unhandled exceptions.
>   - **Misc**:
>     - Improves user experience by showing file contents even if syntax highlighting is unavailable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c64e80c9004c84de668a91510fad3cff05fffcec. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->