### PR TITLE
Move error message for settings import failure into the correct position

### DIFF
--- a/src/i18n/locales/ca/common.json
+++ b/src/i18n/locales/ca/common.json
@@ -55,7 +55,8 @@
 		"failed_delete_repo": "Ha fallat l'eliminació del repositori o branca associada: {{error}}",
 		"failed_remove_directory": "Ha fallat l'eliminació del directori de tasques: {{error}}",
 		"custom_storage_path_unusable": "La ruta d'emmagatzematge personalitzada \"{{path}}\" no és utilitzable, s'utilitzarà la ruta predeterminada",
-		"cannot_access_path": "No es pot accedir a la ruta {{path}}: {{error}}"
+		"cannot_access_path": "No es pot accedir a la ruta {{path}}: {{error}}",
+		"settings_import_failed": "Ha fallat la importació de la configuració: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "No s'ha seleccionat contingut de terminal",
@@ -71,8 +72,7 @@
 		"mcp_server_not_found": "Servidor \"{{serverName}}\" no trobat a la configuració",
 		"custom_storage_path_set": "Ruta d'emmagatzematge personalitzada establerta: {{path}}",
 		"default_storage_path": "S'ha reprès l'ús de la ruta d'emmagatzematge predeterminada",
-		"settings_imported": "Configuració importada correctament.",
-		"settings_import_failed": "Ha fallat la importació de la configuració: {{error}}."
+		"settings_imported": "Configuració importada correctament."
 	},
 	"answers": {
 		"yes": "Sí",

--- a/src/i18n/locales/de/common.json
+++ b/src/i18n/locales/de/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "Fehler beim Löschen des zugehörigen Shadow-Repositorys oder -Zweigs: {{error}}",
 		"failed_remove_directory": "Fehler beim Entfernen des Aufgabenverzeichnisses: {{error}}",
 		"custom_storage_path_unusable": "Benutzerdefinierter Speicherpfad \"{{path}}\" ist nicht verwendbar, Standardpfad wird verwendet",
-		"cannot_access_path": "Zugriff auf Pfad {{path}} nicht möglich: {{error}}"
+		"cannot_access_path": "Zugriff auf Pfad {{path}} nicht möglich: {{error}}",
+		"settings_import_failed": "Fehler beim Importieren der Einstellungen: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Kein Terminal-Inhalt ausgewählt",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Server \"{{serverName}}\" nicht in der Konfiguration gefunden",
 		"custom_storage_path_set": "Benutzerdefinierter Speicherpfad festgelegt: {{path}}",
 		"default_storage_path": "Auf Standardspeicherpfad zurückgesetzt",
-		"settings_imported": "Einstellungen erfolgreich importiert.",
-		"settings_import_failed": "Fehler beim Importieren der Einstellungen: {{error}}."
+		"settings_imported": "Einstellungen erfolgreich importiert."
 	},
 	"answers": {
 		"yes": "Ja",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -51,7 +51,8 @@
 		"failed_remove_directory": "Failed to remove task directory: {{error}}",
 		"custom_storage_path_unusable": "Custom storage path \"{{path}}\" is unusable, will use default path",
 		"cannot_access_path": "Cannot access path {{path}}: {{error}}",
-		"failed_update_project_mcp": "Failed to update project MCP servers"
+		"failed_update_project_mcp": "Failed to update project MCP servers",
+		"settings_import_failed": "Settings import failed: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "No terminal content selected",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Server \"{{serverName}}\" not found in configuration",
 		"custom_storage_path_set": "Custom storage path set: {{path}}",
 		"default_storage_path": "Reverted to using default storage path",
-		"settings_imported": "Settings imported successfully.",
-		"settings_import_failed": "Settings import failed: {{error}}."
+		"settings_imported": "Settings imported successfully."
 	},
 	"answers": {
 		"yes": "Yes",

--- a/src/i18n/locales/es/common.json
+++ b/src/i18n/locales/es/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "Error al eliminar el repositorio o rama asociada: {{error}}",
 		"failed_remove_directory": "Error al eliminar el directorio de tareas: {{error}}",
 		"custom_storage_path_unusable": "La ruta de almacenamiento personalizada \"{{path}}\" no es utilizable, se usará la ruta predeterminada",
-		"cannot_access_path": "No se puede acceder a la ruta {{path}}: {{error}}"
+		"cannot_access_path": "No se puede acceder a la ruta {{path}}: {{error}}",
+		"settings_import_failed": "Error al importar la configuración: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "No hay contenido de terminal seleccionado",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Servidor \"{{serverName}}\" no encontrado en la configuración",
 		"custom_storage_path_set": "Ruta de almacenamiento personalizada establecida: {{path}}",
 		"default_storage_path": "Se ha vuelto a usar la ruta de almacenamiento predeterminada",
-		"settings_imported": "Configuración importada correctamente.",
-		"settings_import_failed": "Error al importar la configuración: {{error}}."
+		"settings_imported": "Configuración importada correctamente."
 	},
 	"answers": {
 		"yes": "Sí",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "Échec de la suppression du repo fantôme ou de la branche associée : {{error}}",
 		"failed_remove_directory": "Échec de la suppression du répertoire de tâches : {{error}}",
 		"custom_storage_path_unusable": "Le chemin de stockage personnalisé \"{{path}}\" est inutilisable, le chemin par défaut sera utilisé",
-		"cannot_access_path": "Impossible d'accéder au chemin {{path}} : {{error}}"
+		"cannot_access_path": "Impossible d'accéder au chemin {{path}} : {{error}}",
+		"settings_import_failed": "Échec de l'importation des paramètres : {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Aucun contenu de terminal sélectionné",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Serveur \"{{serverName}}\" introuvable dans la configuration",
 		"custom_storage_path_set": "Chemin de stockage personnalisé défini : {{path}}",
 		"default_storage_path": "Retour au chemin de stockage par défaut",
-		"settings_imported": "Paramètres importés avec succès.",
-		"settings_import_failed": "Échec de l'importation des paramètres : {{error}}."
+		"settings_imported": "Paramètres importés avec succès."
 	},
 	"answers": {
 		"yes": "Oui",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -52,7 +52,7 @@
 		"failed_remove_directory": "Échec de la suppression du répertoire de tâches : {{error}}",
 		"custom_storage_path_unusable": "Le chemin de stockage personnalisé \"{{path}}\" est inutilisable, le chemin par défaut sera utilisé",
 		"cannot_access_path": "Impossible d'accéder au chemin {{path}} : {{error}}",
-		"settings_import_failed": "Échec de l'importation des paramètres : {{error}}."
+		"settings_import_failed": "Échec de l'importation des paramètres : {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Aucun contenu de terminal sélectionné",

--- a/src/i18n/locales/hi/common.json
+++ b/src/i18n/locales/hi/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "संबंधित शैडो रिपॉजिटरी या ब्रांच हटाने में विफल: {{error}}",
 		"failed_remove_directory": "टास्क डायरेक्टरी हटाने में विफल: {{error}}",
 		"custom_storage_path_unusable": "कस्टम स्टोरेज पाथ \"{{path}}\" उपयोग योग्य नहीं है, डिफ़ॉल्ट पाथ का उपयोग किया जाएगा",
-		"cannot_access_path": "पाथ {{path}} तक पहुंच नहीं पा रहे हैं: {{error}}"
+		"cannot_access_path": "पाथ {{path}} तक पहुंच नहीं पा रहे हैं: {{error}}",
+		"settings_import_failed": "सेटिंग्स इम्पोर्ट करने में विफल: {{error}}।"
 	},
 	"warnings": {
 		"no_terminal_content": "कोई टर्मिनल सामग्री चयनित नहीं",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "सर्वर \"{{serverName}}\" कॉन्फ़िगरेशन में नहीं मिला",
 		"custom_storage_path_set": "कस्टम स्टोरेज पाथ सेट किया गया: {{path}}",
 		"default_storage_path": "डिफ़ॉल्ट स्टोरेज पाथ का उपयोग पुनः शुरू किया गया",
-		"settings_imported": "सेटिंग्स सफलतापूर्वक इम्पोर्ट की गईं।",
-		"settings_import_failed": "सेटिंग्स इम्पोर्ट करने में विफल: {{error}}।"
+		"settings_imported": "सेटिंग्स सफलतापूर्वक इम्पोर्ट की गईं।"
 	},
 	"answers": {
 		"yes": "हां",

--- a/src/i18n/locales/it/common.json
+++ b/src/i18n/locales/it/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "Impossibile eliminare il repository o il ramo associato: {{error}}",
 		"failed_remove_directory": "Impossibile rimuovere la directory delle attività: {{error}}",
 		"custom_storage_path_unusable": "Il percorso di archiviazione personalizzato \"{{path}}\" non è utilizzabile, verrà utilizzato il percorso predefinito",
-		"cannot_access_path": "Impossibile accedere al percorso {{path}}: {{error}}"
+		"cannot_access_path": "Impossibile accedere al percorso {{path}}: {{error}}",
+		"settings_import_failed": "Importazione delle impostazioni fallita: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Nessun contenuto del terminale selezionato",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Server \"{{serverName}}\" non trovato nella configurazione",
 		"custom_storage_path_set": "Percorso di archiviazione personalizzato impostato: {{path}}",
 		"default_storage_path": "Tornato al percorso di archiviazione predefinito",
-		"settings_imported": "Impostazioni importate con successo.",
-		"settings_import_failed": "Importazione delle impostazioni fallita: {{error}}."
+		"settings_imported": "Impostazioni importate con successo."
 	},
 	"answers": {
 		"yes": "Sì",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "関連するシャドウリポジトリまたはブランチの削除に失敗しました：{{error}}",
 		"failed_remove_directory": "タスクディレクトリの削除に失敗しました：{{error}}",
 		"custom_storage_path_unusable": "カスタムストレージパス \"{{path}}\" が使用できないため、デフォルトパスを使用します",
-		"cannot_access_path": "パス {{path}} にアクセスできません：{{error}}"
+		"cannot_access_path": "パス {{path}} にアクセスできません：{{error}}",
+		"settings_import_failed": "設定のインポートに失敗しました：{{error}}。"
 	},
 	"warnings": {
 		"no_terminal_content": "選択されたターミナルコンテンツがありません",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "サーバー\"{{serverName}}\"が設定内に見つかりません",
 		"custom_storage_path_set": "カスタムストレージパスが設定されました：{{path}}",
 		"default_storage_path": "デフォルトのストレージパスに戻りました",
-		"settings_imported": "設定が正常にインポートされました。",
-		"settings_import_failed": "設定のインポートに失敗しました：{{error}}。"
+		"settings_imported": "設定が正常にインポートされました。"
 	},
 	"answers": {
 		"yes": "はい",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -52,7 +52,7 @@
 		"failed_remove_directory": "タスクディレクトリの削除に失敗しました：{{error}}",
 		"custom_storage_path_unusable": "カスタムストレージパス \"{{path}}\" が使用できないため、デフォルトパスを使用します",
 		"cannot_access_path": "パス {{path}} にアクセスできません：{{error}}",
-		"settings_import_failed": "設定のインポートに失敗しました：{{error}}。"
+		"settings_import_failed": "設定のインポートに失敗しました：{{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "選択されたターミナルコンテンツがありません",

--- a/src/i18n/locales/ko/common.json
+++ b/src/i18n/locales/ko/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "관련 shadow 저장소 또는 브랜치 삭제 실패: {{error}}",
 		"failed_remove_directory": "작업 디렉토리 제거 실패: {{error}}",
 		"custom_storage_path_unusable": "사용자 지정 저장 경로 \"{{path}}\"를 사용할 수 없어 기본 경로를 사용합니다",
-		"cannot_access_path": "경로 {{path}}에 접근할 수 없습니다: {{error}}"
+		"cannot_access_path": "경로 {{path}}에 접근할 수 없습니다: {{error}}",
+		"settings_import_failed": "설정 가져오기 실패: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "선택된 터미널 내용이 없습니다",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "구성에서 서버 \"{{serverName}}\"을(를) 찾을 수 없습니다",
 		"custom_storage_path_set": "사용자 지정 저장 경로 설정됨: {{path}}",
 		"default_storage_path": "기본 저장 경로로 되돌아갔습니다",
-		"settings_imported": "설정이 성공적으로 가져와졌습니다.",
-		"settings_import_failed": "설정 가져오기 실패: {{error}}."
+		"settings_imported": "설정이 성공적으로 가져와졌습니다."
 	},
 	"answers": {
 		"yes": "예",

--- a/src/i18n/locales/nl/common.json
+++ b/src/i18n/locales/nl/common.json
@@ -51,7 +51,8 @@
 		"failed_remove_directory": "Verwijderen van taakmap mislukt: {{error}}",
 		"custom_storage_path_unusable": "Aangepast opslagpad \"{{path}}\" is onbruikbaar, standaardpad wordt gebruikt",
 		"cannot_access_path": "Kan pad {{path}} niet openen: {{error}}",
-		"failed_update_project_mcp": "Bijwerken van project MCP-servers mislukt"
+		"failed_update_project_mcp": "Bijwerken van project MCP-servers mislukt",
+		"settings_import_failed": "Importeren van instellingen mislukt: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Geen terminalinhoud geselecteerd",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Server \"{{serverName}}\" niet gevonden in configuratie",
 		"custom_storage_path_set": "Aangepast opslagpad ingesteld: {{path}}",
 		"default_storage_path": "Terug naar standaard opslagpad",
-		"settings_imported": "Instellingen succesvol geïmporteerd.",
-		"settings_import_failed": "Importeren van instellingen mislukt: {{error}}."
+		"settings_imported": "Instellingen succesvol geïmporteerd."
 	},
 	"answers": {
 		"yes": "Ja",

--- a/src/i18n/locales/pl/common.json
+++ b/src/i18n/locales/pl/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "Nie udało się usunąć powiązanego repozytorium lub gałęzi pomocniczej: {{error}}",
 		"failed_remove_directory": "Nie udało się usunąć katalogu zadania: {{error}}",
 		"custom_storage_path_unusable": "Niestandardowa ścieżka przechowywania \"{{path}}\" nie jest użyteczna, zostanie użyta domyślna ścieżka",
-		"cannot_access_path": "Nie można uzyskać dostępu do ścieżki {{path}}: {{error}}"
+		"cannot_access_path": "Nie można uzyskać dostępu do ścieżki {{path}}: {{error}}",
+		"settings_import_failed": "Nie udało się zaimportować ustawień: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Nie wybrano zawartości terminala",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Serwer \"{{serverName}}\" nie znaleziony w konfiguracji",
 		"custom_storage_path_set": "Ustawiono niestandardową ścieżkę przechowywania: {{path}}",
 		"default_storage_path": "Wznowiono używanie domyślnej ścieżki przechowywania",
-		"settings_imported": "Ustawienia zaimportowane pomyślnie.",
-		"settings_import_failed": "Nie udało się zaimportować ustawień: {{error}}."
+		"settings_imported": "Ustawienia zaimportowane pomyślnie."
 	},
 	"answers": {
 		"yes": "Tak",

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -56,7 +56,7 @@
 		"failed_remove_directory": "Falha ao remover o diretório de tarefas: {{error}}",
 		"custom_storage_path_unusable": "O caminho de armazenamento personalizado \"{{path}}\" não pode ser usado, será usado o caminho padrão",
 		"cannot_access_path": "Não é possível acessar o caminho {{path}}: {{error}}",
-		"settings_import_failed": "Falha ao importar configurações: {{error}}."
+		"settings_import_failed": "Falha ao importar configurações: {{error}}"
 	},
 	"warnings": {
 		"no_terminal_content": "Nenhum conteúdo do terminal selecionado",

--- a/src/i18n/locales/pt-BR/common.json
+++ b/src/i18n/locales/pt-BR/common.json
@@ -55,7 +55,8 @@
 		"failed_delete_repo": "Falha ao excluir o repositório ou ramificação associada: {{error}}",
 		"failed_remove_directory": "Falha ao remover o diretório de tarefas: {{error}}",
 		"custom_storage_path_unusable": "O caminho de armazenamento personalizado \"{{path}}\" não pode ser usado, será usado o caminho padrão",
-		"cannot_access_path": "Não é possível acessar o caminho {{path}}: {{error}}"
+		"cannot_access_path": "Não é possível acessar o caminho {{path}}: {{error}}",
+		"settings_import_failed": "Falha ao importar configurações: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Nenhum conteúdo do terminal selecionado",
@@ -71,8 +72,7 @@
 		"mcp_server_not_found": "Servidor \"{{serverName}}\" não encontrado na configuração",
 		"custom_storage_path_set": "Caminho de armazenamento personalizado definido: {{path}}",
 		"default_storage_path": "Retornado ao caminho de armazenamento padrão",
-		"settings_imported": "Configurações importadas com sucesso.",
-		"settings_import_failed": "Falha ao importar configurações: {{error}}."
+		"settings_imported": "Configurações importadas com sucesso."
 	},
 	"answers": {
 		"yes": "Sim",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -51,7 +51,8 @@
 		"failed_remove_directory": "Не удалось удалить директорию задачи: {{error}}",
 		"custom_storage_path_unusable": "Пользовательский путь хранения \"{{path}}\" непригоден, будет использован путь по умолчанию",
 		"cannot_access_path": "Невозможно получить доступ к пути {{path}}: {{error}}",
-		"failed_update_project_mcp": "Не удалось обновить серверы проекта MCP"
+		"failed_update_project_mcp": "Не удалось обновить серверы проекта MCP",
+		"settings_import_failed": "Не удалось импортировать настройки: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Не выбрано содержимое терминала",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Сервер \"{{serverName}}\" не найден в конфигурации",
 		"custom_storage_path_set": "Установлен пользовательский путь хранения: {{path}}",
 		"default_storage_path": "Возвращено использование пути хранения по умолчанию",
-		"settings_imported": "Настройки успешно импортированы.",
-		"settings_import_failed": "Не удалось импортировать настройки: {{error}}."
+		"settings_imported": "Настройки успешно импортированы."
 	},
 	"answers": {
 		"yes": "Да",

--- a/src/i18n/locales/tr/common.json
+++ b/src/i18n/locales/tr/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "İlişkili gölge depo veya dal silinemedi: {{error}}",
 		"failed_remove_directory": "Görev dizini kaldırılamadı: {{error}}",
 		"custom_storage_path_unusable": "Özel depolama yolu \"{{path}}\" kullanılamıyor, varsayılan yol kullanılacak",
-		"cannot_access_path": "{{path}} yoluna erişilemiyor: {{error}}"
+		"cannot_access_path": "{{path}} yoluna erişilemiyor: {{error}}",
+		"settings_import_failed": "Ayarlar içe aktarılamadı: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Seçili terminal içeriği yok",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Yapılandırmada \"{{serverName}}\" sunucusu bulunamadı",
 		"custom_storage_path_set": "Özel depolama yolu ayarlandı: {{path}}",
 		"default_storage_path": "Varsayılan depolama yoluna geri dönüldü",
-		"settings_imported": "Ayarlar başarıyla içe aktarıldı.",
-		"settings_import_failed": "Ayarlar içe aktarılamadı: {{error}}."
+		"settings_imported": "Ayarlar başarıyla içe aktarıldı."
 	},
 	"answers": {
 		"yes": "Evet",

--- a/src/i18n/locales/vi/common.json
+++ b/src/i18n/locales/vi/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "Không thể xóa kho lưu trữ hoặc nhánh liên quan: {{error}}",
 		"failed_remove_directory": "Không thể xóa thư mục nhiệm vụ: {{error}}",
 		"custom_storage_path_unusable": "Đường dẫn lưu trữ tùy chỉnh \"{{path}}\" không thể sử dụng được, sẽ sử dụng đường dẫn mặc định",
-		"cannot_access_path": "Không thể truy cập đường dẫn {{path}}: {{error}}"
+		"cannot_access_path": "Không thể truy cập đường dẫn {{path}}: {{error}}",
+		"settings_import_failed": "Nhập cài đặt thất bại: {{error}}."
 	},
 	"warnings": {
 		"no_terminal_content": "Không có nội dung terminal được chọn",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "Không tìm thấy máy chủ \"{{serverName}}\" trong cấu hình",
 		"custom_storage_path_set": "Đã thiết lập đường dẫn lưu trữ tùy chỉnh: {{path}}",
 		"default_storage_path": "Đã quay lại sử dụng đường dẫn lưu trữ mặc định",
-		"settings_imported": "Cài đặt đã được nhập thành công.",
-		"settings_import_failed": "Nhập cài đặt thất bại: {{error}}."
+		"settings_imported": "Cài đặt đã được nhập thành công."
 	},
 	"answers": {
 		"yes": "Có",

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "删除关联的影子仓库或分支失败：{{error}}",
 		"failed_remove_directory": "删除任务目录失败：{{error}}",
 		"custom_storage_path_unusable": "自定义存储路径 \"{{path}}\" 不可用，将使用默认路径",
-		"cannot_access_path": "无法访问路径 {{path}}：{{error}}"
+		"cannot_access_path": "无法访问路径 {{path}}：{{error}}",
+		"settings_import_failed": "设置导入失败：{{error}}。"
 	},
 	"warnings": {
 		"no_terminal_content": "没有选择终端内容",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "在配置中未找到服务器\"{{serverName}}\"",
 		"custom_storage_path_set": "自定义存储路径已设置：{{path}}",
 		"default_storage_path": "已恢复使用默认存储路径",
-		"settings_imported": "设置已成功导入。",
-		"settings_import_failed": "设置导入失败：{{error}}。"
+		"settings_imported": "设置已成功导入。"
 	},
 	"answers": {
 		"yes": "是",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -51,7 +51,8 @@
 		"failed_delete_repo": "刪除關聯的影子倉庫或分支失敗：{{error}}",
 		"failed_remove_directory": "刪除工作目錄失敗：{{error}}",
 		"custom_storage_path_unusable": "自訂儲存路徑 \"{{path}}\" 無法使用，將使用預設路徑",
-		"cannot_access_path": "無法存取路徑 {{path}}：{{error}}"
+		"cannot_access_path": "無法存取路徑 {{path}}：{{error}}",
+		"settings_import_failed": "設定匯入失敗：{{error}}。"
 	},
 	"warnings": {
 		"no_terminal_content": "沒有選擇終端機內容",
@@ -67,8 +68,7 @@
 		"mcp_server_not_found": "在設定中沒有找到伺服器\"{{serverName}}\"",
 		"custom_storage_path_set": "自訂儲存路徑已設定：{{path}}",
 		"default_storage_path": "已恢復使用預設儲存路徑",
-		"settings_imported": "設定已成功匯入。",
-		"settings_import_failed": "設定匯入失敗：{{error}}。"
+		"settings_imported": "設定已成功匯入。"
 	},
 	"answers": {
 		"yes": "是",


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->
Closes: #3365 

### Description

- Move `settings_import_failed` i18n error message from info to error section
- That message is used in `src\core\webview\webviewMessageHandler.ts:260` file

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

### Type of Change

<!-- Mark all applicable boxes with an 'x'. -->

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [ ] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [x] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [x] **Testing**:
    - [x] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](../CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are not required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move `settings_import_failed` message from info to error section in multiple language `common.json` files.
> 
>   - **i18n Changes**:
>     - Move `settings_import_failed` message from info to error section in `common.json` files for multiple languages including `de`, `en`, `es`, `fr`, `hi`, `it`, `ja`, `ko`, `nl`, `pl`, `pt-BR`, `ru`, `tr`, `vi`, `zh-CN`, and `zh-TW`.
>     - The message is used in `webviewMessageHandler.ts:260`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooVetGit%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1be1265f711dd8e77f2b72491831f9ed785c4e8f. You can [customize](https://app.ellipsis.dev/RooVetGit/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->