### PR TITLE
Format time in ISO 8601

### DIFF
--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -179,22 +179,12 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 	// Add current time information with timezone.
 	const now = new Date()
 
-	const formatter = new Intl.DateTimeFormat(undefined, {
-		year: "numeric",
-		month: "numeric",
-		day: "numeric",
-		hour: "numeric",
-		minute: "numeric",
-		second: "numeric",
-		hour12: true,
-	})
-
-	const timeZone = formatter.resolvedOptions().timeZone
+	const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
 	const timeZoneOffset = -now.getTimezoneOffset() / 60 // Convert to hours and invert sign to match conventional notation
 	const timeZoneOffsetHours = Math.floor(Math.abs(timeZoneOffset))
 	const timeZoneOffsetMinutes = Math.abs(Math.round((Math.abs(timeZoneOffset) - timeZoneOffsetHours) * 60))
 	const timeZoneOffsetStr = `${timeZoneOffset >= 0 ? "+" : "-"}${timeZoneOffsetHours}:${timeZoneOffsetMinutes.toString().padStart(2, "0")}`
-	details += `\n\n# Current Time\n${formatter.format(now)} (${timeZone}, UTC${timeZoneOffsetStr})`
+	details += `\n\n# Current Time\nCurrent time in ISO 8601 UTC format: ${now.toISOString()}\nUser time zone: ${timeZone}, UTC${timeZoneOffsetStr}`
 
 	// Add context tokens information.
 	const { contextTokens, totalCost } = getApiMetrics(cline.clineMessages)


### PR DESCRIPTION
### Description

At Kilo Code we received reports on 11 July that the LLMs (especially Opus 4) were confused about the current date and concluding it was 7 November or even 7 January:

> The user is asking for the current date. I can see from the environment_details that the current time is provided as "7/11/2025, 5:18:34 PM (Europe/Amsterdam, UTC+2:00)". This appears to be in a format of month/day/year.
So the current date is November 7th, 2025.

<img width="400" src="https://github.com/user-attachments/assets/f8ccdd89-dcd4-4b1a-b97c-bcc45224a0ab" />

<img width="500" src="https://github.com/user-attachments/assets/2fe241d5-a265-4971-b7d4-775ba04afb65" />

This pull request changes the date format from something that's dependent on the user's locale, e.g.:

```
# Current Time
7/16/2025, 9:40:17 PM (Europe/Amsterdam, UTC+2:00)
```

to ISO 8601, which is non-ambiguous:

```
# Current Time
Current time in ISO 8601 UTC format: 2025-07-16T19:46:03.839Z
User time zone: Europe/Amsterdam, UTC+2:00
```

Kilo Code PR: https://github.com/Kilo-Org/kilocode/pull/1263

### Test Procedure

Ask a few different models the current date and/or time and verify the results are correct.

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<img width="446" height="356" alt="CleanShot 2025-07-16 at 21 47 25" src="https://github.com/user-attachments/assets/7770cc0a-e96b-4179-bd08-2ae831320bbb" />

### Get in Touch

Christiaan in shared Slack

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change date format to ISO 8601 in `getEnvironmentDetails.ts` to avoid locale-dependent confusion.
> 
>   - **Behavior**:
>     - Change date format to ISO 8601 in `getEnvironmentDetails()` in `getEnvironmentDetails.ts`.
>     - Replaces locale-dependent date format with `now.toISOString()` for clarity.
>   - **Misc**:
>     - Remove unused `Intl.DateTimeFormat` formatter in `getEnvironmentDetails.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d546b9072f77d2be7d27b894ee07c99fbda1254b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->