### PR TITLE
Fix rust evals (run cargo with bash) + logging tweaks

### DIFF
--- a/packages/evals/src/cli/index.ts
+++ b/packages/evals/src/cli/index.ts
@@ -8,7 +8,7 @@ import { runEvals } from "./runEvals.js"
 import { processTask } from "./processTask.js"
 
 const main = async () => {
-	const result = await run(
+	await run(
 		command({
 			name: "cli",
 			description: "Execute an eval run.",
@@ -43,7 +43,6 @@ const main = async () => {
 		process.argv.slice(2),
 	)
 
-	console.log(result)
 	process.exit(0)
 }
 

--- a/packages/evals/src/cli/processTask.ts
+++ b/packages/evals/src/cli/processTask.ts
@@ -25,7 +25,7 @@ export const processTask = async (taskId: number) => {
 		await runTask({ run, task, publish })
 
 		console.log(`[${Date.now()} | ${tag}] testing task ${task.id} (${task.language}/${task.exercise})...`)
-		const passed = await runUnitTest({ task })
+		const passed = await runUnitTest({ run, task })
 
 		console.log(`[${Date.now()} | ${tag}] task ${task.id} (${task.language}/${task.exercise}) -> ${passed}`)
 		await updateTask(task.id, { passed })

--- a/packages/evals/src/cli/runEvals.ts
+++ b/packages/evals/src/cli/runEvals.ts
@@ -1,10 +1,9 @@
-import { execa } from "execa"
 import PQueue from "p-queue"
 
 import { findRun, finishRun, getTasks } from "../db/index.js"
 import { exercisesPath } from "../exercises/index.js"
 
-import { getTag, isDockerContainer } from "./utils.js"
+import { getTag, isDockerContainer, resetEvalsRepo, commitEvalsRepoChanges } from "./utils.js"
 import { processTask, processTaskInContainer } from "./processTask.js"
 import { startHeartbeat, stopHeartbeat } from "./redis.js"
 
@@ -24,31 +23,32 @@ export const runEvals = async (runId: number) => {
 	const tag = getTag("runEvals", { run })
 	console.log(`[${Date.now()} | ${tag}] running ${tasks.length} task(s)`)
 
-	const cwd = exercisesPath
-	await execa({ cwd })`git config user.name "Roo Code"`
-	await execa({ cwd })`git config user.email "support@roocode.com"`
-	await execa({ cwd })`git checkout -f`
-	await execa({ cwd })`git clean -fd`
-	await execa({ cwd })`git checkout -b runs/${run.id}-${crypto.randomUUID().slice(0, 8)} main`
+	const containerized = isDockerContainer()
+
+	if (!containerized) {
+		await resetEvalsRepo({ run, cwd: exercisesPath })
+	}
 
 	const heartbeat = await startHeartbeat(run.id)
 	const queue = new PQueue({ concurrency: run.concurrency })
 
 	try {
-		const containerize = isDockerContainer()
-
 		await queue.addAll(
 			tasks
 				.filter((task) => task.finishedAt === null)
-				.map((task) => () => (containerize ? processTaskInContainer(task.id) : processTask(task.id))),
+				.map((task) => () => (containerized ? processTaskInContainer(task.id) : processTask(task.id))),
 		)
 
 		console.log(`[${Date.now()} | ${tag}] finishRun`)
 		const result = await finishRun(run.id)
 		console.log(`[${Date.now()} | ${tag}] result ->`, result)
 
-		await execa({ cwd: exercisesPath })`git add .`
-		await execa({ cwd: exercisesPath })`git commit -m ${`Run #${run.id}`} --no-verify`
+		// There's no need to commit the changes in the container since they
+		// will lost when the container is destroyed. I think we should
+		// store the diffs in the database instead.
+		if (!containerized) {
+			await commitEvalsRepoChanges({ run, cwd: exercisesPath })
+		}
 	} finally {
 		console.log(`[${Date.now()} | ${tag}] cleaning up`)
 		stopHeartbeat(run.id, heartbeat)

--- a/packages/evals/src/cli/utils.ts
+++ b/packages/evals/src/cli/utils.ts
@@ -1,5 +1,7 @@
 import * as fs from "fs"
 
+import { execa } from "execa"
+
 import type { Run, Task } from "../db/index.js"
 
 export const getTag = (caller: string, { run, task }: { run: Run; task?: Task }) =>
@@ -13,4 +15,17 @@ export const isDockerContainer = () => {
 	} catch (_error) {
 		return false
 	}
+}
+
+export const resetEvalsRepo = async ({ run, cwd }: { run: Run; cwd: string }) => {
+	await execa({ cwd })`git config user.name "Roo Code"`
+	await execa({ cwd })`git config user.email "support@roocode.com"`
+	await execa({ cwd })`git checkout -f`
+	await execa({ cwd })`git clean -fd`
+	await execa({ cwd })`git checkout -b runs/${run.id}-${crypto.randomUUID().slice(0, 8)} main`
+}
+
+export const commitEvalsRepoChanges = async ({ run, cwd }: { run: Run; cwd: string }) => {
+	await execa({ cwd })`git add .`
+	await execa({ cwd })`git commit -m ${`Run #${run.id}`} --no-verify`
 }

--- a/packages/ipc/src/ipc-client.ts
+++ b/packages/ipc/src/ipc-client.ts
@@ -3,7 +3,14 @@ import * as crypto from "node:crypto"
 
 import ipc from "node-ipc"
 
-import { type IpcClientEvents, type IpcMessage, IpcOrigin, IpcMessageType, ipcMessageSchema } from "@roo-code/types"
+import {
+	type TaskCommand,
+	type IpcClientEvents,
+	type IpcMessage,
+	IpcOrigin,
+	IpcMessageType,
+	ipcMessageSchema,
+} from "@roo-code/types"
 
 export class IpcClient extends EventEmitter<IpcClientEvents> {
 	private readonly _socketPath: string
@@ -78,6 +85,17 @@ export class IpcClient extends EventEmitter<IpcClientEvents> {
 
 	private log(...args: unknown[]) {
 		this._log(...args)
+	}
+
+	public sendCommand(command: TaskCommand) {
+		const message: IpcMessage = {
+			type: IpcMessageType.TaskCommand,
+			origin: IpcOrigin.Client,
+			clientId: this._clientId!,
+			data: command,
+		}
+
+		this.sendMessage(message)
 	}
 
 	public sendMessage(message: IpcMessage) {


### PR DESCRIPTION
### Description

Thanks @jr  for flagging.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance Rust evaluation execution with bash, improve logging, and add utility functions for git operations in the evals package.
> 
>   - **Behavior**:
>     - Run Rust evaluations using bash in `runUnitTest()` in `runUnitTest.ts`.
>     - Remove console log of `result` in `main()` in `index.ts`.
>     - Add `sendCommand()` method to `IpcClient` in `ipc-client.ts` for sending task commands.
>   - **Utilities**:
>     - Add `resetEvalsRepo()` and `commitEvalsRepoChanges()` in `utils.ts` for git operations.
>     - Use `resetEvalsRepo()` and `commitEvalsRepoChanges()` in `runEvals()` in `runEvals.ts`.
>   - **Logging**:
>     - Improve logging in `runTask()` in `runTask.ts` and `runUnitTest()` in `runUnitTest.ts`.
>     - Add `log()` and `logError()` utility functions in `runTask.ts` and `runUnitTest.ts` for consistent logging.
>   - **Misc**:
>     - Update `processTask()` in `processTask.ts` to pass `run` to `runUnitTest()`.
>     - Remove unused imports and variables in `runTask.ts` and `runUnitTest.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cd581bc26746f92001b02d17e5cd5aaf9ad9baac. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->