### PR TITLE
Fix changeset:version failure

### DIFF
--- a/.changeset/metal-suns-lay.md
+++ b/.changeset/metal-suns-lay.md
@@ -1,5 +1,0 @@
----
-"roo-code": patch
----
-
-Bug fix for trailing slash error when using LiteLLM provider


### PR DESCRIPTION
### Description

See: https://github.com/RooCodeInc/Roo-Code/actions/runs/15550948085/job/43781330506?pr=4490
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Deletes `.changeset/metal-suns-lay.md` to fix `changeset:version` failure related to a trailing slash error description.
> 
>   - **Fix**:
>     - Deletes `.changeset/metal-suns-lay.md` to resolve `changeset:version` failure.
>     - The deleted file contained a bug fix description for a trailing slash error with LiteLLM provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0de3162eeb2ebd2abbfe906e6340ff9a39c00fbe. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->