### PR TITLE
Fix copy on history items

### DIFF
--- a/webview-ui/src/components/history/CopyButton.tsx
+++ b/webview-ui/src/components/history/CopyButton.tsx
@@ -13,16 +13,13 @@ export const CopyButton = ({ itemTask }: CopyButtonProps) => {
 	const { isCopied, copy } = useClipboard()
 	const { t } = useAppTranslation()
 
-	const onCopy = useCallback(
-		(e: React.MouseEvent) => {
-			e.stopPropagation()
-			const tempDiv = document.createElement("div")
-			tempDiv.innerHTML = itemTask
-			const text = tempDiv.textContent || tempDiv.innerText || ""
-			!isCopied && copy(text)
-		},
-		[isCopied, copy, itemTask],
-	)
+       const onCopy = useCallback(
+               (e: React.MouseEvent) => {
+                       e.stopPropagation()
+                       !isCopied && copy(itemTask)
+               },
+               [isCopied, copy, itemTask],
+       )
 
 	return (
 		<Button


### PR DESCRIPTION
This was generated with codex

Closes #2648

## Summary
- ensure copy button keeps full XML structure when copying history items