### PR TITLE
Fix Qdrant URL input default value

### DIFF
--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -187,7 +187,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		autoCondenseContextPercent: 100,
 		codebaseIndexConfig: {
 			codebaseIndexEnabled: false,
-			codebaseIndexQdrantUrl: "",
+			codebaseIndexQdrantUrl: "http://localhost:6333",
 			codebaseIndexEmbedderProvider: "openai",
 			codebaseIndexEmbedderBaseUrl: "",
 			codebaseIndexEmbedderModelId: "",


### PR DESCRIPTION
Set a default value in ExtensioStateContext for the Qdrant URL
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets default `codebaseIndexQdrantUrl` in `SettingsView.tsx` to ensure indexing starts without user input.
> 
>   - **Behavior**:
>     - Sets default `codebaseIndexQdrantUrl` to `"http://localhost:6333"` in `codebaseIndexConfig` within `SettingsView.tsx`.
>     - Ensures indexing process can start without user-provided URL.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 05897da651817a4fb4af3564119dba38e311988a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->