### PR TITLE
Add claude code as a provider that doesn't need configuration

### DIFF
--- a/src/shared/checkExistApiConfig.ts
+++ b/src/shared/checkExistApiConfig.ts
@@ -5,8 +5,8 @@ export function checkExistKey(config: ProviderSettings | undefined) {
 		return false
 	}
 
-	// Special case for human-relay and fake-ai providers which don't need any configuration.
-	if (config.apiProvider === "human-relay" || config.apiProvider === "fake-ai") {
+	// Special case for human-relay, fake-ai, and claude-code providers which don't need any configuration.
+	if (config.apiProvider && ["human-relay", "fake-ai", "claude-code"].includes(config.apiProvider)) {
 		return true
 	}
 


### PR DESCRIPTION
Fix issue preventing choosing claude code as initial provider
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `claude-code` as a provider in `checkExistKey` that doesn't require configuration.
> 
>   - **Behavior**:
>     - Adds `claude-code` to the list of providers in `checkExistKey` in `checkExistApiConfig.ts` that don't require configuration.
>     - Allows `claude-code` to be selected as an initial provider without configuration.
>   - **Misc**:
>     - Updates comment in `checkExistKey` to include `claude-code`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 050a9dd9977726b649c18fe6459fae4ec0b3d2e0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->