### PR TITLE
Add tests for parseAssistantMessage v3

### DIFF
--- a/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
+++ b/src/core/assistant-message/__tests__/parseAssistantMessage.test.ts
@@ -4,11 +4,12 @@ import { TextContent, ToolUse } from "../../../shared/tools"
 
 import { AssistantMessageContent, parseAssistantMessage as parseAssistantMessageV1 } from "../parseAssistantMessage"
 import { parseAssistantMessageV2 } from "../parseAssistantMessageV2"
+import { parseAssistantMessageV3 } from "../parseAssistantMessageV3"
 
 const isEmptyTextContent = (block: AssistantMessageContent) =>
 	block.type === "text" && (block as TextContent).content === ""
 
-;[parseAssistantMessageV1, parseAssistantMessageV2].forEach((parser, index) => {
+;[parseAssistantMessageV1, parseAssistantMessageV2, parseAssistantMessageV3].forEach((parser, index) => {
 	describe(`parseAssistantMessageV${index + 1}`, () => {
 		describe("text content parsing", () => {
 			it("should parse a simple text message", () => {

--- a/src/core/assistant-message/__tests__/parseAssistantMessageBenchmark.ts
+++ b/src/core/assistant-message/__tests__/parseAssistantMessageBenchmark.ts
@@ -3,6 +3,7 @@
 import { performance } from "perf_hooks"
 import { parseAssistantMessage as parseAssistantMessageV1 } from "../parseAssistantMessage"
 import { parseAssistantMessageV2 } from "../parseAssistantMessageV2"
+import { parseAssistantMessageV3 } from "../parseAssistantMessageV3"
 
 const formatNumber = (num: number): string => {
 	return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
@@ -81,27 +82,29 @@ const runBenchmark = () => {
 	const namePadding = maxNameLength + 2
 
 	console.log(
-		`| ${"Test Case".padEnd(namePadding)} | V1 Time (ms) | V2 Time (ms) | V1/V2 Ratio | V1 Heap (bytes) | V2 Heap (bytes) |`,
+		`| ${"Test Case".padEnd(namePadding)} | V1 Time (ms) | V2 Time (ms) | V3 Time (ms) | V1 Heap (bytes)  | V2 Heap (bytes)  | V3 Heap (bytes)  |`,
 	)
 	console.log(
-		`| ${"-".repeat(namePadding)} | ------------ | ------------ | ----------- | ---------------- | ---------------- |`,
+		`| ${"-".repeat(namePadding)} | ------------ | ------------ | ------------ | ---------------- | ---------------- | ---------------- |`,
 	)
 
 	for (const testCase of testCases) {
 		const v1Time = measureExecutionTime(parseAssistantMessageV1, testCase.input)
 		const v2Time = measureExecutionTime(parseAssistantMessageV2, testCase.input)
-		const timeRatio = v1Time / v2Time
+		const v3Time = measureExecutionTime(parseAssistantMessageV3, testCase.input)
 
 		const v1Memory = measureMemoryUsage(parseAssistantMessageV1, testCase.input)
 		const v2Memory = measureMemoryUsage(parseAssistantMessageV2, testCase.input)
+		const v3Memory = measureMemoryUsage(parseAssistantMessageV3, testCase.input)
 
 		console.log(
 			`| ${testCase.name.padEnd(namePadding)} | ` +
 				`${v1Time.toFixed(4).padStart(12)} | ` +
 				`${v2Time.toFixed(4).padStart(12)} | ` +
-				`${timeRatio.toFixed(2).padStart(11)} | ` +
+				`${v3Time.toFixed(4).padStart(12)} | ` +
 				`${formatNumber(Math.round(v1Memory.heapUsed)).padStart(16)} | ` +
-				`${formatNumber(Math.round(v2Memory.heapUsed)).padStart(16)} |`,
+				`${formatNumber(Math.round(v2Memory.heapUsed)).padStart(16)} | ` +
+				`${formatNumber(Math.round(v3Memory.heapUsed)).padStart(16)} |`,
 		)
 	}
 }

--- a/src/core/assistant-message/parseAssistantMessageV3.ts
+++ b/src/core/assistant-message/parseAssistantMessageV3.ts
@@ -1,0 +1,157 @@
+import { TextContent, ToolParamName, ToolUse, toolParamNames } from "../../shared/tools"
+import { toolNames, ToolName } from "../../schemas"
+
+export type AssistantMessageContent = TextContent | ToolUse
+
+// We keep parsing state between chunks so we don't repeatedly
+// re-scan the entire assistant message each time a new token arrives.
+export interface ParserState {
+	currentToolUse?: ToolUse
+	currentParamName?: ToolParamName
+	currentTextContent?: TextContent
+}
+
+const toolOpeningTags = toolNames.map((name) => `<${name}>`)
+const paramOpeningTags = toolParamNames.map((name) => `<${name}>`)
+
+/**
+ * Parses a chunk of streaming assistant text, mutating `state` and
+ * returning *completed* content blocks in the order they were closed.
+ */
+export function parseAssistantMessageV3(chunk: string, state?: ParserState): AssistantMessageContent[] {
+	if (!state) {
+		state = createInitialParserState()
+	}
+
+	let accumulator = ""
+	const completedBlocks: AssistantMessageContent[] = []
+
+	// Finalise and push current text block.
+	const flushText = () => {
+		if (state.currentTextContent) {
+			state.currentTextContent.content = state.currentTextContent.content + accumulator.trimEnd()
+			accumulator = ""
+			// Only push when a tool starts or chunk ends (done below).
+		}
+	}
+
+	for (let i = 0; i < chunk.length; i++) {
+		const char = chunk[i]
+		accumulator += char
+
+		if (state.currentToolUse && state.currentParamName) {
+			// Inside a param – look for param closing tag.
+			const paramClosing = `</${state.currentParamName}>`
+
+			if (accumulator.endsWith(paramClosing)) {
+				// Strip closing tag from param value.
+				const value = accumulator.slice(0, -paramClosing.length)
+
+				state.currentToolUse.params[state.currentParamName] =
+					(state.currentToolUse.params[state.currentParamName] ?? "") + value
+
+				state.currentParamName = undefined
+				accumulator = "" // Reset accumulator for next parsing portion.
+			}
+
+			continue // Still inside param; don't treat anything else.
+		}
+
+		// Inside a tool but not inside param..
+		if (state.currentToolUse) {
+			const toolClosing = `</${state.currentToolUse.name}>`
+
+			if (accumulator.endsWith(toolClosing)) {
+				// Tool block complete.
+				state.currentToolUse.partial = false
+				state.currentToolUse = undefined
+				accumulator = ""
+				continue
+			}
+
+			// Look for param opening tags.
+			for (const open of paramOpeningTags) {
+				if (accumulator.endsWith(open)) {
+					state.currentParamName = open.slice(1, -1) as ToolParamName
+					accumulator = "" // Reset; param value starts next char.
+					// Initialize empty param value.
+					state.currentToolUse.params[state.currentParamName] = ""
+					break
+				}
+			}
+
+			continue
+		}
+
+		// Not in a tool – look for opening of a tool.
+		for (const open of toolOpeningTags) {
+			if (accumulator.endsWith(open)) {
+				// Flush any text accumulated *before* the tool tag.
+				if (state.currentTextContent) {
+					state.currentTextContent.partial = false
+					completedBlocks.push(state.currentTextContent)
+					state.currentTextContent = undefined
+				}
+
+				state.currentToolUse = {
+					type: "tool_use",
+					name: open.slice(1, -1) as ToolName,
+					params: {},
+					partial: true,
+				}
+
+				// Expose the new (partial) tool block immediately so the UI can
+				// respond (e.g. opening diff view for write_to_file).
+				completedBlocks.push(state.currentToolUse)
+				accumulator = "" // Reset; tool content begins next char.
+				break
+			}
+		}
+
+		// If we just started a tool, skip further text processing.
+		if (state.currentToolUse) {
+			continue
+		}
+
+		// Regular text content.
+		if (!state.currentTextContent) {
+			state.currentTextContent = { type: "text", content: "", partial: true }
+
+			// Immediately push the partial text block so downstream consumers
+			// can stream it progressively.
+			completedBlocks.push(state.currentTextContent)
+		}
+
+		// Text will be flushed at the end or before next block.
+	}
+
+	// End of chunk – append remaining accumulator to current context.
+
+	if (state.currentParamName && state.currentToolUse) {
+		// Still inside param value.
+		state.currentToolUse.params[state.currentParamName] =
+			(state.currentToolUse.params[state.currentParamName] ?? "") + accumulator
+
+		accumulator = ""
+	} else if (state.currentToolUse) {
+		// Inside tool but outside param – append to a special placeholder param? (ignored).
+		// Nothing to do.
+	} else {
+		// Plain text.
+		if (!state.currentTextContent) {
+			state.currentTextContent = { type: "text", content: "", partial: true }
+		}
+
+		state.currentTextContent.content += accumulator
+		accumulator = ""
+	}
+
+	// If end of chunk finalises a text block fully (no open tool starting later).
+	flushText()
+
+	return completedBlocks
+}
+
+export function createInitialParserState(): ParserState {
+	return { currentToolUse: undefined, currentParamName: undefined, currentTextContent: undefined }
+}


### PR DESCRIPTION
### Description

```
| Test Case                                         | V1 Time (ms) | V2 Time (ms) | V3 Time (ms) | V1 Heap (bytes)  | V2 Heap (bytes)  | V3 Heap (bytes)  |
| ------------------------------------------------- | ------------ | ------------ | ------------ | ---------------- | ---------------- | ---------------- |
| Simple text message                               |       0.0267 |       0.0135 |       0.0099 |           34,596 |           26,402 |            6,930 |
| Message with a simple tool use                    |       0.0351 |       0.0212 |       0.0126 |           15,839 |           28,273 |            6,073 |
| Message with a complex tool use (write_to_file)   |       0.0724 |       0.0337 |       0.0275 |           34,597 |           28,344 |           22,334 |
| Message with multiple tool uses                   |       0.1165 |       0.0446 |       0.0312 |           20,597 |            2,797 |           29,778 |
| Large message with repeated tool uses             |       4.1766 |       0.9817 |       0.8436 |          273,522 |           81,416 |           93,245 |
```