### PR TITLE
fix: show properly formatted multi-line commands in preview

### DIFF
--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -12,6 +12,7 @@ import { vscode } from "@src/utils/vscode"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { cn } from "@src/lib/utils"
 import { Button } from "@src/components/ui"
+import CodeBlock from "../common/CodeBlock"
 
 interface CommandExecutionProps {
 	executionId: string
@@ -86,8 +87,8 @@ export const CommandExecution = ({ executionId, text }: CommandExecutionProps) =
 
 	return (
 		<div className="w-full bg-vscode-editor-background border border-vscode-border rounded-xs p-2">
+			<CodeBlock source={command} language="shell" />
 			<div className="flex flex-row items-center justify-between gap-2 px-1">
-				<Line className="text-sm whitespace-nowrap overflow-hidden text-ellipsis">{command}</Line>
 				<div className="flex flex-row items-center gap-1">
 					{status?.status === "started" && (
 						<div className="flex flex-row items-center gap-2 font-mono text-xs">


### PR DESCRIPTION
Replace Line component with CodeBlock to display complete multi-line commands with proper formatting and line breaks in the preview.

This fix is important because users must be able to review commands with correct indentation and structure before execution for safety.

Fixes: #3367

Before: 
![image](https://github.com/user-attachments/assets/bd7ce87d-c3ba-4466-982d-55bb69d12a1e)

After: 
![image](https://github.com/user-attachments/assets/09369d7e-a345-4dc4-b699-4572dfbbcc18)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replace `Line` with `CodeBlock` in `CommandExecution` to properly format multi-line command previews, fixing issue #3367.
> 
>   - **Behavior**:
>     - Replace `Line` with `CodeBlock` in `CommandExecution` to display multi-line commands with proper formatting and line breaks.
>     - Ensures users can review commands with correct indentation and structure before execution.
>   - **Fixes**:
>     - Resolves issue #3367 regarding command preview formatting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 57101c2c10a79fb9a259abc9c113fc4f83bbb42b. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->