### PR TITLE
Revert "Switch to the new Roo message parser"

### DIFF
--- a/.changeset/eighty-rules-slide.md
+++ b/.changeset/eighty-rules-slide.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Revert "Switch to the new Roo message parser"

--- a/src/core/assistant-message/index.ts
+++ b/src/core/assistant-message/index.ts
@@ -1,3 +1,2 @@
 export { type AssistantMessageContent, parseAssistantMessage } from "./parseAssistantMessage"
 export { presentAssistantMessage } from "./presentAssistantMessage"
-export { parseAssistantMessageV2 } from "./parseAssistantMessageV2"

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -60,11 +60,7 @@ import { SYSTEM_PROMPT } from "../prompts/system"
 import { ToolRepetitionDetector } from "../tools/ToolRepetitionDetector"
 import { FileContextTracker } from "../context-tracking/FileContextTracker"
 import { RooIgnoreController } from "../ignore/RooIgnoreController"
-import {
-	type AssistantMessageContent,
-	parseAssistantMessageV2 as parseAssistantMessage,
-	presentAssistantMessage,
-} from "../assistant-message"
+import { type AssistantMessageContent, parseAssistantMessage, presentAssistantMessage } from "../assistant-message"
 import { truncateConversationIfNeeded } from "../sliding-window"
 import { ClineProvider } from "../webview/ClineProvider"
 import { MultiSearchReplaceDiffStrategy } from "../diff/strategies/multi-search-replace"


### PR DESCRIPTION
Reverts RooVetGit/Roo-Code#3567
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Reverts the switch to the new Roo message parser, restoring the previous parser in `index.ts` and `Task.ts`.
> 
>   - **Revert Changes**:
>     - Reverts the switch to `parseAssistantMessageV2` in `index.ts` and `Task.ts`, restoring `parseAssistantMessage`.
>   - **Imports**:
>     - Removes `parseAssistantMessageV2` import from `index.ts` and `Task.ts`.
>     - Updates import statement in `Task.ts` to use `parseAssistantMessage` instead of `parseAssistantMessageV2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0b28f0c5147d625f00e2581f09e3d51bf10511c7. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->