### PR TITLE
3.19.3

### DIFF
--- a/.changeset/v3.19.3.md
+++ b/.changeset/v3.19.3.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+- Fix SSE MCP Invocation - Fixed SSE connection issue in McpHub.ts by ensuring transport.start override only applies to stdio transports, allowing SSE and streamable-http transports to retain their original start methods (thanks @taylorwilsdon!)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix SSE connection issue in `McpHub.ts` by ensuring `transport.start` override only applies to `stdio` transports.
> 
>   - **Fix**:
>     - Fix SSE connection issue in `McpHub.ts` by ensuring `transport.start` override only applies to `stdio` transports.
>     - Allows `SSE` and `streamable-http` transports to retain original start methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b62e36128d3a522243b5322faea4ffc1378c47f2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->