### PR TITLE
Bump cloud to 0.10.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,8 +563,8 @@ importers:
         specifier: ^1.14.0
         version: 1.14.0(typescript@5.8.3)
       '@roo-code/cloud':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       '@roo-code/ipc':
         specifier: workspace:^
         version: link:../packages/ipc
@@ -3065,8 +3065,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@roo-code/cloud@0.9.0':
-    resolution: {integrity: sha512-NU1K0IzGX+JPu7flr8AyfNzi/CJzUs82ZU0npB1+wXccjRGv8+pczRDGdJa29CveoNU/S5w5uXevxdt4SIkYkg==}
+  '@roo-code/cloud@0.10.0':
+    resolution: {integrity: sha512-nP5XD9JVaFFmz+XN9za9XMombCjw7LrS4pFEbBU52raZbobvUAExKuMJw8U+vyXFW+mcVAexM0i39XB6SJvhWA==}
 
   '@roo-code/types@1.45.0':
     resolution: {integrity: sha512-+rFJ9HcukDl59X9pI6lgZDtJHtKqHg6BIdS4LG759X+5MV7wvlNb4S+bQ3qKqIlBsQhH17bzIJCfsWZwjwxecw==}
@@ -12234,7 +12234,7 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.40.2':
     optional: true
 
-  '@roo-code/cloud@0.9.0':
+  '@roo-code/cloud@0.10.0':
     dependencies:
       '@roo-code/types': 1.45.0
       ioredis: 5.6.1
@@ -13480,7 +13480,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.17.57)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.29)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@26.1.0)(lightningcss@1.30.1)(tsx@4.19.4)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:

--- a/src/package.json
+++ b/src/package.json
@@ -420,7 +420,7 @@
 		"@mistralai/mistralai": "^1.3.6",
 		"@modelcontextprotocol/sdk": "^1.9.0",
 		"@qdrant/js-client-rest": "^1.14.0",
-		"@roo-code/cloud": "^0.9.0",
+		"@roo-code/cloud": "^0.10.0",
 		"@roo-code/ipc": "workspace:^",
 		"@roo-code/telemetry": "workspace:^",
 		"@roo-code/types": "workspace:^",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `@roo-code/cloud` version from `^0.9.0` to `^0.10.0` in `package.json`.
> 
>   - **Dependencies**:
>     - Bump `@roo-code/cloud` version from `^0.9.0` to `^0.10.0` in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 735ca22e7e516bb2f330a096a85800f388628cd1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->