### PR TITLE
feat: add prompt caching support for Kimi K2 on Groq

### DIFF
--- a/packages/types/src/providers/groq.ts
+++ b/packages/types/src/providers/groq.ts
@@ -94,9 +94,10 @@ export const groqModels = {
 		maxTokens: 16384,
 		contextWindow: 131072,
 		supportsImages: false,
-		supportsPromptCache: false,
+		supportsPromptCache: true,
 		inputPrice: 1.0,
 		outputPrice: 3.0,
+		cacheReadsPrice: 0.5, // 50% discount for cached input tokens
 		description: "Moonshot AI Kimi K2 Instruct 1T model, 128K context.",
 	},
 	"openai/gpt-oss-120b": {

--- a/src/api/providers/__tests__/groq.spec.ts
+++ b/src/api/providers/__tests__/groq.spec.ts
@@ -108,7 +108,53 @@ describe("GroqHandler", () => {
 		const firstChunk = await stream.next()
 
 		expect(firstChunk.done).toBe(false)
-		expect(firstChunk.value).toEqual({ type: "usage", inputTokens: 10, outputTokens: 20 })
+		expect(firstChunk.value).toMatchObject({
+			type: "usage",
+			inputTokens: 10,
+			outputTokens: 20,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 0,
+		})
+		// Check that totalCost is a number (we don't need to test the exact value as that's tested in cost.spec.ts)
+		expect(typeof firstChunk.value.totalCost).toBe("number")
+	})
+
+	it("createMessage should handle cached tokens in usage data", async () => {
+		mockCreate.mockImplementationOnce(() => {
+			return {
+				[Symbol.asyncIterator]: () => ({
+					next: vitest
+						.fn()
+						.mockResolvedValueOnce({
+							done: false,
+							value: {
+								choices: [{ delta: {} }],
+								usage: {
+									prompt_tokens: 100,
+									completion_tokens: 50,
+									prompt_tokens_details: {
+										cached_tokens: 30,
+									},
+								},
+							},
+						})
+						.mockResolvedValueOnce({ done: true }),
+				}),
+			}
+		})
+
+		const stream = handler.createMessage("system prompt", [])
+		const firstChunk = await stream.next()
+
+		expect(firstChunk.done).toBe(false)
+		expect(firstChunk.value).toMatchObject({
+			type: "usage",
+			inputTokens: 70, // 100 total - 30 cached
+			outputTokens: 50,
+			cacheWriteTokens: 0,
+			cacheReadTokens: 30,
+		})
+		expect(typeof firstChunk.value.totalCost).toBe("number")
 	})
 
 	it("createMessage should pass correct parameters to Groq client", async () => {

--- a/src/api/providers/groq.ts
+++ b/src/api/providers/groq.ts
@@ -1,8 +1,21 @@
 import { type GroqModelId, groqDefaultModelId, groqModels } from "@roo-code/types"
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
 
 import type { ApiHandlerOptions } from "../../shared/api"
+import type { ApiHandlerCreateMessageMetadata } from "../index"
+import { ApiStream } from "../transform/stream"
+import { convertToOpenAiMessages } from "../transform/openai-format"
+import { calculateApiCostOpenAI } from "../../shared/cost"
 
 import { BaseOpenAiCompatibleProvider } from "./base-openai-compatible-provider"
+
+// Enhanced usage interface to support Groq's cached token fields
+interface GroqUsage extends OpenAI.CompletionUsage {
+	prompt_tokens_details?: {
+		cached_tokens?: number
+	}
+}
 
 export class GroqHandler extends BaseOpenAiCompatibleProvider<GroqModelId> {
 	constructor(options: ApiHandlerOptions) {
@@ -15,5 +28,62 @@ export class GroqHandler extends BaseOpenAiCompatibleProvider<GroqModelId> {
 			providerModels: groqModels,
 			defaultTemperature: 0.5,
 		})
+	}
+
+	override async *createMessage(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		metadata?: ApiHandlerCreateMessageMetadata,
+	): ApiStream {
+		const stream = await this.createStream(systemPrompt, messages, metadata)
+
+		for await (const chunk of stream) {
+			const delta = chunk.choices[0]?.delta
+
+			if (delta?.content) {
+				yield {
+					type: "text",
+					text: delta.content,
+				}
+			}
+
+			if (chunk.usage) {
+				yield* this.yieldUsage(chunk.usage as GroqUsage)
+			}
+		}
+	}
+
+	private async *yieldUsage(usage: GroqUsage | undefined): ApiStream {
+		const { info } = this.getModel()
+		const inputTokens = usage?.prompt_tokens || 0
+		const outputTokens = usage?.completion_tokens || 0
+
+		const cacheReadTokens = usage?.prompt_tokens_details?.cached_tokens || 0
+
+		// Groq does not track cache writes
+		const cacheWriteTokens = 0
+
+		// Calculate cost using OpenAI-compatible cost calculation
+		const totalCost = calculateApiCostOpenAI(info, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
+
+		// Calculate non-cached input tokens for proper reporting
+		const nonCachedInputTokens = Math.max(0, inputTokens - cacheReadTokens - cacheWriteTokens)
+
+		console.log("usage", {
+			inputTokens: nonCachedInputTokens,
+			outputTokens,
+			cacheWriteTokens,
+			cacheReadTokens,
+			totalCost,
+		})
+
+		yield {
+			type: "usage",
+			inputTokens: nonCachedInputTokens,
+			outputTokens,
+			cacheWriteTokens,
+			cacheReadTokens,
+			totalCost,
+		}
 	}
 }


### PR DESCRIPTION
## Description

This PR ports the prompt caching support for Kimi K2 on Groq from the upstream Cline repository.

**Ported from:** [cline/cline#5697](https://github.com/cline/cline/pull/5697)

## Changes

- **Added  interface** to handle Groq's cached token fields in the response
- **Implemented proper cost calculation** with cache read discounts using the existing  function
- **Enabled prompt caching for Kimi K2 model** with a 50% discount on cached input tokens
- **Updated tests** to verify the caching functionality works correctly

## Implementation Details

### Groq Handler
- Added a custom  interface that extends OpenAI's CompletionUsage to include 
- Overrode the  method to use a custom  method
- The  method:
  - Extracts cached token information from Groq's response
  - Calculates costs with proper cache discounts
  - Reports non-cached input tokens separately from cached tokens

### Model Configuration
- Set  for the Kimi K2 model
- Added  for 50% discount on cached tokens

### Tests
- Updated existing test to expect the new usage format with cache fields
- Added new test case for cached token handling

## Testing

✅ All tests passing (12/12)
✅ TypeScript compilation successful
✅ ESLint checks pass

## Credits

This implementation is based on the original work from the [Cline repository PR #5697](https://github.com/cline/cline/pull/5697).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds prompt caching support for Kimi K2 on Groq with cost calculation and test updates.
> 
>   - **Behavior**:
>     - Enables prompt caching for `moonshotai/kimi-k2-instruct` model with a 50% discount on cached input tokens in `groq.ts`.
>     - Implements cost calculation with cache read discounts in `GroqHandler`.
>   - **Implementation**:
>     - Adds `GroqUsage` interface in `groq.ts` to handle cached token fields.
>     - Overrides `createMessage()` in `GroqHandler` to yield usage data with cache details.
>     - Introduces `yieldUsage()` in `GroqHandler` to calculate and yield usage costs.
>   - **Tests**:
>     - Updates tests in `groq.spec.ts` to verify caching functionality and cost calculations.
>     - Adds test case for handling cached tokens in usage data.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8fa6f00d175df124092cb29270b181db75058e0f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->