### PR TITLE
fix: prevent sidebar opening in multi-window VS Code setups (#5485)

### DIFF
--- a/src/utils/__tests__/focusPanel.test.ts
+++ b/src/utils/__tests__/focusPanel.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as vscode from "vscode"
+import { focusPanel } from "../focusPanel"
+import { ClineProvider } from "../../core/webview/ClineProvider"
+
+// Mock vscode module
+vi.mock("vscode", () => ({
+	commands: {
+		executeCommand: vi.fn(),
+	},
+	window: {
+		activeTextEditor: undefined,
+		visibleTextEditors: [],
+	},
+	ViewColumn: {
+		Active: 1,
+	},
+}))
+
+// Mock ClineProvider
+vi.mock("../../core/webview/ClineProvider", () => ({
+	ClineProvider: {
+		sideBarId: "roo-code.SidebarProvider",
+		getVisibleInstance: vi.fn(),
+	},
+}))
+
+// Mock Package
+vi.mock("../../shared/package", () => ({
+	Package: {
+		name: "roo-code",
+	},
+}))
+
+describe("focusPanel", () => {
+	const mockExecuteCommand = vi.mocked(vscode.commands.executeCommand)
+	const mockGetVisibleInstance = vi.mocked(ClineProvider.getVisibleInstance)
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		// Reset window state
+		;(vscode.window as any).activeTextEditor = undefined
+		;(vscode.window as any).visibleTextEditors = []
+	})
+
+	describe("when panels exist", () => {
+		it("should reveal tab panel when it exists but is not active", async () => {
+			const mockTabPanel = {
+				active: false,
+				reveal: vi.fn(),
+			} as any
+
+			await focusPanel(mockTabPanel, undefined)
+
+			expect(mockTabPanel.reveal).toHaveBeenCalledWith(1, false)
+			expect(mockExecuteCommand).not.toHaveBeenCalled()
+		})
+
+		it("should focus sidebar panel when it exists", async () => {
+			const mockSidebarPanel = {} as any
+
+			await focusPanel(undefined, mockSidebarPanel)
+
+			expect(mockExecuteCommand).toHaveBeenCalledWith("roo-code.SidebarProvider.focus")
+		})
+
+		it("should prefer tab panel over sidebar panel when both exist", async () => {
+			const mockTabPanel = {
+				active: false,
+				reveal: vi.fn(),
+			} as any
+			const mockSidebarPanel = {} as any
+
+			await focusPanel(mockTabPanel, mockSidebarPanel)
+
+			expect(mockTabPanel.reveal).toHaveBeenCalledWith(1, false)
+			expect(mockExecuteCommand).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("when no panels exist", () => {
+		it("should open sidebar when there is a visible Roo Code instance", async () => {
+			mockGetVisibleInstance.mockReturnValue({} as any)
+
+			await focusPanel(undefined, undefined)
+
+			expect(mockExecuteCommand).toHaveBeenCalledWith("workbench.view.extension.roo-code-ActivityBar")
+		})
+
+		it("should open sidebar when there is an active editor (user is working in this window)", async () => {
+			mockGetVisibleInstance.mockReturnValue(undefined)
+			;(vscode.window as any).activeTextEditor = { document: { fileName: "test.ts" } }
+
+			await focusPanel(undefined, undefined)
+
+			expect(mockExecuteCommand).toHaveBeenCalledWith("workbench.view.extension.roo-code-ActivityBar")
+		})
+
+		it("should open sidebar when there are visible editors (user is working in this window)", async () => {
+			mockGetVisibleInstance.mockReturnValue(undefined)
+			;(vscode.window as any).visibleTextEditors = [{ document: { fileName: "test.ts" } }]
+
+			await focusPanel(undefined, undefined)
+
+			expect(mockExecuteCommand).toHaveBeenCalledWith("workbench.view.extension.roo-code-ActivityBar")
+		})
+
+		it("should NOT open sidebar when no visible instance and no editors (multi-window scenario)", async () => {
+			mockGetVisibleInstance.mockReturnValue(undefined)
+			// No active editor and no visible editors (default state)
+
+			await focusPanel(undefined, undefined)
+
+			expect(mockExecuteCommand).not.toHaveBeenCalled()
+		})
+
+		it("should open sidebar when detection fails (fallback to existing behavior)", async () => {
+			mockGetVisibleInstance.mockImplementation(() => {
+				throw new Error("Test error")
+			})
+
+			await focusPanel(undefined, undefined)
+
+			expect(mockExecuteCommand).toHaveBeenCalledWith("workbench.view.extension.roo-code-ActivityBar")
+		})
+	})
+})

--- a/src/utils/focusPanel.ts
+++ b/src/utils/focusPanel.ts
@@ -15,13 +15,55 @@ export async function focusPanel(
 	const panel = tabPanel || sidebarPanel
 
 	if (!panel) {
-		// If no panel is open, open the sidebar
-		await vscode.commands.executeCommand(`workbench.view.extension.${Package.name}-ActivityBar`)
+		// Check if we should open the sidebar - avoid opening in multi-window scenarios
+		// where the user might be working in a different VS Code window
+		const shouldOpenSidebar = await shouldAllowSidebarActivation()
+
+		if (shouldOpenSidebar) {
+			// If no panel is open, open the sidebar
+			await vscode.commands.executeCommand(`workbench.view.extension.${Package.name}-ActivityBar`)
+		}
 	} else if (panel === tabPanel && !panel.active) {
 		// For tab panels, use reveal to focus
 		panel.reveal(vscode.ViewColumn.Active, false)
 	} else if (panel === sidebarPanel) {
 		// For sidebar panels, focus the sidebar
 		await vscode.commands.executeCommand(`${ClineProvider.sideBarId}.focus`)
+	}
+}
+
+/**
+ * Determines if we should allow automatic sidebar activation
+ * This helps prevent unwanted sidebar opening in multi-window VS Code setups
+ * @returns Promise<boolean> - true if sidebar activation is allowed
+ */
+async function shouldAllowSidebarActivation(): Promise<boolean> {
+	try {
+		// Check if there's a visible Roo Code instance already
+		const visibleProvider = ClineProvider.getVisibleInstance()
+		if (visibleProvider) {
+			// If there's already a visible provider, it's safe to open the sidebar
+			return true
+		}
+
+		// Check if the current window has focus and is the active window
+		// This helps prevent opening sidebar when user is working in another window
+		const activeEditor = vscode.window.activeTextEditor
+		const visibleEditors = vscode.window.visibleTextEditors
+
+		// If there are active editors in this window, it's likely the user's current working window
+		if (activeEditor || visibleEditors.length > 0) {
+			return true
+		}
+
+		// If no editors are visible and no Roo Code instance is visible,
+		// be conservative and don't auto-open the sidebar to avoid disrupting
+		// the user's workflow in other windows
+		return false
+	} catch (error) {
+		// If there's any error in detection, err on the side of caution
+		// and allow sidebar activation to maintain existing functionality
+		console.warn("Error in shouldAllowSidebarActivation:", error)
+		return true
 	}
 }


### PR DESCRIPTION
## Description

Fixes #5485

This PR resolves the issue where Roo Code's sidebar would automatically open when the extension is used in another VS Code window, disrupting the user's workflow in multi-window setups.

## Root Cause

The issue was in the `focusPanel` utility function at line 18-19 in `src/utils/focusPanel.ts`. When no panel was available, it would automatically execute a command to open the sidebar:

```typescript
if (!panel) {
    // If no panel is open, open the sidebar
    await vscode.commands.executeCommand(`workbench.view.extension.${Package.name}-ActivityBar`)
}
```

This command would open the sidebar regardless of which VS Code window the user was currently working in, causing the unwanted behavior described in the issue.

## Changes Made

- **Enhanced `focusPanel` function**: Added logic to detect multi-window scenarios before automatically opening the sidebar
- **Added `shouldAllowSidebarActivation` helper**: Determines if sidebar activation is appropriate based on:
  - Whether there's already a visible Roo Code instance
  - Whether the current window has active editors (indicating user activity)
  - Conservative approach to avoid disrupting workflow in other windows
- **Comprehensive test coverage**: Added 8 test cases covering all scenarios including multi-window detection
- **Backward compatibility**: Maintains existing behavior when appropriate, only prevents unwanted sidebar opening

## Testing

- [x] All existing tests pass
- [x] Added comprehensive unit tests for `focusPanel` functionality (8 test cases)
- [x] TypeScript compilation passes without errors
- [x] Linting passes without warnings
- [x] Manual testing completed:
  - Verified sidebar opens when expected (single window, visible instance)
  - Verified sidebar doesn't open inappropriately (multi-window scenarios)
  - Confirmed existing focus behavior for tab and sidebar panels works correctly

## Verification of Acceptance Criteria

- [x] **Issue reproduction**: Confirmed the bug occurs when Roo Code actions are triggered in one window while user works in another
- [x] **Root cause identified**: Located in `focusPanel` utility function's automatic sidebar opening logic
- [x] **Fix implemented**: Added multi-window detection to prevent unwanted sidebar activation
- [x] **Backward compatibility**: Existing single-window behavior preserved
- [x] **No regressions**: All existing functionality continues to work as expected

## Files Changed

- `src/utils/focusPanel.ts` - Enhanced with multi-window detection logic
- `src/utils/__tests__/focusPanel.test.ts` - Added comprehensive test coverage

## Potential Impacts

- **Breaking changes**: None - maintains backward compatibility
- **Performance**: Minimal impact - only adds lightweight checks when no panel exists
- **User experience**: Significantly improved for multi-window VS Code users
- **Compatibility**: Works with all VS Code versions and configurations

## Related Issues

- Addresses the regression mentioned in the issue that occurred within the last 2 weeks
- Related to issue #4199 which dealt with diff editor problems in multi-window setups
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes unwanted sidebar opening in multi-window VS Code setups by enhancing `focusPanel` with multi-window detection logic and adding comprehensive tests.
> 
>   - **Behavior**:
>     - Fixes unwanted sidebar opening in multi-window VS Code setups by enhancing `focusPanel` in `focusPanel.ts`.
>     - Adds `shouldAllowSidebarActivation` to check if sidebar activation is appropriate based on window state.
>   - **Testing**:
>     - Adds 8 test cases in `focusPanel.test.ts` to cover scenarios including multi-window detection.
>     - Tests ensure sidebar opens only when appropriate (e.g., visible instance, active editors).
>   - **Misc**:
>     - Maintains backward compatibility by preserving existing single-window behavior.
>     - Logs errors in `shouldAllowSidebarActivation` to console and defaults to existing behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a591dcb77f43ece3a40110824431082867b514b8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->