### PR TITLE
docs: document optional todos param for new_task (#6329)

### DIFF
--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/architect-mode-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/architect-mode-prompt.snap
@@ -354,6 +354,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -361,10 +365,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/ask-mode-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/ask-mode-prompt.snap
@@ -251,6 +251,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -258,10 +262,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-disabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-disabled.snap
@@ -354,6 +354,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -361,10 +365,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-enabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/mcp-server-creation-enabled.snap
@@ -403,6 +403,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -410,10 +414,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/partial-reads-enabled.snap
+++ b/src/core/prompts/__tests__/__snapshots__/add-custom-instructions/partial-reads-enabled.snap
@@ -359,6 +359,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -366,10 +370,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/consistent-system-prompt.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/consistent-system-prompt.snap
@@ -354,6 +354,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -361,10 +365,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-computer-use-support.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-computer-use-support.snap
@@ -407,6 +407,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -414,10 +418,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-false.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-false.snap
@@ -354,6 +354,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -361,10 +365,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-true.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-true.snap
@@ -442,6 +442,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -449,10 +453,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-undefined.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-diff-enabled-undefined.snap
@@ -354,6 +354,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -361,10 +365,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-different-viewport-size.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-different-viewport-size.snap
@@ -407,6 +407,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -414,10 +418,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-mcp-hub-provided.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-mcp-hub-provided.snap
@@ -403,6 +403,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -410,10 +414,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/__tests__/__snapshots__/system-prompt/with-undefined-mcp-hub.snap
+++ b/src/core/prompts/__tests__/__snapshots__/system-prompt/with-undefined-mcp-hub.snap
@@ -354,6 +354,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -361,10 +365,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 
 

--- a/src/core/prompts/tools/new-task.ts
+++ b/src/core/prompts/tools/new-task.ts
@@ -7,6 +7,10 @@ Description: This will let you create a new task instance in the chosen mode usi
 Parameters:
 - mode: (required) The slug of the mode to start the new task in (e.g., "code", "debug", "architect").
 - message: (required) The initial user message or instructions for this new task.
+- todos: (optional) A markdown checklist string to initialize the new task's todo list. Use the same single-level checklist format as update_todo_list. If provided, Task parses this during initialization to create the todoList. If omitted, the task starts without a todoList.
+
+Notes:
+- settings.todoListEnabled only gates prompting behavior (i.e., whether update_todo_list is made available in prompts). Passing todos here does not force prompting if todoListEnabled is disabled.
 
 Usage:
 <new_task>
@@ -14,10 +18,23 @@ Usage:
 <message>Your initial instructions here</message>
 </new_task>
 
-Example:
+Example (without todos):
 <new_task>
 <mode>code</mode>
 <message>Implement a new feature for the application.</message>
+</new_task>
+
+Example (with todos):
+<new_task>
+<mode>code</mode>
+<message>Implement user authentication</message>
+<todos>
+[ ] Set up authentication middleware
+[ ] Create login endpoint
+[ ] Create logout endpoint
+[-] Add session management
+[x] Write tests for authentication
+</todos>
 </new_task>
 `
 }

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -155,7 +155,7 @@ export interface SwitchModeToolUse extends ToolUse {
 
 export interface NewTaskToolUse extends ToolUse {
 	name: "new_task"
-	params: Partial<Pick<Record<ToolParamName, string>, "mode" | "message">>
+	params: Partial<Pick<Record<ToolParamName, string>, "mode" | "message" | "todos">>
 }
 
 export interface SearchAndReplaceToolUse extends ToolUse {


### PR DESCRIPTION
<!--
Roo Code PR template per .roo/rules-issue-fixer/9_pr_template.xml
-->

Title: docs(new_task): document optional `todos` parameter; clarify `todoListEnabled` behavior

Summary
- Document the existing optional todos parameter for the new_task tool.
- Add explicit examples for usage with and without todos.
- Clarify that settings.todoListEnabled only gates prompting (exposing update_todo_list), not initialization via todos.
- No functional behavior changes; documentation and typing-only updates.

Context and Motivation
This aligns documentation with current behavior validated by tests. It enables users to initialize a task’s todo list via a markdown checklist passed to new_task, and removes confusion around the todoListEnabled setting.

Changes
- Updated tool docs: [src/core/prompts/tools/new-task.ts](src/core/prompts/tools/new-task.ts)
  - Add todos (optional) param description
  - Add two examples (with and without todos)
  - Add Notes section clarifying todoListEnabled gating of prompting
- Developer typing clarity: [src/shared/tools.ts](src/shared/tools.ts)
  - Extend NewTaskToolUse.params to include "todos"
  - No runtime impact (typing/interface only)
- Snapshots updated for prompt text changes:
  - src/core/prompts/__tests__/__snapshots__/system-prompt/with-undefined-mcp-hub.snap
  - src/core/prompts/__tests__/__snapshots__/add-custom-instructions/architect-mode-prompt.snap

Non-Goals
- No functional code changes.
- No changes to Task parsing or new_task execution logic.

Testing
Automated
- Snapshot updates for prompt content changes only.
- Full suite (as reported in summary): all tests passing.

Manual
- Verified new_task examples render correctly:
  - Without todos: starts task with no initial todo list.
  - With todos: initializes todoList from the markdown checklist.
- Verified that behavior is independent of todoListEnabled (impacts prompting visibility only).

Docs
- Tool documentation updated inline in new-task.ts to maintain consistency with existing prompt documentation patterns.

Screenshots/Demos
N/A (documentation-only changes).

Backward Compatibility
- Backward compatible: todos remains optional; existing flows unaffected.

Risks
- Low. Documentation-only plus typing extension for params. No runtime behavior changes.

Checklist
- [x] Only documentation/typing changes
- [x] Optional todos parameter documented with examples
- [x] Clarified: todoListEnabled gates prompting, not initialization
- [x] Snapshot updates correspond to doc string changes only
- [x] Tests pass locally per implementation summary
- [x] No functional changes introduced

Linked Issue
- #6329
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Document optional `todos` parameter for `new_task` tool and update related typings and snapshots.
> 
>   - **Documentation**:
>     - Document optional `todos` parameter in `new_task` tool in `new-task.ts`.
>     - Add examples for `new_task` usage with and without `todos`.
>     - Clarify `todoListEnabled` setting only affects prompting, not initialization.
>   - **Typing**:
>     - Extend `NewTaskToolUse.params` in `tools.ts` to include `todos`.
>   - **Snapshots**:
>     - Update snapshots in `system-prompt/with-undefined-mcp-hub.snap` and 8 other files for prompt text changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c1163b02aa601adb6455cd0f34b87e6c2ae0ae2b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->