### PR TITLE
Simplify the process of setting the "active" provider profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ out
 out-*
 node_modules
 coverage/
+mock/
 
 .DS_Store
 

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -291,7 +291,7 @@ export class ProviderSettingsManager {
 				return { name, ...providerSettings }
 			})
 		} catch (error) {
-			throw new Error(`Failed to get profile profile: ${error}`)
+			throw new Error(`Failed to get profile: ${error}`)
 		}
 	}
 
@@ -311,7 +311,7 @@ export class ProviderSettingsManager {
 				return { name, ...providerSettings }
 			})
 		} catch (error) {
-			throw new Error(`Failed to activate profile profile: ${error}`)
+			throw new Error(`Failed to activate profile: ${error}`)
 		}
 	}
 

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -311,7 +311,7 @@ export class ProviderSettingsManager {
 				return { name, ...providerSettings }
 			})
 		} catch (error) {
-			throw new Error(`Failed to activate: ${error instanceof Error ? error.message : error}`)
+			throw new Error(`Failed to activate profile: ${error instanceof Error ? error.message : error}`)
 		}
 	}
 

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -259,51 +259,47 @@ export class ProviderSettingsManager {
 	}
 
 	/**
-	 * Load a config by name and set it as the current config.
+	 * Activate a profile by name or ID.
 	 */
-	public async loadConfig(name: string) {
+	public async activateProfile(
+		params: { name: string } | { id: string },
+	): Promise<ProviderSettingsWithId & { name: string }> {
 		try {
 			return await this.lock(async () => {
 				const providerProfiles = await this.load()
-				const providerSettings = providerProfiles.apiConfigs[name]
+				let name: string
+				let providerSettings: ProviderSettingsWithId
 
-				if (!providerSettings) {
-					throw new Error(`Config '${name}' not found`)
+				if ("name" in params) {
+					name = params.name
+
+					if (!providerProfiles.apiConfigs[name]) {
+						throw new Error(`Config with name '${name}' not found`)
+					}
+
+					providerSettings = providerProfiles.apiConfigs[name]
+				} else {
+					const id = params.id
+
+					const entry = Object.entries(providerProfiles.apiConfigs).find(
+						([_, apiConfig]) => apiConfig.id === id,
+					)
+
+					if (!entry) {
+						throw new Error(`Config with ID '${id}' not found`)
+					}
+
+					name = entry[0]
+					providerSettings = entry[1]
 				}
 
 				providerProfiles.currentApiConfigName = name
 				await this.store(providerProfiles)
 
-				return providerSettings
+				return { name, ...providerSettings }
 			})
 		} catch (error) {
 			throw new Error(`Failed to load config: ${error}`)
-		}
-	}
-
-	/**
-	 * Load a config by ID and set it as the current config.
-	 */
-	public async loadConfigById(id: string) {
-		try {
-			return await this.lock(async () => {
-				const providerProfiles = await this.load()
-				const providerSettings = Object.entries(providerProfiles.apiConfigs).find(
-					([_, apiConfig]) => apiConfig.id === id,
-				)
-
-				if (!providerSettings) {
-					throw new Error(`Config with ID '${id}' not found`)
-				}
-
-				const [name, apiConfig] = providerSettings
-				providerProfiles.currentApiConfigName = name
-				await this.store(providerProfiles)
-
-				return { config: apiConfig, name }
-			})
-		} catch (error) {
-			throw new Error(`Failed to load config by ID: ${error}`)
 		}
 	}
 

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -258,12 +258,7 @@ export class ProviderSettingsManager {
 		}
 	}
 
-	/**
-	 * Activate a profile by name or ID.
-	 */
-	public async activateProfile(
-		params: { name: string } | { id: string },
-	): Promise<ProviderSettingsWithId & { name: string }> {
+	public async getProfile(params: { name: string } | { id: string }) {
 		try {
 			return await this.lock(async () => {
 				const providerProfiles = await this.load()
@@ -293,13 +288,30 @@ export class ProviderSettingsManager {
 					providerSettings = entry[1]
 				}
 
-				providerProfiles.currentApiConfigName = name
-				await this.store(providerProfiles)
-
 				return { name, ...providerSettings }
 			})
 		} catch (error) {
-			throw new Error(`Failed to load config: ${error}`)
+			throw new Error(`Failed to get profile profile: ${error}`)
+		}
+	}
+
+	/**
+	 * Activate a profile by name or ID.
+	 */
+	public async activateProfile(
+		params: { name: string } | { id: string },
+	): Promise<ProviderSettingsWithId & { name: string }> {
+		const { name, ...providerSettings } = await this.getProfile(params)
+
+		try {
+			return await this.lock(async () => {
+				const providerProfiles = await this.load()
+				providerProfiles.currentApiConfigName = name
+				await this.store(providerProfiles)
+				return { name, ...providerSettings }
+			})
+		} catch (error) {
+			throw new Error(`Failed to activate profile profile: ${error}`)
 		}
 	}
 

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -311,7 +311,7 @@ export class ProviderSettingsManager {
 				return { name, ...providerSettings }
 			})
 		} catch (error) {
-			throw new Error(`Failed to activate profile: ${error}`)
+			throw new Error(`Failed to activate: ${error instanceof Error ? error.message : error}`)
 		}
 	}
 

