### PR TITLE
Add tests + benchmark for parseAssistantMessage V1 + 2

### DIFF
--- a/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
+++ b/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
@@ -1,0 +1,420 @@
+// npx jest src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
+
+import { TextContent, ToolUse } from "../../../shared/tools"
+
+import { parseAssistantMessage } from "../parseAssistantMessage"
+
+describe("parseAssistantMessage", () => {
+	describe("text content parsing", () => {
+		it("should parse a simple text message", () => {
+			const message = "This is a simple text message"
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				type: "text",
+				content: message,
+				partial: true, // Text is always partial when it's the last content
+			})
+		})
+
+		it("should parse a multi-line text message", () => {
+			const message = "This is a multi-line\ntext message\nwith several lines"
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				type: "text",
+				content: message,
+				partial: true, // Text is always partial when it's the last content
+			})
+		})
+
+		it("should mark text as partial when it's the last content in the message", () => {
+			const message = "This is a partial text"
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(1)
+			expect(result[0]).toEqual({
+				type: "text",
+				content: message,
+				partial: true,
+			})
+		})
+	})
+
+	describe("tool use parsing", () => {
+		it("should parse a simple tool use", () => {
+			const message = "<read_file><path>src/file.ts</path></read_file>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+			expect((result[0] as TextContent).partial).toBe(false)
+
+			// Second content is the tool use
+			expect(result[1].type).toBe("tool_use")
+			expect((result[1] as ToolUse).name).toBe("read_file")
+			expect((result[1] as ToolUse).params.path).toBe("src/file.ts")
+			expect((result[1] as ToolUse).partial).toBe(false)
+		})
+
+		it("should parse a tool use with multiple parameters", () => {
+			const message =
+				"<read_file><path>src/file.ts</path><start_line>10</start_line><end_line>20</end_line></read_file>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			expect(result[1].type).toBe("tool_use")
+			expect((result[1] as ToolUse).name).toBe("read_file")
+			expect((result[1] as ToolUse).params.path).toBe("src/file.ts")
+			expect((result[1] as ToolUse).params.start_line).toBe("10")
+			expect((result[1] as ToolUse).params.end_line).toBe("20")
+			expect((result[1] as ToolUse).partial).toBe(false)
+		})
+
+		it("should mark tool use as partial when it's not closed", () => {
+			const message = "<read_file><path>src/file.ts</path>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the partial tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("read_file")
+			expect(toolUse.params.path).toBe("src/file.ts")
+			expect(toolUse.partial).toBe(true)
+		})
+
+		it("should handle a partial parameter in a tool use", () => {
+			const message = "<read_file><path>src/file.ts"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the partial tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("read_file")
+			expect(toolUse.params.path).toBe("src/file.ts")
+			expect(toolUse.partial).toBe(true)
+		})
+	})
+
+	describe("mixed content parsing", () => {
+		it("should parse text followed by a tool use", () => {
+			const message = "Here's the file content: <read_file><path>src/file.ts</path></read_file>"
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(2)
+
+			const textContent = result[0] as TextContent
+			expect(textContent.type).toBe("text")
+			expect(textContent.content).toBe("Here's the file content:")
+			expect(textContent.partial).toBe(false)
+
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("read_file")
+			expect(toolUse.params.path).toBe("src/file.ts")
+			expect(toolUse.partial).toBe(false)
+		})
+
+		it("should parse a tool use followed by text", () => {
+			const message = "<read_file><path>src/file.ts</path></read_file>Here's what I found in the file."
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(3)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("read_file")
+			expect(toolUse.params.path).toBe("src/file.ts")
+			expect(toolUse.partial).toBe(false)
+
+			// Third content is the text
+			const textContent = result[2] as TextContent
+			expect(textContent.type).toBe("text")
+			expect(textContent.content).toBe("Here's what I found in the file.")
+			expect(textContent.partial).toBe(true)
+		})
+
+		it("should parse multiple tool uses separated by text", () => {
+			const message =
+				"First file: <read_file><path>src/file1.ts</path></read_file>Second file: <read_file><path>src/file2.ts</path></read_file>"
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(4)
+
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("First file:")
+
+			expect(result[1].type).toBe("tool_use")
+			expect((result[1] as ToolUse).name).toBe("read_file")
+			expect((result[1] as ToolUse).params.path).toBe("src/file1.ts")
+
+			expect(result[2].type).toBe("text")
+			expect((result[2] as TextContent).content).toBe("Second file:")
+
+			expect(result[3].type).toBe("tool_use")
+			expect((result[3] as ToolUse).name).toBe("read_file")
+			expect((result[3] as ToolUse).params.path).toBe("src/file2.ts")
+		})
+	})
+
+	describe("special cases", () => {
+		it("should handle the write_to_file tool with content that contains closing tags", () => {
+			const message = `<write_to_file><path>src/file.ts</path><content>
+function example() {
+  // This has XML-like content: </content>
+  return true;
+}
+</content><line_count>5</line_count></write_to_file>`
+
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("write_to_file")
+			expect(toolUse.params.path).toBe("src/file.ts")
+			expect(toolUse.params.line_count).toBe("5")
+			// The content might be slightly different due to whitespace handling
+			expect(toolUse.params.content).toContain("function example()")
+			expect(toolUse.params.content).toContain("// This has XML-like content: </content>")
+			expect(toolUse.params.content).toContain("return true;")
+			expect(toolUse.partial).toBe(false)
+		})
+
+		it("should handle empty messages", () => {
+			const message = ""
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(0)
+		})
+
+		it("should handle malformed tool use tags", () => {
+			const message = "This has a <not_a_tool>malformed tag</not_a_tool>"
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(1)
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe(message)
+		})
+
+		it("should handle tool use with no parameters", () => {
+			const message = "<browser_action></browser_action>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("browser_action")
+			expect(Object.keys(toolUse.params).length).toBe(0)
+			expect(toolUse.partial).toBe(false)
+		})
+
+		it("should handle nested tool tags that aren't actually nested", () => {
+			const message =
+				"<execute_command><command>echo '<read_file><path>test.txt</path></read_file>'</command></execute_command>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("execute_command")
+			expect(toolUse.params.command).toBe("echo '<read_file><path>test.txt</path></read_file>'")
+			expect(toolUse.partial).toBe(false)
+		})
+
+		it("should handle a tool use with a parameter containing XML-like content", () => {
+			const message = "<search_files><regex><div>.*</div></regex><path>src</path></search_files>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("search_files")
+			expect(toolUse.params.regex).toBe("<div>.*</div>")
+			expect(toolUse.params.path).toBe("src")
+			expect(toolUse.partial).toBe(false)
+		})
+
+		it("should handle consecutive tool uses without text in between", () => {
+			const message = "<read_file><path>file1.ts</path></read_file><read_file><path>file2.ts</path></read_file>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds empty text content between tool uses
+			expect(result).toHaveLength(4)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the first tool use
+			expect(result[1].type).toBe("tool_use")
+			expect((result[1] as ToolUse).name).toBe("read_file")
+			expect((result[1] as ToolUse).params.path).toBe("file1.ts")
+			expect((result[1] as ToolUse).partial).toBe(false)
+
+			// Third content is empty text
+			expect(result[2].type).toBe("text")
+			expect((result[2] as TextContent).content).toBe("")
+
+			// Fourth content is the second tool use
+			expect(result[3].type).toBe("tool_use")
+			expect((result[3] as ToolUse).name).toBe("read_file")
+			expect((result[3] as ToolUse).params.path).toBe("file2.ts")
+			expect((result[3] as ToolUse).partial).toBe(false)
+		})
+
+		it("should handle whitespace in parameters", () => {
+			const message = "<read_file><path>  src/file.ts  </path></read_file>"
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("read_file")
+			expect(toolUse.params.path).toBe("src/file.ts")
+			expect(toolUse.partial).toBe(false)
+		})
+
+		it("should handle multi-line parameters", () => {
+			const message = `<write_to_file><path>file.ts</path><content>
+line 1
+line 2
+line 3
+</content><line_count>3</line_count></write_to_file>`
+
+			const result = parseAssistantMessage(message)
+
+			// The parser adds an empty text content at the beginning
+			expect(result).toHaveLength(2)
+
+			// First content is empty text
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("")
+
+			// Second content is the tool use
+			const toolUse = result[1] as ToolUse
+			expect(toolUse.type).toBe("tool_use")
+			expect(toolUse.name).toBe("write_to_file")
+			expect(toolUse.params.path).toBe("file.ts")
+			// Use toContain instead of toBe to handle potential whitespace differences
+			expect(toolUse.params.content).toContain("line 1")
+			expect(toolUse.params.content).toContain("line 2")
+			expect(toolUse.params.content).toContain("line 3")
+			expect(toolUse.params.line_count).toBe("3")
+			expect(toolUse.partial).toBe(false)
+		})
+
+		it("should handle a complex message with multiple content types", () => {
+			const message = `I'll help you with that task.
+
+<read_file><path>src/index.ts</path></read_file>
+
+Now let's modify the file:
+
+<write_to_file><path>src/index.ts</path><content>
+// Updated content
+console.log("Hello world");
+</content><line_count>2</line_count></write_to_file>
+
+Let's run the code:
+
+<execute_command><command>node src/index.ts</command></execute_command>`
+
+			const result = parseAssistantMessage(message)
+
+			expect(result).toHaveLength(6)
+
+			// First text block
+			expect(result[0].type).toBe("text")
+			expect((result[0] as TextContent).content).toBe("I'll help you with that task.")
+
+			// First tool use (read_file)
+			expect(result[1].type).toBe("tool_use")
+			expect((result[1] as ToolUse).name).toBe("read_file")
+
+			// Second text block
+			expect(result[2].type).toBe("text")
+			expect((result[2] as TextContent).content).toContain("Now let's modify the file:")
+
+			// Second tool use (write_to_file)
+			expect(result[3].type).toBe("tool_use")
+			expect((result[3] as ToolUse).name).toBe("write_to_file")
+
+			// Third text block
+			expect(result[4].type).toBe("text")
+			expect((result[4] as TextContent).content).toContain("Let's run the code:")
+
+			// Third tool use (execute_command)
+			expect(result[5].type).toBe("tool_use")
+			expect((result[5] as ToolUse).name).toBe("execute_command")
+		})
+	})
+})

--- a/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
+++ b/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
@@ -2,419 +2,339 @@
 
 import { TextContent, ToolUse } from "../../../shared/tools"
 
-import { parseAssistantMessage } from "../parseAssistantMessage"
+import { AssistantMessageContent, parseAssistantMessage as parseAssistantMessageV1 } from "../parseAssistantMessage"
+import { parseAssistantMessageV2 } from "../parseAssistantMessageV2"
 
