### PR TITLE
feat: increase Ollama API timeout values and extract as constants

### DIFF
--- a/src/services/code-index/embedders/ollama.ts
+++ b/src/services/code-index/embedders/ollama.ts
@@ -7,6 +7,10 @@ import { withValidationErrorHandling, sanitizeErrorMessage } from "../shared/val
 import { TelemetryService } from "@roo-code/telemetry"
 import { TelemetryEventName } from "@roo-code/types"
 
+// Timeout constants for Ollama API requests
+const OLLAMA_EMBEDDING_TIMEOUT_MS = 60000 // 60 seconds for embedding requests
+const OLLAMA_VALIDATION_TIMEOUT_MS = 30000 // 30 seconds for validation requests
+
 /**
  * Implements the IEmbedder interface using a local Ollama instance.
  */
@@ -61,7 +65,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 
 			// Add timeout to prevent indefinite hanging
 			const controller = new AbortController()
-			const timeoutId = setTimeout(() => controller.abort(), 10000) // 10 second timeout
+			const timeoutId = setTimeout(() => controller.abort(), OLLAMA_EMBEDDING_TIMEOUT_MS)
 
 			const response = await fetch(url, {
 				method: "POST",
@@ -140,7 +144,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 
 				// Add timeout to prevent indefinite hanging
 				const controller = new AbortController()
-				const timeoutId = setTimeout(() => controller.abort(), 5000) // 5 second timeout
+				const timeoutId = setTimeout(() => controller.abort(), OLLAMA_VALIDATION_TIMEOUT_MS)
 
 				const modelsResponse = await fetch(modelsUrl, {
 					method: "GET",
@@ -197,7 +201,7 @@ export class CodeIndexOllamaEmbedder implements IEmbedder {
 
 				// Add timeout for test request too
 				const testController = new AbortController()
-				const testTimeoutId = setTimeout(() => testController.abort(), 5000)
+				const testTimeoutId = setTimeout(() => testController.abort(), OLLAMA_VALIDATION_TIMEOUT_MS)
 
 				const testResponse = await fetch(testUrl, {
 					method: "POST",


### PR DESCRIPTION
Fixes #5733
Fixes #5517

Increase Ollama API timeout values from 10s/5s to 60s/30s and extract as module-level constants for better maintainability.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Increase Ollama API timeouts and extract them as constants in `ollama.ts`.
> 
>   - **Timeout Changes**:
>     - Increase embedding timeout from 10s to 60s in `createEmbeddings()`.
>     - Increase validation timeout from 5s to 30s in `validateConfiguration()`.
>   - **Constants**:
>     - Extract timeout values as `OLLAMA_EMBEDDING_TIMEOUT_MS` and `OLLAMA_VALIDATION_TIMEOUT_MS` in `ollama.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 676ca79c0363a3da25aab2cdbdd454f0965b13e4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->