### PR TITLE
Fix how custom instructions are loaded into the API request

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -100,7 +100,6 @@ export type ClineEvents = {
 export type TaskOptions = {
 	provider: ClineProvider
 	apiConfiguration: ProviderSettings
-	customInstructions?: string
 	enableDiff?: boolean
 	enableCheckpoints?: boolean
 	fuzzyMatchThreshold?: number
@@ -134,7 +133,6 @@ export class Task extends EventEmitter<ClineEvents> {
 	isPaused: boolean = false
 	pausedModeSlug: string = defaultModeSlug
 	private pauseInterval: NodeJS.Timeout | undefined
-	customInstructions?: string
 
 	// API
 	readonly apiConfiguration: ProviderSettings
@@ -194,7 +192,6 @@ export class Task extends EventEmitter<ClineEvents> {
 	constructor({
 		provider,
 		apiConfiguration,
-		customInstructions,
 		enableDiff = false,
 		enableCheckpoints = true,
 		fuzzyMatchThreshold = 1.0,
@@ -234,7 +231,6 @@ export class Task extends EventEmitter<ClineEvents> {
 
 		this.urlContentFetcher = new UrlContentFetcher(provider.context)
 		this.browserSession = new BrowserSession(provider.context)
-		this.customInstructions = customInstructions
 		this.diffEnabled = enableDiff
 		this.fuzzyMatchThreshold = fuzzyMatchThreshold
 		this.consecutiveMistakeLimit = consecutiveMistakeLimit
@@ -1417,6 +1413,7 @@ export class Task extends EventEmitter<ClineEvents> {
 			browserViewportSize,
 			mode,
 			customModePrompts,
+			customInstructions,
 			experiments,
 			enableMcpServerCreation,
 			browserToolEnabled,
@@ -1442,7 +1439,7 @@ export class Task extends EventEmitter<ClineEvents> {
 				mode,
 				customModePrompts,
 				customModes,
-				this.customInstructions,
+				customInstructions,
 				this.diffEnabled,
 				experiments,
 				enableMcpServerCreation,

--- a/src/core/task/__tests__/Task.test.ts
+++ b/src/core/task/__tests__/Task.test.ts
@@ -275,13 +275,11 @@ describe("Cline", () => {
 			const cline = new Task({
 				provider: mockProvider,
 				apiConfiguration: mockApiConfig,
-				customInstructions: "custom instructions",
 				fuzzyMatchThreshold: 0.95,
 				task: "test task",
 				startTask: false,
 			})
 
-			expect(cline.customInstructions).toBe("custom instructions")
 			expect(cline.diffEnabled).toBe(false)
 		})
 
@@ -289,7 +287,6 @@ describe("Cline", () => {
 			const cline = new Task({
 				provider: mockProvider,
 				apiConfiguration: mockApiConfig,
-				customInstructions: "custom instructions",
 				enableDiff: true,
 				fuzzyMatchThreshold: 0.95,
 				task: "test task",

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -18,7 +18,7 @@ import { supportPrompt } from "../../shared/support-prompt"
 import { GlobalFileNames } from "../../shared/globalFileNames"
 import { HistoryItem } from "../../shared/HistoryItem"
 import { ExtensionMessage } from "../../shared/ExtensionMessage"
-import { Mode, PromptComponent, defaultModeSlug } from "../../shared/modes"
+import { Mode, defaultModeSlug } from "../../shared/modes"
 import { experimentDefault } from "../../shared/experiments"
 import { formatLanguage } from "../../shared/language"
 import { Terminal } from "../../integrations/terminal/Terminal"
@@ -449,33 +449,21 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 		options: Partial<
 			Pick<
 				TaskOptions,
-				| "customInstructions"
-				| "enableDiff"
-				| "enableCheckpoints"
-				| "fuzzyMatchThreshold"
-				| "consecutiveMistakeLimit"
-				| "experiments"
+				"enableDiff" | "enableCheckpoints" | "fuzzyMatchThreshold" | "consecutiveMistakeLimit" | "experiments"
 			>
 		> = {},
 	) {
 		const {
 			apiConfiguration,
-			customModePrompts,
 			diffEnabled: enableDiff,
 			enableCheckpoints,
 			fuzzyMatchThreshold,
-			mode,
-			customInstructions: globalInstructions,
 			experiments,
 		} = await this.getState()
-
-		const modePrompt = customModePrompts?.[mode] as PromptComponent
-		const effectiveInstructions = [globalInstructions, modePrompt?.customInstructions].filter(Boolean).join("\n\n")
 
 		const cline = new Task({
 			provider: this,
 			apiConfiguration,
-			customInstructions: effectiveInstructions,
 			enableDiff,
 			enableCheckpoints,
 			fuzzyMatchThreshold,
@@ -503,22 +491,15 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 
 		const {
 			apiConfiguration,
-			customModePrompts,
 			diffEnabled: enableDiff,
 			enableCheckpoints,
 			fuzzyMatchThreshold,
-			mode,
-			customInstructions: globalInstructions,
 			experiments,
 		} = await this.getState()
-
-		const modePrompt = customModePrompts?.[mode] as PromptComponent
-		const effectiveInstructions = [globalInstructions, modePrompt?.customInstructions].filter(Boolean).join("\n\n")
 
 		const cline = new Task({
 			provider: this,
 			apiConfiguration,
-			customInstructions: effectiveInstructions,
 			enableDiff,
 			enableCheckpoints,
 			fuzzyMatchThreshold,
@@ -962,11 +943,6 @@ export class ClineProvider extends EventEmitter<ClineProviderEvents> implements 
 	async updateCustomInstructions(instructions?: string) {
 		// User may be clearing the field.
 		await this.updateGlobalState("customInstructions", instructions || undefined)
-
-		if (this.getCurrentCline()) {
-			this.getCurrentCline()!.customInstructions = instructions || undefined
-		}
-
 		await this.postStateToWebview()
 	}
 

--- a/src/core/webview/__tests__/ClineProvider.test.ts
+++ b/src/core/webview/__tests__/ClineProvider.test.ts
@@ -806,45 +806,6 @@ describe("ClineProvider", () => {
 		expect(mockPostMessage).toHaveBeenCalled()
 	})
 
-	test("uses mode-specific custom instructions in Cline initialization", async () => {
-		// Setup mock state
-		const modeCustomInstructions = "Code mode instructions"
-		const mockApiConfig = {
-			apiProvider: "openrouter",
-		}
-
-		jest.spyOn(provider, "getState").mockResolvedValue({
-			apiConfiguration: mockApiConfig,
-			customModePrompts: {
-				code: { customInstructions: modeCustomInstructions },
-			},
-			mode: "code",
-			diffEnabled: true,
-			enableCheckpoints: false,
-			fuzzyMatchThreshold: 1.0,
-			experiments: experimentDefault,
-		} as any)
-
-		// Initialize Cline with a task
-		await provider.initClineWithTask("Test task")
-
-		// Verify Cline was initialized with mode-specific instructions
-		expect(Task).toHaveBeenCalledWith({
-			provider,
-			apiConfiguration: mockApiConfig,
-			customInstructions: modeCustomInstructions,
-			enableDiff: true,
-			enableCheckpoints: false,
-			fuzzyMatchThreshold: 1.0,
-			task: "Test task",
-			experiments: experimentDefault,
-			rootTask: undefined,
-			parentTask: undefined,
-			taskNumber: 1,
-			onCreated: expect.any(Function),
-		})
-	})
-
 	test("handles mode-specific custom instructions updates", async () => {
 		await provider.resolveWebviewView(mockWebviewView)
 		const messageHandler = (mockWebviewView.webview.onDidReceiveMessage as jest.Mock).mock.calls[0][0]


### PR DESCRIPTION
Another take on fixing #3152 based on my comment at https://github.com/RooVetGit/Roo-Code/pull/3553#discussion_r2091824264. I don't think there's any reason for them to be an instance variable on the Task - we should just load them from getState.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor custom instructions handling in `Task.ts` and `ClineProvider.ts` to streamline API request initialization and execution.
> 
>   - **Behavior**:
>     - Removed `customInstructions` from `TaskOptions` and `Task` class in `Task.ts`.
>     - Updated `Task` constructor and methods to handle `customInstructions` directly from `ClineProvider` state.
>     - Adjusted `ClineProvider.ts` to pass `customInstructions` directly when initializing tasks.
>   - **Tests**:
>     - Removed tests related to `customInstructions` in `Task.test.ts`.
>     - Updated `ClineProvider.test.ts` to reflect changes in how `customInstructions` are handled.
>   - **Misc**:
>     - Removed unused imports related to `customInstructions` in `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 68ad7c9dfd0d9a4929141f03ec85271dd2abcabd. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->