### PR TITLE
Fix incorrect reserved tokens calculation on OpenRouter

### DIFF
--- a/webview-ui/src/utils/model-utils.ts
+++ b/webview-ui/src/utils/model-utils.ts
@@ -100,7 +100,8 @@ export const calculateTokenDistribution = (
 
 	// Get the actual max tokens value from the model
 	// If maxTokens is valid, use it, otherwise reserve 20% of the context window as a default
-	const reservedForOutput = maxTokens && maxTokens > 0 ? maxTokens : Math.ceil(safeContextWindow * 0.2)
+	const reservedForOutput =
+		maxTokens && maxTokens > 0 && maxTokens !== safeContextWindow ? maxTokens : Math.ceil(safeContextWindow * 0.2)
 
 	// Calculate sizes directly without buffer display
 	const availableSize = Math.max(0, safeContextWindow - safeContextTokens - reservedForOutput)


### PR DESCRIPTION
### Related GitHub Issue

Closes: #3625

### Description

This PR addresses an issue in the [`calculateTokenDistribution`](webview-ui/src/utils/model-utils.ts:92) function where the `reservedForOutput` value was incorrectly set to the full `contextWindow` size when the provided `maxTokens` was equal to the `safeContextWindow`. This resulted in zero available tokens for the input context.

The fix modifies the logic on line 103 of [`webview-ui/src/utils/model-utils.ts`](webview-ui/src/utils/model-utils.ts) to add a condition. Now, the function checks if `maxTokens` is provided, positive, AND *not* equal to `safeContextWindow`. If all these conditions are met, it uses the provided `maxTokens`; otherwise, it defaults to reserving 20% of the context window.

### Test Procedure

To verify the fix, follow these steps:

1. Select a model from OpenRouter (e.g., Deepseek v3 0324) where the `maxToken` value is equal to the model's context window size.
2. Select a provider that serves the model with the same amount of output tokens as the context window (e.g., GMICloud provider).
3. Observe the token distribution visualization in the UI.
4. **Expected Result:** The reserved tokens should now be approximately 20% of the total context window, leaving available tokens for the input context, rather than reserving the entire context window.

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

This fix ensures that the token distribution calculation behaves correctly even when a model's reported `maxTokens` is equal to its total context window size, preventing the UI from showing zero available tokens in such scenarios.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `calculateTokenDistribution` in `model-utils.ts` to correctly reserve tokens, using `maxTokens` only if positive and not equal to `safeContextWindow`.
> 
>   - **Behavior**:
>     - Fixes `calculateTokenDistribution` in `model-utils.ts` to correctly set `reservedForOutput`.
>     - Adds condition to use `maxTokens` only if positive and not equal to `safeContextWindow`.
>     - Defaults to reserving 20% of `contextWindow` if conditions not met.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for eefe163a91bc1467a2e8f33a43f914b410d0f6f7. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->