### PR TITLE
Fixes #5229: Profile Condense Threshold not working

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1721,7 +1721,18 @@ export class Task extends EventEmitter<ClineEvents> {
 				customCondensingPrompt,
 				condensingApiHandler,
 				profileThresholds,
-				currentProfileId: state?.currentApiConfigName || "default",
+				currentProfileId: (() => {
+					// Find the profile ID from the current profile name
+					const currentProfileName = state?.currentApiConfigName || "default"
+					const listApiConfigMeta = state?.listApiConfigMeta
+					if (listApiConfigMeta && Array.isArray(listApiConfigMeta)) {
+						const matchingConfig = listApiConfigMeta.find(
+							(config: any) => config.name === currentProfileName,
+						)
+						return matchingConfig?.id || "default"
+					}
+					return "default"
+				})(),
 			})
 			if (truncateResult.messages !== this.apiConversationHistory) {
 				await this.overwriteApiConversationHistory(truncateResult.messages)


### PR DESCRIPTION
## Summary

This PR fixes GitHub issue #5229 where profile-specific condensation thresholds were not working correctly.

## Problem

When users set a condensation trigger threshold (e.g., 25%) for a specific profile in Settings->Context->Condensing Trigger Threshold, the automatic context condensation would not trigger at the specified threshold. Instead, it would fall back to the global threshold setting.

## Root Cause

The bug was in `src/core/task/Task.ts` at line 1724. The code was using `currentApiConfigName` (which contains the profile **name**) as the key to lookup profile thresholds, but the `profileThresholds` object is actually keyed by profile **ID**. This mismatch meant the profile-specific threshold was never found.

## Solution

- Fixed the profile ID lookup by properly resolving the profile ID from the profile name
- The fix searches through `listApiConfigMeta` to find the matching profile configuration and extract its ID
- Added a comprehensive test case that reproduces the original issue and verifies the fix works correctly

## Changes

- **src/core/task/Task.ts**: Fixed profile ID resolution logic in `truncateConversationIfNeeded`
- **src/core/sliding-window/__tests__/sliding-window.spec.ts**: Added test case for GitHub issue #5229

## Testing

- All existing tests continue to pass
- New test specifically reproduces the issue scenario and confirms the fix works
- Verified that profile-specific thresholds are now properly applied instead of falling back to global defaults

Closes #5229
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes profile-specific condensation threshold lookup in `Task.ts` by resolving profile ID correctly, with tests added to verify the fix.
> 
>   - **Behavior**:
>     - Fixes profile-specific condensation threshold lookup in `truncateConversationIfNeeded` in `Task.ts` by resolving profile ID from profile name.
>     - Ensures profile-specific thresholds are applied instead of falling back to global defaults.
>   - **Testing**:
>     - Adds test case in `sliding-window.spec.ts` to verify profile ID resolution and correct threshold application.
>     - Confirms that profile-specific thresholds trigger condensation as expected.
>   - **Misc**:
>     - Closes GitHub issue #5229.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dc2b7d621ba2d189534a812e21e605946af9c30d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->