### PR TITLE
Hotfix multiple folder workspace checkpoint

### DIFF
--- a/src/core/checkpoints/index.ts
+++ b/src/core/checkpoints/index.ts
@@ -56,7 +56,7 @@ export async function getCheckpointService(
 	console.log("[Task#getCheckpointService] initializing checkpoints service")
 
 	try {
-		const workspaceDir = getWorkspacePath()
+		const workspaceDir = cline.cwd || getWorkspacePath()
 
 		if (!workspaceDir) {
 			log("[Task#getCheckpointService] workspace folder not found, disabling checkpoints")


### PR DESCRIPTION
https://github.com/RooCodeInc/Roo-Code/issues/6897

In multi-folder workspaces, mimic the history and index status, binding the dialog to the CWD when creating a new ChatView. This will prevent CWD switching during a conversation and further confusion.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes multi-folder workspace handling by using `cline.cwd` for workspace path determination in `getCheckpointService()` and `codebaseSearchTool()`.
> 
>   - **Behavior**:
>     - In `getCheckpointService()` in `index.ts`, use `cline.cwd` as the workspace directory if available, preventing CWD switching during conversations.
>     - In `codebaseSearchTool()` in `codebaseSearchTool.ts`, use `cline.cwd` as the workspace path if available, ensuring correct path determination.
>   - **Misc**:
>     - Fixes issue #6897 related to multi-folder workspace handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ded505d6e8e1f24dc0070737ff34fe5543a8a5dd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->