### PR TITLE
chore: add changeset for v3.23.9 patch release

### DIFF
--- a/.changeset/v3.23.9.md
+++ b/.changeset/v3.23.9.md
@@ -1,0 +1,9 @@
+---
+"roo-cline": patch
+---
+
+- Enable Claude Code provider to run natively on Windows (thanks @SannidhyaSah!)
+- Add configurable timeout for command execution
+- Add gemini-embedding-001 model to code-index service (thanks @daniel-lxs!)
+- Resolve vector dimension mismatch error when switching embedding models
+- Return the cwd in the exec tool's response so that the model is not lost after subsequent calls (thanks @chris-garrett!)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add changeset for v3.23.9 patch release with Windows support, timeout configuration, new model, and error fixes.
> 
>   - **Behavior**:
>     - Enable Claude Code provider to run natively on Windows.
>     - Add configurable timeout for command execution.
>     - Add `gemini-embedding-001` model to code-index service.
>     - Resolve vector dimension mismatch error when switching embedding models.
>     - Return the current working directory in the exec tool's response to maintain model context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1e745b6f49dc8bb68db90c7aba8b18f95a8770ea. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->