### PR TITLE
Cloud: fix provider syncing

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -231,6 +231,15 @@ export async function activate(context: vscode.ExtensionContext) {
 	// Add to subscriptions for proper cleanup on deactivate.
 	context.subscriptions.push(cloudService)
 
+	// Trigger initial cloud profile sync now that CloudService is ready
+	try {
+		await provider.initializeCloudProfileSyncWhenReady()
+	} catch (error) {
+		outputChannel.appendLine(
+			`[CloudService] Failed to initialize cloud profile sync: ${error instanceof Error ? error.message : String(error)}`,
+		)
+	}
+
 	// Finish initializing the provider.
 	TelemetryService.instance.setProvider(provider)
 


### PR DESCRIPTION
`ClineProvider` creation was moved before `CloudService` which broke the old way of doing things.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix cloud profile synchronization in `ClineProvider` by deferring initialization until `CloudService` is ready.
> 
>   - **Behavior**:
>     - In `ClineProvider`, defer `initializeCloudProfileSync()` until `CloudService` is ready.
>     - Add `initializeCloudProfileSyncWhenReady()` in `ClineProvider` to handle sync after `CloudService` initialization.
>   - **Extension Activation**:
>     - In `extension.ts`, call `initializeCloudProfileSyncWhenReady()` after `CloudService` is initialized.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b1f2608f547a6a19d96e79f5f18093eee5419736. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->