### PR TITLE
Ensure form-data >= 4.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
 			"tar-fs": ">=2.1.3",
 			"esbuild": ">=0.25.0",
 			"undici": ">=5.29.0",
-			"brace-expansion": ">=2.0.2"
+			"brace-expansion": ">=2.0.2",
+			"form-data": ">=4.0.4"
 		}
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   esbuild: '>=0.25.0'
   undici: '>=5.29.0'
   brace-expansion: '>=2.0.2'
+  form-data: '>=4.0.4'
 
 importers:
 
@@ -5808,8 +5809,8 @@ packages:
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
-  form-data@4.0.2:
-    resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   formatly@0.2.4:
@@ -13121,7 +13122,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 20.17.57
-      form-data: 4.0.2
+      form-data: 4.0.4
 
   '@types/node-ipc@9.2.3':
     dependencies:
@@ -13463,7 +13464,7 @@ snapshots:
       cheerio: 1.0.0
       cockatiel: 3.2.1
       commander: 12.1.0
-      form-data: 4.0.2
+      form-data: 4.0.4
       glob: 11.0.2
       hosted-git-info: 4.1.0
       jsonc-parser: 3.3.1
@@ -13707,7 +13708,7 @@ snapshots:
   axios@1.9.0:
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.2
+      form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -15360,11 +15361,12 @@ snapshots:
 
   form-data-encoder@1.7.2: {}
 
-  form-data@4.0.2:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   formatly@0.2.4:


### PR DESCRIPTION
https://github.com/advisories/GHSA-fjxv-7rqg-78g4
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add version constraint for `form-data` to `>=4.0.4` in `package.json` to address security advisory.
> 
>   - **Dependencies**:
>     - Add version constraint for `form-data` to `>=4.0.4` in `package.json` to address security advisory GHSA-fjxv-7rqg-78g4.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ef17b88df65b397472c04eadd5373c2f3d2ed57a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->