### PR TITLE
add toggle for disable mcp server tool from prompt

### DIFF
--- a/.changeset/slimy-years-smell.md
+++ b/.changeset/slimy-years-smell.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": minor
+---
+
+new feature allowing users to toggle whether an individual MCP (Model Context Protocol) tool is included in the context provided to the AI model

--- a/src/__mocks__/fs/promises.ts
+++ b/src/__mocks__/fs/promises.ts
@@ -166,6 +166,7 @@ const mockFs = {
 						args: ["test.js"],
 						disabled: false,
 						alwaysAllow: ["existing-tool"],
+						disabledForPromptTools: [],
 					},
 				},
 			}),

--- a/src/core/prompts/instructions/create-mcp-server.ts
+++ b/src/core/prompts/instructions/create-mcp-server.ts
@@ -50,6 +50,7 @@ Common configuration options for both types:
 - \`disabled\`: (optional) Set to true to temporarily disable the server
 - \`timeout\`: (optional) Maximum time in seconds to wait for server responses (default: 60)
 - \`alwaysAllow\`: (optional) Array of tool names that don't require user confirmation
+- \`disabledForPromptTools\`: (optional) Array of tool names that don't includes to system prompt and won't be used
 
 ### Example Local MCP Server
 
@@ -362,7 +363,7 @@ npm run build
 
 5. Install the MCP Server by adding the MCP server configuration to the settings file located at '${await mcpHub.getMcpSettingsFilePath()}'. The settings file may have other MCP servers already configured, so you would read it first and then add your new server to the existing \`mcpServers\` object.
 
-IMPORTANT: Regardless of what else you see in the MCP settings file, you must default any new MCP servers you create to disabled=false and alwaysAllow=[].
+IMPORTANT: Regardless of what else you see in the MCP settings file, you must default any new MCP servers you create to disabled=false, alwaysAllow=[] and disabledForPromptTools=[].
 
 \`\`\`json
 {

--- a/src/core/prompts/sections/mcp-servers.ts
+++ b/src/core/prompts/sections/mcp-servers.ts
@@ -17,6 +17,7 @@ export async function getMcpServersSection(
 					.filter((server) => server.status === "connected")
 					.map((server) => {
 						const tools = server.tools
+							?.filter((tool) => tool.enabledForPrompt !== false)
 							?.map((tool) => {
 								const schemaStr = tool.inputSchema
 									? `    Input Schema:

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -458,6 +458,23 @@ export const webviewMessageHandler = async (provider: ClineProvider, message: We
 			}
 			break
 		}
