### PR TITLE
Fix copy button highlight stripping

### DIFF
--- a/webview-ui/src/components/history/CopyButton.tsx
+++ b/webview-ui/src/components/history/CopyButton.tsx
@@ -13,16 +13,14 @@ export const CopyButton = ({ itemTask }: CopyButtonProps) => {
 	const { isCopied, copy } = useClipboard()
 	const { t } = useAppTranslation()
 
-	const onCopy = useCallback(
-		(e: React.MouseEvent) => {
-			e.stopPropagation()
-			const tempDiv = document.createElement("div")
-			tempDiv.innerHTML = itemTask
-			const text = tempDiv.textContent || tempDiv.innerText || ""
-			!isCopied && copy(text)
-		},
-		[isCopied, copy, itemTask],
-	)
+        const onCopy = useCallback(
+                (e: React.MouseEvent) => {
+                        e.stopPropagation()
+                        const text = itemTask.replace(/<span class="history-item-highlight">|<\/span>/g, "")
+                        !isCopied && copy(text)
+                },
+                [isCopied, copy, itemTask],
+        )
 
 	return (
 		<Button

--- a/webview-ui/src/components/history/__tests__/HistoryView.test.tsx
+++ b/webview-ui/src/components/history/__tests__/HistoryView.test.tsx
@@ -107,10 +107,9 @@ describe("HistoryView", () => {
 		const taskContainer = screen.getByTestId("virtuoso-item-1")
 		fireEvent.mouseEnter(taskContainer)
 		const copyButton = within(taskContainer).getByTestId("copy-prompt-button")
-		fireEvent.click(copyButton)
-		const taskContent = within(taskContainer).getByTestId("task-content")
-		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(taskContent.textContent)
-	})
+                fireEvent.click(copyButton)
+                expect(navigator.clipboard.writeText).toHaveBeenCalledWith(mockTaskHistory[0].task)
+        })
 
 	it("handles sort options correctly", async () => {
 		const onDone = jest.fn()


### PR DESCRIPTION
Closes #3648 

## Summary
- copy task text without using DOM
- update HistoryView test to expect plain task text

## Testing
- `npm run test:webview` *(fails: jest not found)*