### PR TITLE
Fixes #4822: Fix browser cleanup when remote browser connection enabled but no remote browser available

### DIFF
--- a/src/services/browser/__tests__/BrowserSession.test.ts
+++ b/src/services/browser/__tests__/BrowserSession.test.ts
@@ -1,0 +1,184 @@
+import * as vscode from "vscode"
+import { BrowserSession } from "../BrowserSession"
+import { Browser } from "puppeteer-core"
+
+// Mock vscode
+jest.mock("vscode", () => ({
+	ExtensionContext: jest.fn(),
+}))
+
+// Mock fs/promises
+jest.mock("fs/promises", () => ({
+	mkdir: jest.fn().mockResolvedValue(undefined),
+}))
+
+// Mock path
+jest.mock("path", () => ({
+	join: jest.fn((...args) => args.join("/")),
+}))
+
+// Mock puppeteer-core
+jest.mock("puppeteer-core", () => ({
+	launch: jest.fn(),
+	connect: jest.fn(),
+}))
+
+// Mock puppeteer-chromium-resolver
+jest.mock("puppeteer-chromium-resolver", () => {
+	return jest.fn().mockResolvedValue({
+		puppeteer: {
+			launch: jest.fn(),
+		},
+		executablePath: "/mock/chrome/path",
+	})
+})
+
+// Mock browserDiscovery
+jest.mock("../browserDiscovery", () => ({
+	discoverChromeHostUrl: jest.fn(),
+	tryChromeHostUrl: jest.fn(),
+}))
+
+// Mock fs utilities
+jest.mock("../../../utils/fs", () => ({
+	fileExistsAtPath: jest.fn().mockResolvedValue(true),
+}))
+
+// Mock delay and p-wait-for
+jest.mock("delay", () => jest.fn().mockResolvedValue(undefined))
+jest.mock("p-wait-for", () => jest.fn().mockResolvedValue(undefined))
+
+describe("BrowserSession", () => {
+	let mockContext: Partial<vscode.ExtensionContext>
+	let mockBrowser: Partial<Browser>
+	let browserSession: BrowserSession
+	let mockLaunch: jest.Mock
+	let mockConnect: jest.Mock
+	let mockDiscoverChromeHostUrl: jest.Mock
+	let mockTryChromeHostUrl: jest.Mock
+	let mockPCR: jest.Mock
+
+	beforeEach(() => {
+		// Get the mocked functions
+		const puppeteerCore = require("puppeteer-core")
+		mockLaunch = puppeteerCore.launch as jest.Mock
+		mockConnect = puppeteerCore.connect as jest.Mock
+
+		const browserDiscovery = require("../browserDiscovery")
+		mockDiscoverChromeHostUrl = browserDiscovery.discoverChromeHostUrl as jest.Mock
+		mockTryChromeHostUrl = browserDiscovery.tryChromeHostUrl as jest.Mock
+
+		mockPCR = require("puppeteer-chromium-resolver") as jest.Mock
+
+		// Reset all mocks
+		jest.clearAllMocks()
+
+		// Mock browser instance
+		mockBrowser = {
+			close: jest.fn().mockResolvedValue(undefined),
+			disconnect: jest.fn().mockResolvedValue(undefined),
+			newPage: jest.fn(),
+			pages: jest.fn().mockResolvedValue([]),
+		}
+
+		// Mock vscode context
+		mockContext = {
+			globalState: {
+				get: jest.fn(),
+				update: jest.fn(),
+			},
+			globalStorageUri: {
+				fsPath: "/mock/storage/path",
+			},
+		} as any
+
+		// Setup PCR mock
+		mockPCR.mockResolvedValue({
+			puppeteer: {
+				launch: mockLaunch,
+			},
+			executablePath: "/mock/chrome/path",
+		})
+
+		// Setup default mock returns
+		mockLaunch.mockResolvedValue(mockBrowser)
+		mockConnect.mockResolvedValue(mockBrowser)
+		mockTryChromeHostUrl.mockResolvedValue(true)
+
+		browserSession = new BrowserSession(mockContext as vscode.ExtensionContext)
+	})
+
+	describe("closeBrowser with remote browser fallback scenario", () => {
+		it("should close local browser when remote browser is enabled but fallback to local was used", async () => {
+			// Setup: Remote browser is enabled in settings
+			;(mockContext.globalState!.get as jest.Mock).mockImplementation((key: string) => {
+				if (key === "remoteBrowserEnabled") return true
+				if (key === "browserViewportSize") return "900x600"
+				return undefined
+			})
+
+			// Mock discoverChromeHostUrl to fail (no remote browser available)
+			mockDiscoverChromeHostUrl.mockRejectedValue(new Error("No remote browser found"))
+
+			// Launch browser - this should fallback to local browser
+			await browserSession.launchBrowser()
+
+			// Verify that launch was called (local browser)
+			expect(mockLaunch).toHaveBeenCalled()
+
+			// Now close the browser
+			await browserSession.closeBrowser()
+
+			// Verify that close() was called instead of disconnect()
+			expect(mockBrowser.close).toHaveBeenCalled()
+			expect(mockBrowser.disconnect).not.toHaveBeenCalled()
+		})
+
+		it("should disconnect from remote browser when actually connected to remote", async () => {
+			// Setup: Remote browser is enabled in settings
+			;(mockContext.globalState!.get as jest.Mock).mockImplementation((key: string) => {
+				if (key === "remoteBrowserEnabled") return true
+				if (key === "browserViewportSize") return "900x600"
+				return undefined
+			})
+
+			// Mock discoverChromeHostUrl to succeed
+			mockDiscoverChromeHostUrl.mockResolvedValue("ws://localhost:9222")
+
+			// Launch browser - this should connect to remote browser
+			await browserSession.launchBrowser()
+
+			// Verify that connect was called (remote browser)
+			expect(mockConnect).toHaveBeenCalled()
+
+			// Now close the browser
+			await browserSession.closeBrowser()
+
+			// Verify that disconnect() was called instead of close()
+			expect(mockBrowser.disconnect).toHaveBeenCalled()
+			expect(mockBrowser.close).not.toHaveBeenCalled()
+		})
+
+		it("should close local browser when remote browser is disabled", async () => {
+			// Setup: Remote browser is disabled in settings
+			;(mockContext.globalState!.get as jest.Mock).mockImplementation((key: string) => {
+				if (key === "remoteBrowserEnabled") return false
+				if (key === "browserViewportSize") return "900x600"
+				return undefined
+			})
+
+			// Launch browser - this should use local browser
+			await browserSession.launchBrowser()
+
+			// Verify that launch was called (local browser)
+			expect(mockLaunch).toHaveBeenCalled()
+
+			// Now close the browser
+			await browserSession.closeBrowser()
+
+			// Verify that close() was called
+			expect(mockBrowser.close).toHaveBeenCalled()
+			expect(mockBrowser.disconnect).not.toHaveBeenCalled()
+		})
+	})
+})


