### PR TITLE
Improve provider profile management in the external API

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -246,7 +246,7 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 			return false
 		}
 
-		// check if there is a cline instance in the stack (if this provider has an active task)
+		// Check if there is a cline instance in the stack (if this provider has an active task)
 		if (visibleProvider.getCurrentCline()) {
 			return true
 		}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -810,8 +810,6 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 	}
 
 	async upsertProviderProfile(name: string, providerSettings: ProviderSettings): Promise<string | undefined> {
-		console.log("upsertProviderProfile", { name, providerSettings })
-
 		try {
 			const id = await this.providerSettingsManager.saveConfig(name, providerSettings)
 			const { mode } = await this.getState()
@@ -871,8 +869,6 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		])
 
 		const { mode } = await this.getState()
-
-		console.log("activateProviderProfile", { name, id, mode })
 
 		if (id) {
 			await this.providerSettingsManager.setModeConfig(mode, id)

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -612,7 +612,7 @@ describe("ClineProvider", () => {
 		expect(mockContext.globalState.update).toHaveBeenCalledWith("currentApiConfigName", "test-config")
 	})
 
-	test("saves current config when switching to mode without config", async () => {
+	it("saves current config when switching to mode without config", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]
 
@@ -633,15 +633,15 @@ describe("ClineProvider", () => {
 		expect(provider.providerSettingsManager.setModeConfig).toHaveBeenCalledWith("architect", "current-id")
 	})
 
-	test("saves config as default for current mode when loading config", async () => {
+	it("saves config as default for current mode when loading config", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]
 
+		const profile: ProviderSettingsEntry = { apiProvider: "anthropic", id: "new-id", name: "new-config" }
+
 		;(provider as any).providerSettingsManager = {
-			activateProfile: jest
-				.fn()
-				.mockResolvedValue({ config: { apiProvider: "anthropic", id: "new-id" }, name: "new-config" }),
-			listConfig: jest.fn().mockResolvedValue([{ name: "new-config", id: "new-id", apiProvider: "anthropic" }]),
+			activateProfile: jest.fn().mockResolvedValue(profile),
+			listConfig: jest.fn().mockResolvedValue([profile]),
 			setModeConfig: jest.fn(),
 			getModeConfigId: jest.fn().mockResolvedValue(undefined),
 		} as any
@@ -656,18 +656,19 @@ describe("ClineProvider", () => {
 		expect(provider.providerSettingsManager.setModeConfig).toHaveBeenCalledWith("architect", "new-id")
 	})
 
-	test("load API configuration by ID works and updates mode config", async () => {
+	it("load API configuration by ID works and updates mode config", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]
 
+		const profile: ProviderSettingsEntry = {
+			name: "config-by-id",
+			id: "config-id-123",
+			apiProvider: "anthropic",
+		}
+
 		;(provider as any).providerSettingsManager = {
-			activateProfile: jest.fn().mockResolvedValue({
-				config: { apiProvider: "anthropic", id: "config-id-123" },
-				name: "config-by-id",
-			}),
-			listConfig: jest
-				.fn()
-				.mockResolvedValue([{ name: "config-by-id", id: "config-id-123", apiProvider: "anthropic" }]),
+			activateProfile: jest.fn().mockResolvedValue(profile),
+			listConfig: jest.fn().mockResolvedValue([profile]),
 			setModeConfig: jest.fn(),
 			getModeConfigId: jest.fn().mockResolvedValue(undefined),
 		} as any
@@ -881,7 +882,7 @@ describe("ClineProvider", () => {
 		})
 	})
 
-	test("saves mode config when updating API configuration", async () => {
+	it("saves mode config when updating API configuration", async () => {
 		// Setup mock context with mode and config name
 		mockContext = {
 			...mockContext,
@@ -907,12 +908,14 @@ describe("ClineProvider", () => {
 
 		;(provider as any).providerSettingsManager = {
 			listConfig: jest.fn().mockResolvedValue([{ name: "test-config", id: "test-id", apiProvider: "anthropic" }]),
+			saveConfig: jest.fn().mockResolvedValue("test-id"),
 			setModeConfig: jest.fn(),
 		} as any
 
 		// Update API configuration
 		await messageHandler({
-			type: "apiConfiguration",
+			type: "upsertApiConfiguration",
+			text: "test-config",
 			apiConfiguration: { apiProvider: "anthropic" },
 		})
 
@@ -1675,14 +1678,11 @@ describe("ClineProvider", () => {
 				currentApiConfigName: "test-config",
 			} as any)
 
-			// Trigger updateApiConfiguration
+			// Trigger upsertApiConfiguration
 			await messageHandler({
 				type: "upsertApiConfiguration",
 				text: "test-config",
-				apiConfiguration: {
-					apiProvider: "anthropic",
-					apiKey: "test-key",
-				},
+				apiConfiguration: { apiProvider: "anthropic", apiKey: "test-key" },
 			})
 
 			// Verify error was logged and user was notified

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -126,12 +126,6 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 			// task. This essentially creates a fresh slate for the new task.
 			await provider.initClineWithTask(message.text, message.images)
 			break
-		case "apiConfiguration":
-			if (message.apiConfiguration) {
-				await provider.updateApiConfiguration(message.apiConfiguration)
-			}
-			await provider.postStateToWebview()
-			break
 		case "customInstructions":
 			await provider.updateCustomInstructions(message.text)
 			break
@@ -1068,7 +1062,7 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 			break
 		case "upsertApiConfiguration":
 			if (message.text && message.apiConfiguration) {
-				await provider.upsertApiConfiguration(message.text, message.apiConfiguration)
+				await provider.upsertProviderProfile(message.text, message.apiConfiguration)
 			}
 			break
 		case "renameApiConfiguration":

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -270,14 +270,14 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		return this.sidebarProvider.providerSettingsManager.getProfile({ name })
 	}
 
-	public async createProfile(name: string, profile?: ProviderSettings) {
+	public async createProfile(name: string, profile?: ProviderSettings, activate: boolean = true) {
 		const entry = this.getProfileEntry(name)
 
 		if (entry) {
 			throw new Error(`Profile with name "${name}" already exists`)
 		}
 
-		const id = await this.sidebarProvider.upsertProviderProfile(name, profile ?? {})
+		const id = await this.sidebarProvider.upsertProviderProfile(name, profile ?? {}, activate)
 
 		if (!id) {
 			throw new Error(`Failed to create profile with name "${name}"`)
@@ -286,14 +286,18 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		return id
 	}
 
-	public async updateProfile(name: string, profile: ProviderSettings): Promise<string | undefined> {
+	public async updateProfile(
+		name: string,
+		profile: ProviderSettings,
+		activate: boolean = true,
+	): Promise<string | undefined> {
 		const entry = this.getProfileEntry(name)
 
 		if (!entry) {
 			throw new Error(`Profile with name "${name}" does not exist`)
 		}
 
-		const id = await this.sidebarProvider.upsertProviderProfile(name, profile)
+		const id = await this.sidebarProvider.upsertProviderProfile(name, profile, activate)
 
 		if (!id) {
 			throw new Error(`Failed to update profile with name "${name}"`)
@@ -302,8 +306,12 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 		return id
 	}
 
-	public async upsertProfile(name: string, profile: ProviderSettings): Promise<string | undefined> {
-		const id = await this.sidebarProvider.upsertProviderProfile(name, profile)
+	public async upsertProfile(
+		name: string,
+		profile: ProviderSettings,
+		activate: boolean = true,
+	): Promise<string | undefined> {
+		const id = await this.sidebarProvider.upsertProviderProfile(name, profile, activate)
 
 		if (!id) {
 			throw new Error(`Failed to upsert profile with name "${name}"`)

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -6,7 +6,14 @@ import * as path from "path"
 import { getWorkspacePath } from "../utils/path"
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { openClineInNewTab } from "../activate/registerCommands"
-import { RooCodeSettings, RooCodeEvents, RooCodeEventName, ProviderSettings, ProviderSettingsEntry } from "../schemas"
+import {
+	RooCodeSettings,
+	RooCodeEvents,
+	RooCodeEventName,
+	ProviderSettings,
+	ProviderSettingsEntry,
+	isSecretStateKey,
+} from "../schemas"
 import { IpcOrigin, IpcMessageType, TaskCommandName, TaskEvent } from "../schemas/ipc"
 
 import { RooCodeAPI } from "./interface"
@@ -246,8 +253,10 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	// Global Settings Management
 
-	public getConfiguration() {
-		return this.sidebarProvider.getValues()
+	public getConfiguration(): RooCodeSettings {
+		return Object.fromEntries(
+			Object.entries(this.sidebarProvider.getValues()).filter(([key]) => !isSecretStateKey(key)),
+		)
 	}
 
 	public async setConfiguration(values: RooCodeSettings) {
@@ -264,10 +273,6 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	public getProfileEntry(name: string): ProviderSettingsEntry | undefined {
 		return this.sidebarProvider.getProviderProfileEntry(name)
-	}
-
-	public async getProfile(name: string): Promise<ProviderSettings | undefined> {
-		return this.sidebarProvider.providerSettingsManager.getProfile({ name })
 	}
 
 	public async createProfile(name: string, profile?: ProviderSettings, activate: boolean = true) {

--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -6,7 +6,7 @@ import * as path from "path"
 import { getWorkspacePath } from "../utils/path"
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { openClineInNewTab } from "../activate/registerCommands"
-import { RooCodeSettings, RooCodeEvents, RooCodeEventName } from "../schemas"
+import { RooCodeSettings, RooCodeEvents, RooCodeEventName, ProviderSettings, ProviderSettingsEntry } from "../schemas"
 import { IpcOrigin, IpcMessageType, TaskCommandName, TaskEvent } from "../schemas/ipc"
 
 import { RooCodeAPI } from "./interface"
@@ -258,77 +258,82 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	// Provider Profile Management
 
-	private getProfilesMeta() {
-		return this.getConfiguration().listApiConfigMeta || []
+	public getProfiles(): string[] {
+		return this.sidebarProvider.getProviderProfileEntries().map(({ name }) => name)
 	}
 
-	public getProfiles() {
-		return this.getProfilesMeta().map((profile) => profile.name)
+	public getProfileEntry(name: string): ProviderSettingsEntry | undefined {
+		return this.sidebarProvider.getProviderProfileEntry(name)
 	}
 
-	public hasProfile(name: string): boolean {
-		return !!(this.getConfiguration().listApiConfigMeta || []).find((profile) => profile.name === name)
+	public async getProfile(name: string): Promise<ProviderSettings | undefined> {
+		return this.sidebarProvider.providerSettingsManager.getProfile({ name })
 	}
 
-	public async createProfile(name: string) {
-		if (!name || !name.trim()) {
-			throw new Error("Profile name cannot be empty")
+	public async createProfile(name: string, profile?: ProviderSettings) {
+		const entry = this.getProfileEntry(name)
+
+		if (entry) {
+			throw new Error(`Profile with name "${name}" already exists`)
 		}
 
-		const currentSettings = this.getConfiguration()
-		const profiles = currentSettings.listApiConfigMeta || []
+		const id = await this.sidebarProvider.upsertProviderProfile(name, profile ?? {})
 
-		if (profiles.some((profile) => profile.name === name)) {
-			throw new Error(`A profile with the name "${name}" already exists`)
+		if (!id) {
+			throw new Error(`Failed to create profile with name "${name}"`)
 		}
-
-		const id = this.sidebarProvider.providerSettingsManager.generateId()
-
-		await this.setConfiguration({
-			...currentSettings,
-			listApiConfigMeta: [
-				...profiles,
-				{
-					id,
-					name: name.trim(),
-					apiProvider: "openai" as const,
-				},
-			],
-		})
 
 		return id
 	}
 
-	public async deleteProfile(name: string) {
-		const currentSettings = this.getConfiguration()
-		const listApiConfigMeta = this.getProfilesMeta()
-		const targetIndex = listApiConfigMeta.findIndex((p) => p.name === name)
+	public async updateProfile(name: string, profile: ProviderSettings): Promise<string | undefined> {
+		const entry = this.getProfileEntry(name)
 
-		if (targetIndex === -1) {
+		if (!entry) {
 			throw new Error(`Profile with name "${name}" does not exist`)
 		}
 
-		const profileToDelete = listApiConfigMeta[targetIndex]
-		listApiConfigMeta.splice(targetIndex, 1)
+		const id = await this.sidebarProvider.upsertProviderProfile(name, profile)
 
-		// If we're deleting the active profile, clear the currentApiConfigName.
-		const currentApiConfigName =
-			currentSettings.currentApiConfigName === profileToDelete.name
-				? undefined
-				: currentSettings.currentApiConfigName
+		if (!id) {
+			throw new Error(`Failed to update profile with name "${name}"`)
+		}
 
-		await this.setConfiguration({ ...currentSettings, listApiConfigMeta, currentApiConfigName })
+		return id
+	}
+
+	public async upsertProfile(name: string, profile: ProviderSettings): Promise<string | undefined> {
+		const id = await this.sidebarProvider.upsertProviderProfile(name, profile)
+
+		if (!id) {
+			throw new Error(`Failed to upsert profile with name "${name}"`)
+		}
+
+		return id
+	}
+
+	public async deleteProfile(name: string): Promise<void> {
+		const entry = this.getProfileEntry(name)
+
+		if (!entry) {
+			throw new Error(`Profile with name "${name}" does not exist`)
+		}
+
+		await this.sidebarProvider.deleteProviderProfile(entry)
 	}
 
 	public getActiveProfile(): string | undefined {
 		return this.getConfiguration().currentApiConfigName
 	}
 
-	public async setActiveProfile(name: string) {
-		if (!this.hasProfile(name)) {
+	public async setActiveProfile(name: string): Promise<string | undefined> {
+		const entry = this.getProfileEntry(name)
+
+		if (!entry) {
 			throw new Error(`Profile with name "${name}" does not exist`)
 		}
 
 		await this.sidebarProvider.activateProviderProfile({ name })
+		return this.getActiveProfile()
 	}
 }

--- a/src/exports/interface.ts
+++ b/src/exports/interface.ts
@@ -114,12 +114,43 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	getProfiles(): string[]
 
 	/**
+	 * Returns the profile entry for a given name
+	 * @param name The name of the profile
+	 * @returns The profile entry, or undefined if the profile does not exist
+	 */
+	getProfileEntry(name: string): ProviderSettingsEntry | undefined
+
+	/**
+	 * Returns the profile for a given name
+	 * @param name The name of the profile
+	 * @returns The profile, or undefined if the profile does not exist
+	 */
+	getProfile(name: string): Promise<ProviderSettings | undefined>
+
+	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
 	 * @returns The ID of the created profile
 	 * @throws Error if the profile already exists
 	 */
 	createProfile(name: string, profile?: ProviderSettings): Promise<string>
+
+	/**
+	 * Updates an existing API configuration profile
+	 * @param name The name of the profile
+	 * @param profile The profile to update
+	 * @returns The ID of the updated profile
+	 * @throws Error if the profile does not exist
+	 */
+	updateProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
+
+	/**
+	 * Creates a new API configuration profile or updates an existing one
+	 * @param name The name of the profile
+	 * @param profile The profile to create or update
+	 * @returns The ID of the upserted profile
+	 */
+	upsertProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
 
 	/**
 	 * Deletes a profile by name
@@ -139,5 +170,5 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 * @param name The name of the profile to activate
 	 * @throws Error if the profile does not exist
 	 */
-	setActiveProfile(name: string): Promise<void>
+	setActiveProfile(name: string): Promise<string | undefined>
 }

--- a/src/exports/interface.ts
+++ b/src/exports/interface.ts
@@ -121,13 +121,6 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	getProfileEntry(name: string): ProviderSettingsEntry | undefined
 
 	/**
-	 * Returns the profile for a given name
-	 * @param name The name of the profile
-	 * @returns The profile, or undefined if the profile does not exist
-	 */
-	getProfile(name: string): Promise<ProviderSettings | undefined>
-
-	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
 	 * @param profile The profile to create; defaults to an empty object

--- a/src/exports/interface.ts
+++ b/src/exports/interface.ts
@@ -130,27 +130,31 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
+	 * @param profile The profile to create; defaults to an empty object
+	 * @param activate Whether to activate the profile after creation; defaults to true
 	 * @returns The ID of the created profile
 	 * @throws Error if the profile already exists
 	 */
-	createProfile(name: string, profile?: ProviderSettings): Promise<string>
+	createProfile(name: string, profile?: ProviderSettings, activate?: boolean): Promise<string>
 
 	/**
 	 * Updates an existing API configuration profile
 	 * @param name The name of the profile
 	 * @param profile The profile to update
+	 * @param activate Whether to activate the profile after update; defaults to true
 	 * @returns The ID of the updated profile
 	 * @throws Error if the profile does not exist
 	 */
-	updateProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
+	updateProfile(name: string, profile: ProviderSettings, activate?: boolean): Promise<string | undefined>
 
 	/**
 	 * Creates a new API configuration profile or updates an existing one
 	 * @param name The name of the profile
-	 * @param profile The profile to create or update
+	 * @param profile The profile to create or update; defaults to an empty object
+	 * @param activate Whether to activate the profile after upsert; defaults to true
 	 * @returns The ID of the upserted profile
 	 */
-	upsertProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
+	upsertProfile(name: string, profile: ProviderSettings, activate?: boolean): Promise<string | undefined>
 
 	/**
 	 * Deletes a profile by name

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -633,12 +633,39 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 */
 	getProfiles(): string[]
 	/**
+	 * Returns the profile entry for a given name
+	 * @param name The name of the profile
+	 * @returns The profile entry, or undefined if the profile does not exist
+	 */
+	getProfileEntry(name: string): ProviderSettingsEntry | undefined
+	/**
+	 * Returns the profile for a given name
+	 * @param name The name of the profile
+	 * @returns The profile, or undefined if the profile does not exist
+	 */
+	getProfile(name: string): Promise<ProviderSettings | undefined>
+	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
 	 * @returns The ID of the created profile
 	 * @throws Error if the profile already exists
 	 */
 	createProfile(name: string, profile?: ProviderSettings): Promise<string>
+	/**
+	 * Updates an existing API configuration profile
+	 * @param name The name of the profile
+	 * @param profile The profile to update
+	 * @returns The ID of the updated profile
+	 * @throws Error if the profile does not exist
+	 */
+	updateProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
+	/**
+	 * Creates a new API configuration profile or updates an existing one
+	 * @param name The name of the profile
+	 * @param profile The profile to create or update
+	 * @returns The ID of the upserted profile
+	 */
+	upsertProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
 	/**
 	 * Deletes a profile by name
 	 * @param name The name of the profile to delete
@@ -655,7 +682,7 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 * @param name The name of the profile to activate
 	 * @throws Error if the profile does not exist
 	 */
-	setActiveProfile(name: string): Promise<void>
+	setActiveProfile(name: string): Promise<string | undefined>
 }
 
 export {

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -647,25 +647,29 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
+	 * @param profile The profile to create; defaults to an empty object
+	 * @param activate Whether to activate the profile after creation; defaults to true
 	 * @returns The ID of the created profile
 	 * @throws Error if the profile already exists
 	 */
-	createProfile(name: string, profile?: ProviderSettings): Promise<string>
+	createProfile(name: string, profile?: ProviderSettings, activate?: boolean): Promise<string>
 	/**
 	 * Updates an existing API configuration profile
 	 * @param name The name of the profile
 	 * @param profile The profile to update
+	 * @param activate Whether to activate the profile after update; defaults to true
 	 * @returns The ID of the updated profile
 	 * @throws Error if the profile does not exist
 	 */
-	updateProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
+	updateProfile(name: string, profile: ProviderSettings, activate?: boolean): Promise<string | undefined>
 	/**
 	 * Creates a new API configuration profile or updates an existing one
 	 * @param name The name of the profile
-	 * @param profile The profile to create or update
+	 * @param profile The profile to create or update; defaults to an empty object
+	 * @param activate Whether to activate the profile after upsert; defaults to true
 	 * @returns The ID of the upserted profile
 	 */
-	upsertProfile(name: string, profile: ProviderSettings): Promise<string | undefined>
+	upsertProfile(name: string, profile: ProviderSettings, activate?: boolean): Promise<string | undefined>
 	/**
 	 * Deletes a profile by name
 	 * @param name The name of the profile to delete

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -639,12 +639,6 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 */
 	getProfileEntry(name: string): ProviderSettingsEntry | undefined
 	/**
-	 * Returns the profile for a given name
-	 * @param name The name of the profile
-	 * @returns The profile, or undefined if the profile does not exist
-	 */
-	getProfile(name: string): Promise<ProviderSettings | undefined>
-	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
 	 * @param profile The profile to create; defaults to an empty object

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -11,7 +11,6 @@ export type AudioType = "notification" | "celebration" | "progress_loop"
 
 export interface WebviewMessage {
 	type:
-		| "apiConfiguration"
 		| "deleteMultipleTasksWithIds"
 		| "currentApiConfigName"
 		| "saveApiConfiguration"


### PR DESCRIPTION
### Description

I like the idea of the upsert that @jr is working on, and I recalled seeing existing upsert functionality in `ClineProvider`, so I took a stab at using it in the external API.

What do you think?
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances provider profile management by introducing `upsertProviderProfile()` in `ClineProvider` and updating related API methods and tests.
> 
>   - **Behavior**:
>     - Introduces `upsertProviderProfile()` in `ClineProvider` to handle both creation and update of provider profiles.
>     - Replaces `upsertApiConfiguration()` with `upsertProviderProfile()` in `ClineProvider.ts`, `webviewMessageHandler.ts`, and `api.ts`.
>     - Updates `activateProviderProfile()` in `ClineProvider.ts` to use `upsertProviderProfile()` logic.
>   - **API Changes**:
>     - Adds `upsertProfile()` method to `API` class in `api.ts`.
>     - Updates `createProfile()` and `updateProfile()` in `api.ts` to use `upsertProviderProfile()`.
>     - Modifies `RooCodeAPI` interface in `interface.ts` and `roo-code.d.ts` to include `upsertProfile()`.
>   - **Tests**:
>     - Updates tests in `ClineProvider.test.ts` to reflect changes in profile management methods.
>     - Ensures tests cover both creation and update scenarios using `upsertProviderProfile()`.
>   - **Misc**:
>     - Removes `apiConfiguration` message type from `WebviewMessage.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7e95b472e77d5faa6ef04b6aa5e28f5ba195158f. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->