### PR TITLE
Cloud: clear cached settings if already logged-out at startup

### DIFF
--- a/packages/cloud/src/SettingsService.ts
+++ b/packages/cloud/src/SettingsService.ts
@@ -39,6 +39,11 @@ export class SettingsService {
 	public initialize(): void {
 		this.loadCachedSettings()
 
+		// Clear cached settings if we have missed a log out.
+		if (this.authService.getState() == "logged-out" && this.settings) {
+			this.removeSettings()
+		}
+
 		this.authService.on("active-session", () => {
 			this.timer.start()
 		})


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clear cached settings in `SettingsService.ts` if already logged-out at startup to prevent stale settings usage.
> 
>   - **Behavior**:
>     - In `SettingsService.ts`, `initialize()` now clears cached settings if `authService` state is "logged-out" and settings exist.
>   - **Misc**:
>     - Adds a comment explaining the new behavior in `initialize()` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8ce8dc38265e9f48375dac8a10d31d673029e6b1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->