### PR TITLE
fix: prevent empty mode names from being saved (#5766)

### DIFF
--- a/src/core/config/CustomModesManager.ts
+++ b/src/core/config/CustomModesManager.ts
@@ -401,6 +401,14 @@ export class CustomModesManager {
 
 	public async updateCustomMode(slug: string, config: ModeConfig): Promise<void> {
 		try {
+			// Validate the mode configuration before saving
+			const validationResult = modeConfigSchema.safeParse(config)
+			if (!validationResult.success) {
+				const errors = validationResult.error.errors.map((e) => e.message).join(", ")
+				logger.error(`Invalid mode configuration for ${slug}`, { errors: validationResult.error.errors })
+				throw new Error(`Invalid mode configuration: ${errors}`)
+			}
+
 			const isProjectMode = config.source === "project"
 			let targetPath: string
 

--- a/webview-ui/src/components/modes/ModesView.tsx
+++ b/webview-ui/src/components/modes/ModesView.tsx
@@ -110,6 +110,10 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 	const [searchValue, setSearchValue] = useState("")
 	const searchInputRef = useRef<HTMLInputElement>(null)
 
+	// Local state for mode name input to allow visual emptying
+	const [localModeName, setLocalModeName] = useState<string>("")
+	const [currentEditingModeSlug, setCurrentEditingModeSlug] = useState<string | null>(null)
+
 	// Direct update functions
 	const updateAgentPrompt = useCallback(
 		(mode: Mode, promptData: PromptComponent) => {
@@ -217,6 +221,14 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 			checkRulesDirectory(currentMode.slug)
 		}
 	}, [getCurrentMode, checkRulesDirectory, hasRulesToExport])
+
+	// Reset local name state when mode changes
+	useEffect(() => {
+		if (currentEditingModeSlug && currentEditingModeSlug !== visualMode) {
+			setCurrentEditingModeSlug(null)
+			setLocalModeName("")
+		}
+	}, [visualMode, currentEditingModeSlug])
 
 	// Helper function to safely access mode properties
 	const getModeProperty = <T extends keyof ModeConfig>(
@@ -725,16 +737,34 @@ const ModesView = ({ onDone }: ModesViewProps) => {
 								<div className="flex gap-2">
 									<Input
 										type="text"
-										value={getModeProperty(findModeBySlug(visualMode, customModes), "name") ?? ""}
-										onChange={(e) => {
+										value={
+											currentEditingModeSlug === visualMode
+												? localModeName
+												: (getModeProperty(findModeBySlug(visualMode, customModes), "name") ??
+													"")
+										}
+										onFocus={() => {
 											const customMode = findModeBySlug(visualMode, customModes)
 											if (customMode) {
+												setCurrentEditingModeSlug(visualMode)
+												setLocalModeName(customMode.name)
+											}
+										}}
+										onChange={(e) => {
+											setLocalModeName(e.target.value)
+										}}
+										onBlur={() => {
+											const customMode = findModeBySlug(visualMode, customModes)
+											if (customMode && localModeName.trim()) {
+												// Only update if the name is not empty
 												updateCustomMode(visualMode, {
 													...customMode,
-													name: e.target.value,
+													name: localModeName,
 													source: customMode.source || "global",
 												})
 											}
+											// Clear the editing state
+											setCurrentEditingModeSlug(null)
 										}}
 										className="w-full"
 									/>


### PR DESCRIPTION
Fixes #5766

## Problem
If the user cleared the custom mode name field, the change was saved immediately. This made the custom modes YAML file invalid, and all custom modes disappeared.

## Solution
Keep a local state while the field is being edited. Only save the change on blur, and only if the name is not empty.

----

> [!IMPORTANT]
> Fixes issue with empty mode names by adding local state management and backend validation in `ModesView.tsx` and `CustomModesManager.ts`.
> 
>   - **Behavior**:
>     - Allows users to visually empty mode name field in `ModesView.tsx`.
>     - Saves only non-empty mode names on blur in `ModesView.tsx`.
>     - Backend validation in `CustomModesManager.ts` to reject empty mode names.
>   - **State Management**:
>     - Adds `localModeName` and `currentEditingModeSlug` state in `ModesView.tsx` to manage input field state.
>     - Resets local state when mode changes in `ModesView.tsx`.
>   - **Validation**:
>     - Validates mode configuration using `modeConfigSchema` in `CustomModesManager.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fc2c8869442c5f1107b787da5d644ce078fcc94e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->