### PR TITLE
fix: enable export, share, and copy buttons during API operations (#5324)

### DIFF
--- a/webview-ui/src/components/chat/TaskActions.tsx
+++ b/webview-ui/src/components/chat/TaskActions.tsx
@@ -23,7 +23,7 @@ export const TaskActions = ({ item, buttonsDisabled }: TaskActionsProps) => {
 
 	return (
 		<div className="flex flex-row gap-1">
-			<ShareButton item={item} disabled={buttonsDisabled} />
+			<ShareButton item={item} disabled={false} />
 			<IconButton
 				iconClass="codicon-desktop-download"
 				title={t("chat:task.export")}
@@ -33,7 +33,6 @@ export const TaskActions = ({ item, buttonsDisabled }: TaskActionsProps) => {
 				<IconButton
 					iconClass={showCopyFeedback ? "codicon-check" : "codicon-copy"}
 					title={t("history:copyPrompt")}
-					disabled={buttonsDisabled}
 					onClick={(e) => copyWithFeedback(item.task, e)}
 				/>
 			)}

--- a/webview-ui/src/components/chat/__tests__/TaskActions.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/TaskActions.spec.tsx
@@ -371,29 +371,54 @@ describe("TaskActions", () => {
 	})
 
 	describe("Button States", () => {
-		it("disables share button but keeps export button enabled when buttonsDisabled is true", () => {
+		it("keeps share, export, and copy buttons enabled but disables delete button when buttonsDisabled is true", () => {
 			render(<TaskActions item={mockItem} buttonsDisabled={true} />)
 
-			// Find button by its icon class
+			// Find buttons by their labels/icons
 			const buttons = screen.getAllByRole("button")
 			const shareButton = buttons.find((btn) => btn.querySelector(".codicon-link"))
 			const exportButton = screen.getByLabelText("Export task history")
+			const copyButton = buttons.find((btn) => btn.querySelector(".codicon-copy"))
+			const deleteButton = screen.getByLabelText("Delete Task (Shift + Click to skip confirmation)")
 
-			expect(shareButton).toBeDisabled()
-			// Export button should always be enabled regardless of buttonsDisabled
+			// Share, export, and copy buttons should be enabled regardless of buttonsDisabled
+			expect(shareButton).not.toBeDisabled()
 			expect(exportButton).not.toBeDisabled()
+			expect(copyButton).not.toBeDisabled()
+			// Delete button should respect buttonsDisabled
+			expect(deleteButton).toBeDisabled()
 		})
 
-		it("export button is always enabled regardless of buttonsDisabled state", () => {
+		it("share, export, and copy buttons are always enabled while delete button respects buttonsDisabled state", () => {
 			// Test with buttonsDisabled = false
 			const { rerender } = render(<TaskActions item={mockItem} buttonsDisabled={false} />)
+
+			let buttons = screen.getAllByRole("button")
+			let shareButton = buttons.find((btn) => btn.querySelector(".codicon-link"))
 			let exportButton = screen.getByLabelText("Export task history")
+			let copyButton = buttons.find((btn) => btn.querySelector(".codicon-copy"))
+			let deleteButton = screen.getByLabelText("Delete Task (Shift + Click to skip confirmation)")
+
+			expect(shareButton).not.toBeDisabled()
 			expect(exportButton).not.toBeDisabled()
+			expect(copyButton).not.toBeDisabled()
+			expect(deleteButton).not.toBeDisabled()
 
 			// Test with buttonsDisabled = true
 			rerender(<TaskActions item={mockItem} buttonsDisabled={true} />)
+
+			buttons = screen.getAllByRole("button")
+			shareButton = buttons.find((btn) => btn.querySelector(".codicon-link"))
 			exportButton = screen.getByLabelText("Export task history")
+			copyButton = buttons.find((btn) => btn.querySelector(".codicon-copy"))
+			deleteButton = screen.getByLabelText("Delete Task (Shift + Click to skip confirmation)")
+
+			// Share, export, and copy remain enabled
+			expect(shareButton).not.toBeDisabled()
 			expect(exportButton).not.toBeDisabled()
+			expect(copyButton).not.toBeDisabled()
+			// Delete button is disabled
+			expect(deleteButton).toBeDisabled()
 		})
 	})
 })


### PR DESCRIPTION
## Description

Fixes #5324

This PR enables the export, share, and copy buttons to remain functional while the API is active, addressing the regression that prevented users from performing these actions during model operations.

## Changes Made

- Export button: Always enabled (removed disabled attribute)
- Share button: Always enabled (passes `disabled={false}` to ShareButton)
- Copy button: Always enabled (removed disabled attribute)
- Delete button: Still respects `buttonsDisabled` state for safety
- Removed unnecessary `exportAlwaysEnabled` prop
- Updated tests to reflect new behavior

## Testing

- [x] All existing tests pass
- [x] Updated tests for the new button behavior
- [x] Manual testing completed:
  - Export, share, and copy buttons remain enabled during API operations
  - Delete button is properly disabled during API operations
  - All functionality works correctly while model is running

## Verification

- [x] Export task history button now works while API is active
- [x] Share and copy functionality available during model operations
- [x] Delete button safety maintained (disabled during API operations)
- [x] No breaking changes - simplified implementation