### PR TITLE
Fix menu breaking when Roo is moved between primary and secondary sidebars

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -448,7 +448,6 @@ export class ClineProvider
 				} else {
 					this.log("Preserving ClineProvider instance for sidebar view reuse")
 				}
-				}
 			},
 			null,
 			this.disposables,


### PR DESCRIPTION
### Description

Hello Roo Team! We changed this on the Kilo side and thought it might be useful to you!

The menu buttons (Settings etc.) stop working when Roo is moved between the primary and secondary sidebars. This is because ClineProvider is prematurely disposed in that case.

This change prevents the ClineProvider from being disposed when hosted in a sidebar. It should still be disposed when hosted in a tab, because they have their own ClineProvider instance.

Found while investigating https://github.com/Kilo-Org/kilocode/issues/502.

### Test Procedure

- Move the Roo Code window to the secondary sidebar (right click on icon or title -> Move To -> Secondary Sidebar)
- The buttons on the top menu (Settings etc.) should still work

### Type of Change

- [x] 🐛 **Bug Fix**: Non-breaking change that fixes an issue.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes menu button functionality by preventing premature disposal of `ClineProvider` when Roo is moved between sidebars.
> 
>   - **Behavior**:
>     - Prevents `ClineProvider` from being disposed when in sidebar mode in `ClineProvider.ts`.
>     - Ensures `ClineProvider` is disposed only in tab mode.
>   - **Testing**:
>     - Move Roo to secondary sidebar and verify menu buttons work.
>   - **Misc**:
>     - Logs disposal actions in `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 323fce85bf5ebc61ca52374555f86340bcfc547c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->