### PR TITLE
fix: add runtime indexing state check to codebase_search tool (#5662)

### DIFF
--- a/src/core/tools/__tests__/codebaseSearchTool.spec.ts
+++ b/src/core/tools/__tests__/codebaseSearchTool.spec.ts
@@ -1,0 +1,386 @@
+// npx vitest src/core/tools/__tests__/codebaseSearchTool.spec.ts
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as path from "path"
+import { codebaseSearchTool } from "../codebaseSearchTool"
+import { Task } from "../../task/Task"
+import { CodeIndexManager } from "../../../services/code-index/manager"
+import { ToolUse } from "../../../shared/tools"
+import { formatResponse } from "../../prompts/responses"
+
+// Mock vscode
+vi.mock("vscode", () => ({
+	workspace: {
+		asRelativePath: vi.fn().mockImplementation((filePath) => {
+			// Simple mock that just returns the path without workspace prefix
+			return filePath.replace("/test/workspace/", "")
+		}),
+	},
+}))
+
+// Mock dependencies
+vi.mock("../../../utils/path", () => ({
+	getWorkspacePath: vi.fn().mockReturnValue("/test/workspace"),
+}))
+
+vi.mock("../../../services/code-index/manager")
+
+vi.mock("../../prompts/responses", () => ({
+	formatResponse: {
+		toolDenied: vi.fn().mockReturnValue("Tool denied"),
+	},
+}))
+
+describe("codebaseSearchTool", () => {
+	let mockCline: Task
+	let mockAskApproval: any
+	let mockHandleError: any
+	let mockPushToolResult: any
+	let mockRemoveClosingTag: any
+	let mockCodeIndexManager: any
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		// Mock Cline/Task
+		mockCline = {
+			ask: vi.fn().mockResolvedValue(undefined),
+			sayAndCreateMissingParamError: vi.fn().mockResolvedValue("Missing parameter error"),
+			say: vi.fn().mockResolvedValue(undefined),
+			consecutiveMistakeCount: 0,
+			providerRef: {
+				deref: vi.fn().mockReturnValue({
+					context: {},
+				}),
+			},
+		} as any
+
+		// Mock callback functions
+		mockAskApproval = vi.fn().mockResolvedValue(true)
+		mockHandleError = vi.fn().mockResolvedValue(undefined)
+		mockPushToolResult = vi.fn()
+		mockRemoveClosingTag = vi.fn().mockImplementation((tag, value) => value)
+
+		// Mock CodeIndexManager instance
+		mockCodeIndexManager = {
+			isFeatureEnabled: true,
+			isFeatureConfigured: true,
+			state: "Indexed",
+			searchIndex: vi.fn().mockResolvedValue([
+				{
+					score: 0.9,
+					payload: {
+						filePath: "/test/workspace/src/example.ts",
+						startLine: 10,
+						endLine: 20,
+						codeChunk: "function example() { return 'test'; }",
+					},
+				},
+			]),
+		}
+
+		// Mock CodeIndexManager.getInstance
+		vi.mocked(CodeIndexManager).getInstance = vi.fn().mockReturnValue(mockCodeIndexManager)
+	})
+
+	describe("indexing state checks", () => {
+		it("should throw error when indexing state is 'Indexing'", async () => {
+			// Arrange
+			mockCodeIndexManager.state = "Indexing"
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockHandleError).toHaveBeenCalledWith(
+				"codebase_search",
+				expect.objectContaining({
+					message: expect.stringContaining("Semantic search isn't ready yet (currently Indexing)"),
+				}),
+			)
+		})
+
+		it("should throw error when indexing state is 'Standby'", async () => {
+			// Arrange
+			mockCodeIndexManager.state = "Standby"
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockHandleError).toHaveBeenCalledWith(
+				"codebase_search",
+				expect.objectContaining({
+					message: expect.stringContaining("Semantic search isn't ready yet (currently Standby)"),
+				}),
+			)
+		})
+
+		it("should throw error when indexing state is 'Error'", async () => {
+			// Arrange
+			mockCodeIndexManager.state = "Error"
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockHandleError).toHaveBeenCalledWith(
+				"codebase_search",
+				expect.objectContaining({
+					message: expect.stringContaining("Semantic search isn't ready yet (currently Error)"),
+				}),
+			)
+		})
+
+		it("should proceed with search when indexing state is 'Indexed'", async () => {
+			// Arrange
+			mockCodeIndexManager.state = "Indexed"
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockHandleError).not.toHaveBeenCalled()
+			expect(mockCodeIndexManager.searchIndex).toHaveBeenCalledWith("test query", undefined)
+			expect(mockPushToolResult).toHaveBeenCalledWith(expect.stringContaining("test query"))
+			expect(mockPushToolResult).toHaveBeenCalledWith(expect.stringContaining("example.ts"))
+		})
+	})
+
+	describe("feature availability checks", () => {
+		it("should throw error when feature is disabled", async () => {
+			// Arrange
+			mockCodeIndexManager.isFeatureEnabled = false
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockHandleError).toHaveBeenCalledWith(
+				"codebase_search",
+				expect.objectContaining({
+					message: "Code Indexing is disabled in the settings.",
+				}),
+			)
+		})
+
+		it("should throw error when feature is not configured", async () => {
+			// Arrange
+			mockCodeIndexManager.isFeatureConfigured = false
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockHandleError).toHaveBeenCalledWith(
+				"codebase_search",
+				expect.objectContaining({
+					message: "Code Indexing is not configured (Missing OpenAI Key or Qdrant URL).",
+				}),
+			)
+		})
+	})
+
+	describe("parameter validation", () => {
+		it("should handle missing query parameter", async () => {
+			// Arrange
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockCline.sayAndCreateMissingParamError).toHaveBeenCalledWith("codebase_search", "query")
+			expect(mockPushToolResult).toHaveBeenCalledWith("Missing parameter error")
+		})
+
+		it("should handle user denial", async () => {
+			// Arrange
+			mockAskApproval.mockResolvedValue(false)
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockPushToolResult).toHaveBeenCalledWith("Tool denied")
+			expect(mockCodeIndexManager.searchIndex).not.toHaveBeenCalled()
+		})
+	})
+
+	describe("search results handling", () => {
+		it("should handle empty search results", async () => {
+			// Arrange
+			mockCodeIndexManager.searchIndex.mockResolvedValue([])
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "nonexistent query",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			expect(mockPushToolResult).toHaveBeenCalledWith(
+				'No relevant code snippets found for the query: "nonexistent query"',
+			)
+		})
+
+		it("should handle search with directory prefix", async () => {
+			// Arrange
+			const block: ToolUse = {
+				type: "tool_use",
+				name: "codebase_search",
+				params: {
+					query: "test query",
+					path: "src/components",
+				},
+				partial: false,
+			}
+
+			// Act
+			await codebaseSearchTool(
+				mockCline,
+				block,
+				mockAskApproval,
+				mockHandleError,
+				mockPushToolResult,
+				mockRemoveClosingTag,
+			)
+
+			// Assert
+			// The path gets normalized in the tool, so we need to check for the normalized version
+			expect(mockCodeIndexManager.searchIndex).toHaveBeenCalledWith(
+				"test query",
+				path.normalize("src/components"),
+			)
+		})
+	})
+})

