### PR TITLE
fix: mark unused Ollama schema properties as optional

### DIFF
--- a/src/api/providers/fetchers/__tests__/ollama.test.ts
+++ b/src/api/providers/fetchers/__tests__/ollama.test.ts
@@ -31,6 +31,31 @@ describe("Ollama Fetcher", () => {
 				description: "Family: qwen3, Context: 40960, Size: 32.8B",
 			})
 		})
+
+		it("should handle models with null families field", () => {
+			const modelDataWithNullFamilies = {
+				...ollamaModelsData["qwen3-2to16:latest"],
+				details: {
+					...ollamaModelsData["qwen3-2to16:latest"].details,
+					families: null,
+				},
+			}
+
+			const parsedModel = parseOllamaModel(modelDataWithNullFamilies as any)
+
+			expect(parsedModel).toEqual({
+				maxTokens: 40960,
+				contextWindow: 40960,
+				supportsImages: false,
+				supportsComputerUse: false,
+				supportsPromptCache: true,
+				inputPrice: 0,
+				outputPrice: 0,
+				cacheWritesPrice: 0,
+				cacheReadsPrice: 0,
+				description: "Family: qwen3, Context: 40960, Size: 32.8B",
+			})
+		})
 	})
 
 	describe("getOllamaModels", () => {
@@ -128,6 +153,70 @@ describe("Ollama Fetcher", () => {
 			expect(result).toEqual({})
 
 			consoleInfoSpy.mockRestore() // Restore original console.info
+		})
+
+		it("should handle models with null families field in API response", async () => {
+			const baseUrl = "http://localhost:11434"
+			const modelName = "test-model:latest"
+
+			const mockApiTagsResponse = {
+				models: [
+					{
+						name: modelName,
+						model: modelName,
+						modified_at: "2025-06-03T09:23:22.610222878-04:00",
+						size: 14333928010,
+						digest: "6a5f0c01d2c96c687d79e32fdd25b87087feb376bf9838f854d10be8cf3c10a5",
+						details: {
+							family: "llama",
+							families: null, // This is the case we're testing
+							format: "gguf",
+							parameter_size: "23.6B",
+							parent_model: "",
+							quantization_level: "Q4_K_M",
+						},
+					},
+				],
+			}
+			const mockApiShowResponse = {
+				license: "Mock License",
+				modelfile: "FROM /path/to/blob\nTEMPLATE {{ .Prompt }}",
+				parameters: "num_ctx 4096\nstop_token <eos>",
+				template: "{{ .System }}USER: {{ .Prompt }}ASSISTANT:",
+				modified_at: "2025-06-03T09:23:22.610222878-04:00",
+				details: {
+					parent_model: "",
+					format: "gguf",
+					family: "llama",
+					families: null, // This is the case we're testing
+					parameter_size: "23.6B",
+					quantization_level: "Q4_K_M",
+				},
+				model_info: {
+					"ollama.context_length": 4096,
+					"some.other.info": "value",
+				},
+				capabilities: ["completion"],
+			}
+
+			mockedAxios.get.mockResolvedValueOnce({ data: mockApiTagsResponse })
+			mockedAxios.post.mockResolvedValueOnce({ data: mockApiShowResponse })
+
+			const result = await getOllamaModels(baseUrl)
+
+			expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+			expect(mockedAxios.get).toHaveBeenCalledWith(`${baseUrl}/api/tags`)
+
+			expect(mockedAxios.post).toHaveBeenCalledTimes(1)
+			expect(mockedAxios.post).toHaveBeenCalledWith(`${baseUrl}/api/show`, { model: modelName })
+
+			expect(typeof result).toBe("object")
+			expect(result).not.toBeInstanceOf(Array)
+			expect(Object.keys(result).length).toBe(1)
+			expect(result[modelName]).toBeDefined()
+
+			// Verify the model was parsed correctly despite null families
+			expect(result[modelName].description).toBe("Family: llama, Context: 4096, Size: 23.6B")
 		})
 	})
 })

--- a/src/api/providers/fetchers/ollama.ts
+++ b/src/api/providers/fetchers/ollama.ts
@@ -4,26 +4,26 @@ import { z } from "zod"
 
 const OllamaModelDetailsSchema = z.object({
 	family: z.string(),
-	families: z.array(z.string()),
-	format: z.string(),
+	families: z.array(z.string()).nullable().optional(),
+	format: z.string().optional(),
 	parameter_size: z.string(),
-	parent_model: z.string(),
-	quantization_level: z.string(),
+	parent_model: z.string().optional(),
+	quantization_level: z.string().optional(),
 })
 
 const OllamaModelSchema = z.object({
 	details: OllamaModelDetailsSchema,
-	digest: z.string(),
+	digest: z.string().optional(),
 	model: z.string(),
-	modified_at: z.string(),
+	modified_at: z.string().optional(),
 	name: z.string(),
-	size: z.number(),
+	size: z.number().optional(),
 })
 
 const OllamaModelInfoResponseSchema = z.object({
-	modelfile: z.string(),
-	parameters: z.string(),
-	template: z.string(),
+	modelfile: z.string().optional(),
+	parameters: z.string().optional(),
+	template: z.string().optional(),
 	details: OllamaModelDetailsSchema,
 	model_info: z.record(z.string(), z.any()),
 	capabilities: z.array(z.string()).optional(),


### PR DESCRIPTION
## Description

This PR fixes a Zod validation error that occurs when Ollama returns `null` for the `families` field in model details.

## Changes

- Made the `families` field nullable and optional in `OllamaModelDetailsSchema`
- Marked all unused properties as optional in Ollama schemas to prevent future validation errors
- Only properties that are actually used in the code remain as required fields
- Added comprehensive test cases to verify handling of null values

## Properties marked as optional:

**OllamaModelDetailsSchema:**
- `families` (nullable and optional)
- `format`
- `parent_model`
- `quantization_level`

**OllamaModelSchema:**
- `digest`
- `modified_at`
- `size`

**OllamaModelInfoResponseSchema:**
- `modelfile`
- `parameters`
- `template`

## Testing

- Added test case for models with null `families` field
- Added integration test to verify API response parsing with null values
- All existing tests continue to pass

## Related Issues

Fixes #5013
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Zod validation error by marking unused Ollama schema properties as optional and adding tests for null handling.
> 
>   - **Schema Changes**:
>     - `families` field in `OllamaModelDetailsSchema` is now nullable and optional.
>     - Marked unused properties as optional in `OllamaModelDetailsSchema`, `OllamaModelSchema`, and `OllamaModelInfoResponseSchema`.
>   - **Testing**:
>     - Added test case in `ollama.test.ts` for models with null `families` field.
>     - Added integration test for API response parsing with null values.
>   - **Behavior**:
>     - Only required properties are those used in the code, reducing validation errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0400f565e23ab9495c2762ddcbf6572e2ec42fe7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->