### PR TITLE
fix: Exclude cache files from rules compilation

### DIFF
--- a/src/core/prompts/sections/custom-instructions.ts
+++ b/src/core/prompts/sections/custom-instructions.ts
@@ -333,16 +333,12 @@ function shouldIncludeRuleFile(filename: string): boolean {
 		"Thumbs.db",
 	]
 
-	for (const pattern of cachePatterns) {
+	return !cachePatterns.some((pattern) => {
 		if (pattern.startsWith("*.")) {
 			const extension = pattern.slice(1)
-			if (basename.endsWith(extension)) {
-				return false
-			}
-		} else if (basename === pattern) {
-			return false
+			return basename.endsWith(extension)
+		} else {
+			return basename === pattern
 		}
-	}
-
-	return true
+	})
 }


### PR DESCRIPTION
### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #2728 

### Description

## Summary
Prevents system files like `.DS_Store`, `.Thumbs.db`, and other cache files from being processed as rule files in the `.roo/rules-{mode-slug}` directories.

## Changes
- Added `shouldIncludeRuleFile()` function to filter out unwanted files during rule compilation
- Modified `readTextFilesFromDirectory()` to apply file filtering before processing
- Added support for 21 common cache file patterns including `.DS_Store`, `.db`, `.bak`, `.log`, etc.
- Updated comment to reflect the new filtering behavior

## Impact
- Fixes issue where macOS `.DS_Store` files were being included in system prompts
- Prevents other cache and temporary files from polluting rule compilation
- Improves system prompt quality and reduces noise

### Test Procedure

Manual Testing
- Create a .roo/rules-{mode-slug}/ directory
- Create a .DS_Store (or other files in the exclusion pattern), add random content like "AAAAAAAAA"
- Go to Roo modes, click to copy the system prompt for the mode
- Paste on Notepad, CTRL + F for "AAAAA"

On the current main branch, we see the content from the .DS_Store and other files being added, there's no filter.
With this implementation, the files are filtered and not included in the rules.

- **Test Coverage**: Added `"should filter out cache files from .roo/rules/ directory"` test case
  - Tests filtering of `.DS_Store`, `Thumbs.db`, `.bak`, `.log`, `.tmp`, `.pyc` files
  - Verifies rule files are still processed correctly
  - Confirms cache files are completely excluded from processing
  - Prevents future regressions in filtering logic

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [X] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [X] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [X] **Self-Review**: I have performed a thorough self-review of my code.
- [X] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [X] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [X] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [X] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->
**Why we didn't import from existing exclusion patterns:**

The existing `getCacheFilePatterns()` function in `src/services/checkpoints/excludes.ts` contains identical patterns, but we cannot import from it due to architectural constraints:

- The `custom-instructions.ts` file is imported by webview components that run in the browser
- `excludes.ts` has Node.js dependencies (`fs/promises`, `path`) that cannot be bundled for browser environments
- Importing from `excludes.ts` would cause Vite build failures in the webview

This is a necessary architectural trade-off to maintain browser compatibility while solving the cache file inclusion issue.

Let me know if any other changes are needed, or if I should add tests for the filtering logic.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->
@MuriloFP

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `shouldIncludeRuleFile()` to filter out cache files from rule compilation in `custom-instructions.ts`, improving prompt quality.
> 
>   - **Behavior**:
>     - Adds `shouldIncludeRuleFile()` in `custom-instructions.ts` to exclude cache files like `.DS_Store`, `.Thumbs.db`, etc., from rule compilation.
>     - Modifies `readTextFilesFromDirectory()` to use `shouldIncludeRuleFile()` for filtering files before processing.
>   - **Impact**:
>     - Fixes issue with `.DS_Store` files being included in system prompts.
>     - Prevents cache and temporary files from affecting rule compilation.
>     - Enhances system prompt quality by reducing noise.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ec62e2fcb9231a6f31ddbb6515ca20346aec6567. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->