### PR TITLE
Implement hierarchical task history with parent-child relationships

### DIFF
--- a/src/core/task-persistence/taskMetadata.ts
+++ b/src/core/task-persistence/taskMetadata.ts
@@ -17,6 +17,7 @@ export type TaskMetadataOptions = {
 	taskNumber: number
 	globalStoragePath: string
 	workspace: string
+	parentTaskId?: string
 }
 
 export async function taskMetadata({
@@ -25,6 +26,7 @@ export async function taskMetadata({
 	taskNumber,
 	globalStoragePath,
 	workspace,
+	parentTaskId,
 }: TaskMetadataOptions) {
 	const taskDir = await getTaskDirectoryPath(globalStoragePath, taskId)
 	const taskMessage = messages[0] // First message is always the task say.
@@ -57,6 +59,7 @@ export async function taskMetadata({
 		totalCost: tokenUsage.totalCost,
 		size: taskDirSize,
 		workspace,
+		parent_task_id: parentTaskId,
 	}
 
 	return { historyItem, tokenUsage }

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -117,6 +117,7 @@ export class Task extends EventEmitter<ClineEvents> {
 
 	readonly rootTask: Task | undefined = undefined
 	readonly parentTask: Task | undefined = undefined
+	readonly parentTaskId?: string
 	readonly taskNumber: number
 	readonly workspacePath: string
 
@@ -237,6 +238,9 @@ export class Task extends EventEmitter<ClineEvents> {
 
 		this.rootTask = rootTask
 		this.parentTask = parentTask
+		if (parentTask) {
+			this.parentTaskId = parentTask.taskId
+		}
 		this.taskNumber = taskNumber
 
 		if (historyItem) {
@@ -344,6 +348,7 @@ export class Task extends EventEmitter<ClineEvents> {
 				taskNumber: this.taskNumber,
 				globalStoragePath: this.globalStoragePath,
 				workspace: this.cwd,
+				parentTaskId: this.parentTaskId,
 			})
 
 			this.emit("taskTokenUsageUpdated", this.taskId, tokenUsage)

--- a/src/exports/roo-code.d.ts
+++ b/src/exports/roo-code.d.ts
@@ -54,6 +54,7 @@ type GlobalSettings = {
 				totalCost: number
 				size?: number | undefined
 				workspace?: string | undefined
+				parent_task_id?: string | undefined
 		  }[]
 		| undefined
 	autoApprovalEnabled?: boolean | undefined
@@ -767,6 +768,7 @@ type IpcMessage =
 											totalCost: number
 											size?: number | undefined
 											workspace?: string | undefined
+											parent_task_id?: string | undefined
 									  }[]
 									| undefined
 								autoApprovalEnabled?: boolean | undefined
@@ -1230,6 +1232,7 @@ type TaskCommand =
 								totalCost: number
 								size?: number | undefined
 								workspace?: string | undefined
+								parent_task_id?: string | undefined
 						  }[]
 						| undefined
 					autoApprovalEnabled?: boolean | undefined

--- a/src/exports/types.ts
+++ b/src/exports/types.ts
@@ -54,6 +54,7 @@ type GlobalSettings = {
 				totalCost: number
 				size?: number | undefined
 				workspace?: string | undefined
+				parent_task_id?: string | undefined
 		  }[]
 		| undefined
 	autoApprovalEnabled?: boolean | undefined
@@ -781,6 +782,7 @@ type IpcMessage =
 											totalCost: number
 											size?: number | undefined
 											workspace?: string | undefined
+											parent_task_id?: string | undefined
 									  }[]
 									| undefined
 								autoApprovalEnabled?: boolean | undefined
@@ -1246,6 +1248,7 @@ type TaskCommand =
 								totalCost: number
 								size?: number | undefined
 								workspace?: string | undefined
+								parent_task_id?: string | undefined
 						  }[]
 						| undefined
 					autoApprovalEnabled?: boolean | undefined

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -150,6 +150,7 @@ export const historyItemSchema = z.object({
 	totalCost: z.number(),
 	size: z.number().optional(),
 	workspace: z.string().optional(),
+	parent_task_id: z.string().optional(),
 })
 
 export type HistoryItem = z.infer<typeof historyItemSchema>


### PR DESCRIPTION
## Context

This PR implements a hierarchical task history feature that tracks parent-child relationships between tasks, particularly for tasks created using the `new_task` tool.

## Implementation

- Added `parent_task_id` field to `HistoryItem` schema
- Modified `Task` class to store parent task ID
- Updated `taskMetadata` to include parent task ID in history items
- Enhanced History UI components to display hierarchical relationships with collapsible sections
- Added visual indicators for tasks with children
- Added green styling for completed tasks (those that used `attempt_completion`)

## Screenshots

| before | after |
| ------ | ----- |
| Flat task list without parent-child relationships | Hierarchical task list with collapsible sections and visual indicators |

## How to Test

1. Create a task
2. Use the `new_task` tool to create a subtask
3. Complete the subtask with `attempt_completion`
4. Open the History view
5. Verify that the subtask appears as a child of the parent task
6. Verify that the completed subtask has a green background

## Get in Touch

Discord: KJ7LNW