### PR TITLE
fix(ui): make auto approve toggle trigger stay

### DIFF
--- a/webview-ui/src/components/chat/AutoApproveMenu.tsx
+++ b/webview-ui/src/components/chat/AutoApproveMenu.tsx
@@ -234,11 +234,9 @@ const AutoApproveMenu = ({ style }: AutoApproveMenuProps) => {
 						{displayText}
 					</span>
 					<span
-						className={`codicon codicon-chevron-${isExpanded ? "up" : "right"}`}
-						style={{
-							flexShrink: 0,
-							marginLeft: isExpanded ? "2px" : "-2px",
-						}}
+						className={`codicon codicon-chevron-right flex-shrink-0 transition-transform duration-200 ease-in-out ${
+							isExpanded ? "-rotate-90 ml-[2px]" : "rotate-0 -ml-[2px]"
+						}`}
 					/>
 				</div>
 			</div>


### PR DESCRIPTION
### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #3909 

### Roo Code Task Context (Optional)

-

### Description

Changed the auto approve menu toggle to stay at the bottom, this provides better UX since the trigger stays. It's also consistent with the behaviour of the top bar where the trigger stays at the top. It reduces mouse movements needed.

### Test Procedure

Manual testing

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

https://github.com/user-attachments/assets/004101c9-c03e-4f3e-b87b-ab5594108920

### Documentation Updates
-

### Additional Notes

-

### Get in Touch

@elianiva
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `AutoApproveMenu` to keep the toggle at the bottom when expanded, improving UX by reducing mouse movement.
> 
>   - **UI Behavior**:
>     - In `AutoApproveMenu`, when `isExpanded` is true, the toggle section is now rendered at the bottom of the component.
>     - Adjusts padding and chevron icon direction to reflect the new toggle position.
>   - **Code Changes**:
>     - Moves the expanded content block to render before the toggle trigger in `AutoApproveMenu.tsx`.
>     - Updates chevron icon class to `codicon-chevron-up` when expanded.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 156cbe7be64599af95356905c7f01bfcea87c80f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->