### PR TITLE
feat: remove individual review comments option from PR Reviewer mode

### DIFF
--- a/.roo/rules-pr-reviewer/1_workflow.xml
+++ b/.roo/rules-pr-reviewer/1_workflow.xml
@@ -163,12 +163,10 @@
       [Summary of findings organized by priority]
 
       Would you like me to:
-      1. Submit these as individual review comments
-      2. Create a comprehensive review with all comments
-      3. Modify any of the suggestions
-      4. Skip the review submission</question>
+      1. Create a comprehensive review with all comments
+      2. Modify any of the suggestions
+      3. Skip the review submission</question>
       <follow_up>
-      <suggest>Submit as individual review comments</suggest>
       <suggest>Create a comprehensive review</suggest>
       <suggest>Let me modify the suggestions first</suggest>
       <suggest>Skip submission - just wanted the analysis</suggest>
@@ -180,9 +178,22 @@
   <step number="9">
     <name>Submit Review</name>
     <instructions>
-      Based on user preference, submit the review:
+      Based on user preference, submit the review as a comprehensive review:
       
-      For individual comments:
+      1. First create a pending review:
+      <use_mcp_tool>
+      <server_name>github</server_name>
+      <tool_name>create_pending_pull_request_review</tool_name>
+      <arguments>
+      {
+        "owner": "[owner]",
+        "repo": "[repo]",
+        "pullNumber": [number]
+      }
+      </arguments>
+      </use_mcp_tool>
+      
+      2. Add comments to the pending review using:
       <use_mcp_tool>
       <server_name>github</server_name>
       <tool_name>add_pull_request_review_comment_to_pending_review</tool_name>
@@ -198,22 +209,6 @@
       }
       </arguments>
       </use_mcp_tool>
-      
-      For comprehensive review:
-      1. First create a pending review:
-      <use_mcp_tool>
-      <server_name>github</server_name>
-      <tool_name>create_pending_pull_request_review</tool_name>
-      <arguments>
-      {
-        "owner": "[owner]",
-        "repo": "[repo]",
-        "pullNumber": [number]
-      }
-      </arguments>
-      </use_mcp_tool>
-      
-      2. Add comments to the pending review
       
       3. Submit the review:
       <use_mcp_tool>


### PR DESCRIPTION
## Description

Removes the option to submit individual review comments from PR Reviewer mode. Now only supports comprehensive reviews where all comments are grouped together.

## Changes

- Removed "Submit as individual review comments" option from step 8
- Updated step 9 to only include comprehensive review workflow
- All PR reviews will now be submitted as a single comprehensive review
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes individual review comments option from PR Reviewer mode, focusing on comprehensive reviews in `1_workflow.xml`.
> 
>   - **Behavior**:
>     - Removed option to submit individual review comments in PR Reviewer mode.
>     - Step 8 now only offers comprehensive review, modify suggestions, or skip submission.
>     - Step 9 updated to submit reviews as comprehensive only.
>   - **Workflow Changes**:
>     - Removed individual review comment option from step 8 in `1_workflow.xml`.
>     - Updated step 9 in `1_workflow.xml` to reflect comprehensive review submission process.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1e528da4fbbe47a5660a9e7c186b90f21c15ceb4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->