### PR TITLE
Update `xaiModels` and `xaiDefaultModelId` in `src/shared/api.ts`

### DIFF
--- a/.changeset/thick-streets-give.md
+++ b/.changeset/thick-streets-give.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": minor
+---
+
+Update `xaiModels` and `xaiDefaultModelId` in `src/shared/api.ts`

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1264,7 +1264,7 @@ export const litellmDefaultModelInfo: ModelInfo = {
 // xAI
 // https://docs.x.ai/docs/api-reference
 export type XAIModelId = keyof typeof xaiModels
-export const xaiDefaultModelId: XAIModelId = "grok-3-beta"
+export const xaiDefaultModelId: XAIModelId = "grok-3"
 export const xaiModels = {
 	"grok-3-beta": {
 		maxTokens: 8192,
@@ -1302,6 +1302,44 @@ export const xaiModels = {
 		inputPrice: 0.6,
 		outputPrice: 4.0,
 		description: "xAI's Grok-3 mini fast beta model with 131K context window",
+		supportsReasoningEffort: true,
+	},
+	"grok-3": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 3.0,
+		outputPrice: 15.0,
+		description: "xAI's Grok-3 model with 131K context window",
+	},
+	"grok-3-fast": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 5.0,
+		outputPrice: 25.0,
+		description: "xAI's Grok-3 fast model with 131K context window",
+	},
+	"grok-3-mini": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.3,
+		outputPrice: 0.5,
+		description: "xAI's Grok-3 mini model with 131K context window",
+		supportsReasoningEffort: true,
+	},
+	"grok-3-mini-fast": {
+		maxTokens: 8192,
+		contextWindow: 131072,
+		supportsImages: false,
+		supportsPromptCache: false,
+		inputPrice: 0.6,
+		outputPrice: 4.0,
+		description: "xAI's Grok-3 mini fast model with 131K context window",
 		supportsReasoningEffort: true,
 	},
 	"grok-2-latest": {


### PR DESCRIPTION
### Description

This PR adds stable Grok-3 model variants to the xAI API configuration and updates the default model selection.

**Key Changes:**
- Added four new stable Grok-3 models: `grok-3`, `grok-3-fast`, `grok-3-mini`, and `grok-3-mini-fast`
- Updated `xaiDefaultModelId` from `grok-3-beta` to the stable `grok-3`
- Preserved `supportsReasoningEffort: true` for mini variants consistent with their beta counterparts
- All new models maintain the same 131K context window and pricing structure

**Implementation Details:**
- Configuration-only changes to `src/shared/api.ts`
- Maintains backward compatibility by keeping all existing beta models
- Follows the established pattern for model definitions

### Test Procedure

This change involves API configuration updates that don't require functional testing:

1. **Verification Steps:**
   - Confirm the application builds successfully with new model definitions
   - Verify the default model selection updates correctly
   - Check that existing beta models remain available

2. **Expected Behavior:**
   - Users should see the new stable Grok-3 models in model selection
   - Default model should now be `grok-3` instead of `grok-3-beta`
   - All existing functionality should remain unchanged

**Testing Rationale:** This is a pure configuration addition that extends available options without modifying existing behavior or API calls.

### Type of Change

- [ ] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.
- [x] ✨ **New Feature**: Non-breaking change that adds functionality.
- [ ] 💥 **Breaking Change**: Fix or feature that would cause existing functionality to not work as expected.
- [ ] ♻️ **Refactor**: Code change that neither fixes a bug nor adds a feature.
- [ ] 💅 **Style**: Changes that do not affect the meaning of the code (white-space, formatting, etc.).
- [ ] 📚 **Documentation**: Updates to documentation files.
- [ ] ⚙️ **Build/CI**: Changes to the build process or CI configuration.
- [ ] 🧹 **Chore**: Other changes that don't modify `src` or test files.

### Pre-Submission Checklist

- [ ] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Code Quality**:
    - [x] My code adheres to the project's style guidelines.
    - [x] There are no new linting errors or warnings (`npm run lint`).
    - [x] All debug code (e.g., `console.log`) has been removed.
- [ ] **Testing**:
    - [ ] New and/or updated tests have been added to cover my changes.
    - [x] All tests pass locally (`npm test`).
    - [x] The application builds successfully with my changes.
- [x] **Branch Hygiene**: My branch is up-to-date (rebased) with the `main` branch.
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [ ] **Changeset**: A changeset has been created using `npm run changeset` if this PR includes user-facing changes or dependency updates.
- [ ] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A - Configuration changes only

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

This update aligns with xAI's release of stable Grok-3 models, providing users with production-ready alternatives to beta versions. The change is purely additive and maintains full backward compatibility.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add stable Grok-3 models to `xaiModels` and update `xaiDefaultModelId` to `grok-3` in `src/shared/api.ts`.
> 
>   - **Models**:
>     - Add `grok-3`, `grok-3-fast`, `grok-3-mini`, `grok-3-mini-fast` to `xaiModels` in `src/shared/api.ts`.
>     - Update `xaiDefaultModelId` from `grok-3-beta` to `grok-3`.
>     - Preserve `supportsReasoningEffort: true` for mini variants.
>   - **Misc**:
>     - Maintain backward compatibility by keeping existing beta models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5d44c945052142ae4aba53f1deb772e16cbe58c2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->