### PR TITLE
Disconnect extension bridge on logout

### DIFF
--- a/packages/cloud/src/bridge/BridgeOrchestrator.ts
+++ b/packages/cloud/src/bridge/BridgeOrchestrator.ts
@@ -61,13 +61,19 @@ export class BridgeOrchestrator {
 	public static async connectOrDisconnect(
 		userInfo: CloudUserInfo | null,
 		remoteControlEnabled: boolean | undefined,
-		options: BridgeOrchestratorOptions,
+		options?: BridgeOrchestratorOptions,
 	): Promise<void> {
 		const isEnabled = BridgeOrchestrator.isEnabled(userInfo, remoteControlEnabled)
 		const instance = BridgeOrchestrator.instance
 
 		if (isEnabled) {
 			if (!instance) {
+				if (!options) {
+					console.error(
+						`[BridgeOrchestrator#connectOrDisconnect] Cannot connect: options are required for connection`,
+					)
+					return
+				}
 				try {
 					console.log(`[BridgeOrchestrator#connectOrDisconnect] Connecting...`)
 					BridgeOrchestrator.instance = new BridgeOrchestrator(options)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,14 +135,9 @@ export async function activate(context: vscode.ExtensionContext) {
 		if (data.state === "logged-out") {
 			try {
 				// Disconnect the bridge when user logs out
-				// Pass null userInfo and false for remoteControlEnabled to trigger disconnection
-				await BridgeOrchestrator.connectOrDisconnect(null, false, {
-					userId: "",
-					socketBridgeUrl: "",
-					token: "",
-					provider,
-					sessionId: vscode.env.sessionId,
-				})
+				// When userInfo is null and remoteControlEnabled is false, BridgeOrchestrator
+				// will disconnect. The options parameter is not needed for disconnection.
+				await BridgeOrchestrator.connectOrDisconnect(null, false)
 
 				cloudLogger("[CloudService] BridgeOrchestrator disconnected on logout")
 			} catch (error) {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Update `authStateChangedHandler` to disconnect `BridgeOrchestrator` on logout and improve error handling in `connectOrDisconnect`.
> 
>   - **Behavior**:
>     - `authStateChangedHandler` in `extension.ts` updated to disconnect `BridgeOrchestrator` on user logout by calling `connectOrDisconnect` with `null` and `false`.
>     - Logs success or failure of disconnection to `cloudLogger`.
>   - **Error Handling**:
>     - In `BridgeOrchestrator.ts`, `connectOrDisconnect` logs an error if `options` are missing when attempting to connect.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1f8be2b1c0f98642e003900bc2d46026d6d0a123. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->