### PR TITLE
Improve pr-reviewer to verify resolved comments by checking code

### DIFF
--- a/.roo/rules-pr-reviewer/1_workflow.xml
+++ b/.roo/rules-pr-reviewer/1_workflow.xml
@@ -100,7 +100,7 @@
       </arguments>
       </use_mcp_tool>
       
-      Examine existing PR comments to understand the current state of discussion. Always verify whether a comment is current or already addressed before suggesting action.
+      Examine existing PR comments to understand the current state of discussion. When reading the comments and reviews, you must verify which are resolved by reading the files they refer to, since they might already be resolved. This prevents you from making redundant suggestions.
     </instructions>
   </step>
 

--- a/.roo/rules-pr-reviewer/2_best_practices.xml
+++ b/.roo/rules-pr-reviewer/2_best_practices.xml
@@ -2,7 +2,7 @@
   - Always fetch and review the entire PR diff before commenting
   - Check for and review any associated issue for context
   - Check out the PR locally for better context understanding
-  - Review existing comments to avoid duplicate feedback
+  - Review existing comments and verify against the current code to avoid redundant feedback on already resolved issues
   - Focus on the changes made, not unrelated code
   - Ensure all changes are directly related to the linked issue
   - Use a friendly, curious tone in all comments

--- a/.roo/rules-pr-reviewer/3_common_mistakes_to_avoid.xml
+++ b/.roo/rules-pr-reviewer/3_common_mistakes_to_avoid.xml
@@ -7,7 +7,7 @@
   - Using markdown headings (###, ##, #) in review comments
   - Using excessive markdown formatting when plain text would suffice
   - Submitting comments without user preview/approval
-  - Ignoring existing PR comments and discussions
+  - Ignoring existing PR comments or failing to verify if they have already been resolved by checking the code
   - Forgetting to check for an associated issue for additional context
   - Missing critical security or performance issues
   - Not checking for proper i18n in UI changes


### PR DESCRIPTION
Updates pr-reviewer mode rules to verify if PR comments have already been resolved by checking the referenced files, preventing redundant suggestions.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates pr-reviewer rules to verify resolved comments by checking code, preventing redundant suggestions.
> 
>   - **Behavior**:
>     - Updates `1_workflow.xml` to verify if PR comments are resolved by checking referenced files, preventing redundant suggestions.
>   - **Best Practices**:
>     - Modifies `2_best_practices.xml` to include verification of comments against current code to avoid redundant feedback.
>   - **Common Mistakes**:
>     - Updates `3_common_mistakes_to_avoid.xml` to emphasize verifying if comments are resolved by checking the code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 889263c015f3bfaf025bd437d2deeb493f31e02f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->