+		case "toggleToolEnabledForPrompt": {
+			try {
+				await provider
+					.getMcpHub()
+					?.toggleToolEnabledForPrompt(
+						message.serverName!,
+						message.source as "global" | "project",
+						message.toolName!,
+						Boolean(message.isEnabled),
+					)
+			} catch (error) {
+				provider.log(
+					`Failed to toggle enabled for prompt for tool ${message.toolName}: ${JSON.stringify(error, Object.getOwnPropertyNames(error), 2)}`,
+				)
+			}
+			break
+		}
 		case "toggleMcpServer": {
 			try {
 				await provider

--- a/src/services/mcp/McpHub.ts
+++ b/src/services/mcp/McpHub.ts
@@ -44,6 +44,7 @@ const BaseConfigSchema = z.object({
 	timeout: z.number().min(1).max(3600).optional().default(60),
 	alwaysAllow: z.array(z.string()).default([]),
 	watchPaths: z.array(z.string()).optional(), // paths to watch for changes and restart server
+	disabledForPromptTools: z.array(z.string()).default([]),
 })
 
 // Custom error messages for better user feedback
@@ -635,34 +636,39 @@ export class McpHub {
 			const actualSource = connection.server.source || "global"
 			let configPath: string
 			let alwaysAllowConfig: string[] = []
+			let disabledForPromptToolsList: string[] = []
 
 			// Read from the appropriate config file based on the actual source
 			try {
+				let serverConfigData: any
 				if (actualSource === "project") {
 					// Get project MCP config path
 					const projectMcpPath = await this.getProjectMcpPath()
 					if (projectMcpPath) {
 						configPath = projectMcpPath
 						const content = await fs.readFile(configPath, "utf-8")
-						const config = JSON.parse(content)
-						alwaysAllowConfig = config.mcpServers?.[serverName]?.alwaysAllow || []
+						serverConfigData = JSON.parse(content)
 					}
 				} else {
 					// Get global MCP settings path
 					configPath = await this.getMcpSettingsFilePath()
 					const content = await fs.readFile(configPath, "utf-8")
-					const config = JSON.parse(content)
-					alwaysAllowConfig = config.mcpServers?.[serverName]?.alwaysAllow || []
+					serverConfigData = JSON.parse(content)
+				}
+				if (serverConfigData) {
+					alwaysAllowConfig = serverConfigData.mcpServers?.[serverName]?.alwaysAllow || []
+					disabledForPromptToolsList = serverConfigData.mcpServers?.[serverName]?.disabledForPromptTools || []
 				}
 			} catch (error) {
-				console.error(`Failed to read alwaysAllow config for ${serverName}:`, error)
-				// Continue with empty alwaysAllowConfig
+				console.error(`Failed to read tool configuration for ${serverName}:`, error)
+				// Continue with empty configs
 			}
 
-			// Mark tools as always allowed based on settings
+			// Mark tools as always allowed and enabled for prompt based on settings
 			const tools = (response?.tools || []).map((tool) => ({
 				...tool,
 				alwaysAllow: alwaysAllowConfig.includes(tool.name),
+				enabledForPrompt: !disabledForPromptToolsList.includes(tool.name),
 			}))
 
 			return tools
@@ -1275,6 +1281,74 @@ export class McpHub {
 			// Update the tools list to reflect the change
 			if (connection) {
 				// Explicitly pass the source to ensure we're updating the correct server's tools
+				connection.server.tools = await this.fetchToolsList(serverName, source)
+				await this.notifyWebviewOfServerChanges()
+			}
+		} catch (error) {
+			this.showErrorMessage(
+				`Failed to toggle always allow for tool "${toolName}" on server "${serverName}" with source "${source}"`,
+				error,
+			)
+			throw error
+		}
+	}
+
+	async toggleToolEnabledForPrompt(
+		serverName: string,
+		source: "global" | "project",
+		toolName: string,
+		isEnabled: boolean,
+	): Promise<void> {
+		try {
+			const connection = this.findConnection(serverName, source)
+			if (!connection) {
+				throw new Error(`Server ${serverName} with source ${source} not found`)
+			}
+
+			let configPath: string
+			if (source === "project") {
+				const projectMcpPath = await this.getProjectMcpPath()
+				if (!projectMcpPath) {
+					throw new Error("Project MCP configuration file not found")
+				}
+				configPath = projectMcpPath
+			} else {
+				configPath = await this.getMcpSettingsFilePath()
+			}
+
+			const normalizedPath = process.platform === "win32" ? configPath.replace(/\\/g, "/") : configPath
+			const content = await fs.readFile(normalizedPath, "utf-8")
+			const config = JSON.parse(content)
+
+			if (!config.mcpServers) {
+				config.mcpServers = {}
+			}
+			if (!config.mcpServers[serverName]) {
+				// Initialize with minimal valid config if server entry doesn't exist
+				config.mcpServers[serverName] = {
+					type: "stdio",
+					command: "echo",
+					args: ["MCP server not fully configured"],
+				}
+			}
+			if (!config.mcpServers[serverName].disabledForPromptTools) {
+				config.mcpServers[serverName].disabledForPromptTools = []
+			}
+
+			const disabledList = config.mcpServers[serverName].disabledForPromptTools
+			const toolIndex = disabledList.indexOf(toolName)
+
+			if (!isEnabled && toolIndex === -1) {
+				// If tool should be disabled (not included in prompt) and is not in disabled list
+				disabledList.push(toolName)
+			} else if (isEnabled && toolIndex !== -1) {
+				// If tool should be enabled (included in prompt) and is in disabled list
+				disabledList.splice(toolIndex, 1)
+			}
+
+			await fs.writeFile(normalizedPath, JSON.stringify(config, null, 2))
+
+			if (connection) {
 				connection.server.tools = await this.fetchToolsList(serverName, source)
 				await this.notifyWebviewOfServerChanges()
 			}

--- a/src/services/mcp/__tests__/McpHub.test.ts
+++ b/src/services/mcp/__tests__/McpHub.test.ts
@@ -100,6 +100,7 @@ describe("McpHub", () => {
 						command: "node",
 						args: ["test.js"],
 						alwaysAllow: ["allowed-tool"],
+						disabledForPromptTools: ["disabled-tool"],
 					},
 				},
 			}),
@@ -210,6 +211,107 @@ describe("McpHub", () => {
 			const writtenConfig = JSON.parse(callToUse[1])
 			expect(writtenConfig.mcpServers["test-server"].alwaysAllow).toBeDefined()
 			expect(writtenConfig.mcpServers["test-server"].alwaysAllow).toContain("new-tool")
+		})
+	})
+
+	describe("toggleToolEnabledForPrompt", () => {
+		it("should add tool to disabledForPromptTools list when enabling", async () => {
+			const mockConfig = {
+				mcpServers: {
+					"test-server": {
+						type: "stdio",
+						command: "node",
+						args: ["test.js"],
+						disabledForPromptTools: [],
+					},
+				},
+			}
+
+			// Mock reading initial config
+			;(fs.readFile as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockConfig))
+
+			await mcpHub.toggleToolEnabledForPrompt("test-server", "global", "new-tool", false)
+
+			// Verify the config was updated correctly
+			const writeCalls = (fs.writeFile as jest.Mock).mock.calls
+			expect(writeCalls.length).toBeGreaterThan(0)
+
+			// Find the write call
+			const callToUse = writeCalls[writeCalls.length - 1]
+			expect(callToUse).toBeTruthy()
+
+			// The path might be normalized differently on different platforms,
+			// so we'll just check that we have a call with valid content
+			const writtenConfig = JSON.parse(callToUse[1])
+			expect(writtenConfig.mcpServers).toBeDefined()
+			expect(writtenConfig.mcpServers["test-server"]).toBeDefined()
+			expect(Array.isArray(writtenConfig.mcpServers["test-server"].enabledForPrompt)).toBe(false)
+			expect(writtenConfig.mcpServers["test-server"].disabledForPromptTools).toContain("new-tool")
+		})
+
+		it("should remove tool from disabledForPromptTools list when disabling", async () => {
+			const mockConfig = {
+				mcpServers: {
+					"test-server": {
+						type: "stdio",
+						command: "node",
+						args: ["test.js"],
+						disabledForPromptTools: ["existing-tool"],
+					},
+				},
+			}
+
+			// Mock reading initial config
+			;(fs.readFile as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockConfig))
+
+			await mcpHub.toggleToolEnabledForPrompt("test-server", "global", "existing-tool", true)
+
+			// Verify the config was updated correctly
+			const writeCalls = (fs.writeFile as jest.Mock).mock.calls
+			expect(writeCalls.length).toBeGreaterThan(0)
+
+			// Find the write call
+			const callToUse = writeCalls[writeCalls.length - 1]
+			expect(callToUse).toBeTruthy()
+
+			// The path might be normalized differently on different platforms,
+			// so we'll just check that we have a call with valid content
+			const writtenConfig = JSON.parse(callToUse[1])
+			expect(writtenConfig.mcpServers).toBeDefined()
+			expect(writtenConfig.mcpServers["test-server"]).toBeDefined()
+			expect(Array.isArray(writtenConfig.mcpServers["test-server"].enabledForPrompt)).toBe(false)
+			expect(writtenConfig.mcpServers["test-server"].disabledForPromptTools).not.toContain("existing-tool")
+		})
+
+		it("should initialize disabledForPromptTools if it does not exist", async () => {
+			const mockConfig = {
+				mcpServers: {
+					"test-server": {
+						type: "stdio",
+						command: "node",
+						args: ["test.js"],
+					},
+				},
+			}
+
+			// Mock reading initial config
+			;(fs.readFile as jest.Mock).mockResolvedValueOnce(JSON.stringify(mockConfig))
+
+			// Call with false because of "true" is default value
+			await mcpHub.toggleToolEnabledForPrompt("test-server", "global", "new-tool", false)
+
+			// Verify the config was updated with initialized disabledForPromptTools
+			// Find the write call with the normalized path
+			const normalizedSettingsPath = "/mock/settings/path/cline_mcp_settings.json"
+			const writeCalls = (fs.writeFile as jest.Mock).mock.calls
+
+			// Find the write call with the normalized path
+			const writeCall = writeCalls.find((call) => call[0] === normalizedSettingsPath)
+			const callToUse = writeCall || writeCalls[0]
+
+			const writtenConfig = JSON.parse(callToUse[1])
+			expect(writtenConfig.mcpServers["test-server"].disabledForPromptTools).toBeDefined()
+			expect(writtenConfig.mcpServers["test-server"].disabledForPromptTools).toContain("new-tool")
 		})
 	})
 

