### PR TITLE
Check rooignore for insert_content and search_and_replace

### DIFF
--- a/src/core/tools/insertContentTool.ts
+++ b/src/core/tools/insertContentTool.ts
@@ -58,6 +58,14 @@ export async function insertContentTool(
 			return
 		}
 
+		const accessAllowed = cline.rooIgnoreController?.validateAccess(relPath)
+
+		if (!accessAllowed) {
+			await cline.say("rooignore_error", relPath)
+			pushToolResult(formatResponse.toolError(formatResponse.rooIgnoreError(relPath)))
+			return
+		}
+
 		const absolutePath = path.resolve(cline.cwd, relPath)
 		const fileExists = await fileExistsAtPath(absolutePath)
 

--- a/src/core/tools/searchAndReplaceTool.ts
+++ b/src/core/tools/searchAndReplaceTool.ts
@@ -115,6 +115,14 @@ export async function searchAndReplaceTool(
 			endLine: endLine,
 		}
 
+		const accessAllowed = cline.rooIgnoreController?.validateAccess(validRelPath)
+
+		if (!accessAllowed) {
+			await cline.say("rooignore_error", validRelPath)
+			pushToolResult(formatResponse.toolError(formatResponse.rooIgnoreError(validRelPath)))
+			return
+		}
+
 		const absolutePath = path.resolve(cline.cwd, validRelPath)
 		const fileExists = await fileExistsAtPath(absolutePath)
 


### PR DESCRIPTION
Just noticed this while reading the docs https://docs.roocode.com/features/rooignore#file-editing-tools-potential-write-bypass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `rooignore` checks to `insertContentTool` and `searchAndReplaceTool` to prevent operations on ignored files.
> 
>   - **Behavior**:
>     - Add `rooignore` check in `insertContentTool()` to prevent operations on ignored files.
>     - Add `rooignore` check in `searchAndReplaceTool()` to prevent operations on ignored files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 791a1650dd7fa626fe394b84a13945d5f73b56a8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->