### PR DESCRIPTION
## Summary

This PR fixes issue #4822 where Chrome helper processes were not being properly cleaned up when remote browser connection was enabled but no remote browser was available.

## Problem

When remote browser connection is enabled in settings but no remote browser is actually available, the code would:
1. Try to connect to a remote browser
2. Fail and fall back to launching a local browser
3. But during cleanup, still try to `disconnect()` instead of `close()` the browser
4. This left Chrome helper processes running

## Solution

- Added `isUsingRemoteBrowser` flag to track the actual connection type (not just the setting)
- Modified `closeBrowser()` to use the actual connection type instead of just checking the setting
- Ensure `resetBrowserState()` is always called to properly clean up all state
- Added comprehensive tests covering all browser connection scenarios

## Testing

Added unit tests that verify:
- Local browser is properly closed when remote connection is enabled but falls back to local
- Remote browser is properly disconnected when actually connected to remote
- Local browser is properly closed when remote connection is disabled

All tests pass and demonstrate the fix working correctly.

## Changes

- `src/services/browser/BrowserSession.ts`: Added connection tracking and fixed cleanup logic
- `src/services/browser/__tests__/BrowserSession.test.ts`: Added comprehensive test coverage

Fixes #4822
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes browser cleanup logic in `BrowserSession` by tracking actual connection type and updating tests.
> 
>   - **Behavior**:
>     - Adds `isUsingRemoteBrowser` flag in `BrowserSession` to track actual connection type.
>     - Modifies `closeBrowser()` in `BrowserSession` to use `isUsingRemoteBrowser` for cleanup logic.
>     - Ensures `resetBrowserState()` is always called for proper cleanup.
>   - **Testing**:
>     - Adds tests in `BrowserSession.test.ts` to verify local browser closes when remote fallback is used.
>     - Tests remote browser disconnects when connected, and local closes when remote is disabled.
>   - **Files**:
>     - `BrowserSession.ts`: Connection tracking and cleanup logic.
>     - `BrowserSession.test.ts`: Comprehensive test coverage for connection scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d422915f08ee02502e61624d5a438b66958112d5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->