### PR TITLE
Don't return api keys through the api

### DIFF
--- a/src/exports/api.ts
+++ b/src/exports/api.ts
@@ -6,7 +6,14 @@ import * as path from "path"
 import { getWorkspacePath } from "../utils/path"
 import { ClineProvider } from "../core/webview/ClineProvider"
 import { openClineInNewTab } from "../activate/registerCommands"
-import { RooCodeSettings, RooCodeEvents, RooCodeEventName, ProviderSettings, ProviderSettingsEntry } from "../schemas"
+import {
+	RooCodeSettings,
+	RooCodeEvents,
+	RooCodeEventName,
+	ProviderSettings,
+	ProviderSettingsEntry,
+	isSecretStateKey,
+} from "../schemas"
 import { IpcOrigin, IpcMessageType, TaskCommandName, TaskEvent } from "../schemas/ipc"
 
 import { RooCodeAPI } from "./interface"
@@ -246,8 +253,10 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	// Global Settings Management
 
-	public getConfiguration() {
-		return this.sidebarProvider.getValues()
+	public getConfiguration(): RooCodeSettings {
+		return Object.fromEntries(
+			Object.entries(this.sidebarProvider.getValues()).filter(([key]) => !isSecretStateKey(key)),
+		)
 	}
 
 	public async setConfiguration(values: RooCodeSettings) {
@@ -264,10 +273,6 @@ export class API extends EventEmitter<RooCodeEvents> implements RooCodeAPI {
 
 	public getProfileEntry(name: string): ProviderSettingsEntry | undefined {
 		return this.sidebarProvider.getProviderProfileEntry(name)
-	}
-
-	public async getProfile(name: string): Promise<ProviderSettings | undefined> {
-		return this.sidebarProvider.providerSettingsManager.getProfile({ name })
 	}
 
 	public async createProfile(name: string, profile?: ProviderSettings, activate: boolean = true) {

--- a/src/exports/interface.ts
+++ b/src/exports/interface.ts
@@ -121,13 +121,6 @@ export interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	getProfileEntry(name: string): ProviderSettingsEntry | undefined
 
 	/**
-	 * Returns the profile for a given name
-	 * @param name The name of the profile
-	 * @returns The profile, or undefined if the profile does not exist
-	 */
-	getProfile(name: string): Promise<ProviderSettings | undefined>
-
-	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
 	 * @param profile The profile to create; defaults to an empty object

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -639,12 +639,6 @@ interface RooCodeAPI extends EventEmitter<RooCodeEvents> {
 	 */
 	getProfileEntry(name: string): ProviderSettingsEntry | undefined
 	/**
-	 * Returns the profile for a given name
-	 * @param name The name of the profile
-	 * @returns The profile, or undefined if the profile does not exist
-	 */
-	getProfile(name: string): Promise<ProviderSettings | undefined>
-	/**
 	 * Creates a new API configuration profile
 	 * @param name The name of the profile
 	 * @param profile The profile to create; defaults to an empty object


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> `getConfiguration()` now filters out secret keys, and `getProfile()` is removed from the API.
> 
>   - **Behavior**:
>     - `getConfiguration()` in `api.ts` now filters out secret keys using `isSecretStateKey`.
>     - Removed `getProfile()` method from `api.ts`, `interface.ts`, and `roo-code.d.ts`.
>   - **Misc**:
>     - Updated imports in `api.ts` to include `isSecretStateKey`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 331941a2a1eb9dec78f656080f964191d7515ba1. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->