### PR TITLE
Fix: Add skipContextCompression flag to prevent unwanted compression - Fixes #4430

### DIFF
--- a/src/core/sliding-window/index.ts
+++ b/src/core/sliding-window/index.ts
@@ -77,10 +77,7 @@ type TruncateOptions = {
 	condensingApiHandler?: ApiHandler
 	profileThresholds: Record<string, number>
 	currentProfileId: string
-	// Context for batch operations and settings saves - cleaner architecture
-	isBatchActive?: boolean
-	isSettingsSave?: boolean
-	maxConcurrentFileReads?: number
+	skipContextCompression?: boolean
 }
 
 type TruncateResponse = SummarizeResponse & { prevContextTokens: number }

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1275,6 +1275,11 @@ export const webviewMessageHandler = async (
 			break
 		case "maxReadFileLine":
 			await updateGlobalState("maxReadFileLine", message.value)
+			// Skip context compression for file reading settings changes
+			const activeTaskForFileRead = provider.getCurrentCline()
+			if (activeTaskForFileRead) {
+				activeTaskForFileRead.setSkipNextContextCompression()
+			}
 			await provider.postStateToWebview()
 			break
 		case "maxImageFileSize":
@@ -1290,7 +1295,7 @@ export const webviewMessageHandler = async (
 			await updateGlobalState("maxConcurrentFileReads", valueToSave)
 			const activeTask = provider.getCurrentCline()
 			if (activeTask && typeof valueToSave === "number" && valueToSave > 1) {
-				;(activeTask as any)._skipNextContextCompressionCheck = true
+				activeTask.setSkipNextContextCompression()
 			}
 			await provider.postStateToWebview()
 			break
@@ -1298,10 +1303,20 @@ export const webviewMessageHandler = async (
 			// Only apply default if the value is truly undefined (not false)
 			const includeValue = message.bool !== undefined ? message.bool : true
 			await updateGlobalState("includeDiagnosticMessages", includeValue)
+			// Skip context compression for diagnostic settings changes
+			const activeTaskForDiagnostics = provider.getCurrentCline()
+			if (activeTaskForDiagnostics) {
+				activeTaskForDiagnostics.setSkipNextContextCompression()
+			}
 			await provider.postStateToWebview()
 			break
 		case "maxDiagnosticMessages":
 			await updateGlobalState("maxDiagnosticMessages", message.value ?? 50)
+			// Skip context compression for diagnostic settings changes
+			const activeTaskForMaxDiagnostics = provider.getCurrentCline()
+			if (activeTaskForMaxDiagnostics) {
+				activeTaskForMaxDiagnostics.setSkipNextContextCompression()
+			}
 			await provider.postStateToWebview()
 			break
 		case "setHistoryPreviewCollapsed": // Add the new case handler


### PR DESCRIPTION
…- Fixes #4430

This PR implements a `skipContextCompression` flag to prevent unwanted context compression during multi-file read operations and settings save operations. The fix addresses the issue where context compression was being triggered inappropriately, causing performance issues and unexpected behavior.

**Key implementation details:**
- Added `skipContextCompression` parameter to `truncateConversationIfNeeded` function
- When the flag is `true`, the function returns early without performing compression, even if the context usage exceeds the threshold
- The flag is designed to be used in scenarios where compression should be temporarily disabled (e.g., during multi-file reads, settings operations)
- Maintains backward compatibility by making the parameter optional with a default value of `false`

**Reviewers should pay attention to:**
- The early return logic in the sliding window function
- Test coverage for both skip and normal compression scenarios
- Integration points where the flag needs to be passed through

### Test Procedure

**How I tested this implementation:**
1. Created comprehensive unit tests covering:
   - Skip functionality when flag is `true`
   - Normal compression when flag is `false`
   - Edge cases with different threshold values
   - Multi-file read scenario simulation

2. All existing tests continue to pass, ensuring no regression

**How reviewers can verify:**
1. Run the test suite: `pnpm test`
2. Check the new test file: `src/core/sliding-window/__tests__/context-compression-fix.test.ts`
3. Verify that the `skipContextCompression` parameter is properly handled in the main function

**Testing environment:** 
- Node.js 20.19.2
- All tests passing with vitest framework

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (#4430)
- [x] **Scope**: My changes are focused on the linked issue (context compression skip functionality)
- [x] **Self-Review**: I have performed a thorough self-review of my code
- [x] **Testing**: New comprehensive tests have been added to cover the skip functionality
- [x] **Documentation Impact**: No user-facing documentation updates required (internal API change)
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines

### Screenshots / Videos

<!-- Not applicable - this is a backend logic fix with no UI changes -->

### Documentation Updates

- [x] No documentation updates are required (internal API enhancement)

### Additional Notes

This fix specifically addresses the performance issue mentioned in #4430 where context compression was being triggered during multi-file read operations when `maxConcurrentFileReads > 1`. The `skipContextCompression` flag provides a clean way to temporarily disable compression during these operations while maintaining the existing compression logic for normal use cases.

The implementation is designed to be:
- **Safe**: Backward compatible with existing code
- **Targeted**: Only affects compression behavior when explicitly requested
- **Testable**: Comprehensive test coverage for all scenarios

### Get in Touch
shirish.gone@smartsheet.com

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `skipContextCompression` flag to control context compression, preventing unwanted compression during multi-file reads and settings operations.
> 
>   - **Behavior**:
>     - Adds `skipContextCompression` flag to `truncateConversationIfNeeded` in `index.ts` to prevent unwanted context compression.
>     - When `true`, skips compression even if context usage exceeds threshold.
>     - Used during multi-file reads and settings operations to avoid performance issues.
>     - Backward compatible with default `false` value.
>   - **Integration**:
>     - `Task.ts`: Passes `skipContextCompression` flag in `truncateConversationIfNeeded` calls.
>     - `webviewMessageHandler.ts`: Sets `_skipNextContextCompressionCheck` when `maxConcurrentFileReads > 1`.
>   - **Testing**:
>     - New tests in `context-compression-fix.test.ts` for scenarios with and without the flag.
>     - Tests cover edge cases and multi-file read scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for eb95b87f8c4e959926cf98b67a0c29c8646fd7bb. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->