### PR TITLE
fix: use anthropic protocol for token counting when using anthropic models via Vercel AI Gateway

### DIFF
--- a/packages/types/src/__tests__/provider-settings.test.ts
+++ b/packages/types/src/__tests__/provider-settings.test.ts
@@ -39,6 +39,26 @@ describe("getApiProtocol", () => {
 		})
 	})
 
+	describe("Vercel AI Gateway provider", () => {
+		it("should return 'anthropic' for vercel-ai-gateway provider with anthropic models", () => {
+			expect(getApiProtocol("vercel-ai-gateway", "anthropic/claude-3-opus")).toBe("anthropic")
+			expect(getApiProtocol("vercel-ai-gateway", "anthropic/claude-3.5-sonnet")).toBe("anthropic")
+			expect(getApiProtocol("vercel-ai-gateway", "ANTHROPIC/claude-sonnet-4")).toBe("anthropic")
+			expect(getApiProtocol("vercel-ai-gateway", "anthropic/claude-opus-4.1")).toBe("anthropic")
+		})
+
+		it("should return 'openai' for vercel-ai-gateway provider with non-anthropic models", () => {
+			expect(getApiProtocol("vercel-ai-gateway", "openai/gpt-4")).toBe("openai")
+			expect(getApiProtocol("vercel-ai-gateway", "google/gemini-pro")).toBe("openai")
+			expect(getApiProtocol("vercel-ai-gateway", "meta/llama-3")).toBe("openai")
+			expect(getApiProtocol("vercel-ai-gateway", "mistral/mixtral")).toBe("openai")
+		})
+
+		it("should return 'openai' for vercel-ai-gateway provider without model", () => {
+			expect(getApiProtocol("vercel-ai-gateway")).toBe("openai")
+		})
+	})
+
 	describe("Other providers", () => {
 		it("should return 'openai' for non-anthropic providers regardless of model", () => {
 			expect(getApiProtocol("openrouter", "claude-3-opus")).toBe("openai")

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -453,6 +453,11 @@ export const getApiProtocol = (provider: ProviderName | undefined, modelId?: str
 		return "anthropic"
 	}
 
+	// Vercel AI Gateway uses anthropic protocol for anthropic models
+	if (provider && provider === "vercel-ai-gateway" && modelId && modelId.toLowerCase().startsWith("anthropic/")) {
+		return "anthropic"
+	}
+
 	return "openai"
 }
 


### PR DESCRIPTION
## Description

This PR fixes the token counting issue for Vercel AI Gateway when using Anthropic models.

## Problem
Vercel AI Gateway was incorrectly using OpenAI's token counting protocol for all models, including Anthropic models. This caused incorrect token metrics because:
- **Anthropic protocol**: Input tokens do NOT include cache tokens (they're counted separately)
- **OpenAI protocol**: Input tokens INCLUDE cache tokens (they're part of the total)

## Solution
Added logic to the `getApiProtocol` function to return "anthropic" protocol when:
- Provider is "vercel-ai-gateway" AND
- Model ID starts with "anthropic/"

This ensures proper token counting for Anthropic models accessed through Vercel AI Gateway.

## Changes
- Updated `getApiProtocol` function in `packages/types/src/provider-settings.ts`
- Added comprehensive tests for Vercel AI Gateway provider protocol detection

## Testing
- All existing tests pass
- Added new tests specifically for Vercel AI Gateway protocol detection with both Anthropic and non-Anthropic models

Fixes the token counting discrepancy reported in the original issue.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes token counting for Anthropic models via Vercel AI Gateway by updating `getApiProtocol` to use the correct protocol.
> 
>   - **Behavior**:
>     - `getApiProtocol` in `provider-settings.ts` now returns "anthropic" for Vercel AI Gateway with model IDs starting with "anthropic/".
>     - Ensures correct token counting for Anthropic models via Vercel AI Gateway.
>   - **Testing**:
>     - Added tests in `provider-settings.test.ts` for Vercel AI Gateway with Anthropic and non-Anthropic models.
>     - All existing tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c224d05b311e8f01e40efdda9f631f46c4d07820. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->