### PR TITLE
Make prompt input textareas resizable (#3691)

### DIFF
--- a/webview-ui/src/components/prompts/PromptsView.tsx
+++ b/webview-ui/src/components/prompts/PromptsView.tsx
@@ -715,6 +715,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							{t("prompts:roleDefinition.description")}
 						</div>
 						<VSCodeTextArea
+							resize="vertical"
 							value={(() => {
 								const customMode = findModeBySlug(visualMode, customModes)
 								const prompt = customModePrompts?.[visualMode] as PromptComponent
@@ -743,7 +744,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 									})
 								}
 							}}
-							className="resize-y w-full"
+							className="w-full"
 							rows={4}
 							data-testid={`${getCurrentMode()?.slug || "code"}-prompt-textarea`}
 						/>
@@ -773,6 +774,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							{t("prompts:whenToUse.description")}
 						</div>
 						<VSCodeTextArea
+							resize="vertical"
 							value={(() => {
 								const customMode = findModeBySlug(visualMode, customModes)
 								const prompt = customModePrompts?.[visualMode] as PromptComponent
@@ -797,7 +799,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 									})
 								}
 							}}
-							className="resize-y w-full"
+							className="w-full"
 							rows={3}
 							data-testid={`${getCurrentMode()?.slug || "code"}-when-to-use-textarea`}
 						/>
@@ -924,6 +926,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							})}
 						</div>
 						<VSCodeTextArea
+							resize="vertical"
 							value={(() => {
 								const customMode = findModeBySlug(visualMode, customModes)
 								const prompt = customModePrompts?.[visualMode] as PromptComponent
@@ -955,7 +958,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 								}
 							}}
 							rows={4}
-							className="w-full resize-y"
+							className="w-full"
 							data-testid={`${getCurrentMode()?.slug || "code"}-custom-instructions-textarea`}
 						/>
 						<div className="text-xs text-vscode-descriptionForeground mt-1.5">
@@ -1092,6 +1095,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						</Trans>
 					</div>
 					<VSCodeTextArea
+						resize="vertical"
 						value={customInstructions || ""}
 						onChange={(e) => {
 							const value =
@@ -1104,7 +1108,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 							})
 						}}
 						rows={4}
-						className="w-full resize-y"
+						className="w-full"
 						data-testid="global-custom-instructions-textarea"
 					/>
 					<div className="text-xs text-vscode-descriptionForeground mt-1.5">
@@ -1170,6 +1174,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 						</div>
 
 						<VSCodeTextArea
+							resize="vertical"
 							value={getSupportPromptValue(activeSupportOption)}
 							onChange={(e) => {
 								const value =
@@ -1179,7 +1184,7 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 								updateSupportPrompt(activeSupportOption, trimmedValue || undefined)
 							}}
 							rows={6}
-							className="resize-y w-full"
+							className="w-full"
 						/>
 
 						{activeSupportOption === "ENHANCE" && (
@@ -1230,11 +1235,12 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 
 								<div className="mt-4">
 									<VSCodeTextArea
+										resize="vertical"
 										value={testPrompt}
 										onChange={(e) => setTestPrompt((e.target as HTMLTextAreaElement).value)}
 										placeholder={t("prompts:supportPrompts.enhance.testPromptPlaceholder")}
 										rows={3}
-										className="w-full resize-y"
+										className="w-full"
 										data-testid="test-prompt-textarea"
 									/>
 									<div className="mt-2 flex justify-start items-center gap-2">
@@ -1335,12 +1341,13 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 									{t("prompts:createModeDialog.roleDefinition.description")}
 								</div>
 								<VSCodeTextArea
+									resize="vertical"
 									value={newModeRoleDefinition}
 									onChange={(e) => {
 										setNewModeRoleDefinition((e.target as HTMLTextAreaElement).value)
 									}}
 									rows={4}
-									className="w-full resize-y"
+									className="w-full"
 								/>
 								{roleDefinitionError && (
 									<div className="text-xs text-vscode-errorForeground mt-1">
@@ -1355,12 +1362,13 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 									{t("prompts:createModeDialog.whenToUse.description")}
 								</div>
 								<VSCodeTextArea
+									resize="vertical"
 									value={newModeWhenToUse}
 									onChange={(e) => {
 										setNewModeWhenToUse((e.target as HTMLTextAreaElement).value)
 									}}
 									rows={3}
-									className="w-full resize-y"
+									className="w-full"
 								/>
 							</div>
 							<div className="mb-4">
@@ -1401,12 +1409,13 @@ const PromptsView = ({ onDone }: PromptsViewProps) => {
 									{t("prompts:createModeDialog.customInstructions.description")}
 								</div>
 								<VSCodeTextArea
+									resize="vertical"
 									value={newModeCustomInstructions}
 									onChange={(e) => {
 										setNewModeCustomInstructions((e.target as HTMLTextAreaElement).value)
 									}}
 									rows={4}
-									className="w-full resize-y"
+									className="w-full"
 								/>
 							</div>
 						</div>


### PR DESCRIPTION
### Related GitHub Issue

Closes: #3691 

### Description

We lost the resize='vertical' attribute in some recent changes.

### Test Procedure

Look at the textareas, they are resizable now!

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

Before:
![Screenshot 2025-05-20 at 12 52 28 AM](https://github.com/user-attachments/assets/8768c2f5-acbb-432f-9c1e-71d0cfaa0c63)

After:
![Screenshot 2025-05-20 at 12 51 37 AM](https://github.com/user-attachments/assets/c78a62ab-d964-4c98-b2c9-91bff67c4524)

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores vertical resizing for textareas in `PromptsView.tsx` by adding `resize="vertical"` to `VSCodeTextArea` components.
> 
>   - **Bug Fix**:
>     - Adds `resize="vertical"` to `VSCodeTextArea` components in `PromptsView.tsx` to restore vertical resizing capability.
>     - Affects textareas for role definition, when to use, custom instructions, and support prompts.
>   - **Misc**:
>     - Removes `resize-y` class from textareas in `PromptsView.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2773cf9c7ca1aab511a17224fcecf03f904fda4b. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->