--- a/src/shared/WebviewMessage.ts
+++ b/src/shared/WebviewMessage.ts
@@ -74,6 +74,7 @@ export interface WebviewMessage {
 		| "openProjectMcpSettings"
 		| "restartMcpServer"
 		| "toggleToolAlwaysAllow"
+		| "toggleToolEnabledForPrompt"
 		| "toggleMcpServer"
 		| "updateMcpTimeout"
 		| "fuzzyMatchThreshold"
@@ -142,6 +143,7 @@ export interface WebviewMessage {
 	serverName?: string
 	toolName?: string
 	alwaysAllow?: boolean
+	isEnabled?: boolean
 	mode?: Mode
 	promptMode?: PromptMode
 	customPrompt?: PromptComponent

--- a/src/shared/mcp.ts
+++ b/src/shared/mcp.ts
@@ -24,6 +24,7 @@ export type McpTool = {
 	description?: string
 	inputSchema?: object
 	alwaysAllow?: boolean
+	enabledForPrompt?: boolean
 }
 
 export type McpResource = {

--- a/webview-ui/src/components/mcp/McpToolRow.tsx
+++ b/webview-ui/src/components/mcp/McpToolRow.tsx
@@ -23,6 +23,17 @@ const McpToolRow = ({ tool, serverName, serverSource, alwaysAllowMcp }: McpToolR
 		})
 	}
 
+	const handleEnabledForPromptChange = () => {
+		if (!serverName) return
+		vscode.postMessage({
+			type: "toggleToolEnabledForPrompt",
+			serverName,
+			source: serverSource || "global",
+			toolName: tool.name,
+			isEnabled: !tool.enabledForPrompt,
+		})
+	}
+
 	return (
 		<div
 			key={tool.name}
@@ -37,11 +48,35 @@ const McpToolRow = ({ tool, serverName, serverSource, alwaysAllowMcp }: McpToolR
 					<span className="codicon codicon-symbol-method" style={{ marginRight: "6px" }}></span>
 					<span style={{ fontWeight: 500 }}>{tool.name}</span>
 				</div>
-				{serverName && alwaysAllowMcp && (
-					<VSCodeCheckbox checked={tool.alwaysAllow} onChange={handleAlwaysAllowChange} data-tool={tool.name}>
-						{t("mcp:tool.alwaysAllow")}
-					</VSCodeCheckbox>
-				)}
+				<div className="flex items-center space-x-4">
+					{" "}
+					{/* Wrapper for checkboxes */}
+					{serverName && (
+						<div
+							role="switch"
+							aria-checked={tool.enabledForPrompt}
+							className={`flex items-center cursor-pointer rounded-full w-8 h-4 transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 ${
+								tool.enabledForPrompt ? "bg-blue-600" : "bg-gray-200 dark:bg-gray-700"
+							}`}
+							onClick={handleEnabledForPromptChange}
+							data-tool-prompt-toggle={tool.name}
+							title={t("mcp:tool.togglePromptInclusion")}>
+							<span
+								className={`pointer-events-none inline-block h-3 w-3 transform rounded-full bg-white shadow-lg ring-0 transition-transform duration-200 ease-in-out ${
+									tool.enabledForPrompt ? "translate-x-4" : "translate-x-1"
+								}`}
+							/>
+						</div>
+					)}
+					{serverName && alwaysAllowMcp && (
+						<VSCodeCheckbox
+							checked={tool.alwaysAllow}
+							onChange={handleAlwaysAllowChange}
+							data-tool={tool.name}>
+							{t("mcp:tool.alwaysAllow")}
+						</VSCodeCheckbox>
+					)}
+				</div>
 			</div>
 			{tool.description && (
 				<div

--- a/webview-ui/src/i18n/locales/en/mcp.json
+++ b/webview-ui/src/i18n/locales/en/mcp.json
@@ -15,7 +15,8 @@
 	"tool": {
 		"alwaysAllow": "Always allow",
 		"parameters": "Parameters",
-		"noDescription": "No description"
+		"noDescription": "No description",
+		"togglePromptInclusion": "Toggle inclusion in prompt"
 	},
 	"tabs": {
 		"tools": "Tools",


### PR DESCRIPTION
### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #3346

### Description

This PR introduces a new feature allowing users to toggle whether an individual MCP (Model Context Protocol) tool is included in the context provided to the AI model. This gives users finer-grained control over which tools the AI can see and potentially use.

The changes include:
-   **Core Logic (`McpHub.ts`):**
    -   Added a `disabledForPromptTools` array to the MCP server configuration in `mcp.json` (both project and global).
    -   Implemented `toggleToolEnabledForPrompt` method to add/remove tool names from this `disabledForPromptTools` list.
    -   Modified `fetchToolsList` to populate an `enabledForPrompt` boolean on each tool object based on whether it's in the `disabledForPromptTools` list.
-   **Prompt Generation (`mcp-servers.ts`):**
    -   Updated the prompt section generation to filter tools based on the new `tool.enabledForPrompt` flag.
    -  Add  related instruction in create-mcp-server prompt (set to [])
-   **Webview Communication (`webviewMessageHandler.ts`, `WebviewMessage.ts`):**
    -   Added a new `toggleToolEnabledForPrompt` message type and handler to facilitate communication between the webview UI and the extension backend.
-   **Shared Types (`mcp.ts`):**
    -   Added `enabledForPrompt?: boolean` to the `McpTool` type.
-   **UI (`McpToolRow.tsx`, `mcp.json` i18n):**
    -   Added a new toggle switch UI component in the MCP server settings for each tool.
    -   This switch allows users to enable/disable a tool's inclusion in the prompt.
    -   Added new i18n string for the toggle's title.


### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

**Unit Tests:**
-   **`McpHub.test.ts`:**
    -  add tool to disabledForPromptTools list when enabling
    -  remove tool from disabledForPromptTools list when disabling
    - initialize disabledForPromptTools if it does not exist
- **Manual testing**
   - tool not included in prompt, when disabled
   - tool included in prompt when enabled
   - default is enabled

**Manual Testing Steps:**
1.  Navigate to the Roo MCP settings page in VS Code.
2.  For a connected MCP server with multiple tools:
    a.  Locate the new toggle switch next to each tool (it might look like a slider).
    b.  **Verify Initial State:** Observe the initial state of the toggles.
    c.  **Toggle Off:** Click the toggle for a specific tool to disable its inclusion in the prompt.
        i.  Check the corresponding `mcp.json` file (either project's `.roo/mcp.json` or global MCP settings) to ensure the tool's name is added to the `disabledForPromptTools` array for that server.
        ii.Verify that when a prompt is generated that would normally include MCP tools, this specific tool is now omitted from the context.
    d.  **Toggle On:** Click the toggle again for the same tool to re-enable its inclusion in the prompt.
        i.  Check the `mcp.json` file again to ensure the tool's name is removed from the `disabledForPromptTools` array.
        ii.  Verify the tool is now included in the prompt context.
3.  Test with both project-level (`.roo/mcp.json`) and global MCP configurations if applicable.
4.  Ensure the "Always Allow" checkbox functionality remains independent and unaffected.

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

**Before:**
[Link to Before Screenshot/Video - e.g., showing the MCP tool row without the new toggle]
![image](https://github.com/user-attachments/assets/afe223c2-d611-492e-86b9-77a95a655301)

**After:**
[Link to After Screenshot/Video - e.g., showing the MCP tool row WITH the new toggle, and demonstrating its on/off states]
![image](https://github.com/user-attachments/assets/39217274-ad86-495a-8141-7a5b67fcfcd5)

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

- [x] No documentation updates are required. (The UI change is self-explanatory within the settings page).

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

This feature enhances user control over the AI's context, potentially improving relevance and reducing token usage by excluding unnecessary tools from prompts.
