### PR TITLE
Sync extension bridge settings with cloud

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1892,7 +1892,7 @@ export class ClineProvider
 			includeDiagnosticMessages: includeDiagnosticMessages ?? true,
 			maxDiagnosticMessages: maxDiagnosticMessages ?? 50,
 			includeTaskHistoryInEnhance: includeTaskHistoryInEnhance ?? true,
-			remoteControlEnabled: remoteControlEnabled ?? false,
+			remoteControlEnabled,
 		}
 	}
 
@@ -1967,6 +1967,17 @@ export class ClineProvider
 		} catch (error) {
 			console.error(
 				`[getState] failed to get organization settings version: ${error instanceof Error ? error.message : String(error)}`,
+			)
+		}
+
+		let remoteControlEnabled: boolean = false
+
+		try {
+			const cloudSettings = CloudService.instance.getUserSettings()
+			remoteControlEnabled = cloudSettings?.settings?.extensionBridgeEnabled ?? false
+		} catch (error) {
+			console.error(
+				`[getState] failed to get remote control setting from cloud: ${error instanceof Error ? error.message : String(error)}`,
 			)
 		}
 
@@ -2080,8 +2091,8 @@ export class ClineProvider
 			maxDiagnosticMessages: stateValues.maxDiagnosticMessages ?? 50,
 			// Add includeTaskHistoryInEnhance setting
 			includeTaskHistoryInEnhance: stateValues.includeTaskHistoryInEnhance ?? true,
-			// Add remoteControlEnabled setting
-			remoteControlEnabled: stateValues.remoteControlEnabled ?? false,
+			// Add remoteControlEnabled setting - get from cloud settings
+			remoteControlEnabled,
 		}
 	}
 

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -950,7 +950,15 @@ export const webviewMessageHandler = async (
 			await provider.postStateToWebview()
 			break
 		case "remoteControlEnabled":
-			await updateGlobalState("remoteControlEnabled", message.bool ?? false)
+			// Update cloud settings instead of local globalState
+			try {
+				await CloudService.instance.updateUserSettings({
+					extensionBridgeEnabled: message.bool ?? false,
+				})
+			} catch (error) {
+				provider.log(`Failed to update cloud settings for remote control: ${error}`)
+				// Don't fall back to local storage - cloud settings are the source of truth
+			}
 			await provider.handleRemoteControlToggle(message.bool ?? false)
 			await provider.postStateToWebview()
 			break


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Sync `remoteControlEnabled` setting with cloud, making cloud the source of truth, and improve error handling for cloud interactions.
> 
>   - **Behavior**:
>     - `remoteControlEnabled` setting in `ClineProvider.ts` now fetched from cloud settings using `CloudService.instance.getUserSettings()`.
>     - In `webviewMessageHandler.ts`, updates to `remoteControlEnabled` now update cloud settings via `CloudService.instance.updateUserSettings()`.
>     - `extension.ts` updates `ExtensionBridgeService` with `remoteControlEnabled` from cloud settings.
>   - **Error Handling**:
>     - Improved error logging for cloud setting fetch failures in `ClineProvider.ts` and `extension.ts`.
>   - **Misc**:
>     - Removed default value for `remoteControlEnabled` in `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dace718877ab25543aa8982f750bfe0285279de6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->