### PR TITLE
Encourage use of start_line in multi-file diff to match legacy diff

### DIFF
--- a/src/core/diff/strategies/multi-file-search-replace.ts
+++ b/src/core/diff/strategies/multi-file-search-replace.ts
@@ -107,12 +107,12 @@ Parameters:
   - path: (required) The path of the file to modify (relative to the current workspace directory ${args.cwd})
   - diff: (required) One or more diff elements containing:
     - content: (required) The search/replace block defining the changes.
-    - start_line: (optional) The line number of original content where the search block starts.
+    - start_line: (required) The line number of original content where the search block starts.
 
 Diff format:
 \`\`\`
 <<<<<<< SEARCH
-:start_line: (optional) The line number of original content where the search block starts.
+:start_line: (required) The line number of original content where the search block starts.
 -------
 [exact content to find including whitespace]
 =======
@@ -294,7 +294,7 @@ Each file requires its own path, start_line, and diff elements.
 				"\n" +
 				"CORRECT FORMAT:\n\n" +
 				"<<<<<<< SEARCH\n" +
-				":start_line: (optional) The line number of original content where the search block starts.\n" +
+				":start_line: (required) The line number of original content where the search block starts.\n" +
 				"-------\n" +
 				"[exact content to find including whitespace]\n" +
 				"=======\n" +

--- a/src/core/tools/multiApplyDiffTool.ts
+++ b/src/core/tools/multiApplyDiffTool.ts
@@ -153,7 +153,7 @@ Expected structure:
     <path>relative/path/to/file.ext</path>
     <diff>
       <content>diff content here</content>
-      <start_line>optional line number</start_line>
+      <start_line>line number</start_line>
     </diff>
   </file>
 </args>


### PR DESCRIPTION
To match https://github.com/RooCodeInc/Roo-Code/blob/c10fbbc3a7473f6f1c1ca818fafba29b19805af2/src/core/diff/strategies/multi-search-replace.ts#L109
Closes  #4744
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `start_line` parameter mandatory in diff operations to match legacy behavior.
> 
>   - **Behavior**:
>     - Change `start_line` from optional to required in `multi-file-search-replace.ts` and `multiApplyDiffTool.ts`.
>     - Affects diff processing and validation, ensuring `start_line` is always specified.
>   - **Documentation**:
>     - Update comments and error messages in `multi-file-search-replace.ts` to reflect `start_line` requirement.
>     - Modify XML parsing error message in `multiApplyDiffTool.ts` to indicate `start_line` is required.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 38dd071f579c58e5edd0905152d42f548c27aae3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->