### PR TITLE
build: enable source maps for improved debugging

### DIFF
--- a/webview-ui/package.json
+++ b/webview-ui/package.json
@@ -59,6 +59,7 @@
 		"remove-markdown": "^0.6.0",
 		"shell-quote": "^1.8.2",
 		"shiki": "^3.2.1",
+		"source-map": "^0.7.4",
 		"styled-components": "^6.1.13",
 		"tailwind-merge": "^2.6.0",
 		"tailwindcss": "^4.0.0",

--- a/webview-ui/tsconfig.json
+++ b/webview-ui/tsconfig.json
@@ -10,6 +10,8 @@
 		"forceConsistentCasingInFileNames": true,
 		"noFallthroughCasesInSwitch": true,
 		"module": "esnext",
+		"sourceMap": true,
+		"inlineSources": false,
 		"moduleResolution": "bundler",
 		"resolveJsonModule": true,
 		"isolatedModules": true,

--- a/webview-ui/vite.config.ts
+++ b/webview-ui/vite.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
 	build: {
 		outDir: "build",
 		reportCompressedSize: false,
+		sourcemap: true,
 		rollupOptions: {
 			output: {
 				entryFileNames: `assets/[name].js`,


### PR DESCRIPTION
## Context

This PR enables source maps in the webview UI to help with debugging stack traces. When errors occur in the bundled JavaScript, source maps allow us to map the error location back to the original TypeScript source files.

Note: While these changes could increase the size of the deployment package, they provide incredibly useful debugging information for users that find bugs, especially those that crash the application. The ability to trace errors back to the original source code is invaluable for troubleshooting complex issues.

This was particularly useful in determining the cause of the following backtrace, which was extremely difficult to debug without source maps:

```js
index.js:41 Error: Bad substitution: {
    at H (index.js:1642:33775)
    at index.js:1642:34347
    at Array.map (<anonymous>)
    at b (index.js:1642:33515)
    at Object.$R [as parse] (index.js:1642:34484)
    at kbt (index.js:1642:35235)
    at _bt (index.js:1642:35957)
    at index.js:2361:28912
    at index.js:2361:29257
    at index.js:2361:22928
```

With source maps enabled, this backtrace would be transformed to something like:

```js
Error: Bad substitution: {
    at parseEnvVar (node_modules/shell-quote/parse.js:128:11)
    at parseCommand (src/utils/command-validation.ts:42:15)
    at Array.map (<anonymous>)
    at tokenizeCommand (node_modules/shell-quote/parse.js:85:22)
    at Object.parse (node_modules/shell-quote/parse.js:156:18)
    at validateCommand (src/utils/command-validation.ts:112:34)
    at isAllowedCommand (src/components/chat/ChatView.tsx:736:7)
    at isAutoApproved (src/components/chat/ChatView.tsx:766:42)
    at handleMessageApproval (src/components/chat/ChatView.tsx:924:15)
    at processMessage (src/components/chat/ChatView.tsx:1088:22)
```

## Implementation

The changes include:
- Adding sourceMap: true to tsconfig.json
- Setting inlineSources: false in tsconfig.json
- Enabling sourcemap: true in vite.config.ts
- Adding source-map package as a dependency

## How to Test

1. Build the webview UI with source maps enabled
2. When an error occurs in the bundled code, the stack trace will now show the original source file location
3. You can also use the source-map library to manually map locations using the included helper script

The webview-ui/map-location.js script provides a simple way to manually map bundle locations to source locations:

```ts
import { readFileSync } from 'fs';
import { SourceMapConsumer } from 'source-map';

async function mapLocation(gLine, gCol) {
  const rawMap = readFileSync('./build/assets/index.js.map', 'utf8');
  const consumer = await new SourceMapConsumer(rawMap);
  const orig = consumer.originalPositionFor({
    line: gLine,
    column: gCol
  });
  console.log(
    `bundle.js:${gLine}:${gCol} → ${orig.source}:${orig.line}:${orig.column} (${orig.name || 'unnamed'})`
  );
  consumer.destroy();
}

// Example: Map the location from the error stack trace
mapLocation(1642, 33775);
```

## Get in Touch

Discord: KJ7LNW
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable source maps in `vite.config.ts` and add `source-map` dependency for improved debugging.
> 
>   - **Configuration**:
>     - Enable `sourcemap: true` in `vite.config.ts` for build process.
>     - Add `sourceMap: true` and `inlineSources: false` to `tsconfig.json`.
>   - **Dependencies**:
>     - Add `source-map` package to `package.json` dependencies.
>   - **Misc**:
>     - Provide a script `map-location.js` for manual source mapping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 833a65b466f2043c39bce803a804a50c16ee18a4. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->