### PR TITLE
feat: remove RooTips from welcome screen to clean up UI

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -36,7 +36,6 @@ import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { useSelectedModel } from "@src/components/ui/hooks/useSelectedModel"
 import RooHero from "@src/components/welcome/RooHero"
-import RooTips from "@src/components/welcome/RooTips"
 import { StandardTooltip } from "@src/components/ui"
 
 import TelemetryBanner from "../common/TelemetryBanner"
@@ -1675,9 +1674,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 								}}
 							/>
 						</p>
-						<div className="mb-2.5">
-							<RooTips cycle={false} />
-						</div>
 						{/* Show the task history preview if expanded and tasks exist */}
 						{taskHistory.length > 0 && isExpanded && <HistoryPreview />}
 					</div>


### PR DESCRIPTION
Fixes #5683

## Summary
Removes the RooTips component from the welcome screen to create a cleaner, less cluttered user interface as requested in issue #5683.

## Changes Made
- Removed `<RooTips cycle={false} />` component from ChatView welcome section
- Removed unused import of RooTips component
- Kept RooTips component intact for potential future use

## Impact
- Eliminates informational tips about "Customizable Modes" and "Task Orchestration" from the main UI
- Results in a cleaner welcome screen experience
- No breaking changes - component is simply not rendered

## Testing
- ✅ Build passes successfully
- ✅ TypeScript compilation passes
- ✅ Linting passes
- ✅ Application loads without errors

The RooTips component itself remains available in the codebase and can be easily re-enabled in the future if needed.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes `RooTips` from `ChatView.tsx` welcome screen for a cleaner UI, keeping the component in the codebase for future use.
> 
>   - **Behavior**:
>     - Removes `<RooTips cycle={false} />` from the welcome section in `ChatView.tsx`.
>     - Eliminates tips about "Customizable Modes" and "Task Orchestration" from the UI.
>     - No breaking changes; `RooTips` component remains in codebase.
>   - **Imports**:
>     - Removes unused import of `RooTips` in `ChatView.tsx`.
>   - **Testing**:
>     - Build, TypeScript compilation, and linting pass successfully.
>     - Application loads without errors.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d097a620f4bdcdccb26bbe118ce45c028fb6dcf8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->