### PR TITLE
feat: add OpenRouter multi-provider failover support

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -136,7 +136,9 @@ const openRouterSchema = baseProviderSettingsSchema.extend({
 	openRouterApiKey: z.string().optional(),
 	openRouterModelId: z.string().optional(),
 	openRouterBaseUrl: z.string().optional(),
-	openRouterSpecificProvider: z.string().optional(),
+	openRouterSpecificProvider: z.string().optional(), // Keep for backward compatibility
+	openRouterProviders: z.array(z.string()).max(4).optional(), // New multi-provider support
+	openRouterFailoverEnabled: z.boolean().optional(), // Enable automatic failover
 	openRouterUseMiddleOutTransform: z.boolean().optional(),
 })
 

--- a/src/api/providers/__tests__/openrouter-multi-provider.spec.ts
+++ b/src/api/providers/__tests__/openrouter-multi-provider.spec.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { OpenRouterHandler } from "../openrouter"
+import type { ApiHandlerOptions } from "../../../shared/api"
+
+// Mock OpenAI
+vi.mock("openai")
+
+describe("OpenRouterHandler Multi-Provider Support", () => {
+	let mockOptions: ApiHandlerOptions
+	let handler: OpenRouterHandler
+
+	beforeEach(() => {
+		mockOptions = {
+			openRouterApiKey: "test-api-key",
+			openRouterModelId: "anthropic/claude-sonnet-4",
+			openRouterFailoverEnabled: true,
+		}
+	})
+
+	afterEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	describe("getProvidersToUse", () => {
+		it("should return multi-provider configuration when available", () => {
+			const optionsWithMultiProvider: ApiHandlerOptions = {
+				...mockOptions,
+				openRouterProviders: ["provider1", "provider2", "provider3"],
+			}
+			handler = new OpenRouterHandler(optionsWithMultiProvider)
+
+			// Access private method for testing
+			const providers = (handler as any).getProvidersToUse()
+			expect(providers).toEqual(["provider1", "provider2", "provider3"])
+		})
+
+		it("should fallback to single provider configuration", () => {
+			const optionsWithSingleProvider: ApiHandlerOptions = {
+				...mockOptions,
+				openRouterSpecificProvider: "single-provider",
+			}
+			handler = new OpenRouterHandler(optionsWithSingleProvider)
+
+			const providers = (handler as any).getProvidersToUse()
+			expect(providers).toEqual(["single-provider"])
+		})
+
+		it("should return empty array when no providers configured", () => {
+			handler = new OpenRouterHandler(mockOptions)
+
+			const providers = (handler as any).getProvidersToUse()
+			expect(providers).toEqual([])
+		})
+
+		it("should filter out default provider from multi-provider list", () => {
+			const optionsWithDefault: ApiHandlerOptions = {
+				...mockOptions,
+				openRouterProviders: ["provider1", "[default]", "provider2"],
+			}
+			handler = new OpenRouterHandler(optionsWithDefault)
+
+			const providers = (handler as any).getProvidersToUse()
+			expect(providers).toEqual(["provider1", "provider2"])
+		})
+	})
+
+	describe("shouldFailover", () => {
+		beforeEach(() => {
+			handler = new OpenRouterHandler(mockOptions)
+		})
+
+		it("should failover on rate limit errors (429)", () => {
+			const error = { status: 429, message: "Rate limit exceeded" }
+			expect((handler as any).shouldFailover(error)).toBe(true)
+		})
+
+		it("should failover on service unavailable errors", () => {
+			const error503 = { status: 503, message: "Service unavailable" }
+			const error502 = { status: 502, message: "Bad gateway" }
+
+			expect((handler as any).shouldFailover(error503)).toBe(true)
+			expect((handler as any).shouldFailover(error502)).toBe(true)
+		})
+
+		it("should failover on context window errors", () => {
+			const contextErrors = [
+				{ status: 400, message: "context length exceeded" },
+				{ status: 400, message: "maximum context window reached" },
+				{ status: 400, message: "too many tokens in request" },
+				{ status: 400, message: "input tokens exceed limit" },
+			]
+
+			contextErrors.forEach((error) => {
+				expect((handler as any).shouldFailover(error)).toBe(true)
+			})
+		})
+
+		it("should failover on timeout errors", () => {
+			const timeoutErrors = [{ code: "ECONNABORTED", message: "timeout" }, { message: "timeout error occurred" }]
+
+			timeoutErrors.forEach((error) => {
+				expect((handler as any).shouldFailover(error)).toBe(true)
+			})
+		})
+
+		it("should not failover on non-failover errors", () => {
+			const nonFailoverErrors = [
+				{ status: 401, message: "Unauthorized" },
+				{ status: 400, message: "Invalid request format" },
+				{ status: 500, message: "Internal server error" },
+				null,
+				undefined,
+			]
+
+			nonFailoverErrors.forEach((error) => {
+				expect((handler as any).shouldFailover(error)).toBe(false)
+			})
+		})
+	})
+
+	describe("createCompletionParams", () => {
+		beforeEach(() => {
+			handler = new OpenRouterHandler(mockOptions)
+		})
+
+		it("should create params with single provider routing", () => {
+			const providers = ["provider1"]
+			const params = (handler as any).createCompletionParams(
+				"test-model",
+				4096,
+				0.7,
+				0.9,
+				[{ role: "user", content: "test" }],
+				["middle-out"],
+				undefined,
+				providers,
+				0,
+			)
+
+			expect(params.provider).toEqual({
+				order: ["provider1"],
+				only: ["provider1"],
+				allow_fallbacks: false,
+			})
+		})
+
+		it("should create params with multi-provider routing for first attempt", () => {
+			const providers = ["provider1", "provider2", "provider3"]
+			const params = (handler as any).createCompletionParams(
+				"test-model",
+				4096,
+				0.7,
+				0.9,
+				[{ role: "user", content: "test" }],
+				["middle-out"],
+				undefined,
+				providers,
+				0,
+			)
+
+			expect(params.provider).toEqual({
+				order: ["provider1", "provider2", "provider3"],
+				only: ["provider1", "provider2", "provider3"],
+				allow_fallbacks: true,
+			})
+		})
+
+		it("should create params with remaining providers for retry attempt", () => {
+			const providers = ["provider1", "provider2", "provider3"]
+			const params = (handler as any).createCompletionParams(
+				"test-model",
+				4096,
+				0.7,
+				0.9,
+				[{ role: "user", content: "test" }],
+				["middle-out"],
+				undefined,
+				providers,
+				1,
+			)
+
+			expect(params.provider).toEqual({
+				order: ["provider2", "provider3"],
+				only: ["provider2", "provider3"],
+				allow_fallbacks: true,
+			})
+		})
+
+		it("should create params with last provider only for final attempt", () => {
+			const providers = ["provider1", "provider2", "provider3"]
+			const params = (handler as any).createCompletionParams(
+				"test-model",
+				4096,
+				0.7,
+				0.9,
+				[{ role: "user", content: "test" }],
+				["middle-out"],
+				undefined,
+				providers,
+				2,
+			)
+
+			expect(params.provider).toEqual({
+				order: ["provider3"],
+				only: ["provider3"],
+				allow_fallbacks: false,
+			})
+		})
+	})
+
+	describe("backward compatibility", () => {
+		it("should support legacy single provider configuration", () => {
+			const legacyOptions: ApiHandlerOptions = {
+				...mockOptions,
+				openRouterSpecificProvider: "legacy-provider",
+				openRouterFailoverEnabled: false,
+			}
+			handler = new OpenRouterHandler(legacyOptions)
+
+			const providers = (handler as any).getProvidersToUse()
+			expect(providers).toEqual(["legacy-provider"])
+		})
+
+		it("should prefer multi-provider over single provider when both are set", () => {
+			const mixedOptions: ApiHandlerOptions = {
+				...mockOptions,
+				openRouterProviders: ["multi1", "multi2"],
+				openRouterSpecificProvider: "single-provider",
+			}
+			handler = new OpenRouterHandler(mixedOptions)
+
+			const providers = (handler as any).getProvidersToUse()
+			expect(providers).toEqual(["multi1", "multi2"])
+		})
+	})
+})

