### PR TITLE
fix: prevent model selection failures when API requests fail (fixes #3813, #3874)

### DIFF
--- a/webview-ui/src/components/settings/ModelPicker.tsx
+++ b/webview-ui/src/components/settings/ModelPicker.tsx
@@ -94,12 +94,14 @@ export const ModelPicker = ({
 	}, [])
 
 	useEffect(() => {
-		if (!selectedModelId && !isInitialized.current) {
-			const initialValue = modelIds.includes(selectedModelId) ? selectedModelId : defaultModelId
-			setApiConfigurationField(modelIdKey, initialValue)
+		if (!isInitialized.current) {
+			// If no model is selected or the selected model is not in the available models list,
+			// initialize with the default model
+			if (!selectedModelId || !modelIds.includes(selectedModelId)) {
+				setApiConfigurationField(modelIdKey, defaultModelId)
+			}
+			isInitialized.current = true
 		}
-
-		isInitialized.current = true
 	}, [modelIds, setApiConfigurationField, modelIdKey, selectedModelId, defaultModelId])
 
 	return (


### PR DESCRIPTION
fix: prevent model selection failures when API requests fail (fixes #3813, fixes #3874)

This PR addresses issues #3813 and #3874 where users were unable to select models in the settings interface when certain provider APIs failed.

Changes:
- Replace Promise.all with Promise.allSettled in webviewMessageHandler.ts to handle provider API failures gracefully
- Fix model initialization logic in ModelPicker component to ensure proper default selection
- Ensure models can be selected even when some provider APIs fail

Technical details:
The previous implementation used Promise.all which would fail entirely if any single provider API request failed. By switching to Promise.allSettled, we now properly handle partial failures and allow users to select from available models even when some providers are unreachable or return errors. Additionally, the initialization logic in ModelPicker has been fixed to properly handle the default model selection.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch to `Promise.allSettled` for API requests and fix default model selection in `ModelPicker` to handle failures gracefully.
> 
>   - **Behavior**:
>     - Replace `Promise.all` with `Promise.allSettled` in `webviewMessageHandler.ts` to handle API failures gracefully.
>     - Fix default model selection logic in `ModelPicker` to ensure proper initialization.
>   - **Technical Details**:
>     - `Promise.allSettled` allows handling of partial failures, enabling model selection even if some APIs fail.
>     - Initialization logic in `ModelPicker` ensures default model is selected if no valid model is chosen.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1f01a425eba02384c991a32968075d637071ecd8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->