### PR TITLE
Fixes #4875: Fix codebase re-indexing race condition

### DIFF
--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1440,7 +1440,7 @@ export const webviewMessageHandler = async (
 						await manager.initialize(provider.contextProxy)
 					}
 
-					manager.startIndexing()
+					await manager.startIndexing()
 				}
 			} catch (error) {
 				provider.log(`Error starting indexing: ${error instanceof Error ? error.message : String(error)}`)


### PR DESCRIPTION
- Fixed race condition in CodeIndexOrchestrator where clearIndexData and startIndexing could conflict
- Separated _isProcessing check from state validation in startIndexing for better error reporting
- Made webview startIndexing handler properly await the operation
- Removed _isProcessing reset from stopWatcher to prevent interference with calling methods
- Added comprehensive tests for clearIndexData and startIndexing sequence
- Ensures users can successfully re-index after clearing index data

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in `CodeIndexOrchestrator` by improving `startIndexing` logic and adding tests for re-indexing sequence.
> 
>   - **Behavior**:
>     - Fixes race condition in `CodeIndexOrchestrator` by separating `_isProcessing` check from state validation in `startIndexing()`.
>     - Ensures `webviewMessageHandler.ts` properly awaits `startIndexing()`.
>     - Removes `_isProcessing` reset from `stopWatcher()` to prevent interference.
>   - **Tests**:
>     - Adds tests in `manager.spec.ts` for `clearIndexData` and `startIndexing` sequence.
>     - Tests handle rapid calls and ensure no errors in sequence execution.
>   - **Misc**:
>     - Ensures users can re-index after clearing index data without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 65e18215a1205f884e0f8e2fc3a3edfb8ac337dd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->