### PR TITLE
fix: command validation failing on shell array indexing

### DIFF
--- a/webview-ui/.eslintrc.json
+++ b/webview-ui/.eslintrc.json
@@ -4,5 +4,14 @@
 	"rules": {
 		"no-unused-vars": "off",
 		"@typescript-eslint/no-unused-vars": ["error", { "varsIgnorePattern": "^_", "argsIgnorePattern": "^_" }]
-	}
+	},
+	"overrides": [
+		{
+			"files": ["webview-ui/src/__tests__/utils/command-validation.test.ts"],
+			"rules": {
+				"no-template-curly-in-string": "off",
+				"no-useless-escape": "off"
+			}
+		}
+	]
 }

--- a/webview-ui/src/__tests__/utils/command-validation.test.ts
+++ b/webview-ui/src/__tests__/utils/command-validation.test.ts
@@ -48,7 +48,7 @@ describe("command-validation", () => {
 			}).not.toThrow()
 		})
 
-		it("should throw an error when parsing commands with $RANDOM in array index", () => {
+		it("should not throw an error when parsing commands with $RANDOM in array index", () => {
 			// This test reproduces the specific bug reported in the error
 			const commandWithRandom = "level=${levels[$RANDOM % ${#levels[@]}]}"
 
@@ -75,7 +75,7 @@ describe("command-validation", () => {
 			}).not.toThrow()
 		})
 
-		it("should throw an error with complex array indexing using $RANDOM and arithmetic", () => {
+		it("should not throw an error with complex array indexing using $RANDOM and arithmetic", () => {
 			// This test reproduces the exact expression from the original error
 			const commandWithComplexRandom = "echo ${levels[$RANDOM % ${#levels[@]}]}"
 
@@ -84,7 +84,7 @@ describe("command-validation", () => {
 			}).not.toThrow("Bad substitution")
 		})
 
-		it("should throw an error when parsing the full log generator command", () => {
+		it("should not throw an error when parsing the full log generator command", () => {
 			// This is the exact command from the original error message
 			const logGeneratorCommand = `while true; do \\
   levels=(INFO WARN ERROR DEBUG); \\
@@ -101,7 +101,7 @@ done`
 			}).not.toThrow("Bad substitution: levels[$RANDOM")
 		})
 
-		it("should throw an error when parsing just the problematic part", () => {
+		it("should not throw an error when parsing just the problematic part", () => {
 			// This isolates just the part mentioned in the error message
 			const problematicPart = "level=${levels[$RANDOM"
 

--- a/webview-ui/src/__tests__/utils/command-validation.test.ts
+++ b/webview-ui/src/__tests__/utils/command-validation.test.ts
@@ -1,0 +1,158 @@
+import { parseCommand, validateCommand } from "../../utils/command-validation"
+
+/**
+ * Tests for the command-validation module
+ *
+ * These tests include a reproduction of a bug where the shell-quote library
+ * used in parseCommand throws an error when parsing commands that contain
+ * the Bash $RANDOM variable in array indexing expressions.
+ *
+ * Error: "Bad substitution: levels[$RANDOM"
+ *
+ * The issue occurs specifically with complex expressions like:
+ * ${levels[$RANDOM % ${#levels[@]}]}
+ */
+describe("command-validation", () => {
+	describe("parseCommand", () => {
+		it("should correctly parse simple commands", () => {
+			const result = parseCommand("echo hello")
+			expect(result).toEqual(["echo hello"])
+		})
+
+		it("should correctly parse commands with chaining operators", () => {
+			const result = parseCommand("echo hello && echo world")
+			expect(result).toEqual(["echo hello", "echo world"])
+		})
+
+		it("should correctly parse commands with quotes", () => {
+			const result = parseCommand('echo "hello world"')
+			expect(result).toEqual(['echo "hello world"'])
+		})
+
+		it("should correctly parse commands with redirections", () => {
+			const result = parseCommand("echo hello 2>&1")
+			expect(result).toEqual(["echo hello 2>&1"])
+		})
+
+		it("should correctly parse commands with subshells", () => {
+			const result = parseCommand("echo $(date)")
+			expect(result).toEqual(["echo", "date"])
+		})
+
+		it("should not throw an error when parsing commands with simple array indexing", () => {
+			// Simple array indexing works fine
+			const commandWithArrayIndex = "value=${array[$index]}"
+
+			expect(() => {
+				parseCommand(commandWithArrayIndex)
+			}).not.toThrow()
+		})
+
+		it("should throw an error when parsing commands with $RANDOM in array index", () => {
+			// This test reproduces the specific bug reported in the error
+			const commandWithRandom = "level=${levels[$RANDOM % ${#levels[@]}]}"
+
+			expect(() => {
+				parseCommand(commandWithRandom)
+			}).not.toThrow()
+		})
+
+		it("should not throw an error with simple $RANDOM variable", () => {
+			// Simple $RANDOM usage works fine
+			const commandWithRandom = "echo $RANDOM"
+
+			expect(() => {
+				parseCommand(commandWithRandom)
+			}).not.toThrow()
+		})
+
+		it("should not throw an error with simple array indexing using $RANDOM", () => {
+			// Simple array indexing with $RANDOM works fine
+			const commandWithRandomIndex = "echo ${array[$RANDOM]}"
+
+			expect(() => {
+				parseCommand(commandWithRandomIndex)
+			}).not.toThrow()
+		})
+
+		it("should throw an error with complex array indexing using $RANDOM and arithmetic", () => {
+			// This test reproduces the exact expression from the original error
+			const commandWithComplexRandom = "echo ${levels[$RANDOM % ${#levels[@]}]}"
+
+			expect(() => {
+				parseCommand(commandWithComplexRandom)
+			}).not.toThrow("Bad substitution")
+		})
+
+		it("should throw an error when parsing the full log generator command", () => {
+			// This is the exact command from the original error message
+			const logGeneratorCommand = `while true; do \\
+  levels=(INFO WARN ERROR DEBUG); \\
+  msgs=("User logged in" "Connection timeout" "Processing request" "Cache miss" "Database query"); \\
+  level=\${levels[$RANDOM % \${#levels[@]}]}; \\
+  msg=\${msgs[$RANDOM % \${#msgs[@]}]}; \\
+  echo "\$(date '+%Y-%m-%d %H:%M:%S') [$level] $msg"; \\
+  sleep 1; \\
+done`
+
+			// This reproduces the original error
+			expect(() => {
+				parseCommand(logGeneratorCommand)
+			}).not.toThrow("Bad substitution: levels[$RANDOM")
+		})
+
+		it("should throw an error when parsing just the problematic part", () => {
+			// This isolates just the part mentioned in the error message
+			const problematicPart = "level=${levels[$RANDOM"
+
+			expect(() => {
+				parseCommand(problematicPart)
+			}).not.toThrow("Bad substitution")
+		})
+	})
+
+	describe("validateCommand", () => {
+		it("should validate allowed commands", () => {
+			const result = validateCommand("echo hello", ["echo"])
+			expect(result).toBe(true)
+		})
+
+		it("should reject disallowed commands", () => {
+			const result = validateCommand("rm -rf /", ["echo", "ls"])
+			expect(result).toBe(false)
+		})
+
+		it("should not fail validation for commands with simple $RANDOM variable", () => {
+			const commandWithRandom = "echo $RANDOM"
+
+			expect(() => {
+				validateCommand(commandWithRandom, ["echo"])
+			}).not.toThrow()
+		})
+
+		it("should not fail validation for commands with simple array indexing using $RANDOM", () => {
+			const commandWithRandomIndex = "echo ${array[$RANDOM]}"
+
+			expect(() => {
+				validateCommand(commandWithRandomIndex, ["echo"])
+			}).not.toThrow()
+		})
+
+		it("should return false for the full log generator command due to subshell detection", () => {
+			// This is the exact command from the original error message
+			const logGeneratorCommand = `while true; do \\
+  levels=(INFO WARN ERROR DEBUG); \\
+  msgs=("User logged in" "Connection timeout" "Processing request" "Cache miss" "Database query"); \\
+  level=\${levels[$RANDOM % \${#levels[@]}]}; \\
+  msg=\${msgs[$RANDOM % \${#msgs[@]}]}; \\
+  echo "\$(date '+%Y-%m-%d %H:%M:%S') [$level] $msg"; \\
+  sleep 1; \\
+done`
+
+			// validateCommand should return false due to subshell detection
+			// without throwing an error
+			const result = validateCommand(logGeneratorCommand, ["while"])
+			expect(result).toBe(false)
+		})
+	})
+})


### PR DESCRIPTION
Previously command validation would fail with 'Bad substitution' error when encountering shell array indexing expressions like ${array[var]}.

Added parsing support for array indexing expressions before they reach shell-quote parser to prevent the error. This allows proper validation of shell commands that use array indexing.

Test cases added to verify handling of:
- Simple array indexing
- Array indexing with variables 
- Complex array indexing expressions

Disabled ESLint rules no-template-curly-in-string and no-useless-escape specifically for command-validation test file since they conflict with shell command syntax testing.

Fixes #3529
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes command validation error for shell array indexing by adding parsing support and updates ESLint rules for testing.
> 
>   - **Behavior**:
>     - Fixes command validation error for shell array indexing expressions like `${array[var]}` in `command-validation.ts`.
>     - Adds parsing support for array indexing before shell-quote parsing to prevent 'Bad substitution' errors.
>     - Test cases added in `command-validation.test.ts` for simple, variable, and complex array indexing.
>   - **ESLint**:
>     - Disables `no-template-curly-in-string` and `no-useless-escape` rules for `command-validation.test.ts` in `.eslintrc.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 58bff0e380c063e9074c8068abf6b6e806510c50. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->