### PR TITLE
create a new profile when being redirected from requesty

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1425,7 +1425,9 @@ export class ClineProvider
 			requestyModelId: apiConfiguration?.requestyModelId || requestyDefaultModelId,
 		}
 
-		await this.upsertProviderProfile(currentApiConfigName, newConfiguration)
+		// Create a new profile with a unique name to trigger settings refresh
+		const newProfileName = currentApiConfigName === "default" ? "requesty-oauth" : currentApiConfigName
+		await this.upsertProviderProfile(newProfileName, newConfiguration)
 	}
 
 	// Task history


### PR DESCRIPTION
App Version
Latest

API Provider
Requesty

Model Used
N/A

Roo Code Task Links (Optional)
When you click on  Requesty API key from the settings and get redirected to the Requesty url, you will now create a new profile in order to be able to use the newly created api key.

🔁 Steps to Reproduce
Use Requesty as a provider when starting Roo-Code
Click "Get Requesty API Key" and you'll see get redirected to Requesty. After the redirect from Requesty to Roo Code a new profile would have been created with the new api key.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> In `ClineProvider.ts`, `handleRequestyCallback()` now creates a new profile with a unique name when redirected from Requesty to ensure settings refresh.
> 
>   - **Behavior**:
>     - In `ClineProvider.ts`, `handleRequestyCallback()` now creates a new profile with a unique name when redirected from Requesty, ensuring settings refresh.
>     - Uses `requesty-oauth` as the profile name if the current profile is `default`.
>   - **Misc**:
>     - Adds a comment explaining the purpose of creating a new profile with a unique name.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 742b010989cf0f6b2508c90f687caa25ecbf32ee. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->