--- a/webview-ui/src/components/settings/providers/OpenRouter.tsx
+++ b/webview-ui/src/components/settings/providers/OpenRouter.tsx
@@ -112,6 +112,16 @@ export const OpenRouter = ({
 							}}
 						/>
 					</Checkbox>
+					<div>
+						<Checkbox
+							checked={apiConfiguration?.openRouterFailoverEnabled ?? true}
+							onChange={handleInputChange("openRouterFailoverEnabled", noTransform)}>
+							Enable automatic failover
+						</Checkbox>
+						<div className="text-sm text-vscode-descriptionForeground mt-1">
+							When enabled, automatically try backup providers if the primary provider fails
+						</div>
+					</div>
 				</>
 			)}
 			<ModelPicker

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel-multiProvider.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel-multiProvider.spec.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest"
+import type { ProviderSettings, ModelInfo } from "@roo-code/types"
+import type { RouterModels } from "@roo/api"
+
+// Mock the internal getSelectedModel function for OpenRouter case only
+function getSelectedModelOpenRouter({
+	apiConfiguration,
+	routerModels,
+	openRouterModelProviders,
+}: {
+	apiConfiguration: ProviderSettings
+	routerModels: RouterModels
+	openRouterModelProviders: Record<string, ModelInfo>
+}): { id: string; info: ModelInfo | undefined } {
+	const id = apiConfiguration.openRouterModelId ?? "anthropic/claude-sonnet-4"
+	let info = routerModels.openrouter[id]
+
+	// Determine which provider to use for model info
+	let providerToUse: string | undefined
+
+	// Check multi-provider configuration first
+	if (apiConfiguration.openRouterProviders && apiConfiguration.openRouterProviders.length > 0) {
+		// Use the first (primary) provider from the multi-provider list
+		providerToUse = apiConfiguration.openRouterProviders[0]
+	} else {
+		// Fallback to legacy single provider
+		providerToUse = apiConfiguration.openRouterSpecificProvider
+	}
+
+	if (providerToUse && openRouterModelProviders[providerToUse]) {
+		// Overwrite the info with the selected provider info. Some
+		// fields are missing the model info for `openRouterModelProviders`
+		// so we need to merge the two.
+		info = info ? { ...info, ...openRouterModelProviders[providerToUse] } : openRouterModelProviders[providerToUse]
+	}
+
+	return { id, info }
+}
+
+describe("useSelectedModel Multi-Provider Support", () => {
+	const mockRouterModels: RouterModels = {
+		openrouter: {
+			"moonshot/kimi-k2": {
+				maxTokens: 120000,
+				contextWindow: 120000,
+				supportsImages: true,
+				supportsPromptCache: false,
+				inputPrice: 0.0014,
+				outputPrice: 0.0028,
+			},
+		},
+		requesty: {},
+		glama: {},
+		unbound: {},
+		litellm: {},
+		ollama: {},
+		lmstudio: {},
+		"io-intelligence": {},
+	}
+
+	const mockOpenRouterModelProviders = {
+		groq: {
+			maxTokens: 16400,
+			contextWindow: 131100,
+			supportsImages: true,
+			supportsPromptCache: true,
+			inputPrice: 1.0,
+			outputPrice: 3.0,
+			cacheReadsPrice: 0.5,
+			label: "Groq",
+		},
+		novitaai: {
+			maxTokens: 131100,
+			contextWindow: 131100,
+			supportsImages: true,
+			supportsPromptCache: false,
+			inputPrice: 0.57,
+			outputPrice: 2.3,
+			label: "NovitaAI",
+		},
+		fireworks: {
+			maxTokens: 131100,
+			contextWindow: 131100,
+			supportsImages: true,
+			supportsPromptCache: false,
+			inputPrice: 0.6,
+			outputPrice: 2.5,
+			label: "Fireworks",
+		},
+		atlascloud: {
+			maxTokens: 131100,
+			contextWindow: 131100,
+			supportsImages: true,
+			supportsPromptCache: false,
+			inputPrice: 0.7,
+			outputPrice: 2.5,
+			label: "AtlasCloud",
+		},
+		targon: {
+			maxTokens: 63000,
+			contextWindow: 63000,
+			supportsImages: true,
+			supportsPromptCache: false,
+			inputPrice: 0.14,
+			outputPrice: 2.49,
+			label: "Targon",
+		},
+	}
+
+	describe("multi-provider context window selection", () => {
+		it("should use primary provider context window when multi-provider is configured", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "openrouter",
+				openRouterModelId: "moonshot/kimi-k2",
+				openRouterProviders: ["groq", "novitaai", "fireworks", "atlascloud"], // Primary = Groq
+				openRouterFailoverEnabled: true,
+			}
+
+			const result = getSelectedModelOpenRouter({
+				apiConfiguration,
+				routerModels: mockRouterModels,
+				openRouterModelProviders: mockOpenRouterModelProviders,
+			})
+
+			// Should use Groq's context window (131100), not base model's (120000) or Targon's (63000)
+			expect(result.info?.contextWindow).toBe(131100)
+			expect(result.info?.inputPrice).toBe(1.0) // Groq's pricing
+			expect(result.info?.outputPrice).toBe(3.0) // Groq's pricing
+			expect(result.info?.supportsPromptCache).toBe(true) // Groq's cache support
+		})
+
+		it("should fallback to legacy single provider when multi-provider not configured", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "openrouter",
+				openRouterModelId: "moonshot/kimi-k2",
+				openRouterSpecificProvider: "fireworks", // Legacy single provider
+			}
+
+			const result = getSelectedModelOpenRouter({
+				apiConfiguration,
+				routerModels: mockRouterModels,
+				openRouterModelProviders: mockOpenRouterModelProviders,
+			})
+
+			// Should use Fireworks' context window (131100), not base model's (120000)
+			expect(result.info?.contextWindow).toBe(131100)
+			expect(result.info?.inputPrice).toBe(0.6) // Fireworks' pricing
+			expect(result.info?.outputPrice).toBe(2.5) // Fireworks' pricing
+		})
+
+		it("should prefer multi-provider over legacy when both are configured", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "openrouter",
+				openRouterModelId: "moonshot/kimi-k2",
+				openRouterProviders: ["novitaai", "groq"], // Primary = NovitaAI
+				openRouterSpecificProvider: "targon", // Legacy provider (should be ignored)
+			}
+
+			const result = getSelectedModelOpenRouter({
+				apiConfiguration,
+				routerModels: mockRouterModels,
+				openRouterModelProviders: mockOpenRouterModelProviders,
+			})
+
+			// Should use NovitaAI's context window (131100), NOT Targon's (63000)
+			expect(result.info?.contextWindow).toBe(131100)
+			expect(result.info?.inputPrice).toBe(0.57) // NovitaAI's pricing, not Targon's 0.14
+			expect(result.info?.outputPrice).toBe(2.3) // NovitaAI's pricing, not Targon's 2.49
+		})
+
+		it("should use base model info when no providers are configured", () => {
+			const apiConfiguration: ProviderSettings = {
+				apiProvider: "openrouter",
+				openRouterModelId: "moonshot/kimi-k2",
+				// No providers configured
+			}
+
+			const result = getSelectedModelOpenRouter({
+				apiConfiguration,
+				routerModels: mockRouterModels,
+				openRouterModelProviders: mockOpenRouterModelProviders,
+			})
+
+			// Should use base model's context window (120000)
+			expect(result.info?.contextWindow).toBe(120000)
+			expect(result.info?.inputPrice).toBe(0.0014)
+			expect(result.info?.outputPrice).toBe(0.0028)
+		})
+	})
+})

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -119,15 +119,26 @@ function getSelectedModel({
 		case "openrouter": {
 			const id = apiConfiguration.openRouterModelId ?? openRouterDefaultModelId
 			let info = routerModels.openrouter[id]
-			const specificProvider = apiConfiguration.openRouterSpecificProvider
 
-			if (specificProvider && openRouterModelProviders[specificProvider]) {
-				// Overwrite the info with the specific provider info. Some
+			// Determine which provider to use for model info
+			let providerToUse: string | undefined
+
+			// Check multi-provider configuration first
+			if (apiConfiguration.openRouterProviders && apiConfiguration.openRouterProviders.length > 0) {
+				// Use the first (primary) provider from the multi-provider list
+				providerToUse = apiConfiguration.openRouterProviders[0]
+			} else {
+				// Fallback to legacy single provider
+				providerToUse = apiConfiguration.openRouterSpecificProvider
+			}
+
+			if (providerToUse && openRouterModelProviders[providerToUse]) {
+				// Overwrite the info with the selected provider info. Some
 				// fields are missing the model info for `openRouterModelProviders`
 				// so we need to merge the two.
 				info = info
-					? { ...info, ...openRouterModelProviders[specificProvider] }
-					: openRouterModelProviders[specificProvider]
+					? { ...info, ...openRouterModelProviders[providerToUse] }
+					: openRouterModelProviders[providerToUse]
 			}
 
 			return { id, info }

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -387,6 +387,17 @@
 				"title": "OpenRouter Provider Routing",
 				"description": "OpenRouter routes requests to the best available providers for your model. By default, requests are load balanced across the top providers to maximize uptime. However, you can choose a specific provider to use for this model.",
 				"learnMore": "Learn more about provider routing"
+			},
+			"multiProvider": {
+				"title": "Multiple Providers",
+				"description": "Select up to 4 providers for automatic failover",
+				"failoverEnabled": "Enable automatic failover",
+				"failoverDescription": "When enabled, automatically try backup providers if the primary provider fails",
+				"primaryProvider": "Primary Provider",
+				"secondaryProvider": "Secondary Provider",
+				"tertiaryProvider": "Tertiary Provider",
+				"quaternaryProvider": "Quaternary Provider",
+				"dragToReorder": "Drag to reorder priority"
 			}
 		},
 		"customModel": {


### PR DESCRIPTION
- Add support for up to 4 OpenRouter providers with automatic failover
- Implement priority-based provider selection in UI with dynamic dropdowns
- Add comprehensive test coverage for multi-provider functionality
- Enable seamless switching between single and multi-provider modes
- Ensure primary provider's context window and pricing is used for model info

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds multi-provider failover support for OpenRouter with UI updates and comprehensive test coverage, ensuring backward compatibility.
> 
>   - **Behavior**:
>     - Adds support for up to 4 OpenRouter providers with automatic failover in `openrouter.ts`.
>     - Implements priority-based provider selection in `ApiOptions.tsx` with dynamic dropdowns.
>     - Ensures primary provider's context window and pricing is used for model info in `useSelectedModel.ts`.
>   - **Tests**:
>     - Adds comprehensive test coverage for multi-provider functionality in `openrouter-multi-provider.spec.ts` and `useSelectedModel-multiProvider.spec.ts`.
>   - **UI**:
>     - Updates `ApiOptions.tsx` and `OpenRouter.tsx` to enable seamless switching between single and multi-provider modes.
>     - Adds UI elements for multi-provider selection and failover enablement.
>   - **Misc**:
>     - Keeps `openRouterSpecificProvider` for backward compatibility in `provider-settings.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f586d7e7f1088a6d6d1261b6a6b8c27b90f248ec. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->