### PR TITLE
fix: Use cline.cwd as primary source for workspace path in codebaseSearchTool

### DIFF
--- a/src/core/tools/codebaseSearchTool.ts
+++ b/src/core/tools/codebaseSearchTool.ts
@@ -17,7 +17,7 @@ export async function codebaseSearchTool(
 	removeClosingTag: RemoveClosingTag,
 ) {
 	const toolName = "codebase_search"
-	const workspacePath = cline.cwd || getWorkspacePath()
+	const workspacePath = (cline.cwd && cline.cwd.trim() !== '') ? cline.cwd : getWorkspacePath()
 
 	if (!workspacePath) {
 		// This case should ideally not happen if Cline is initialized correctly


### PR DESCRIPTION
https://github.com/RooCodeInc/Roo-Code/issues/6897

In multi-folder workspaces, mimic the history and index status, binding the dialog to the CWD when creating a new ChatView. This will prevent CWD switching during a conversation and further confusion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prioritize `cline.cwd` over `getWorkspacePath()` in `codebaseSearchTool.ts` to prevent CWD switching in multi-folder workspaces.
> 
>   - **Behavior**:
>     - In `codebaseSearchTool.ts`, prioritize `cline.cwd` over `getWorkspacePath()` for determining `workspacePath`.
>     - Prevents CWD switching during conversations in multi-folder workspaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for eb488b452ba87982ba770db024f861ef27858aed. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->