--- a/src/core/config/ProviderSettingsManager.ts
+++ b/src/core/config/ProviderSettingsManager.ts
@@ -291,7 +291,7 @@ export class ProviderSettingsManager {
 				return { name, ...providerSettings }
 			})
 		} catch (error) {
-			throw new Error(`Failed to get profile: ${error}`)
+			throw new Error(`Failed to get profile: ${error instanceof Error ? error.message : error}`)
 		}
 	}
 

--- a/src/core/config/__tests__/ProviderSettingsManager.test.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.test.ts
@@ -430,7 +430,7 @@ describe("ProviderSettingsManager", () => {
 			mockSecrets.store.mockRejectedValueOnce(new Error("Storage failed"))
 
 			await expect(providerSettingsManager.activateProfile({ name: "test" })).rejects.toThrow(
-				"Failed to activate profile: Error: Failed to write provider profiles to secrets: Error: Storage failed",
+				"Failed to activate profile: Failed to write provider profiles to secrets: Error: Storage failed",
 			)
 		})
 

--- a/src/core/config/__tests__/ProviderSettingsManager.test.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.test.ts
@@ -430,7 +430,7 @@ describe("ProviderSettingsManager", () => {
 			mockSecrets.store.mockRejectedValueOnce(new Error("Storage failed"))
 
 			await expect(providerSettingsManager.activateProfile({ name: "test" })).rejects.toThrow(
-				"Failed to load config: Error: Failed to write provider profiles to secrets: Error: Storage failed",
+				"Failed to activate profile: Error: Failed to write provider profiles to secrets: Error: Storage failed",
 			)
 		})
 

