### PR TITLE
Simplify history copy logic

### DIFF
--- a/webview-ui/src/components/history/CopyButton.tsx
+++ b/webview-ui/src/components/history/CopyButton.tsx
@@ -13,16 +13,13 @@ export const CopyButton = ({ itemTask }: CopyButtonProps) => {
 	const { isCopied, copy } = useClipboard()
 	const { t } = useAppTranslation()
 
-	const onCopy = useCallback(
-		(e: React.MouseEvent) => {
-			e.stopPropagation()
-			const tempDiv = document.createElement("div")
-			tempDiv.innerHTML = itemTask
-			const text = tempDiv.textContent || tempDiv.innerText || ""
-			!isCopied && copy(text)
-		},
-		[isCopied, copy, itemTask],
-	)
+       const onCopy = useCallback(
+               (e: React.MouseEvent) => {
+                       e.stopPropagation()
+                       if (!isCopied) copy(itemTask)
+               },
+               [isCopied, copy, itemTask],
+       )
 
 	return (
 		<Button

--- a/webview-ui/src/components/history/__tests__/HistoryView.test.tsx
+++ b/webview-ui/src/components/history/__tests__/HistoryView.test.tsx
@@ -103,13 +103,12 @@ describe("HistoryView", () => {
 		const updatedRadio = within(radioGroup).getByTestId("radio-most-relevant")
 		expect(updatedRadio).toBeInTheDocument()
 
-		// Verify copy the plain text content of the task when the copy button is clicked
-		const taskContainer = screen.getByTestId("virtuoso-item-1")
-		fireEvent.mouseEnter(taskContainer)
-		const copyButton = within(taskContainer).getByTestId("copy-prompt-button")
-		fireEvent.click(copyButton)
-		const taskContent = within(taskContainer).getByTestId("task-content")
-		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(taskContent.textContent)
+               // Verify clipboard receives the item's task when the copy button is clicked
+               const taskContainer = screen.getByTestId("virtuoso-item-1")
+               fireEvent.mouseEnter(taskContainer)
+               const copyButton = within(taskContainer).getByTestId("copy-prompt-button")
+               fireEvent.click(copyButton)
+               expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockTaskHistory[0].task)
 	})
 
 	it("handles sort options correctly", async () => {
@@ -241,8 +240,8 @@ describe("HistoryView", () => {
 			await Promise.resolve()
 		})
 
-		// Verify clipboard was called
-		expect(navigator.clipboard.writeText).toHaveBeenCalledWith("Test task 1")
+               // Verify clipboard was called with the item's task
+               expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockTaskHistory[0].task)
 
 		// Advance timer to trigger the setTimeout for modal disappearance
 		act(() => {


### PR DESCRIPTION
Closes https://github.com/RooVetGit/Roo-Code/issues/2648

## Summary
- streamline clipboard copy in `CopyButton`
- expect HTML string when copying tasks in history tests

## Testing
- `npm test` *(fails: jest not found)*