### PR TITLE
Add padding to image model picker

### DIFF
--- a/webview-ui/src/components/settings/ImageGenerationSettings.tsx
+++ b/webview-ui/src/components/settings/ImageGenerationSettings.tsx
@@ -94,7 +94,7 @@ export const ImageGenerationSettings = ({
 							onChange={(e: any) => setSelectedModel(e.target.value)}
 							className="w-full">
 							{IMAGE_GENERATION_MODELS.map((model) => (
-								<VSCodeOption key={model.value} value={model.value}>
+								<VSCodeOption key={model.value} value={model.value} className="py-2 px-3">
 									{model.label}
 								</VSCodeOption>
 							))}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds padding to `VSCodeOption` elements in `ImageGenerationSettings.tsx` for better spacing in the dropdown.
> 
>   - **UI Update**:
>     - Adds `py-2 px-3` padding to `VSCodeOption` elements in `ImageGenerationSettings.tsx` to improve spacing in the image model picker dropdown.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for faf54101cf64b2713d3853857ff89b07db2adcce. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->