### PR TITLE
Send custom modes to the extension bridge

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2392,8 +2392,12 @@ export class ClineProvider
 	// Modes
 
 	public async getModes(): Promise<{ slug: string; name: string }[]> {
-		const customModes = await this.customModesManager.getCustomModes()
-		return [...DEFAULT_MODES, ...customModes].map((mode) => ({ slug: mode.slug, name: mode.name }))
+		try {
+			const customModes = await this.customModesManager.getCustomModes()
+			return [...DEFAULT_MODES, ...customModes].map(({ slug, name }) => ({ slug, name }))
+		} catch (error) {
+			return DEFAULT_MODES.map(({ slug, name }) => ({ slug, name }))
+		}
 	}
 
 	public async getMode(): Promise<string> {


### PR DESCRIPTION
Send all mode to the extension bridge.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance `getModes()` in `ClineProvider.ts` to include custom modes from `customModesManager`.
> 
>   - **Behavior**:
>     - `getModes()` in `ClineProvider.ts` now includes custom modes from `customModesManager` in addition to `DEFAULT_MODES`.
>     - If `customModesManager.getCustomModes()` fails, it falls back to returning only `DEFAULT_MODES`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cb6527b34a26f90be5b6f7aa49126d1970b776cf. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->