### PR TITLE
Increase sonic max_tokens to 16384

### DIFF
--- a/packages/types/src/providers/roo.ts
+++ b/packages/types/src/providers/roo.ts
@@ -7,7 +7,7 @@ export const rooDefaultModelId: RooModelId = "roo/sonic"
 
 export const rooModels = {
 	"roo/sonic": {
-		maxTokens: 8192,
+		maxTokens: 16_384,
 		contextWindow: 262_144,
 		supportsImages: false,
 		supportsPromptCache: true,

--- a/src/api/providers/__tests__/roo.spec.ts
+++ b/src/api/providers/__tests__/roo.spec.ts
@@ -328,7 +328,7 @@ describe("RooHandler", () => {
 			expect(modelInfo.id).toBe("unknown-model-id")
 			expect(modelInfo.info).toBeDefined()
 			// Should return fallback info for unknown models
-			expect(modelInfo.info.maxTokens).toBe(8192)
+			expect(modelInfo.info.maxTokens).toBe(16_384)
 			expect(modelInfo.info.contextWindow).toBe(262_144)
 			expect(modelInfo.info.supportsImages).toBe(false)
 			expect(modelInfo.info.supportsPromptCache).toBe(true)

--- a/src/api/providers/roo.ts
+++ b/src/api/providers/roo.ts
@@ -81,7 +81,7 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<RooModelId> {
 		return {
 			id: modelId as RooModelId,
 			info: {
-				maxTokens: 8192,
+				maxTokens: 16_384,
 				contextWindow: 262_144,
 				supportsImages: false,
 				supportsPromptCache: true,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Increase `maxTokens` for `roo/sonic` model from 8192 to 16384 in `roo.ts` and update related tests in `roo.spec.ts`.
> 
>   - **Behavior**:
>     - Increase `maxTokens` for `roo/sonic` model from 8192 to 16384 in `roo.ts` and `roo.spec.ts`.
>   - **Tests**:
>     - Update test in `roo.spec.ts` to expect `maxTokens` of 16384 for unknown models.
>   - **Model Configuration**:
>     - Update `maxTokens` in `roo.ts` to 16384 for `roo/sonic` model.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f64124ceb9c25d091a4f28e7d4b4152b7109f6a8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->