--- a/src/core/config/__tests__/ProviderSettingsManager.test.ts
+++ b/src/core/config/__tests__/ProviderSettingsManager.test.ts
@@ -391,17 +391,15 @@ describe("ProviderSettingsManager", () => {
 			mockGlobalState.get.mockResolvedValue(42)
 			mockSecrets.get.mockResolvedValue(JSON.stringify(existingConfig))
 
-			const config = await providerSettingsManager.loadConfig("test")
+			const { name, ...providerSettings } = await providerSettingsManager.activateProfile({ name: "test" })
 
-			expect(config).toEqual({
-				apiProvider: "anthropic",
-				apiKey: "test-key",
-				id: "test-id",
-			})
+			expect(name).toBe("test")
+			expect(providerSettings).toEqual({ apiProvider: "anthropic", apiKey: "test-key", id: "test-id" })
 
-			// Get the stored config to check the structure
+			// Get the stored config to check the structure.
 			const storedConfig = JSON.parse(mockSecrets.store.mock.calls[1][1])
 			expect(storedConfig.currentApiConfigName).toBe("test")
+
 			expect(storedConfig.apiConfigs.test).toEqual({
 				apiProvider: "anthropic",
 				apiKey: "test-key",
@@ -413,17 +411,12 @@ describe("ProviderSettingsManager", () => {
 			mockSecrets.get.mockResolvedValue(
 				JSON.stringify({
 					currentApiConfigName: "default",
-					apiConfigs: {
-						default: {
-							config: {},
-							id: "default",
-						},
-					},
+					apiConfigs: { default: { config: {}, id: "default" } },
 				}),
 			)
 
-			await expect(providerSettingsManager.loadConfig("nonexistent")).rejects.toThrow(
-				"Config 'nonexistent' not found",
+			await expect(providerSettingsManager.activateProfile({ name: "nonexistent" })).rejects.toThrow(
+				"Config with name 'nonexistent' not found",
 			)
 		})
 
@@ -431,19 +424,12 @@ describe("ProviderSettingsManager", () => {
 			mockSecrets.get.mockResolvedValue(
 				JSON.stringify({
 					currentApiConfigName: "default",
-					apiConfigs: {
-						test: {
-							config: {
-								apiProvider: "anthropic",
-							},
-							id: "test-id",
-						},
-					},
+					apiConfigs: { test: { config: { apiProvider: "anthropic" }, id: "test-id" } },
 				}),
 			)
 			mockSecrets.store.mockRejectedValueOnce(new Error("Storage failed"))
 
-			await expect(providerSettingsManager.loadConfig("test")).rejects.toThrow(
+			await expect(providerSettingsManager.activateProfile({ name: "test" })).rejects.toThrow(
 				"Failed to load config: Error: Failed to write provider profiles to secrets: Error: Storage failed",
 			)
 		})
@@ -494,12 +480,7 @@ describe("ProviderSettingsManager", () => {
 			mockSecrets.get.mockResolvedValue(
 				JSON.stringify({
 					currentApiConfigName: "test",
-					apiConfigs: {
-						test: {
-							apiProvider: "anthropic",
-							id: "test-id",
-						},
-					},
+					apiConfigs: { test: { apiProvider: "anthropic", id: "test-id" } },
 				}),
 			)
 
@@ -514,18 +495,8 @@ describe("ProviderSettingsManager", () => {
 		it("should return true for existing config", async () => {
 			const existingConfig: ProviderProfiles = {
 				currentApiConfigName: "default",
-				apiConfigs: {
-					default: {
-						id: "default",
-					},
-					test: {
-						apiProvider: "anthropic",
-						id: "test-id",
-					},
-				},
-				migrations: {
-					rateLimitSecondsMigrated: false,
-				},
+				apiConfigs: { default: { id: "default" }, test: { apiProvider: "anthropic", id: "test-id" } },
+				migrations: { rateLimitSecondsMigrated: false },
 			}
 
 			mockSecrets.get.mockResolvedValue(JSON.stringify(existingConfig))
@@ -536,10 +507,7 @@ describe("ProviderSettingsManager", () => {
 
 		it("should return false for non-existent config", async () => {
 			mockSecrets.get.mockResolvedValue(
-				JSON.stringify({
-					currentApiConfigName: "default",
-					apiConfigs: { default: {} },
-				}),
+				JSON.stringify({ currentApiConfigName: "default", apiConfigs: { default: {} } }),
 			)
 
 			const hasConfig = await providerSettingsManager.hasConfig("nonexistent")

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -808,9 +808,9 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		await Promise.all([
 			this.contextProxy.setValue("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
 			this.contextProxy.setValue("currentApiConfigName", name),
-			this.updateApiConfiguration(providerSettings),
 		])
 
+		await this.updateApiConfiguration(providerSettings)
 		await this.postStateToWebview()
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -762,7 +762,6 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 	 * @param newMode The mode to switch to
 	 */
 	public async handleModeSwitch(newMode: Mode) {
-		// Capture mode switch telemetry event
 		const cline = this.getCurrentCline()
 
 		if (cline) {
@@ -781,17 +780,17 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 
 		// If this mode has a saved config, use it.
 		if (savedConfigId) {
-			const hasConfig = !!listApiConfig.find(({ id }) => id === savedConfigId)
+			const profile = listApiConfig.find(({ id }) => id === savedConfigId)
 
-			if (hasConfig) {
-				await this.activateProviderProfile({ id: savedConfigId })
+			if (profile?.name) {
+				await this.activateProviderProfile({ name: profile.name })
 			}
 		} else {
 			// If no saved config for this mode, save current config as default.
 			const currentApiConfigName = this.getGlobalState("currentApiConfigName")
 
 			if (currentApiConfigName) {
-				const config = listApiConfig?.find((c) => c.name === currentApiConfigName)
+				const config = listApiConfig.find((c) => c.name === currentApiConfigName)
 
 				if (config?.id) {
 					await this.providerSettingsManager.setModeConfig(newMode, config.id)

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -784,7 +784,9 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			const config = listApiConfig?.find((c) => c.id === savedConfigId)
 
 			if (config?.name) {
-				const apiConfig = await this.providerSettingsManager.loadConfig(config.name)
+				const { name: _, ...apiConfig } = await this.providerSettingsManager.activateProfile({
+					name: config.name,
+				})
 
 				await Promise.all([
 					this.updateGlobalState("currentApiConfigName", config.name),
@@ -803,6 +805,18 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 				}
 			}
 		}
+
+		await this.postStateToWebview()
+	}
+
+	async activateProviderProfile(args: { name: string } | { id: string }) {
+		const { name, ...providerSettings } = await this.providerSettingsManager.activateProfile(args)
+
+		await Promise.all([
+			this.contextProxy.setValue("listApiConfigMeta", await this.providerSettingsManager.listConfig()),
+			this.contextProxy.setValue("currentApiConfigName", name),
+			this.updateApiConfiguration(providerSettings),
+		])
 
 		await this.postStateToWebview()
 	}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -779,22 +779,15 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		// Update listApiConfigMeta first to ensure UI has latest data
 		await this.updateGlobalState("listApiConfigMeta", listApiConfig)
 
-		// If this mode has a saved config, use it
+		// If this mode has a saved config, use it.
 		if (savedConfigId) {
-			const config = listApiConfig?.find((c) => c.id === savedConfigId)
+			const hasConfig = !!listApiConfig.find(({ id }) => id === savedConfigId)
 
-			if (config?.name) {
-				const { name: _, ...apiConfig } = await this.providerSettingsManager.activateProfile({
-					name: config.name,
-				})
-
-				await Promise.all([
-					this.updateGlobalState("currentApiConfigName", config.name),
-					this.updateApiConfiguration(apiConfig),
-				])
+			if (hasConfig) {
+				await this.activateProviderProfile({ id: savedConfigId })
 			}
 		} else {
-			// If no saved config for this mode, save current config as default
+			// If no saved config for this mode, save current config as default.
 			const currentApiConfigName = this.getGlobalState("currentApiConfigName")
 
 			if (currentApiConfigName) {

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -5,7 +5,7 @@ import * as vscode from "vscode"
 import axios from "axios"
 
 import { ClineProvider } from "../ClineProvider"
-import { ClineMessage, ExtensionMessage, ExtensionState } from "../../../shared/ExtensionMessage"
+import { ApiConfigMeta, ClineMessage, ExtensionMessage, ExtensionState } from "../../../shared/ExtensionMessage"
 import { setSoundEnabled } from "../../../utils/sound"
 import { setTtsEnabled } from "../../../utils/tts"
 import { defaultModeSlug } from "../../../shared/modes"
@@ -226,12 +226,6 @@ jest.mock("../../../integrations/misc/extract-text", () => ({
 		return lines.map((line, index) => `${index + 1} | ${line}`).join("\n")
 	}),
 }))
-
-// Spy on console.error and console.log to suppress expected messages
-beforeAll(() => {
-	jest.spyOn(console, "error").mockImplementation(() => {})
-	jest.spyOn(console, "log").mockImplementation(() => {})
-})
 
 afterAll(() => {
 	jest.restoreAllMocks()
@@ -596,14 +590,16 @@ describe("ClineProvider", () => {
 		expect(state.alwaysApproveResubmit).toBe(false)
 	})
 
-	test("loads saved API config when switching modes", async () => {
+	it("loads saved API config when switching modes", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]
 
+		const profile: ApiConfigMeta = { name: "test-config", id: "test-id", apiProvider: "anthropic" }
+
 		;(provider as any).providerSettingsManager = {
 			getModeConfigId: jest.fn().mockResolvedValue("test-id"),
-			listConfig: jest.fn().mockResolvedValue([{ name: "test-config", id: "test-id", apiProvider: "anthropic" }]),
-			activateProfile: jest.fn().mockResolvedValue({ apiProvider: "anthropic" }),
+			listConfig: jest.fn().mockResolvedValue([profile]),
+			activateProfile: jest.fn().mockResolvedValue(profile),
 			setModeConfig: jest.fn(),
 		} as any
 
@@ -1542,12 +1538,12 @@ describe("ClineProvider", () => {
 		})
 
 		it("loads saved API config when switching modes", async () => {
+			const profile: ApiConfigMeta = { name: "saved-config", id: "saved-config-id", apiProvider: "anthropic" }
+
 			;(provider as any).providerSettingsManager = {
 				getModeConfigId: jest.fn().mockResolvedValue("saved-config-id"),
-				listConfig: jest
-					.fn()
-					.mockResolvedValue([{ name: "saved-config", id: "saved-config-id", apiProvider: "anthropic" }]),
-				activateProfile: jest.fn().mockResolvedValue({ apiProvider: "anthropic" }),
+				listConfig: jest.fn().mockResolvedValue([profile]),
+				activateProfile: jest.fn().mockResolvedValue(profile),
 				setModeConfig: jest.fn(),
 			} as any
 

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -603,7 +603,7 @@ describe("ClineProvider", () => {
 		;(provider as any).providerSettingsManager = {
 			getModeConfigId: jest.fn().mockResolvedValue("test-id"),
 			listConfig: jest.fn().mockResolvedValue([{ name: "test-config", id: "test-id", apiProvider: "anthropic" }]),
-			loadConfig: jest.fn().mockResolvedValue({ apiProvider: "anthropic" }),
+			activateProfile: jest.fn().mockResolvedValue({ apiProvider: "anthropic" }),
 			setModeConfig: jest.fn(),
 		} as any
 
@@ -612,7 +612,7 @@ describe("ClineProvider", () => {
 
 		// Should load the saved config for architect mode
 		expect(provider.providerSettingsManager.getModeConfigId).toHaveBeenCalledWith("architect")
-		expect(provider.providerSettingsManager.loadConfig).toHaveBeenCalledWith("test-config")
+		expect(provider.providerSettingsManager.activateProfile).toHaveBeenCalledWith({ name: "test-config" })
 		expect(mockContext.globalState.update).toHaveBeenCalledWith("currentApiConfigName", "test-config")
 	})
 
@@ -642,8 +642,7 @@ describe("ClineProvider", () => {
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]
 
 		;(provider as any).providerSettingsManager = {
-			loadConfig: jest.fn().mockResolvedValue({ apiProvider: "anthropic", id: "new-id" }),
-			loadConfigById: jest
+			activateProfile: jest
 				.fn()
 				.mockResolvedValue({ config: { apiProvider: "anthropic", id: "new-id" }, name: "new-config" }),
 			listConfig: jest.fn().mockResolvedValue([{ name: "new-config", id: "new-id", apiProvider: "anthropic" }]),
@@ -666,7 +665,7 @@ describe("ClineProvider", () => {
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]
 
 		;(provider as any).providerSettingsManager = {
-			loadConfigById: jest.fn().mockResolvedValue({
+			activateProfile: jest.fn().mockResolvedValue({
 				config: { apiProvider: "anthropic", id: "config-id-123" },
 				name: "config-by-id",
 			}),
@@ -686,8 +685,8 @@ describe("ClineProvider", () => {
 		// Should save new config as default for architect mode
 		expect(provider.providerSettingsManager.setModeConfig).toHaveBeenCalledWith("architect", "config-id-123")
 
-		// Ensure the loadConfigById method was called with the correct ID
-		expect(provider.providerSettingsManager.loadConfigById).toHaveBeenCalledWith("config-id-123")
+		// Ensure the `activateProfile` method was called with the correct ID
+		expect(provider.providerSettingsManager.activateProfile).toHaveBeenCalledWith({ id: "config-id-123" })
 	})
 
 	test("handles browserToolEnabled setting", async () => {
@@ -1542,13 +1541,13 @@ describe("ClineProvider", () => {
 			await provider.resolveWebviewView(mockWebviewView)
 		})
 
-		test("loads saved API config when switching modes", async () => {
+		it("loads saved API config when switching modes", async () => {
 			;(provider as any).providerSettingsManager = {
 				getModeConfigId: jest.fn().mockResolvedValue("saved-config-id"),
 				listConfig: jest
 					.fn()
 					.mockResolvedValue([{ name: "saved-config", id: "saved-config-id", apiProvider: "anthropic" }]),
-				loadConfig: jest.fn().mockResolvedValue({ apiProvider: "anthropic" }),
+				activateProfile: jest.fn().mockResolvedValue({ apiProvider: "anthropic" }),
 				setModeConfig: jest.fn(),
 			} as any
 
@@ -1560,7 +1559,7 @@ describe("ClineProvider", () => {
 
 			// Verify saved config was loaded
 			expect(provider.providerSettingsManager.getModeConfigId).toHaveBeenCalledWith("architect")
-			expect(provider.providerSettingsManager.loadConfig).toHaveBeenCalledWith("saved-config")
+			expect(provider.providerSettingsManager.activateProfile).toHaveBeenCalledWith({ name: "saved-config" })
 			expect(mockContext.globalState.update).toHaveBeenCalledWith("currentApiConfigName", "saved-config")
 
 			// Verify state was posted to webview

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -88,25 +88,13 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 					const currentConfigName = getGlobalState("currentApiConfigName")
 
 					if (currentConfigName) {
-						const manager = provider.providerSettingsManager
-						const hasConfig = await manager.hasConfig(currentConfigName)
-
-						if (!hasConfig) {
+						if (!(await provider.providerSettingsManager.hasConfig(currentConfigName))) {
 							// Current config name not valid, get first config in list.
-							await updateGlobalState("currentApiConfigName", listApiConfig?.[0]?.name)
+							const name = listApiConfig[0]?.name
+							await updateGlobalState("currentApiConfigName", name)
 
-							if (listApiConfig?.[0]?.name) {
-								const { name: _, ...providerSettings } = await manager.activateProfile({
-									name: listApiConfig?.[0]?.name,
-								})
-
-								await Promise.all([
-									updateGlobalState("listApiConfigMeta", listApiConfig),
-									provider.postMessageToWebview({ type: "listApiConfig", listApiConfig }),
-									provider.updateApiConfiguration(providerSettings),
-								])
-
-								await provider.postStateToWebview()
+							if (name) {
+								await provider.activateProviderProfile({ name })
 								return
 							}
 						}

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -217,21 +217,24 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		return id
 	}
 
+	private getProfilesMeta() {
+		return this.getConfiguration().listApiConfigMeta || []
+	}
+
 	public getProfiles() {
-		return (this.getConfiguration().listApiConfigMeta || []).map((profile) => profile.name)
+		return this.getProfilesMeta().map((profile) => profile.name)
+	}
+
+	public hasProfile(name: string): boolean {
+		return !!(this.getConfiguration().listApiConfigMeta || []).find((profile) => profile.name === name)
 	}
 
 	public async setActiveProfile(name: string) {
-		const currentSettings = this.getConfiguration()
-		const profiles = currentSettings.listApiConfigMeta || []
-
-		const profile = profiles.find((p) => p.name === name)
-
-		if (!profile) {
+		if (!this.hasProfile(name)) {
 			throw new Error(`Profile with name "${name}" does not exist`)
 		}
 
-		await this.setConfiguration({ ...currentSettings, currentApiConfigName: profile.name })
+		await this.sidebarProvider.activateProviderProfile({ name })
 	}
 
 	public getActiveProfile() {
@@ -240,27 +243,23 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	public async deleteProfile(name: string) {
 		const currentSettings = this.getConfiguration()
-		const profiles = currentSettings.listApiConfigMeta || []
-		const targetIndex = profiles.findIndex((p) => p.name === name)
+		const listApiConfigMeta = this.getProfilesMeta()
+		const targetIndex = listApiConfigMeta.findIndex((p) => p.name === name)
 
 		if (targetIndex === -1) {
 			throw new Error(`Profile with name "${name}" does not exist`)
 		}
 
-		const profileToDelete = profiles[targetIndex]
-		profiles.splice(targetIndex, 1)
+		const profileToDelete = listApiConfigMeta[targetIndex]
+		listApiConfigMeta.splice(targetIndex, 1)
 
 		// If we're deleting the active profile, clear the currentApiConfigName.
-		const newSettings: RooCodeSettings = {
-			...currentSettings,
-			listApiConfigMeta: profiles,
-			currentApiConfigName:
-				currentSettings.currentApiConfigName === profileToDelete.name
-					? undefined
-					: currentSettings.currentApiConfigName,
-		}
+		const currentApiConfigName =
+			currentSettings.currentApiConfigName === profileToDelete.name
+				? undefined
+				: currentSettings.currentApiConfigName
 
-		await this.setConfiguration(newSettings)
+		await this.setConfiguration({ ...currentSettings, listApiConfigMeta, currentApiConfigName })
 	}
 
 	public isReady() {


### PR DESCRIPTION
### Description

Here's a first foray into simplifying / drying up the code related to "provider profile" switches. Related to the Netflix configurator.

I combined `loadConfig` and `loadConfigById` into a new `activateProfile` method, and added a helper to `ClineProvider` that does everything required for setting a new active profile.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies profile activation by consolidating methods into `activateProfile` and updating related logic across the codebase.
> 
>   - **Behavior**:
>     - Consolidates `loadConfig` and `loadConfigById` into `activateProfile` in `ProviderSettingsManager`.
>     - Updates `ClineProvider` to use `activateProviderProfile` for setting active profiles.
>     - Modifies `webviewMessageHandler` to handle profile activation using `activateProfile`.
>   - **Tests**:
>     - Updates tests in `ProviderSettingsManager.test.ts` and `ClineProvider.test.ts` to reflect new profile activation logic.
>   - **API**:
>     - Updates `API` class in `api.ts` to use `activateProviderProfile` for setting active profiles.
>     - Removes redundant methods related to profile loading by name or ID.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3b6146b2faaf88fe602eec60e40d1eac50cf1cc5. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->