### PR TITLE
Add getting and upserting configuration profiles to the extension api

### DIFF
--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -250,7 +250,7 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		await this.sidebarProvider.providerSettingsManager.saveConfig(name, settings)
 
 		if (name === this.getConfiguration().currentApiConfigName) {
-			this.sidebarProvider.activateProviderProfile({ name })
+			await this.sidebarProvider.activateProviderProfile({ name })
 		} else {
 			// We still need to update the webview with the new state, but we don't want to change the active provider.
 			const listApiConfig = await this.sidebarProvider.providerSettingsManager.listConfig()

--- a/src/exports/interface.ts
+++ b/src/exports/interface.ts
@@ -113,6 +113,21 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	getActiveProfile(): string | undefined
 
 	/**
+	 * Gets a profile by name.
+	 * @param name The name of the profile to get
+	 * @returns The profile
+	 * @throws Error if the profile does not exist
+	 */
+	getProfile(name: string): Promise<ProviderSettings>
+
+	/**
+	 * Updates a profile by name, creating it if it does not already exist.
+	 * @param name The profile name.
+	 * @param settings The profile settings
+	 */
+	upsertProfile(name: string, settings: ProviderSettings): Promise<void>
+
+	/**
 	 * Deletes a profile by name
 	 * @param name The name of the profile to delete
 	 * @throws Error if the profile does not exist

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -616,6 +616,19 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 */
 	getActiveProfile(): string | undefined
 	/**
+	 * Gets a profile by name.
+	 * @param name The name of the profile to get
+	 * @returns The profile
+	 * @throws Error if the profile does not exist
+	 */
+	getProfile(name: string): Promise<ProviderSettings>
+	/**
+	 * Updates a profile by name, creating it if it does not already exist.
+	 * @param name The profile name.
+	 * @param settings The profile settings
+	 */
+	upsertProfile(name: string, settings: ProviderSettings): Promise<void>
+	/**
 	 * Deletes a profile by name
 	 * @param name The name of the profile to delete
 	 * @throws Error if the profile does not exist


### PR DESCRIPTION
Some missing pieces for controlling config through api. (Much easier after #3366).

This just does name lookups in keeping with the existing api calls, but possibly it should do name|id like the `ProviderSettingsManager` methods do...

Can be tested with something like https://github.com/jr/roo-api-test + modifying `.vscode/launch.json` to add another `--extensionDevelopmentPath=PATH_TO_roo-api-test` (you may need to build roo-api-test at least once before they both work together...)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `getProfile` and `upsertProfile` methods to `API` for managing configuration profiles via the extension API.
> 
>   - **API Changes**:
>     - Add `getProfile(name: string): Promise<ProviderSettings>` to `API` class in `api.ts` for fetching profiles by name.
>     - Add `upsertProfile(name: string, settings: ProviderSettings): Promise<void>` to `API` class in `api.ts` for updating or creating profiles by name.
>     - Update `RooCodeAPI` interface in `interface.ts` and `roo-code.d.ts` to include `getProfile` and `upsertProfile` methods.
>   - **Behavior**:
>     - `upsertProfile` updates webview state if the profile is not the active one.
>     - `getProfile` throws an error if the profile does not exist.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 89597e33e8e40c0610d9e7c52b88837e34c97ae9. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->