-describe("parseAssistantMessage", () => {
-	describe("text content parsing", () => {
-		it("should parse a simple text message", () => {
-			const message = "This is a simple text message"
-			const result = parseAssistantMessage(message)
+const isEmptyTextContent = (block: AssistantMessageContent) =>
+	block.type === "text" && (block as TextContent).content === ""
 
-			expect(result).toHaveLength(1)
-			expect(result[0]).toEqual({
-				type: "text",
-				content: message,
-				partial: true, // Text is always partial when it's the last content
+;[parseAssistantMessageV1, parseAssistantMessageV2].forEach((parser, index) => {
+	describe(`parseAssistantMessageV${index + 1}`, () => {
+		describe("text content parsing", () => {
+			it("should parse a simple text message", () => {
+				const message = "This is a simple text message"
+				const result = parser(message)
+
+				expect(result).toHaveLength(1)
+				expect(result[0]).toEqual({
+					type: "text",
+					content: message,
+					partial: true, // Text is always partial when it's the last content
+				})
+			})
+
+			it("should parse a multi-line text message", () => {
+				const message = "This is a multi-line\ntext message\nwith several lines"
+				const result = parser(message)
+
+				expect(result).toHaveLength(1)
+				expect(result[0]).toEqual({
+					type: "text",
+					content: message,
+					partial: true, // Text is always partial when it's the last content
+				})
+			})
+
+			it("should mark text as partial when it's the last content in the message", () => {
+				const message = "This is a partial text"
+				const result = parser(message)
+
+				expect(result).toHaveLength(1)
+				expect(result[0]).toEqual({
+					type: "text",
+					content: message,
+					partial: true,
+				})
 			})
 		})
 
-		it("should parse a multi-line text message", () => {
-			const message = "This is a multi-line\ntext message\nwith several lines"
-			const result = parseAssistantMessage(message)
+		describe("tool use parsing", () => {
+			it("should parse a simple tool use", () => {
+				const message = "<read_file><path>src/file.ts</path></read_file>"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
 
-			expect(result).toHaveLength(1)
-			expect(result[0]).toEqual({
-				type: "text",
-				content: message,
-				partial: true, // Text is always partial when it's the last content
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("read_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should parse a tool use with multiple parameters", () => {
+				const message =
+					"<read_file><path>src/file.ts</path><start_line>10</start_line><end_line>20</end_line></read_file>"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("read_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.params.start_line).toBe("10")
+				expect(toolUse.params.end_line).toBe("20")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should mark tool use as partial when it's not closed", () => {
+				const message = "<read_file><path>src/file.ts</path>"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("read_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.partial).toBe(true)
+			})
+
+			it("should handle a partial parameter in a tool use", () => {
+				const message = "<read_file><path>src/file.ts"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("read_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.partial).toBe(true)
 			})
 		})
 
-		it("should mark text as partial when it's the last content in the message", () => {
-			const message = "This is a partial text"
-			const result = parseAssistantMessage(message)
+		describe("mixed content parsing", () => {
+			it("should parse text followed by a tool use", () => {
+				const message = "Here's the file content: <read_file><path>src/file.ts</path></read_file>"
+				const result = parser(message)
 
-			expect(result).toHaveLength(1)
-			expect(result[0]).toEqual({
-				type: "text",
-				content: message,
-				partial: true,
+				expect(result).toHaveLength(2)
+
+				const textContent = result[0] as TextContent
+				expect(textContent.type).toBe("text")
+				expect(textContent.content).toBe("Here's the file content:")
+				expect(textContent.partial).toBe(false)
+
+				const toolUse = result[1] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("read_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should parse a tool use followed by text", () => {
+				const message = "<read_file><path>src/file.ts</path></read_file>Here's what I found in the file."
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(2)
+
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("read_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.partial).toBe(false)
+
+				const textContent = result[1] as TextContent
+				expect(textContent.type).toBe("text")
+				expect(textContent.content).toBe("Here's what I found in the file.")
+				expect(textContent.partial).toBe(true)
+			})
+
+			it("should parse multiple tool uses separated by text", () => {
+				const message =
+					"First file: <read_file><path>src/file1.ts</path></read_file>Second file: <read_file><path>src/file2.ts</path></read_file>"
+				const result = parser(message)
+
+				expect(result).toHaveLength(4)
+
+				expect(result[0].type).toBe("text")
+				expect((result[0] as TextContent).content).toBe("First file:")
+
+				expect(result[1].type).toBe("tool_use")
+				expect((result[1] as ToolUse).name).toBe("read_file")
+				expect((result[1] as ToolUse).params.path).toBe("src/file1.ts")
+
+				expect(result[2].type).toBe("text")
+				expect((result[2] as TextContent).content).toBe("Second file:")
+
+				expect(result[3].type).toBe("tool_use")
+				expect((result[3] as ToolUse).name).toBe("read_file")
+				expect((result[3] as ToolUse).params.path).toBe("src/file2.ts")
 			})
 		})
-	})
-
-	describe("tool use parsing", () => {
-		it("should parse a simple tool use", () => {
-			const message = "<read_file><path>src/file.ts</path></read_file>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-			expect((result[0] as TextContent).partial).toBe(false)
-
-			// Second content is the tool use
-			expect(result[1].type).toBe("tool_use")
-			expect((result[1] as ToolUse).name).toBe("read_file")
-			expect((result[1] as ToolUse).params.path).toBe("src/file.ts")
-			expect((result[1] as ToolUse).partial).toBe(false)
-		})
-
-		it("should parse a tool use with multiple parameters", () => {
-			const message =
-				"<read_file><path>src/file.ts</path><start_line>10</start_line><end_line>20</end_line></read_file>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			expect(result[1].type).toBe("tool_use")
-			expect((result[1] as ToolUse).name).toBe("read_file")
-			expect((result[1] as ToolUse).params.path).toBe("src/file.ts")
-			expect((result[1] as ToolUse).params.start_line).toBe("10")
-			expect((result[1] as ToolUse).params.end_line).toBe("20")
-			expect((result[1] as ToolUse).partial).toBe(false)
-		})
-
-		it("should mark tool use as partial when it's not closed", () => {
-			const message = "<read_file><path>src/file.ts</path>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the partial tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("read_file")
-			expect(toolUse.params.path).toBe("src/file.ts")
-			expect(toolUse.partial).toBe(true)
-		})
-
-		it("should handle a partial parameter in a tool use", () => {
-			const message = "<read_file><path>src/file.ts"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the partial tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("read_file")
-			expect(toolUse.params.path).toBe("src/file.ts")
-			expect(toolUse.partial).toBe(true)
-		})
-	})
-
-	describe("mixed content parsing", () => {
-		it("should parse text followed by a tool use", () => {
-			const message = "Here's the file content: <read_file><path>src/file.ts</path></read_file>"
-			const result = parseAssistantMessage(message)
-
-			expect(result).toHaveLength(2)
-
-			const textContent = result[0] as TextContent
-			expect(textContent.type).toBe("text")
-			expect(textContent.content).toBe("Here's the file content:")
-			expect(textContent.partial).toBe(false)
-
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("read_file")
-			expect(toolUse.params.path).toBe("src/file.ts")
-			expect(toolUse.partial).toBe(false)
-		})
-
-		it("should parse a tool use followed by text", () => {
-			const message = "<read_file><path>src/file.ts</path></read_file>Here's what I found in the file."
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(3)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("read_file")
-			expect(toolUse.params.path).toBe("src/file.ts")
-			expect(toolUse.partial).toBe(false)
-
-			// Third content is the text
-			const textContent = result[2] as TextContent
-			expect(textContent.type).toBe("text")
-			expect(textContent.content).toBe("Here's what I found in the file.")
-			expect(textContent.partial).toBe(true)
-		})
-
-		it("should parse multiple tool uses separated by text", () => {
-			const message =
-				"First file: <read_file><path>src/file1.ts</path></read_file>Second file: <read_file><path>src/file2.ts</path></read_file>"
-			const result = parseAssistantMessage(message)
-
-			expect(result).toHaveLength(4)
-
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("First file:")
-
-			expect(result[1].type).toBe("tool_use")
-			expect((result[1] as ToolUse).name).toBe("read_file")
-			expect((result[1] as ToolUse).params.path).toBe("src/file1.ts")
-
-			expect(result[2].type).toBe("text")
-			expect((result[2] as TextContent).content).toBe("Second file:")
-
-			expect(result[3].type).toBe("tool_use")
-			expect((result[3] as ToolUse).name).toBe("read_file")
-			expect((result[3] as ToolUse).params.path).toBe("src/file2.ts")
-		})
-	})
-
-	describe("special cases", () => {
-		it("should handle the write_to_file tool with content that contains closing tags", () => {
-			const message = `<write_to_file><path>src/file.ts</path><content>
-function example() {
-  // This has XML-like content: </content>
-  return true;
-}
-</content><line_count>5</line_count></write_to_file>`
-
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("write_to_file")
-			expect(toolUse.params.path).toBe("src/file.ts")
-			expect(toolUse.params.line_count).toBe("5")
-			// The content might be slightly different due to whitespace handling
-			expect(toolUse.params.content).toContain("function example()")
-			expect(toolUse.params.content).toContain("// This has XML-like content: </content>")
-			expect(toolUse.params.content).toContain("return true;")
-			expect(toolUse.partial).toBe(false)
-		})
-
-		it("should handle empty messages", () => {
-			const message = ""
-			const result = parseAssistantMessage(message)
-
-			expect(result).toHaveLength(0)
-		})
-
-		it("should handle malformed tool use tags", () => {
-			const message = "This has a <not_a_tool>malformed tag</not_a_tool>"
-			const result = parseAssistantMessage(message)
-
-			expect(result).toHaveLength(1)
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe(message)
-		})
-
-		it("should handle tool use with no parameters", () => {
-			const message = "<browser_action></browser_action>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("browser_action")
-			expect(Object.keys(toolUse.params).length).toBe(0)
-			expect(toolUse.partial).toBe(false)
-		})
-
-		it("should handle nested tool tags that aren't actually nested", () => {
-			const message =
-				"<execute_command><command>echo '<read_file><path>test.txt</path></read_file>'</command></execute_command>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("execute_command")
-			expect(toolUse.params.command).toBe("echo '<read_file><path>test.txt</path></read_file>'")
-			expect(toolUse.partial).toBe(false)
-		})
-
-		it("should handle a tool use with a parameter containing XML-like content", () => {
-			const message = "<search_files><regex><div>.*</div></regex><path>src</path></search_files>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("search_files")
-			expect(toolUse.params.regex).toBe("<div>.*</div>")
-			expect(toolUse.params.path).toBe("src")
-			expect(toolUse.partial).toBe(false)
-		})
-
-		it("should handle consecutive tool uses without text in between", () => {
-			const message = "<read_file><path>file1.ts</path></read_file><read_file><path>file2.ts</path></read_file>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds empty text content between tool uses
-			expect(result).toHaveLength(4)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the first tool use
-			expect(result[1].type).toBe("tool_use")
-			expect((result[1] as ToolUse).name).toBe("read_file")
-			expect((result[1] as ToolUse).params.path).toBe("file1.ts")
-			expect((result[1] as ToolUse).partial).toBe(false)
-
-			// Third content is empty text
-			expect(result[2].type).toBe("text")
-			expect((result[2] as TextContent).content).toBe("")
-
-			// Fourth content is the second tool use
-			expect(result[3].type).toBe("tool_use")
-			expect((result[3] as ToolUse).name).toBe("read_file")
-			expect((result[3] as ToolUse).params.path).toBe("file2.ts")
-			expect((result[3] as ToolUse).partial).toBe(false)
-		})
-
-		it("should handle whitespace in parameters", () => {
-			const message = "<read_file><path>  src/file.ts  </path></read_file>"
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("read_file")
-			expect(toolUse.params.path).toBe("src/file.ts")
-			expect(toolUse.partial).toBe(false)
-		})
-
-		it("should handle multi-line parameters", () => {
-			const message = `<write_to_file><path>file.ts</path><content>
-line 1
-line 2
-line 3
-</content><line_count>3</line_count></write_to_file>`
-
-			const result = parseAssistantMessage(message)
-
-			// The parser adds an empty text content at the beginning
-			expect(result).toHaveLength(2)
-
-			// First content is empty text
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("")
-
-			// Second content is the tool use
-			const toolUse = result[1] as ToolUse
-			expect(toolUse.type).toBe("tool_use")
-			expect(toolUse.name).toBe("write_to_file")
-			expect(toolUse.params.path).toBe("file.ts")
-			// Use toContain instead of toBe to handle potential whitespace differences
-			expect(toolUse.params.content).toContain("line 1")
-			expect(toolUse.params.content).toContain("line 2")
-			expect(toolUse.params.content).toContain("line 3")
-			expect(toolUse.params.line_count).toBe("3")
-			expect(toolUse.partial).toBe(false)
-		})
-
-		it("should handle a complex message with multiple content types", () => {
-			const message = `I'll help you with that task.
-
-<read_file><path>src/index.ts</path></read_file>
-
-Now let's modify the file:
-
-<write_to_file><path>src/index.ts</path><content>
-// Updated content
-console.log("Hello world");
-</content><line_count>2</line_count></write_to_file>
-
-Let's run the code:
-
-<execute_command><command>node src/index.ts</command></execute_command>`
-
-			const result = parseAssistantMessage(message)
-
-			expect(result).toHaveLength(6)
-
-			// First text block
-			expect(result[0].type).toBe("text")
-			expect((result[0] as TextContent).content).toBe("I'll help you with that task.")
-
-			// First tool use (read_file)
-			expect(result[1].type).toBe("tool_use")
-			expect((result[1] as ToolUse).name).toBe("read_file")
-
-			// Second text block
-			expect(result[2].type).toBe("text")
-			expect((result[2] as TextContent).content).toContain("Now let's modify the file:")
-
-			// Second tool use (write_to_file)
-			expect(result[3].type).toBe("tool_use")
-			expect((result[3] as ToolUse).name).toBe("write_to_file")
-
-			// Third text block
-			expect(result[4].type).toBe("text")
-			expect((result[4] as TextContent).content).toContain("Let's run the code:")
-
-			// Third tool use (execute_command)
-			expect(result[5].type).toBe("tool_use")
-			expect((result[5] as ToolUse).name).toBe("execute_command")
+
+		describe("special cases", () => {
+			it("should handle the write_to_file tool with content that contains closing tags", () => {
+				const message = `<write_to_file><path>src/file.ts</path><content>
+	function example() {
+	// This has XML-like content: </content>
+	return true;
+	}
+	</content><line_count>5</line_count></write_to_file>`
+
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("write_to_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.params.line_count).toBe("5")
+				expect(toolUse.params.content).toContain("function example()")
+				expect(toolUse.params.content).toContain("// This has XML-like content: </content>")
+				expect(toolUse.params.content).toContain("return true;")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should handle empty messages", () => {
+				const message = ""
+				const result = parser(message)
+
+				expect(result).toHaveLength(0)
+			})
+
+			it("should handle malformed tool use tags", () => {
+				const message = "This has a <not_a_tool>malformed tag</not_a_tool>"
+				const result = parser(message)
+
+				expect(result).toHaveLength(1)
+				expect(result[0].type).toBe("text")
+				expect((result[0] as TextContent).content).toBe(message)
+			})
+
+			it("should handle tool use with no parameters", () => {
+				const message = "<browser_action></browser_action>"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("browser_action")
+				expect(Object.keys(toolUse.params).length).toBe(0)
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should handle nested tool tags that aren't actually nested", () => {
+				const message =
+					"<execute_command><command>echo '<read_file><path>test.txt</path></read_file>'</command></execute_command>"
+
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("execute_command")
+				expect(toolUse.params.command).toBe("echo '<read_file><path>test.txt</path></read_file>'")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should handle a tool use with a parameter containing XML-like content", () => {
+				const message = "<search_files><regex><div>.*</div></regex><path>src</path></search_files>"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("search_files")
+				expect(toolUse.params.regex).toBe("<div>.*</div>")
+				expect(toolUse.params.path).toBe("src")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should handle consecutive tool uses without text in between", () => {
+				const message =
+					"<read_file><path>file1.ts</path></read_file><read_file><path>file2.ts</path></read_file>"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(2)
+
+				const toolUse1 = result[0] as ToolUse
+				expect(toolUse1.type).toBe("tool_use")
+				expect(toolUse1.name).toBe("read_file")
+				expect(toolUse1.params.path).toBe("file1.ts")
+				expect(toolUse1.partial).toBe(false)
+
+				const toolUse2 = result[1] as ToolUse
+				expect(toolUse2.type).toBe("tool_use")
+				expect(toolUse2.name).toBe("read_file")
+				expect(toolUse2.params.path).toBe("file2.ts")
+				expect(toolUse2.partial).toBe(false)
+			})
+
+			it("should handle whitespace in parameters", () => {
+				const message = "<read_file><path>  src/file.ts  </path></read_file>"
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("read_file")
+				expect(toolUse.params.path).toBe("src/file.ts")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should handle multi-line parameters", () => {
+				const message = `<write_to_file><path>file.ts</path><content>
+	line 1
+	line 2
+	line 3
+	</content><line_count>3</line_count></write_to_file>`
+				const result = parser(message).filter((block) => !isEmptyTextContent(block))
+
+				expect(result).toHaveLength(1)
+				const toolUse = result[0] as ToolUse
+				expect(toolUse.type).toBe("tool_use")
+				expect(toolUse.name).toBe("write_to_file")
+				expect(toolUse.params.path).toBe("file.ts")
+				expect(toolUse.params.content).toContain("line 1")
+				expect(toolUse.params.content).toContain("line 2")
+				expect(toolUse.params.content).toContain("line 3")
+				expect(toolUse.params.line_count).toBe("3")
+				expect(toolUse.partial).toBe(false)
+			})
+
+			it("should handle a complex message with multiple content types", () => {
+				const message = `I'll help you with that task.
+
+	<read_file><path>src/index.ts</path></read_file>
+
+	Now let's modify the file:
+
+	<write_to_file><path>src/index.ts</path><content>
+	// Updated content
+	console.log("Hello world");
+	</content><line_count>2</line_count></write_to_file>
+
+	Let's run the code:
+
+	<execute_command><command>node src/index.ts</command></execute_command>`
+
+				const result = parser(message)
+
+				expect(result).toHaveLength(6)
+
+				// First text block
+				expect(result[0].type).toBe("text")
+				expect((result[0] as TextContent).content).toBe("I'll help you with that task.")
+
+				// First tool use (read_file)
+				expect(result[1].type).toBe("tool_use")
+				expect((result[1] as ToolUse).name).toBe("read_file")
+
+				// Second text block
+				expect(result[2].type).toBe("text")
+				expect((result[2] as TextContent).content).toContain("Now let's modify the file:")
+
+				// Second tool use (write_to_file)
+				expect(result[3].type).toBe("tool_use")
+				expect((result[3] as ToolUse).name).toBe("write_to_file")
+
+				// Third text block
+				expect(result[4].type).toBe("text")
+				expect((result[4] as TextContent).content).toContain("Let's run the code:")
+
+				// Third tool use (execute_command)
+				expect(result[5].type).toBe("tool_use")
+				expect((result[5] as ToolUse).name).toBe("execute_command")
+			})
 		})
 	})
 })

--- a/src/core/assistant-message/__tests__/parseAssistantMessageBenchmark.ts
+++ b/src/core/assistant-message/__tests__/parseAssistantMessageBenchmark.ts
@@ -1,0 +1,109 @@
+// node --expose-gc --import tsx src/core/assistant-message/__tests__/parseAssistantMessageBenchmark.ts
+
+import { performance } from "perf_hooks"
+import { parseAssistantMessage as parseAssistantMessageV1 } from "../parseAssistantMessage"
+import { parseAssistantMessageV2 } from "../parseAssistantMessageV2"
+
+const formatNumber = (num: number): string => {
+	return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+}
+
+const measureExecutionTime = (fn: Function, input: string, iterations: number = 1000): number => {
+	for (let i = 0; i < 10; i++) {
+		fn(input)
+	}
+
+	const start = performance.now()
+
+	for (let i = 0; i < iterations; i++) {
+		fn(input)
+	}
+
+	const end = performance.now()
+	return (end - start) / iterations // Average time per iteration in ms.
+}
+
+const measureMemoryUsage = (
+	fn: Function,
+	input: string,
+	iterations: number = 100,
+): { heapUsed: number; heapTotal: number } => {
+	if (global.gc) {
+		// Force garbage collection if available.
+		global.gc()
+	} else {
+		console.warn("No garbage collection hook! Run with --expose-gc for more accurate memory measurements.")
+	}
+
+	const initialMemory = process.memoryUsage()
+
+	for (let i = 0; i < iterations; i++) {
+		fn(input)
+	}
+
+	const finalMemory = process.memoryUsage()
+
+	return {
+		heapUsed: (finalMemory.heapUsed - initialMemory.heapUsed) / iterations,
+		heapTotal: (finalMemory.heapTotal - initialMemory.heapTotal) / iterations,
+	}
+}
+
+const testCases = [
+	{
+		name: "Simple text message",
+		input: "This is a simple text message without any tool uses.",
+	},
+	{
+		name: "Message with a simple tool use",
+		input: "Let's read a file: <read_file><path>src/file.ts</path></read_file>",
+	},
+	{
+		name: "Message with a complex tool use (write_to_file)",
+		input: "<write_to_file><path>src/file.ts</path><content>\nfunction example() {\n  // This has XML-like content: </content>\n  return true;\n}\n</content><line_count>5</line_count></write_to_file>",
+	},
+	{
+		name: "Message with multiple tool uses",
+		input: "First file: <read_file><path>src/file1.ts</path></read_file>\nSecond file: <read_file><path>src/file2.ts</path></read_file>\nLet's write a new file: <write_to_file><path>src/file3.ts</path><content>\nexport function newFunction() {\n  return 'Hello world';\n}\n</content><line_count>3</line_count></write_to_file>",
+	},
+	{
+		name: "Large message with repeated tool uses",
+		input: Array(50)
+			.fill(
+				'<read_file><path>src/file.ts</path></read_file>\n<write_to_file><path>output.ts</path><content>console.log("hello");</content><line_count>1</line_count></write_to_file>',
+			)
+			.join("\n"),
+	},
+]
+
+const runBenchmark = () => {
+	const maxNameLength = testCases.reduce((max, testCase) => Math.max(max, testCase.name.length), 0)
+	const namePadding = maxNameLength + 2
+
+	console.log(
+		`| ${"Test Case".padEnd(namePadding)} | V1 Time (ms) | V2 Time (ms) | V1/V2 Ratio | V1 Heap (bytes) | V2 Heap (bytes) |`,
+	)
+	console.log(
+		`| ${"-".repeat(namePadding)} | ------------ | ------------ | ----------- | ---------------- | ---------------- |`,
+	)
+
+	for (const testCase of testCases) {
+		const v1Time = measureExecutionTime(parseAssistantMessageV1, testCase.input)
+		const v2Time = measureExecutionTime(parseAssistantMessageV2, testCase.input)
+		const timeRatio = v1Time / v2Time
+
+		const v1Memory = measureMemoryUsage(parseAssistantMessageV1, testCase.input)
+		const v2Memory = measureMemoryUsage(parseAssistantMessageV2, testCase.input)
+
+		console.log(
+			`| ${testCase.name.padEnd(namePadding)} | ` +
+				`${v1Time.toFixed(4).padStart(12)} | ` +
+				`${v2Time.toFixed(4).padStart(12)} | ` +
+				`${timeRatio.toFixed(2).padStart(11)} | ` +
+				`${formatNumber(Math.round(v1Memory.heapUsed)).padStart(16)} | ` +
+				`${formatNumber(Math.round(v2Memory.heapUsed)).padStart(16)} |`,
+		)
+	}
+}
+
+runBenchmark()

--- a/src/core/assistant-message/parseAssistantMessage.ts
+++ b/src/core/assistant-message/parseAssistantMessage.ts
@@ -3,7 +3,7 @@ import { toolNames, ToolName } from "../../schemas"
 
 export type AssistantMessageContent = TextContent | ToolUse
 
-export function parseAssistantMessage(assistantMessage: string) {
+export function parseAssistantMessage(assistantMessage: string): AssistantMessageContent[] {
 	let contentBlocks: AssistantMessageContent[] = []
 	let currentTextContent: TextContent | undefined = undefined
 	let currentTextContentStartIndex = 0
@@ -17,28 +17,28 @@ export function parseAssistantMessage(assistantMessage: string) {
 		const char = assistantMessage[i]
 		accumulator += char
 
-		// there should not be a param without a tool use
+		// There should not be a param without a tool use.
 		if (currentToolUse && currentParamName) {
 			const currentParamValue = accumulator.slice(currentParamValueStartIndex)
 			const paramClosingTag = `</${currentParamName}>`
 			if (currentParamValue.endsWith(paramClosingTag)) {
-				// end of param value
+				// End of param value.
 				currentToolUse.params[currentParamName] = currentParamValue.slice(0, -paramClosingTag.length).trim()
 				currentParamName = undefined
 				continue
 			} else {
-				// partial param value is accumulating
+				// Partial param value is accumulating.
 				continue
 			}
 		}
 
-		// no currentParamName
+		// No currentParamName.
 
 		if (currentToolUse) {
 			const currentToolValue = accumulator.slice(currentToolUseStartIndex)
 			const toolUseClosingTag = `</${currentToolUse.name}>`
 			if (currentToolValue.endsWith(toolUseClosingTag)) {
-				// end of a tool use
+				// End of a tool use.
 				currentToolUse.partial = false
 				contentBlocks.push(currentToolUse)
 				currentToolUse = undefined
@@ -47,23 +47,29 @@ export function parseAssistantMessage(assistantMessage: string) {
 				const possibleParamOpeningTags = toolParamNames.map((name) => `<${name}>`)
 				for (const paramOpeningTag of possibleParamOpeningTags) {
 					if (accumulator.endsWith(paramOpeningTag)) {
-						// start of a new parameter
+						// Start of a new parameter.
 						currentParamName = paramOpeningTag.slice(1, -1) as ToolParamName
 						currentParamValueStartIndex = accumulator.length
 						break
 					}
 				}
 
-				// there's no current param, and not starting a new param
+				// There's no current param, and not starting a new param.
 
-				// special case for write_to_file where file contents could contain the closing tag, in which case the param would have closed and we end up with the rest of the file contents here. To work around this, we get the string between the starting content tag and the LAST content tag.
+				// Special case for write_to_file where file contents could
+				// contain the closing tag, in which case the param would have
+				// closed and we end up with the rest of the file contents here.
+				// To work around this, we get the string between the starting
+				// ontent tag and the LAST content tag.
 				const contentParamName: ToolParamName = "content"
+
 				if (currentToolUse.name === "write_to_file" && accumulator.endsWith(`</${contentParamName}>`)) {
 					const toolContent = accumulator.slice(currentToolUseStartIndex)
 					const contentStartTag = `<${contentParamName}>`
 					const contentEndTag = `</${contentParamName}>`
 					const contentStartIndex = toolContent.indexOf(contentStartTag) + contentStartTag.length
 					const contentEndIndex = toolContent.lastIndexOf(contentEndTag)
+
 					if (contentStartIndex !== -1 && contentEndIndex !== -1 && contentEndIndex > contentStartIndex) {
 						currentToolUse.params[contentParamName] = toolContent
 							.slice(contentStartIndex, contentEndIndex)
@@ -71,32 +77,38 @@ export function parseAssistantMessage(assistantMessage: string) {
 					}
 				}
 
-				// partial tool value is accumulating
+				// Partial tool value is accumulating.
 				continue
 			}
 		}
 
-		// no currentToolUse
+		// No currentToolUse.
 
 		let didStartToolUse = false
 		const possibleToolUseOpeningTags = toolNames.map((name) => `<${name}>`)
+
 		for (const toolUseOpeningTag of possibleToolUseOpeningTags) {
 			if (accumulator.endsWith(toolUseOpeningTag)) {
-				// start of a new tool use
+				// Start of a new tool use.
 				currentToolUse = {
 					type: "tool_use",
 					name: toolUseOpeningTag.slice(1, -1) as ToolName,
 					params: {},
 					partial: true,
 				}
+
 				currentToolUseStartIndex = accumulator.length
-				// this also indicates the end of the current text content
+
+				// This also indicates the end of the current text content.
 				if (currentTextContent) {
 					currentTextContent.partial = false
-					// remove the partially accumulated tool use tag from the end of text (<tool)
+
+					// Remove the partially accumulated tool use tag from the
+					// end of text (<tool).
 					currentTextContent.content = currentTextContent.content
 						.slice(0, -toolUseOpeningTag.slice(0, -1).length)
 						.trim()
+
 					contentBlocks.push(currentTextContent)
 					currentTextContent = undefined
 				}
@@ -107,10 +119,12 @@ export function parseAssistantMessage(assistantMessage: string) {
 		}
 
 		if (!didStartToolUse) {
-			// no tool use, so it must be text either at the beginning or between tools
+			// No tool use, so it must be text either at the beginning or
+			// between tools.
 			if (currentTextContent === undefined) {
 				currentTextContentStartIndex = i
 			}
+
 			currentTextContent = {
 				type: "text",
 				content: accumulator.slice(currentTextContentStartIndex).trim(),
@@ -120,17 +134,20 @@ export function parseAssistantMessage(assistantMessage: string) {
 	}
 
 	if (currentToolUse) {
-		// stream did not complete tool call, add it as partial
+		// Stream did not complete tool call, add it as partial.
 		if (currentParamName) {
-			// tool call has a parameter that was not completed
+			// Tool call has a parameter that was not completed.
 			currentToolUse.params[currentParamName] = accumulator.slice(currentParamValueStartIndex).trim()
 		}
+
 		contentBlocks.push(currentToolUse)
 	}
 
-	// Note: it doesnt matter if check for currentToolUse or currentTextContent, only one of them will be defined since only one can be partial at a time
+	// NOTE: It doesn't matter if check for currentToolUse or
+	// currentTextContent, only one of them will be defined since only one can
+	// be partial at a time.
 	if (currentTextContent) {
-		// stream did not complete text content, add it as partial
+		// Stream did not complete text content, add it as partial.
 		contentBlocks.push(currentTextContent)
 	}
 

--- a/src/core/assistant-message/parseAssistantMessageV2.ts
+++ b/src/core/assistant-message/parseAssistantMessageV2.ts
@@ -1,0 +1,278 @@
+import { TextContent, ToolUse, ToolParamName, toolParamNames } from "../../shared/tools"
+import { toolNames, ToolName } from "../../schemas"
+
+export type AssistantMessageContent = TextContent | ToolUse
+
+/**
+ * Parses an assistant message string potentially containing mixed text and tool
+ * usage blocks marked with XML-like tags into an array of structured content
+ * objects.
+ *
+ * This version aims for efficiency by avoiding the character-by-character
+ * accumulator of V1. It iterates through the string using an index `i`. At each
+ * position, it checks if the substring *ending* at `i` matches any known
+ * opening or closing tags for tools or parameters using `startsWith` with an
+ * offset.
+ * It uses pre-computed Maps (`toolUseOpenTags`, `toolParamOpenTags`) for quick
+ * tag lookups.
+ * State is managed using indices (`currentTextContentStart`,
+ * `currentToolUseStart`, `currentParamValueStart`) pointing to the start of the
+ * current block within the original `assistantMessage` string.
+ *
+ * Slicing is used to extract content only when a block (text, parameter, or
+ * tool use) is completed.
+ *
+ * Special handling for `write_to_file` and `new_rule` content parameters is
+ * included, using `indexOf` and `lastIndexOf` on the relevant slice to handle
+ * potentially nested closing tags.
+ *
+ * If the input string ends mid-block, the last open block is added and marked
+ * as partial.
+ *
+ * @param assistantMessage The raw string output from the assistant.
+ * @returns An array of `AssistantMessageContent` objects, which can be
+ *          `TextContent` or `ToolUse`. Blocks that were not fully closed by the
+ *          end of the input string will have their `partial` flag set to
+ *          `true`.
+ */
+
+export function parseAssistantMessageV2(assistantMessage: string): AssistantMessageContent[] {
+	const contentBlocks: AssistantMessageContent[] = []
+
+	let currentTextContentStart = 0 // Index where the current text block started.
+	let currentTextContent: TextContent | undefined = undefined
+	let currentToolUseStart = 0 // Index *after* the opening tag of the current tool use.
+	let currentToolUse: ToolUse | undefined = undefined
+	let currentParamValueStart = 0 // Index *after* the opening tag of the current param.
+	let currentParamName: ToolParamName | undefined = undefined
+
+	// Precompute tags for faster lookups.
+	const toolUseOpenTags = new Map<string, ToolName>()
+	const toolParamOpenTags = new Map<string, ToolParamName>()
+
+	for (const name of toolNames) {
+		toolUseOpenTags.set(`<${name}>`, name)
+	}
+
+	for (const name of toolParamNames) {
+		toolParamOpenTags.set(`<${name}>`, name)
+	}
+
+	const len = assistantMessage.length
+
+	for (let i = 0; i < len; i++) {
+		const currentCharIndex = i
+
+		// Parsing a tool parameter
+		if (currentToolUse && currentParamName) {
+			const closeTag = `</${currentParamName}>`
+			// Check if the string *ending* at index `i` matches the closing tag
+			if (
+				currentCharIndex >= closeTag.length - 1 &&
+				assistantMessage.startsWith(
+					closeTag,
+					currentCharIndex - closeTag.length + 1, // Start checking from potential start of tag.
+				)
+			) {
+				// Found the closing tag for the parameter.
+				const value = assistantMessage
+					.slice(
+						currentParamValueStart, // Start after the opening tag.
+						currentCharIndex - closeTag.length + 1, // End before the closing tag.
+					)
+					.trim()
+				currentToolUse.params[currentParamName] = value
+				currentParamName = undefined // Go back to parsing tool content.
+				// We don't continue loop here, need to check for tool close or other params at index i.
+			} else {
+				continue // Still inside param value, move to next char.
+			}
+		}
+
+		// Parsing a tool use (but not a specific parameter).
+		if (currentToolUse && !currentParamName) {
+			// Ensure we are not inside a parameter already.
+			// Check if starting a new parameter.
+			let startedNewParam = false
+
+			for (const [tag, paramName] of toolParamOpenTags.entries()) {
+				if (
+					currentCharIndex >= tag.length - 1 &&
+					assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)
+				) {
+					currentParamName = paramName
+					currentParamValueStart = currentCharIndex + 1 // Value starts after the tag.
+					startedNewParam = true
+					break
+				}
+			}
+
+			if (startedNewParam) {
+				continue // Handled start of param, move to next char.
+			}
+
+			// Check if closing the current tool use.
+			const toolCloseTag = `</${currentToolUse.name}>`
+
+			if (
+				currentCharIndex >= toolCloseTag.length - 1 &&
+				assistantMessage.startsWith(toolCloseTag, currentCharIndex - toolCloseTag.length + 1)
+			) {
+				// End of the tool use found.
+				// Special handling for content params *before* finalizing the
+				// tool.
+				const toolContentSlice = assistantMessage.slice(
+					currentToolUseStart, // From after the tool opening tag.
+					currentCharIndex - toolCloseTag.length + 1, // To before the tool closing tag.
+				)
+
+				// Check if content parameter needs special handling
+				// (write_to_file/new_rule).
+				// This check is important if the closing </content> tag was
+				// missed by the parameter parsing logic (e.g., if content is
+				// empty or parsing logic prioritizes tool close).
+				const contentParamName: ToolParamName = "content"
+				if (
+					currentToolUse.name === "write_to_file" /* || currentToolUse.name === "new_rule" */ &&
+					// !(contentParamName in currentToolUse.params) && // Only if not already parsed.
+					toolContentSlice.includes(`<${contentParamName}>`) // Check if tag exists.
+				) {
+					const contentStartTag = `<${contentParamName}>`
+					const contentEndTag = `</${contentParamName}>`
+					const contentStart = toolContentSlice.indexOf(contentStartTag)
+
+					// Use `lastIndexOf` for robustness against nested tags.
+					const contentEnd = toolContentSlice.lastIndexOf(contentEndTag)
+
+					if (contentStart !== -1 && contentEnd !== -1 && contentEnd > contentStart) {
+						const contentValue = toolContentSlice
+							.slice(contentStart + contentStartTag.length, contentEnd)
+							.trim()
+
+						currentToolUse.params[contentParamName] = contentValue
+					}
+				}
+
+				currentToolUse.partial = false // Mark as complete.
+				contentBlocks.push(currentToolUse)
+				currentToolUse = undefined // Reset state.
+				currentTextContentStart = currentCharIndex + 1 // Potential text starts after this tag.
+				continue // Move to next char.
+			}
+
+			// If not starting a param and not closing the tool, continue
+			// accumulating tool content implicitly.
+			continue
+		}
+
+		// Parsing text / looking for tool start.
+		if (!currentToolUse) {
+			// Check if starting a new tool use.
+			let startedNewTool = false
+
+			for (const [tag, toolName] of toolUseOpenTags.entries()) {
+				if (
+					currentCharIndex >= tag.length - 1 &&
+					assistantMessage.startsWith(tag, currentCharIndex - tag.length + 1)
+				) {
+					// End current text block if one was active.
+					if (currentTextContent) {
+						currentTextContent.content = assistantMessage
+							.slice(
+								currentTextContentStart, // From where text started.
+								currentCharIndex - tag.length + 1, // To before the tool tag starts.
+							)
+							.trim()
+
+						currentTextContent.partial = false // Ended because tool started.
+
+						if (currentTextContent.content.length > 0) {
+							contentBlocks.push(currentTextContent)
+						}
+
+						currentTextContent = undefined
+					} else {
+						// Check for any text between the last block and this tag.
+						const potentialText = assistantMessage
+							.slice(
+								currentTextContentStart, // From where text *might* have started.
+								currentCharIndex - tag.length + 1, // To before the tool tag starts.
+							)
+							.trim()
+
+						if (potentialText.length > 0) {
+							contentBlocks.push({
+								type: "text",
+								content: potentialText,
+								partial: false,
+							})
+						}
+					}
+
+					// Start the new tool use.
+					currentToolUse = {
+						type: "tool_use",
+						name: toolName,
+						params: {},
+						partial: true, // Assume partial until closing tag is found.
+					}
+
+					currentToolUseStart = currentCharIndex + 1 // Tool content starts after the opening tag.
+					startedNewTool = true
+
+					break
+				}
+			}
+
+			if (startedNewTool) {
+				continue // Handled start of tool, move to next char.
+			}
+
+			// If not starting a tool, it must be text content.
+			if (!currentTextContent) {
+				// Start a new text block if we aren't already in one.
+				currentTextContentStart = currentCharIndex // Text starts at the current character.
+
+				// Check if the current char is the start of potential text *immediately* after a tag.
+				// This needs the previous state - simpler to let slicing handle it later.
+				// Resetting start index accurately is key.
+				// It should be the index *after* the last processed tag.
+				// The logic managing currentTextContentStart after closing tags handles this.
+				currentTextContent = {
+					type: "text",
+					content: "", // Will be determined by slicing at the end or when a tool starts
+					partial: true,
+				}
+			}
+			// Continue accumulating text implicitly; content is extracted later.
+		}
+	}
+
+	// Finalize any open parameter within an open tool use.
+	if (currentToolUse && currentParamName) {
+		currentToolUse.params[currentParamName] = assistantMessage
+			.slice(currentParamValueStart) // From param start to end of string.
+			.trim()
+		// Tool use remains partial.
+	}
+
+	// Finalize any open tool use (which might contain the finalized partial param).
+	if (currentToolUse) {
+		// Tool use is partial because the loop finished before its closing tag.
+		contentBlocks.push(currentToolUse)
+	}
+	// Finalize any trailing text content.
+	// Only possible if a tool use wasn't open at the very end.
+	else if (currentTextContent) {
+		currentTextContent.content = assistantMessage
+			.slice(currentTextContentStart) // From text start to end of string.
+			.trim()
+
+		// Text is partial because the loop finished.
+		if (currentTextContent.content.length > 0) {
+			contentBlocks.push(currentTextContent)
+		}
+	}
+
+	return contentBlocks
+}

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -1,16 +1,19 @@
 import * as vscode from "vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
+import * as diff from "diff"
+import stripBom from "strip-bom"
+
 import { createDirectoriesForFile } from "../../utils/fs"
 import { arePathsEqual } from "../../utils/path"
 import { formatResponse } from "../../core/prompts/responses"
-import { DecorationController } from "./DecorationController"
-import * as diff from "diff"
 import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
-import stripBom from "strip-bom"
+
+import { DecorationController } from "./DecorationController"
 
 export const DIFF_VIEW_URI_SCHEME = "cline-diff"
 
+// TODO: https://github.com/cline/cline/pull/3354
 export class DiffViewProvider {
 	editType?: "create" | "modify"
 	isEditing = false
@@ -32,17 +35,21 @@ export class DiffViewProvider {
 		const fileExists = this.editType === "modify"
 		const absolutePath = path.resolve(this.cwd, relPath)
 		this.isEditing = true
-		// if the file is already open, ensure it's not dirty before getting its contents
+
+		// If the file is already open, ensure it's not dirty before getting its
+		// contents.
 		if (fileExists) {
 			const existingDocument = vscode.workspace.textDocuments.find((doc) =>
 				arePathsEqual(doc.uri.fsPath, absolutePath),
 			)
+
 			if (existingDocument && existingDocument.isDirty) {
 				await existingDocument.save()
 			}
 		}
 
-		// get diagnostics before editing the file, we'll compare to diagnostics after editing to see if cline needs to fix anything
+		// Get diagnostics before editing the file, we'll compare to diagnostics
+		// after editing to see if cline needs to fix anything.
 		this.preDiagnostics = vscode.languages.getDiagnostics()
 
 		if (fileExists) {
@@ -50,33 +57,41 @@ export class DiffViewProvider {
 		} else {
 			this.originalContent = ""
 		}
-		// for new files, create any necessary directories and keep track of new directories to delete if the user denies the operation
+
+		// For new files, create any necessary directories and keep track of new
+		// directories to delete if the user denies the operation.
 		this.createdDirs = await createDirectoriesForFile(absolutePath)
-		// make sure the file exists before we open it
+
+		// Make sure the file exists before we open it.
 		if (!fileExists) {
 			await fs.writeFile(absolutePath, "")
 		}
-		// if the file was already open, close it (must happen after showing the diff view since if it's the only tab the column will close)
+
+		// If the file was already open, close it (must happen after showing the
+		// diff view since if it's the only tab the column will close).
 		this.documentWasOpen = false
-		// close the tab if it's open (it's already saved above)
+
+		// Close the tab if it's open (it's already saved above).
 		const tabs = vscode.window.tabGroups.all
 			.map((tg) => tg.tabs)
 			.flat()
 			.filter(
 				(tab) => tab.input instanceof vscode.TabInputText && arePathsEqual(tab.input.uri.fsPath, absolutePath),
 			)
+
 		for (const tab of tabs) {
 			if (!tab.isDirty) {
 				await vscode.window.tabGroups.close(tab)
 			}
 			this.documentWasOpen = true
 		}
+
 		this.activeDiffEditor = await this.openDiffEditor()
 		this.fadedOverlayController = new DecorationController("fadedOverlay", this.activeDiffEditor)
 		this.activeLineController = new DecorationController("activeLine", this.activeDiffEditor)
-		// Apply faded overlay to all lines initially
+		// Apply faded overlay to all lines initially.
 		this.fadedOverlayController.addLines(0, this.activeDiffEditor.document.lineCount)
-		this.scrollEditorToLine(0) // will this crash for new files?
+		this.scrollEditorToLine(0) // Will this crash for new files?
 		this.streamedLines = []
 	}
 
@@ -84,58 +99,70 @@ export class DiffViewProvider {
 		if (!this.relPath || !this.activeLineController || !this.fadedOverlayController) {
 			throw new Error("Required values not set")
 		}
+
 		this.newContent = accumulatedContent
 		const accumulatedLines = accumulatedContent.split("\n")
+
 		if (!isFinal) {
-			accumulatedLines.pop() // remove the last partial line only if it's not the final update
+			accumulatedLines.pop() // Remove the last partial line only if it's not the final update.
 		}
 
 		const diffEditor = this.activeDiffEditor
 		const document = diffEditor?.document
+
 		if (!diffEditor || !document) {
 			throw new Error("User closed text editor, unable to edit file...")
 		}
 
-		// Place cursor at the beginning of the diff editor to keep it out of the way of the stream animation
+		// Place cursor at the beginning of the diff editor to keep it out of
+		// the way of the stream animation.
 		const beginningOfDocument = new vscode.Position(0, 0)
 		diffEditor.selection = new vscode.Selection(beginningOfDocument, beginningOfDocument)
 
 		const endLine = accumulatedLines.length
-		// Replace all content up to the current line with accumulated lines
+		// Replace all content up to the current line with accumulated lines.
 		const edit = new vscode.WorkspaceEdit()
 		const rangeToReplace = new vscode.Range(0, 0, endLine + 1, 0)
 		const contentToReplace = accumulatedLines.slice(0, endLine + 1).join("\n") + "\n"
 		edit.replace(document.uri, rangeToReplace, this.stripAllBOMs(contentToReplace))
 		await vscode.workspace.applyEdit(edit)
-		// Update decorations
+		// Update decorations.
 		this.activeLineController.setActiveLine(endLine)
 		this.fadedOverlayController.updateOverlayAfterLine(endLine, document.lineCount)
-		// Scroll to the current line
+		// Scroll to the current line.
 		this.scrollEditorToLine(endLine)
 
-		// Update the streamedLines with the new accumulated content
+		// Update the streamedLines with the new accumulated content.
 		this.streamedLines = accumulatedLines
+
 		if (isFinal) {
-			// Handle any remaining lines if the new content is shorter than the original
+			// Handle any remaining lines if the new content is shorter than the
+			// original.
 			if (this.streamedLines.length < document.lineCount) {
 				const edit = new vscode.WorkspaceEdit()
 				edit.delete(document.uri, new vscode.Range(this.streamedLines.length, 0, document.lineCount, 0))
 				await vscode.workspace.applyEdit(edit)
 			}
-			// Preserve empty last line if original content had one
+
+			// Preserve empty last line if original content had one.
 			const hasEmptyLastLine = this.originalContent?.endsWith("\n")
+
 			if (hasEmptyLastLine && !accumulatedContent.endsWith("\n")) {
 				accumulatedContent += "\n"
 			}
-			// Apply the final content
+
+			// Apply the final content.
 			const finalEdit = new vscode.WorkspaceEdit()
+
 			finalEdit.replace(
 				document.uri,
 				new vscode.Range(0, 0, document.lineCount, 0),
 				this.stripAllBOMs(accumulatedContent),
 			)
+
 			await vscode.workspace.applyEdit(finalEdit)
-			// Clear all decorations at the end (after applying final edit)
+
+			// Clear all decorations at the end (after applying final edit).
 			this.fadedOverlayController.clear()
 			this.activeLineController.clear()
 		}
@@ -149,9 +176,11 @@ export class DiffViewProvider {
 		if (!this.relPath || !this.newContent || !this.activeDiffEditor) {
 			return { newProblemsMessage: undefined, userEdits: undefined, finalContent: undefined }
 		}
+
 		const absolutePath = path.resolve(this.cwd, this.relPath)
 		const updatedDocument = this.activeDiffEditor.document
 		const editedContent = updatedDocument.getText()
+
 		if (updatedDocument.isDirty) {
 			await updatedDocument.save()
 		}
@@ -159,49 +188,56 @@ export class DiffViewProvider {
 		await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), { preview: false })
 		await this.closeAllDiffViews()
 
-		/*
-		Getting diagnostics before and after the file edit is a better approach than
-		automatically tracking problems in real-time. This method ensures we only
-		report new problems that are a direct result of this specific edit.
-		Since these are new problems resulting from Roo's edit, we know they're
-		directly related to the work he's doing. This eliminates the risk of Roo
-		going off-task or getting distracted by unrelated issues, which was a problem
-		with the previous auto-debug approach. Some users' machines may be slow to
-		update diagnostics, so this approach provides a good balance between automation
-		and avoiding potential issues where Roo might get stuck in loops due to
-		outdated problem information. If no new problems show up by the time the user
-		accepts the changes, they can always debug later using the '@problems' mention.
-		This way, Roo only becomes aware of new problems resulting from his edits
-		and can address them accordingly. If problems don't change immediately after
-		applying a fix, won't be notified, which is generally fine since the
-		initial fix is usually correct and it may just take time for linters to catch up.
-		*/
+		// Getting diagnostics before and after the file edit is a better approach than
+		// automatically tracking problems in real-time. This method ensures we only
+		// report new problems that are a direct result of this specific edit.
+		// Since these are new problems resulting from Roo's edit, we know they're
+		// directly related to the work he's doing. This eliminates the risk of Roo
+		// going off-task or getting distracted by unrelated issues, which was a problem
+		// with the previous auto-debug approach. Some users' machines may be slow to
+		// update diagnostics, so this approach provides a good balance between automation
+		// and avoiding potential issues where Roo might get stuck in loops due to
+		// outdated problem information. If no new problems show up by the time the user
+		// accepts the changes, they can always debug later using the '@problems' mention.
+		// This way, Roo only becomes aware of new problems resulting from his edits
+		// and can address them accordingly. If problems don't change immediately after
+		// applying a fix, won't be notified, which is generally fine since the
+		// initial fix is usually correct and it may just take time for linters to catch up.
 		const postDiagnostics = vscode.languages.getDiagnostics()
+
 		const newProblems = await diagnosticsToProblemsString(
 			getNewDiagnostics(this.preDiagnostics, postDiagnostics),
 			[
 				vscode.DiagnosticSeverity.Error, // only including errors since warnings can be distracting (if user wants to fix warnings they can use the @problems mention)
 			],
 			this.cwd,
-		) // will be empty string if no errors
+		) // Will be empty string if no errors.
+
 		const newProblemsMessage =
 			newProblems.length > 0 ? `\n\nNew problems detected after saving the file:\n${newProblems}` : ""
 
-		// If the edited content has different EOL characters, we don't want to show a diff with all the EOL differences.
+		// If the edited content has different EOL characters, we don't want to
+		// show a diff with all the EOL differences.
 		const newContentEOL = this.newContent.includes("\r\n") ? "\r\n" : "\n"
-		const normalizedEditedContent = editedContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL // trimEnd to fix issue where editor adds in extra new line automatically
-		// just in case the new content has a mix of varying EOL characters
+
+		// `trimEnd` to fix issue where editor adds in extra new line
+		// automatically.
+		const normalizedEditedContent = editedContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL
+
+		// Just in case the new content has a mix of varying EOL characters.
 		const normalizedNewContent = this.newContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL
+
 		if (normalizedEditedContent !== normalizedNewContent) {
-			// user made changes before approving edit
+			// User made changes before approving edit.
 			const userEdits = formatResponse.createPrettyPatch(
 				this.relPath.toPosix(),
 				normalizedNewContent,
 				normalizedEditedContent,
 			)
+
 			return { newProblemsMessage, userEdits, finalContent: normalizedEditedContent }
 		} else {
-			// no changes to cline's edits
+			// No changes to Roo's edits.
 			return { newProblemsMessage, userEdits: undefined, finalContent: normalizedEditedContent }
 		}
 	}
@@ -210,42 +246,52 @@ export class DiffViewProvider {
 		if (!this.relPath || !this.activeDiffEditor) {
 			return
 		}
+
 		const fileExists = this.editType === "modify"
 		const updatedDocument = this.activeDiffEditor.document
 		const absolutePath = path.resolve(this.cwd, this.relPath)
+
 		if (!fileExists) {
 			if (updatedDocument.isDirty) {
 				await updatedDocument.save()
 			}
+
 			await this.closeAllDiffViews()
 			await fs.unlink(absolutePath)
-			// Remove only the directories we created, in reverse order
+
+			// Remove only the directories we created, in reverse order.
 			for (let i = this.createdDirs.length - 1; i >= 0; i--) {
 				await fs.rmdir(this.createdDirs[i])
 				console.log(`Directory ${this.createdDirs[i]} has been deleted.`)
 			}
+
 			console.log(`File ${absolutePath} has been deleted.`)
 		} else {
-			// revert document
+			// Revert document.
 			const edit = new vscode.WorkspaceEdit()
+
 			const fullRange = new vscode.Range(
 				updatedDocument.positionAt(0),
 				updatedDocument.positionAt(updatedDocument.getText().length),
 			)
+
 			edit.replace(updatedDocument.uri, fullRange, this.originalContent ?? "")
-			// Apply the edit and save, since contents shouldnt have changed this wont show in local history unless of course the user made changes and saved during the edit
+
+			// Apply the edit and save, since contents shouldnt have changed
+			// this won't show in local history unless of course the user made
+			// changes and saved during the edit.
 			await vscode.workspace.applyEdit(edit)
 			await updatedDocument.save()
 			console.log(`File ${absolutePath} has been reverted to its original content.`)
+
 			if (this.documentWasOpen) {
-				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
-					preview: false,
-				})
+				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), { preview: false })
 			}
+
 			await this.closeAllDiffViews()
 		}
 
-		// edit is done
+		// Edit is done.
 		await this.reset()
 	}
 
@@ -257,8 +303,9 @@ export class DiffViewProvider {
 					tab.input instanceof vscode.TabInputTextDiff &&
 					tab.input?.original?.scheme === DIFF_VIEW_URI_SCHEME,
 			)
+
 		for (const tab of tabs) {
-			// trying to close dirty views results in save popup
+			// Trying to close dirty views results in save popup.
 			if (!tab.isDirty) {
 				await vscode.window.tabGroups.close(tab)
 			}
@@ -269,8 +316,12 @@ export class DiffViewProvider {
 		if (!this.relPath) {
 			throw new Error("No file path set")
 		}
+
 		const uri = vscode.Uri.file(path.resolve(this.cwd, this.relPath))
-		// If this diff editor is already open (ie if a previous write file was interrupted) then we should activate that instead of opening a new diff
+
+		// If this diff editor is already open (ie if a previous write file was
+		// interrupted) then we should activate that instead of opening a new
+		// diff.
 		const diffTab = vscode.window.tabGroups.all
 			.flatMap((group) => group.tabs)
 			.find(
@@ -279,11 +330,13 @@ export class DiffViewProvider {
 					tab.input?.original?.scheme === DIFF_VIEW_URI_SCHEME &&
 					arePathsEqual(tab.input.modified.fsPath, uri.fsPath),
 			)
+
 		if (diffTab && diffTab.input instanceof vscode.TabInputTextDiff) {
 			const editor = await vscode.window.showTextDocument(diffTab.input.modified)
 			return editor
 		}
-		// Open new diff editor
+
+		// Open new diff editor.
 		return new Promise<vscode.TextEditor>((resolve, reject) => {
 			const fileName = path.basename(uri.fsPath)
 			const fileExists = this.editType === "modify"
@@ -293,6 +346,7 @@ export class DiffViewProvider {
 					resolve(editor)
 				}
 			})
+
 			vscode.commands.executeCommand(
 				"vscode.diff",
 				vscode.Uri.parse(`${DIFF_VIEW_URI_SCHEME}:${fileName}`).with({
@@ -301,7 +355,8 @@ export class DiffViewProvider {
 				uri,
 				`${fileName}: ${fileExists ? "Original ↔ Roo's Changes" : "New File"} (Editable)`,
 			)
-			// This may happen on very slow machines ie project idx
+
+			// This may happen on very slow machines i.e. project idx.
 			setTimeout(() => {
 				disposable.dispose()
 				reject(new Error("Failed to open diff editor, please try again..."))
@@ -312,6 +367,7 @@ export class DiffViewProvider {
 	private scrollEditorToLine(line: number) {
 		if (this.activeDiffEditor) {
 			const scrollLine = line + 4
+
 			this.activeDiffEditor.revealRange(
 				new vscode.Range(scrollLine, 0, scrollLine, 0),
 				vscode.TextEditorRevealType.InCenter,
@@ -323,9 +379,12 @@ export class DiffViewProvider {
 		if (!this.activeDiffEditor) {
 			return
 		}
+
 		const currentContent = this.activeDiffEditor.document.getText()
 		const diffs = diff.diffLines(this.originalContent || "", currentContent)
+
 		let lineCount = 0
+
 		for (const part of diffs) {
 			if (part.added || part.removed) {
 				// Found the first diff, scroll to it
@@ -333,8 +392,10 @@ export class DiffViewProvider {
 					new vscode.Range(lineCount, 0, lineCount, 0),
 					vscode.TextEditorRevealType.InCenter,
 				)
+
 				return
 			}
+
 			if (!part.removed) {
 				lineCount += part.count || 0
 			}
@@ -344,17 +405,24 @@ export class DiffViewProvider {
 	private stripAllBOMs(input: string): string {
 		let result = input
 		let previous
+
 		do {
 			previous = result
 			result = stripBom(result)
 		} while (result !== previous)
+
 		return result
 	}
 
-	// close editor if open?
 	async reset() {
-		// Ensure any diff views opened by this provider are closed to release memory
-		await this.closeAllDiffViews();
+		// Ensure any diff views opened by this provider are closed to release
+		// memory.
+		try {
+			await this.closeAllDiffViews()
+		} catch (error) {
+			console.error("Error closing diff views", error)
+		}
+
 		this.editType = undefined
 		this.isEditing = false
 		this.originalContent = undefined

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -1,19 +1,16 @@
 import * as vscode from "vscode"
 import * as path from "path"
 import * as fs from "fs/promises"
-import * as diff from "diff"
-import stripBom from "strip-bom"
-
 import { createDirectoriesForFile } from "../../utils/fs"
 import { arePathsEqual } from "../../utils/path"
 import { formatResponse } from "../../core/prompts/responses"
-import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
-
 import { DecorationController } from "./DecorationController"
+import * as diff from "diff"
+import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
+import stripBom from "strip-bom"
 
 export const DIFF_VIEW_URI_SCHEME = "cline-diff"
 
-// TODO: https://github.com/cline/cline/pull/3354
 export class DiffViewProvider {
 	editType?: "create" | "modify"
 	isEditing = false
@@ -35,21 +32,17 @@ export class DiffViewProvider {
 		const fileExists = this.editType === "modify"
 		const absolutePath = path.resolve(this.cwd, relPath)
 		this.isEditing = true
-
-		// If the file is already open, ensure it's not dirty before getting its
-		// contents.
+		// if the file is already open, ensure it's not dirty before getting its contents
 		if (fileExists) {
 			const existingDocument = vscode.workspace.textDocuments.find((doc) =>
 				arePathsEqual(doc.uri.fsPath, absolutePath),
 			)
-
 			if (existingDocument && existingDocument.isDirty) {
 				await existingDocument.save()
 			}
 		}
 
-		// Get diagnostics before editing the file, we'll compare to diagnostics
-		// after editing to see if cline needs to fix anything.
+		// get diagnostics before editing the file, we'll compare to diagnostics after editing to see if cline needs to fix anything
 		this.preDiagnostics = vscode.languages.getDiagnostics()
 
 		if (fileExists) {
@@ -57,41 +50,33 @@ export class DiffViewProvider {
 		} else {
 			this.originalContent = ""
 		}
-
-		// For new files, create any necessary directories and keep track of new
-		// directories to delete if the user denies the operation.
+		// for new files, create any necessary directories and keep track of new directories to delete if the user denies the operation
 		this.createdDirs = await createDirectoriesForFile(absolutePath)
-
-		// Make sure the file exists before we open it.
+		// make sure the file exists before we open it
 		if (!fileExists) {
 			await fs.writeFile(absolutePath, "")
 		}
-
-		// If the file was already open, close it (must happen after showing the
-		// diff view since if it's the only tab the column will close).
+		// if the file was already open, close it (must happen after showing the diff view since if it's the only tab the column will close)
 		this.documentWasOpen = false
-
-		// Close the tab if it's open (it's already saved above).
+		// close the tab if it's open (it's already saved above)
 		const tabs = vscode.window.tabGroups.all
 			.map((tg) => tg.tabs)
 			.flat()
 			.filter(
 				(tab) => tab.input instanceof vscode.TabInputText && arePathsEqual(tab.input.uri.fsPath, absolutePath),
 			)
-
 		for (const tab of tabs) {
 			if (!tab.isDirty) {
 				await vscode.window.tabGroups.close(tab)
 			}
 			this.documentWasOpen = true
 		}
-
 		this.activeDiffEditor = await this.openDiffEditor()
 		this.fadedOverlayController = new DecorationController("fadedOverlay", this.activeDiffEditor)
 		this.activeLineController = new DecorationController("activeLine", this.activeDiffEditor)
-		// Apply faded overlay to all lines initially.
+		// Apply faded overlay to all lines initially
 		this.fadedOverlayController.addLines(0, this.activeDiffEditor.document.lineCount)
-		this.scrollEditorToLine(0) // Will this crash for new files?
+		this.scrollEditorToLine(0) // will this crash for new files?
 		this.streamedLines = []
 	}
 
@@ -99,70 +84,58 @@ export class DiffViewProvider {
 		if (!this.relPath || !this.activeLineController || !this.fadedOverlayController) {
 			throw new Error("Required values not set")
 		}
-
 		this.newContent = accumulatedContent
 		const accumulatedLines = accumulatedContent.split("\n")
-
 		if (!isFinal) {
-			accumulatedLines.pop() // Remove the last partial line only if it's not the final update.
+			accumulatedLines.pop() // remove the last partial line only if it's not the final update
 		}
 
 		const diffEditor = this.activeDiffEditor
 		const document = diffEditor?.document
-
 		if (!diffEditor || !document) {
 			throw new Error("User closed text editor, unable to edit file...")
 		}
 
-		// Place cursor at the beginning of the diff editor to keep it out of
-		// the way of the stream animation.
+		// Place cursor at the beginning of the diff editor to keep it out of the way of the stream animation
 		const beginningOfDocument = new vscode.Position(0, 0)
 		diffEditor.selection = new vscode.Selection(beginningOfDocument, beginningOfDocument)
 
 		const endLine = accumulatedLines.length
-		// Replace all content up to the current line with accumulated lines.
+		// Replace all content up to the current line with accumulated lines
 		const edit = new vscode.WorkspaceEdit()
 		const rangeToReplace = new vscode.Range(0, 0, endLine + 1, 0)
 		const contentToReplace = accumulatedLines.slice(0, endLine + 1).join("\n") + "\n"
 		edit.replace(document.uri, rangeToReplace, this.stripAllBOMs(contentToReplace))
 		await vscode.workspace.applyEdit(edit)
-		// Update decorations.
+		// Update decorations
 		this.activeLineController.setActiveLine(endLine)
 		this.fadedOverlayController.updateOverlayAfterLine(endLine, document.lineCount)
-		// Scroll to the current line.
+		// Scroll to the current line
 		this.scrollEditorToLine(endLine)
 
-		// Update the streamedLines with the new accumulated content.
+		// Update the streamedLines with the new accumulated content
 		this.streamedLines = accumulatedLines
-
 		if (isFinal) {
-			// Handle any remaining lines if the new content is shorter than the
-			// original.
+			// Handle any remaining lines if the new content is shorter than the original
 			if (this.streamedLines.length < document.lineCount) {
 				const edit = new vscode.WorkspaceEdit()
 				edit.delete(document.uri, new vscode.Range(this.streamedLines.length, 0, document.lineCount, 0))
 				await vscode.workspace.applyEdit(edit)
 			}
-
-			// Preserve empty last line if original content had one.
+			// Preserve empty last line if original content had one
 			const hasEmptyLastLine = this.originalContent?.endsWith("\n")
-
 			if (hasEmptyLastLine && !accumulatedContent.endsWith("\n")) {
 				accumulatedContent += "\n"
 			}
-
-			// Apply the final content.
+			// Apply the final content
 			const finalEdit = new vscode.WorkspaceEdit()
-
 			finalEdit.replace(
 				document.uri,
 				new vscode.Range(0, 0, document.lineCount, 0),
 				this.stripAllBOMs(accumulatedContent),
 			)
-
 			await vscode.workspace.applyEdit(finalEdit)
-
-			// Clear all decorations at the end (after applying final edit).
+			// Clear all decorations at the end (after applying final edit)
 			this.fadedOverlayController.clear()
 			this.activeLineController.clear()
 		}
@@ -176,11 +149,9 @@ export class DiffViewProvider {
 		if (!this.relPath || !this.newContent || !this.activeDiffEditor) {
 			return { newProblemsMessage: undefined, userEdits: undefined, finalContent: undefined }
 		}
-
 		const absolutePath = path.resolve(this.cwd, this.relPath)
 		const updatedDocument = this.activeDiffEditor.document
 		const editedContent = updatedDocument.getText()
-
 		if (updatedDocument.isDirty) {
 			await updatedDocument.save()
 		}
@@ -188,56 +159,49 @@ export class DiffViewProvider {
 		await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), { preview: false })
 		await this.closeAllDiffViews()
 
-		// Getting diagnostics before and after the file edit is a better approach than
-		// automatically tracking problems in real-time. This method ensures we only
-		// report new problems that are a direct result of this specific edit.
-		// Since these are new problems resulting from Roo's edit, we know they're
-		// directly related to the work he's doing. This eliminates the risk of Roo
-		// going off-task or getting distracted by unrelated issues, which was a problem
-		// with the previous auto-debug approach. Some users' machines may be slow to
-		// update diagnostics, so this approach provides a good balance between automation
-		// and avoiding potential issues where Roo might get stuck in loops due to
-		// outdated problem information. If no new problems show up by the time the user
-		// accepts the changes, they can always debug later using the '@problems' mention.
-		// This way, Roo only becomes aware of new problems resulting from his edits
-		// and can address them accordingly. If problems don't change immediately after
-		// applying a fix, won't be notified, which is generally fine since the
-		// initial fix is usually correct and it may just take time for linters to catch up.
+		/*
+		Getting diagnostics before and after the file edit is a better approach than
+		automatically tracking problems in real-time. This method ensures we only
+		report new problems that are a direct result of this specific edit.
+		Since these are new problems resulting from Roo's edit, we know they're
+		directly related to the work he's doing. This eliminates the risk of Roo
+		going off-task or getting distracted by unrelated issues, which was a problem
+		with the previous auto-debug approach. Some users' machines may be slow to
+		update diagnostics, so this approach provides a good balance between automation
+		and avoiding potential issues where Roo might get stuck in loops due to
+		outdated problem information. If no new problems show up by the time the user
+		accepts the changes, they can always debug later using the '@problems' mention.
+		This way, Roo only becomes aware of new problems resulting from his edits
+		and can address them accordingly. If problems don't change immediately after
+		applying a fix, won't be notified, which is generally fine since the
+		initial fix is usually correct and it may just take time for linters to catch up.
+		*/
 		const postDiagnostics = vscode.languages.getDiagnostics()
-
 		const newProblems = await diagnosticsToProblemsString(
 			getNewDiagnostics(this.preDiagnostics, postDiagnostics),
 			[
 				vscode.DiagnosticSeverity.Error, // only including errors since warnings can be distracting (if user wants to fix warnings they can use the @problems mention)
 			],
 			this.cwd,
-		) // Will be empty string if no errors.
-
+		) // will be empty string if no errors
 		const newProblemsMessage =
 			newProblems.length > 0 ? `\n\nNew problems detected after saving the file:\n${newProblems}` : ""
 
-		// If the edited content has different EOL characters, we don't want to
-		// show a diff with all the EOL differences.
+		// If the edited content has different EOL characters, we don't want to show a diff with all the EOL differences.
 		const newContentEOL = this.newContent.includes("\r\n") ? "\r\n" : "\n"
-
-		// `trimEnd` to fix issue where editor adds in extra new line
-		// automatically.
-		const normalizedEditedContent = editedContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL
-
-		// Just in case the new content has a mix of varying EOL characters.
+		const normalizedEditedContent = editedContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL // trimEnd to fix issue where editor adds in extra new line automatically
+		// just in case the new content has a mix of varying EOL characters
 		const normalizedNewContent = this.newContent.replace(/\r\n|\n/g, newContentEOL).trimEnd() + newContentEOL
-
 		if (normalizedEditedContent !== normalizedNewContent) {
-			// User made changes before approving edit.
+			// user made changes before approving edit
 			const userEdits = formatResponse.createPrettyPatch(
 				this.relPath.toPosix(),
 				normalizedNewContent,
 				normalizedEditedContent,
 			)
-
 			return { newProblemsMessage, userEdits, finalContent: normalizedEditedContent }
 		} else {
-			// No changes to Roo's edits.
+			// no changes to cline's edits
 			return { newProblemsMessage, userEdits: undefined, finalContent: normalizedEditedContent }
 		}
 	}
@@ -246,52 +210,42 @@ export class DiffViewProvider {
 		if (!this.relPath || !this.activeDiffEditor) {
 			return
 		}
-
 		const fileExists = this.editType === "modify"
 		const updatedDocument = this.activeDiffEditor.document
 		const absolutePath = path.resolve(this.cwd, this.relPath)
-
 		if (!fileExists) {
 			if (updatedDocument.isDirty) {
 				await updatedDocument.save()
 			}
-
 			await this.closeAllDiffViews()
 			await fs.unlink(absolutePath)
-
-			// Remove only the directories we created, in reverse order.
+			// Remove only the directories we created, in reverse order
 			for (let i = this.createdDirs.length - 1; i >= 0; i--) {
 				await fs.rmdir(this.createdDirs[i])
 				console.log(`Directory ${this.createdDirs[i]} has been deleted.`)
 			}
-
 			console.log(`File ${absolutePath} has been deleted.`)
 		} else {
-			// Revert document.
+			// revert document
 			const edit = new vscode.WorkspaceEdit()
-
 			const fullRange = new vscode.Range(
 				updatedDocument.positionAt(0),
 				updatedDocument.positionAt(updatedDocument.getText().length),
 			)
-
 			edit.replace(updatedDocument.uri, fullRange, this.originalContent ?? "")
-
-			// Apply the edit and save, since contents shouldnt have changed
-			// this won't show in local history unless of course the user made
-			// changes and saved during the edit.
+			// Apply the edit and save, since contents shouldnt have changed this wont show in local history unless of course the user made changes and saved during the edit
 			await vscode.workspace.applyEdit(edit)
 			await updatedDocument.save()
 			console.log(`File ${absolutePath} has been reverted to its original content.`)
-
 			if (this.documentWasOpen) {
-				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), { preview: false })
+				await vscode.window.showTextDocument(vscode.Uri.file(absolutePath), {
+					preview: false,
+				})
 			}
-
 			await this.closeAllDiffViews()
 		}
 
-		// Edit is done.
+		// edit is done
 		await this.reset()
 	}
 
@@ -303,9 +257,8 @@ export class DiffViewProvider {
 					tab.input instanceof vscode.TabInputTextDiff &&
 					tab.input?.original?.scheme === DIFF_VIEW_URI_SCHEME,
 			)
-
 		for (const tab of tabs) {
-			// Trying to close dirty views results in save popup.
+			// trying to close dirty views results in save popup
 			if (!tab.isDirty) {
 				await vscode.window.tabGroups.close(tab)
 			}
@@ -316,12 +269,8 @@ export class DiffViewProvider {
 		if (!this.relPath) {
 			throw new Error("No file path set")
 		}
-
 		const uri = vscode.Uri.file(path.resolve(this.cwd, this.relPath))
-
-		// If this diff editor is already open (ie if a previous write file was
-		// interrupted) then we should activate that instead of opening a new
-		// diff.
+		// If this diff editor is already open (ie if a previous write file was interrupted) then we should activate that instead of opening a new diff
 		const diffTab = vscode.window.tabGroups.all
 			.flatMap((group) => group.tabs)
 			.find(
@@ -330,13 +279,11 @@ export class DiffViewProvider {
 					tab.input?.original?.scheme === DIFF_VIEW_URI_SCHEME &&
 					arePathsEqual(tab.input.modified.fsPath, uri.fsPath),
 			)
-
 		if (diffTab && diffTab.input instanceof vscode.TabInputTextDiff) {
 			const editor = await vscode.window.showTextDocument(diffTab.input.modified)
 			return editor
 		}
-
-		// Open new diff editor.
+		// Open new diff editor
 		return new Promise<vscode.TextEditor>((resolve, reject) => {
 			const fileName = path.basename(uri.fsPath)
 			const fileExists = this.editType === "modify"
@@ -346,7 +293,6 @@ export class DiffViewProvider {
 					resolve(editor)
 				}
 			})
-
 			vscode.commands.executeCommand(
 				"vscode.diff",
 				vscode.Uri.parse(`${DIFF_VIEW_URI_SCHEME}:${fileName}`).with({
@@ -355,8 +301,7 @@ export class DiffViewProvider {
 				uri,
 				`${fileName}: ${fileExists ? "Original ↔ Roo's Changes" : "New File"} (Editable)`,
 			)
-
-			// This may happen on very slow machines i.e. project idx.
+			// This may happen on very slow machines ie project idx
 			setTimeout(() => {
 				disposable.dispose()
 				reject(new Error("Failed to open diff editor, please try again..."))
@@ -367,7 +312,6 @@ export class DiffViewProvider {
 	private scrollEditorToLine(line: number) {
 		if (this.activeDiffEditor) {
 			const scrollLine = line + 4
-
 			this.activeDiffEditor.revealRange(
 				new vscode.Range(scrollLine, 0, scrollLine, 0),
 				vscode.TextEditorRevealType.InCenter,
@@ -379,12 +323,9 @@ export class DiffViewProvider {
 		if (!this.activeDiffEditor) {
 			return
 		}
-
 		const currentContent = this.activeDiffEditor.document.getText()
 		const diffs = diff.diffLines(this.originalContent || "", currentContent)
-
 		let lineCount = 0
-
 		for (const part of diffs) {
 			if (part.added || part.removed) {
 				// Found the first diff, scroll to it
@@ -392,10 +333,8 @@ export class DiffViewProvider {
 					new vscode.Range(lineCount, 0, lineCount, 0),
 					vscode.TextEditorRevealType.InCenter,
 				)
-
 				return
 			}
-
 			if (!part.removed) {
 				lineCount += part.count || 0
 			}
@@ -405,24 +344,17 @@ export class DiffViewProvider {
 	private stripAllBOMs(input: string): string {
 		let result = input
 		let previous
-
 		do {
 			previous = result
 			result = stripBom(result)
 		} while (result !== previous)
-
 		return result
 	}
 
+	// close editor if open?
 	async reset() {
-		// Ensure any diff views opened by this provider are closed to release
-		// memory.
-		try {
-			await this.closeAllDiffViews()
-		} catch (error) {
-			console.error("Error closing diff views", error)
-		}
-
+		// Ensure any diff views opened by this provider are closed to release memory
+		await this.closeAllDiffViews()
 		this.editType = undefined
 		this.isEditing = false
 		this.originalContent = undefined


### PR DESCRIPTION
### Description

I noticed this awesome PR: https://github.com/cline/cline/pull/3425

I was curious about the performance as well as any potential differences in behavior, so I ran both against a reasonable set of unit tests and also benchmarked them. Here are the results:

```sh
$ node --expose-gc --import tsx src/core/assistant-message/__tests__/parseAssistantMessageBenchmark.ts
| Test Case                                         | V1 Time (ms) | V2 Time (ms) | V1/V2 Ratio | V1 Heap (bytes) | V2 Heap (bytes) |
| ------------------------------------------------- | ------------ | ------------ | ----------- | ---------------- | ---------------- |
| Simple text message                               |       0.0266 |       0.0128 |        2.07 |           37,586 |           27,025 |
| Message with a simple tool use                    |       0.0343 |       0.0197 |        1.74 |           22,290 |              870 |
| Message with a complex tool use (write_to_file)   |       0.0737 |       0.0328 |        2.25 |           34,614 |           28,381 |
| Message with multiple tool uses                   |       0.1122 |       0.0354 |        3.17 |            5,206 |           33,006 |
| Large message with repeated tool uses             |       4.1538 |       0.9819 |        4.23 |          270,946 |           84,000 |
```

One unit test did fail for V2, and it looks like it's doing the wrong thing. Here's the test:
```typescript
it("should handle the write_to_file tool with content that contains closing tags", () => {
	const message = `<write_to_file><path>src/file.ts</path><content>
function example() {
// This has XML-like content: </content>
return true;
}
</content><line_count>5</line_count></write_to_file>`

	const result = parser(message).filter((block) => !isEmptyTextContent(block))

	expect(result).toHaveLength(1)
	const toolUse = result[0] as ToolUse
	expect(toolUse.type).toBe("tool_use")
	expect(toolUse.name).toBe("write_to_file")
	expect(toolUse.params.path).toBe("src/file.ts")
	expect(toolUse.params.line_count).toBe("5")
	expect(toolUse.params.content).toContain("function example()")
	expect(toolUse.params.content).toContain("// This has XML-like content: </content>")
	expect(toolUse.params.content).toContain("return true;")
	expect(toolUse.partial).toBe(false)
})
```

Note that V1 correctly parses the full code snippet and V2 does not. I updated the V2 implementation to fix the test. This appeared to be the culprit:

```typescript
if (
	currentToolUse.name === "write_to_file" || currentToolUse.name === "new_rule" &&
	!(contentParamName in currentToolUse.params) && // Only if not already parsed.
	toolContentSlice.includes(`<${contentParamName}>`) // Check if tag exists.
)
```

In particular the `!(contentParamName in currentToolUse.params)` part of the check.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add tests and benchmarks for `parseAssistantMessage` V1 and V2, and fix a bug in V2 related to parsing content with closing tags.
> 
>   - **Tests**:
>     - Add `parseAssistantMessage.test.ts` to test `parseAssistantMessageV1` and `parseAssistantMessageV2` for various message parsing scenarios.
>     - Tests include simple text, tool use, mixed content, and special cases like malformed tags and nested content.
>   - **Benchmark**:
>     - Add `parseAssistantMessageBenchmark.ts` to benchmark `parseAssistantMessageV1` and `parseAssistantMessageV2`.
>     - Benchmarks measure execution time and memory usage for different message types.
>   - **Bug Fix**:
>     - Fix bug in `parseAssistantMessageV2` where content with closing tags was not parsed correctly.
>     - Update logic in `parseAssistantMessageV2` to handle `write_to_file` content correctly.
>   - **Misc**:
>     - Minor logging change in `DiffViewProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f18eb0e5c4d6423712eae10ab8fbcc69baea4c9b. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->