### PR TITLE
Fix: Improve scroll lock behavior while maintaining memory efficiency

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -70,10 +70,10 @@ export interface ChatViewRef {
 
 export const MAX_IMAGES_PER_MESSAGE = 20 // Anthropic limits to 20 images
 
-// Viewport buffer constants for memory-efficient scroll behavior
-const VIEWPORT_BUFFER_AT_BOTTOM = 10_000 // Larger buffer when at bottom to maintain scroll lock
-const VIEWPORT_BUFFER_SCROLLED_UP = 1_000 // Smaller buffer when scrolled up to preserve memory efficiency
-const VIEWPORT_BUFFER_TOP = 3_000 // Top buffer for smooth scrolling
+// Viewport buffer constants
+const VIEWPORT_BUFFER_AT_BOTTOM = 10_000 // Maintains scroll lock when at bottom
+const VIEWPORT_BUFFER_SCROLLED_UP = 1_000 // Reduces memory usage when scrolled up
+const VIEWPORT_BUFFER_TOP = 3_000
 
 const isMac = navigator.platform.toUpperCase().indexOf("MAC") >= 0
 
@@ -1437,12 +1437,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 
 	useEvent("wheel", handleWheel, window, { passive: true }) // passive improves scrolling performance
 
-	// Debounce the isAtBottom state to prevent rapid viewport buffer changes
-	// This adds hysteresis to avoid performance issues when users quickly scroll between top and bottom
+	// Debounce isAtBottom to prevent rapid viewport buffer changes
 	useEffect(() => {
 		const timer = setTimeout(() => {
 			setDebouncedIsAtBottom(isAtBottom)
-		}, 300) // 300ms delay provides good balance between responsiveness and stability
+		}, 300)
 
 		return () => clearTimeout(timer)
 	}, [isAtBottom])
@@ -1906,11 +1905,8 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							className="scrollable grow overflow-y-scroll mb-1"
 							increaseViewportBy={{
 								top: VIEWPORT_BUFFER_TOP,
-								// Dynamic bottom buffer based on scroll position:
-								// - When at bottom: Use larger buffer to maintain scroll lock behavior
-								// - When scrolled up: Use smaller buffer to preserve memory efficiency
-								// This balances the memory leak fix from PR #6697 with proper scroll lock functionality
-								// Using debounced state to prevent rapid toggling during quick scrolling
+								// Dynamic bottom buffer: larger when at bottom for scroll lock,
+								// smaller when scrolled up for memory efficiency
 								bottom: debouncedIsAtBottom ? VIEWPORT_BUFFER_AT_BOTTOM : VIEWPORT_BUFFER_SCROLLED_UP,
 							}}
 							data={groupedMessages}
@@ -1924,9 +1920,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							}}
 							atBottomThreshold={10}
 							initialTopMostItemIndex={groupedMessages.length - 1}
-							// followOutput='smooth' ensures smooth scrolling animation when new content arrives,
-							// working in conjunction with the dynamic viewport buffer to maintain scroll lock
-							// when the user is at the bottom of the chat
+							// Smooth scrolling when new content arrives
 							followOutput="smooth"
 						/>
 					</div>


### PR DESCRIPTION
## Problem
PR #6697 fixed a memory leak by reducing the `increaseViewportBy` bottom value from `Number.MAX_SAFE_INTEGER` to `1000`, but this caused scroll lock issues where the chat view doesn't always stay pinned to the bottom when it should.

## Solution
This PR implements a dynamic approach that balances both memory efficiency and proper scroll behavior:

- **When scrolled to bottom**: Uses a larger viewport buffer (10,000px) to ensure smooth scroll lock behavior
- **When scrolled up**: Uses the smaller buffer (1,000px) to preserve memory efficiency
- **Added `followOutput='smooth'`**: Improves the scrolling animation when new content arrives

## Technical Details
The key change is making the `increaseViewportBy.bottom` value dynamic based on the `isAtBottom` state:
```tsx
increaseViewportBy={{ 
  top: 3_000, 
  // Use a dynamic bottom value: larger when at bottom to maintain scroll lock,
  // smaller when scrolled up to preserve memory efficiency
  bottom: isAtBottom ? 10_000 : 1000 
}}
```

This approach ensures:
1. ✅ Memory efficiency is maintained when users scroll up to review messages
2. ✅ Scroll stays locked to bottom when new messages arrive (when already at bottom)
3. ✅ No unbounded memory growth from rendering all messages

## Testing
- All existing tests pass
- Manual testing confirms scroll lock behavior is restored
- Memory usage remains bounded

Fixes the scroll lock regression introduced in #6697 while preserving the memory leak fix.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Dynamic viewport buffer adjustment in `ChatView.tsx` to fix scroll lock issues while maintaining memory efficiency.
> 
>   - **Behavior**:
>     - Dynamic `increaseViewportBy.bottom` in `ChatView.tsx` based on `isAtBottom` state: 10,000px when at bottom, 1,000px when scrolled up.
>     - Adds `followOutput='smooth'` for smoother scrolling when new content arrives.
>   - **State Management**:
>     - Introduces `debouncedIsAtBottom` state to prevent rapid viewport buffer changes.
>     - Updates `atBottomStateChange` to manage scroll lock and visibility of scroll-to-bottom button.
>   - **Constants**:
>     - Defines `VIEWPORT_BUFFER_AT_BOTTOM`, `VIEWPORT_BUFFER_SCROLLED_UP`, and `VIEWPORT_BUFFER_TOP` for viewport buffer management.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d368697c58ec85afac1be9db1406ac2882d790e3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->