### PR TITLE
fix: prevent duplicate LM Studio models with case-insensitive deduplication

### DIFF
--- a/src/api/providers/fetchers/__tests__/lmstudio.test.ts
+++ b/src/api/providers/fetchers/__tests__/lmstudio.test.ts
@@ -190,6 +190,181 @@ describe("LMStudio Fetcher", () => {
 			expect(result[mockDownloadedModel.path]).toBeUndefined()
 		})
 
+		it("should handle deduplication with path-based matching", async () => {
+			const mockDownloadedModel: LLMInfo = {
+				type: "llm" as const,
+				modelKey: "Meta/Llama-3.1/8B-Instruct",
+				format: "gguf",
+				displayName: "Llama 3.1 8B Instruct",
+				path: "Meta/Llama-3.1/8B-Instruct",
+				sizeBytes: 8000000000,
+				architecture: "llama",
+				vision: false,
+				trainedForToolUse: false,
+				maxContextLength: 8192,
+			}
+
+			const mockLoadedModel: LLMInstanceInfo = {
+				type: "llm",
+				modelKey: "Llama-3.1", // Should match the path segment
+				format: "gguf",
+				displayName: "Llama 3.1",
+				path: "Meta/Llama-3.1/8B-Instruct",
+				sizeBytes: 8000000000,
+				architecture: "llama",
+				identifier: "Meta/Llama-3.1/8B-Instruct",
+				instanceReference: "ABC123",
+				vision: false,
+				trainedForToolUse: false,
+				maxContextLength: 8192,
+				contextLength: 4096,
+			}
+
+			mockedAxios.get.mockResolvedValueOnce({ data: { status: "ok" } })
+			mockListDownloadedModels.mockResolvedValueOnce([mockDownloadedModel])
+			mockListLoaded.mockResolvedValueOnce([{ getModelInfo: vi.fn().mockResolvedValueOnce(mockLoadedModel) }])
+
+			const result = await getLMStudioModels(baseUrl)
+
+			expect(Object.keys(result)).toHaveLength(1)
+			expect(result[mockLoadedModel.modelKey]).toBeDefined()
+			expect(result[mockDownloadedModel.path]).toBeUndefined()
+		})
+
+		it("should not deduplicate models with similar but distinct names", async () => {
+			const mockDownloadedModels: LLMInfo[] = [
+				{
+					type: "llm" as const,
+					modelKey: "mistral-7b",
+					format: "gguf",
+					displayName: "Mistral 7B",
+					path: "mistralai/mistral-7b-instruct",
+					sizeBytes: 7000000000,
+					architecture: "mistral",
+					vision: false,
+					trainedForToolUse: false,
+					maxContextLength: 4096,
+				},
+				{
+					type: "llm" as const,
+					modelKey: "codellama",
+					format: "gguf",
+					displayName: "Code Llama",
+					path: "meta/codellama/7b",
+					sizeBytes: 7000000000,
+					architecture: "llama",
+					vision: false,
+					trainedForToolUse: false,
+					maxContextLength: 4096,
+				},
+			]
+
+			const mockLoadedModel: LLMInstanceInfo = {
+				type: "llm",
+				modelKey: "llama", // Should not match "codellama" or "mistral-7b"
+				format: "gguf",
+				displayName: "Llama",
+				path: "meta/llama/7b",
+				sizeBytes: 7000000000,
+				architecture: "llama",
+				identifier: "meta/llama/7b",
+				instanceReference: "XYZ789",
+				vision: false,
+				trainedForToolUse: false,
+				maxContextLength: 4096,
+				contextLength: 2048,
+			}
+
+			mockedAxios.get.mockResolvedValueOnce({ data: { status: "ok" } })
+			mockListDownloadedModels.mockResolvedValueOnce(mockDownloadedModels)
+			mockListLoaded.mockResolvedValueOnce([{ getModelInfo: vi.fn().mockResolvedValueOnce(mockLoadedModel) }])
+
+			const result = await getLMStudioModels(baseUrl)
+
+			// Should have 3 models: mistral-7b (not deduped), codellama (not deduped), and llama (loaded)
+			expect(Object.keys(result)).toHaveLength(3)
+			expect(result["mistralai/mistral-7b-instruct"]).toBeDefined() // Should NOT be removed
+			expect(result["meta/codellama/7b"]).toBeDefined() // Should NOT be removed (codellama != llama)
+			expect(result[mockLoadedModel.modelKey]).toBeDefined()
+		})
+
+		it("should handle multiple loaded models with various duplicate scenarios", async () => {
+			const mockDownloadedModels: LLMInfo[] = [
+				{
+					type: "llm" as const,
+					modelKey: "mistral-7b",
+					format: "gguf",
+					displayName: "Mistral 7B",
+					path: "mistralai/mistral-7b/instruct",
+					sizeBytes: 7000000000,
+					architecture: "mistral",
+					vision: false,
+					trainedForToolUse: false,
+					maxContextLength: 8192,
+				},
+				{
+					type: "llm" as const,
+					modelKey: "llama-3.1",
+					format: "gguf",
+					displayName: "Llama 3.1",
+					path: "meta/llama-3.1/8b",
+					sizeBytes: 8000000000,
+					architecture: "llama",
+					vision: false,
+					trainedForToolUse: false,
+					maxContextLength: 8192,
+				},
+			]
+
+			const mockLoadedModels: LLMInstanceInfo[] = [
+				{
+					type: "llm",
+					modelKey: "mistral-7b", // Exact match with path segment
+					format: "gguf",
+					displayName: "Mistral 7B",
+					path: "mistralai/mistral-7b/instruct",
+					sizeBytes: 7000000000,
+					architecture: "mistral",
+					identifier: "mistralai/mistral-7b/instruct",
+					instanceReference: "REF1",
+					vision: false,
+					trainedForToolUse: false,
+					maxContextLength: 8192,
+					contextLength: 4096,
+				},
+				{
+					type: "llm",
+					modelKey: "gpt-4", // No match, new model
+					format: "gguf",
+					displayName: "GPT-4",
+					path: "openai/gpt-4",
+					sizeBytes: 10000000000,
+					architecture: "gpt",
+					identifier: "openai/gpt-4",
+					instanceReference: "REF2",
+					vision: true,
+					trainedForToolUse: true,
+					maxContextLength: 32768,
+					contextLength: 16384,
+				},
+			]
+
+			mockedAxios.get.mockResolvedValueOnce({ data: { status: "ok" } })
+			mockListDownloadedModels.mockResolvedValueOnce(mockDownloadedModels)
+			mockListLoaded.mockResolvedValueOnce(
+				mockLoadedModels.map((model) => ({ getModelInfo: vi.fn().mockResolvedValueOnce(model) })),
+			)
+
+			const result = await getLMStudioModels(baseUrl)
+
+			// Should have 3 models: llama-3.1 (downloaded), mistral-7b (loaded, replaced), gpt-4 (loaded, new)
+			expect(Object.keys(result)).toHaveLength(3)
+			expect(result["meta/llama-3.1/8b"]).toBeDefined() // Downloaded, not replaced
+			expect(result["mistralai/mistral-7b/instruct"]).toBeUndefined() // Downloaded, replaced
+			expect(result["mistral-7b"]).toBeDefined() // Loaded, replaced downloaded
+			expect(result["gpt-4"]).toBeDefined() // Loaded, new
+		})
+
 		it("should use default baseUrl if an empty string is provided", async () => {
 			const defaultBaseUrl = "http://localhost:1234"
 			const defaultLmsUrl = "ws://localhost:1234"


### PR DESCRIPTION
## Summary

This PR fixes the issue where LM Studio models appeared twice in the Provider Configuration Profile when they were both downloaded and loaded. This implementation addresses the feedback from @mechanicmuthu about LM Studio's JIT Model Loading feature.

## Problem

The previous implementation fetched models from two different LM Studio APIs:
- `listDownloadedModels()` - showed all models on disk
- `listLoaded()` - showed models currently in memory

This caused duplicates when a model was both downloaded and loaded, with inconsistent keys (`model.path` vs `model.modelKey`).

## Solution

This PR implements a **case-insensitive deduplication approach** that:
- **Keeps both API calls** to support LM Studio's JIT Model Loading (available since v0.3.5)
- **Deduplicates models** by checking if any existing model key contains the loaded model's identifier (case-insensitive)
- **Prefers loaded model data** when duplicates are found, as it provides more accurate runtime information (contextLength)
- **Maintains compatibility** with JIT loading where models can be automatically loaded on-demand

## Benefits

- ✅ Eliminates duplicates with smart deduplication
- ✅ Supports JIT Model Loading feature (models can be auto-loaded when requested)
- ✅ Shows all available models (both downloaded and loaded)
- ✅ Provides accurate runtime metadata when models are loaded
- ✅ Handles auto-unload after 60-minute timeout gracefully

## Testing

- All existing tests pass
- Added new test case for deduplication logic
- Verified that duplicates are properly handled

## Context

This replaces PR #7141 which only showed loaded models and didn't align with LM Studio's JIT loading capabilities.

Fixes #6954
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Implements case-insensitive deduplication in `getLMStudioModels()` to prevent duplicate model entries, preferring loaded models for accurate runtime data.
> 
>   - **Behavior**:
>     - Implements case-insensitive deduplication in `getLMStudioModels()` in `lmstudio.ts` to prevent duplicate model entries.
>     - Prefers loaded model data over downloaded when duplicates are found.
>     - Ensures compatibility with JIT Model Loading by keeping both API calls.
>   - **Testing**:
>     - Adds test cases in `lmstudio.test.ts` for deduplication logic, including path-based matching and distinct name handling.
>     - Verifies that duplicates are properly handled and runtime metadata is accurate.
>   - **Misc**:
>     - Handles auto-unload after 60-minute timeout gracefully.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6aba8e562f61bb4e898ac5a939833eca26165384. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->