### PR TITLE
fix: get model id from ApiHandler

### DIFF
--- a/src/core/environment/__tests__/getEnvironmentDetails.test.ts
+++ b/src/core/environment/__tests__/getEnvironmentDetails.test.ts
@@ -69,7 +69,6 @@ describe("getEnvironmentDetails", () => {
 			maxOpenTabsContext: 10,
 			mode: "code",
 			customModes: [],
-			apiModelId: "test-model",
 			experiments: {},
 			customInstructions: "test instructions",
 			language: "en",
@@ -102,7 +101,7 @@ describe("getEnvironmentDetails", () => {
 			} as unknown as RooIgnoreController,
 			clineMessages: [],
 			api: {
-				getModel: jest.fn().mockReturnValue({ info: { contextWindow: 100000 } }),
+				getModel: jest.fn().mockReturnValue({ id: "test-model", info: { contextWindow: 100000 } }),
 				createMessage: jest.fn(),
 				countTokens: jest.fn(),
 			} as unknown as ApiHandler,
@@ -144,6 +143,7 @@ describe("getEnvironmentDetails", () => {
 		expect(result).toContain("# Current Context Size (Tokens)")
 		expect(result).toContain("# Current Cost")
 		expect(result).toContain("# Current Mode")
+		expect(result).toContain("<model>test-model</model>")
 
 		expect(mockProvider.getState).toHaveBeenCalled()
 

--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -190,7 +190,7 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 
 	// Add context tokens information.
 	const { contextTokens, totalCost } = getApiMetrics(cline.clineMessages)
-	const modelInfo = cline.api.getModel().info
+	const { id: modelId, info: modelInfo } = cline.api.getModel()
 	const contextWindow = modelInfo.contextWindow
 
 	const contextPercentage =
@@ -203,7 +203,6 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 	const {
 		mode,
 		customModes,
-		apiModelId,
 		customModePrompts,
 		experiments = {} as Record<ExperimentId, boolean>,
 		customInstructions: globalCustomInstructions,
@@ -221,7 +220,7 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 	details += `\n\n# Current Mode\n`
 	details += `<slug>${currentMode}</slug>\n`
 	details += `<name>${modeDetails.name}</name>\n`
-	details += `<model>${apiModelId}</model>\n`
+	details += `<model>${modelId}</model>\n`
 
 	if (Experiments.isEnabled(experiments ?? {}, EXPERIMENT_IDS.POWER_STEERING)) {
 		details += `<role>${modeDetails.roleDefinition}</role>\n`


### PR DESCRIPTION
Not all handlers/providers use `apiModelId`, but they do all return a model id from `getModel()`.

If `<model>human-relay</model>` is ok, then this arguably addresses #2706, although maybe it would be better to explicitly omit the model line when it's `human-relay`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `getEnvironmentDetails` now retrieves model ID from `getModel()` instead of `apiModelId`, with corresponding test updates.
> 
>   - **Behavior**:
>     - `getEnvironmentDetails` in `getEnvironmentDetails.ts` now uses `id` from `getModel()` instead of `apiModelId`.
>     - Updates test in `getEnvironmentDetails.test.ts` to reflect this change.
>   - **Tests**:
>     - Modify mock return value of `getModel()` to include `id` in `getEnvironmentDetails.test.ts`.
>     - Add expectation for `<model>test-model</model>` in `getEnvironmentDetails.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for edc9e21d2501a0bc0465ee0278f0e3f0f130a02b. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->