--- a/src/core/tools/codebaseSearchTool.ts
+++ b/src/core/tools/codebaseSearchTool.ts
@@ -82,6 +82,14 @@ export async function codebaseSearchTool(
 			throw new Error("Code Indexing is not configured (Missing OpenAI Key or Qdrant URL).")
 		}
 
+		// Check if indexing is complete
+		const indexingState = manager.state
+		if (indexingState !== "Indexed") {
+			throw new Error(
+				`Semantic search isn't ready yet (currently ${indexingState}). The codebase is still being indexed. Please try again once indexing is complete, or use other tools like read_file or search_files for now.`,
+			)
+		}
+
 		const searchResults: VectorStoreSearchResult[] = await manager.searchIndex(query, directoryPrefix)
 
 		// 3. Format and push results


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #5662 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

_No Roo Code task context for this PR_

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

This PR implements a runtime check for the indexing state in the `codebase_search` tool, as suggested by @daniel-lxs in the issue comments. Instead of hiding the tool from the tool list when indexing is not complete (as attempted in PR #5663), this solution:

- Keeps the `codebase_search` tool always available in the tool list
- Performs a runtime check when the tool is actually used
- Provides a clear, informative error message when indexing is not complete
- Guides users to use alternative tools (read_file, search_files) while indexing is in progress

The key implementation detail is the addition of a state check before executing the search:
```typescript
if (indexingState !== 'Indexed') {
    throw new Error(`Semantic search isn't ready yet (currently ${indexingState}). The codebase is still being indexed. Please try again once indexing is complete, or use other tools like read_file or search_files for now.`)
}
```

This approach provides better user experience by:
1. Making state transitions smoother (e.g., when indexing finishes mid-conversation)
2. Keeping the logic in one place (inside the tool)
3. Helping users understand why semantic search isn't available instead of silently hiding it

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

**Unit Tests:**
- Created comprehensive test suite in `src/core/tools/__tests__/codebaseSearchTool.spec.ts`
- Tests cover all indexing states: 'Standby', 'Indexing', 'Error', and 'Indexed'
- Tests verify the error messages are shown correctly for non-'Indexed' states
- All 10 new tests pass
- All existing tests continue to pass (238 test files, 2906 tests)

**Manual Testing Steps:**
1. Disable code indexing in settings and try to use `codebase_search` - should get "disabled" error
2. Enable indexing but don't configure (missing API key) - should get "not configured" error  
3. Start indexing and immediately try to use `codebase_search` - should get "currently Indexing" error
4. Wait for indexing to complete and use `codebase_search` - should work normally

**To run the tests:**
```bash
cd src && npx vitest core/tools/__tests__/codebaseSearchTool.spec.ts
```

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

_No UI changes in this PR_

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

- [x] No documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

This implementation follows the suggestion from @daniel-lxs in the issue comments, which provides a better user experience than the approach in PR #5663. The error messages are designed to be informative and guide users to alternative solutions while waiting for indexing to complete.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

_Discord username not provided_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds runtime indexing state check to `codebaseSearchTool` and comprehensive tests for various states and configurations.
> 
>   - **Behavior**:
>     - Adds runtime check in `codebaseSearchTool` to ensure indexing state is 'Indexed' before proceeding.
>     - Throws error with informative message if indexing state is 'Indexing', 'Standby', or 'Error'.
>     - Keeps `codebase_search` tool available in tool list regardless of indexing state.
>   - **Tests**:
>     - Adds `codebaseSearchTool.spec.ts` with tests for indexing states: 'Standby', 'Indexing', 'Error', and 'Indexed'.
>     - Tests for feature availability: disabled and not configured states.
>     - Tests for parameter validation and search results handling.
>   - **Misc**:
>     - Guides users to alternative tools if indexing is incomplete.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8bd4fc58b83ba88caf3c74a4fb3c486796863b77. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->