### PR TITLE
Add Qwen3 model series to the Chutes provider

### DIFF
--- a/.changeset/curly-plants-pull.md
+++ b/.changeset/curly-plants-pull.md
@@ -1,0 +1,11 @@
+---
+"roo-cline": patch
+---
+
+New models for the Chutes provider:
+
+- Qwen/Qwen3-235B-A22B
+- Qwen/Qwen3-32B
+- Qwen/Qwen3-30B-A3B
+- Qwen/Qwen3-14B
+- Qwen/Qwen3-8B

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1533,6 +1533,11 @@ export type ChutesModelId =
 	| "deepseek-ai/DeepSeek-V3-Base"
 	| "deepseek-ai/DeepSeek-R1-Zero"
 	| "deepseek-ai/DeepSeek-V3-0324"
+	| "Qwen/Qwen3-235B-A22B"
+	| "Qwen/Qwen3-32B"
+	| "Qwen/Qwen3-30B-A3B"
+	| "Qwen/Qwen3-14B"
+	| "Qwen/Qwen3-8B"
 	| "microsoft/MAI-DS-R1-FP8"
 	| "tngtech/DeepSeek-R1T-Chimera"
 export const chutesDefaultModelId: ChutesModelId = "deepseek-ai/DeepSeek-R1"
@@ -1662,6 +1667,51 @@ export const chutesModels = {
 		inputPrice: 0,
 		outputPrice: 0,
 		description: "DeepSeek V3 (0324) model.",
+	},
+	"Qwen/Qwen3-235B-A22B": {
+		maxTokens: 32768,
+		contextWindow: 40960,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "Qwen3 235B A22B model.",
+	},
+	"Qwen/Qwen3-32B": {
+		maxTokens: 32768,
+		contextWindow: 40960,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "Qwen3 32B model.",
+	},
+	"Qwen/Qwen3-30B-A3B": {
+		maxTokens: 32768,
+		contextWindow: 40960,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "Qwen3 30B A3B model.",
+	},
+	"Qwen/Qwen3-14B": {
+		maxTokens: 32768,
+		contextWindow: 40960,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "Qwen3 14B model.",
+	},
+	"Qwen/Qwen3-8B": {
+		maxTokens: 32768,
+		contextWindow: 40960,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0,
+		outputPrice: 0,
+		description: "Qwen3 8B model.",
 	},
 	"microsoft/MAI-DS-R1-FP8": {
 		maxTokens: 32768,


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: https://github.com/RooVetGit/Roo-Code/discussions/3450

### Description

New models for the Chutes provider:

- Qwen/Qwen3-235B-A22B
- Qwen/Qwen3-32B
- Qwen/Qwen3-30B-A3B
- Qwen/Qwen3-14B
- Qwen/Qwen3-8B

### Test Procedure

Added new models to chutes provider, context windows taken from Chutes API response

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [ ] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

![image](https://github.com/user-attachments/assets/b7bec067-edd9-4ad7-a535-26e1091b0811)
![image](https://github.com/user-attachments/assets/91e91afa-a299-4c3b-8fca-87a69fcaea9c)

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

These are all free models. See the Aider evaluation of these models [here](https://aider.chat/docs/leaderboards/)

![image](https://github.com/user-attachments/assets/5d503a45-4369-42da-a318-832536bb3da1)

Sadly only 40k context on Chutes, but oh well 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Qwen3 model series to Chutes provider in `api.ts` with specific configurations.
> 
>   - **Models Added**:
>     - Adds Qwen3 models to `ChutesModelId` in `api.ts`: `Qwen/Qwen3-235B-A22B`, `Qwen/Qwen3-32B`, `Qwen/Qwen3-30B-A3B`, `Qwen/Qwen3-14B`, `Qwen/Qwen3-8B`.
>   - **Model Configurations**:
>     - Each model has `maxTokens: 32768`, `contextWindow: 40960`, `supportsImages: false`, `supportsPromptCache: false`, `inputPrice: 0`, `outputPrice: 0`.
>     - Descriptions added for each model in `chutesModels` in `api.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bb12163ad7c308c25d32cc135d95427c19cffff1. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->