### PR TITLE
feat: OpenAI Native service tier support (selection, API fallback, resolved-tier costing, tiered pricing UI)

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -496,7 +496,11 @@ const ApiOptions = ({
 			)}
 
 			{selectedProvider === "openai-native" && (
-				<OpenAI apiConfiguration={apiConfiguration} setApiConfigurationField={setApiConfigurationField} />
+				<OpenAI
+					apiConfiguration={apiConfiguration}
+					setApiConfigurationField={setApiConfigurationField}
+					selectedModelInfo={selectedModelInfo}
+				/>
 			)}
 
 			{selectedProvider === "mistral" && (

--- a/webview-ui/src/components/settings/ModelInfoView.tsx
+++ b/webview-ui/src/components/settings/ModelInfoView.tsx
@@ -25,7 +25,14 @@ export const ModelInfoView = ({
 }: ModelInfoViewProps) => {
 	const { t } = useAppTranslation()
 
-	const infoItems = [
+	// Show tiered pricing table for OpenAI Native when model supports non-standard tiers
+	const allowedTiers =
+		(modelInfo?.allowedServiceTiers || []).filter((tier) => tier === "flex" || tier === "priority") ?? []
+	const tierPricing = modelInfo?.serviceTierPricing
+	const shouldShowTierPricingTable = apiProvider === "openai-native" && allowedTiers.length > 0 && !!tierPricing
+	const fmt = (n?: number) => (typeof n === "number" ? `${formatPrice(n)}` : "—")
+
+	const baseInfoItems = [
 		typeof modelInfo?.contextWindow === "number" && modelInfo.contextWindow > 0 && (
 			<>
 				<span className="font-medium">{t("settings:modelInfo.contextWindow")}</span>{" "}
@@ -53,6 +60,21 @@ export const ModelInfoView = ({
 			supportsLabel={t("settings:modelInfo.supportsPromptCache")}
 			doesNotSupportLabel={t("settings:modelInfo.noPromptCache")}
 		/>,
+		apiProvider === "gemini" && (
+			<span className="italic">
+				{selectedModelId.includes("pro-preview")
+					? t("settings:modelInfo.gemini.billingEstimate")
+					: t("settings:modelInfo.gemini.freeRequests", {
+							count: selectedModelId && selectedModelId.includes("flash") ? 15 : 2,
+						})}{" "}
+				<VSCodeLink href="https://ai.google.dev/pricing" className="text-sm">
+					{t("settings:modelInfo.gemini.pricingDetails")}
+				</VSCodeLink>
+			</span>
+		),
+	].filter(Boolean)
+
+	const priceInfoItems = [
 		modelInfo?.inputPrice !== undefined && modelInfo.inputPrice > 0 && (
 			<>
 				<span className="font-medium">{t("settings:modelInfo.inputPrice")}:</span>{" "}
@@ -77,19 +99,9 @@ export const ModelInfoView = ({
 				{formatPrice(modelInfo.cacheWritesPrice || 0)} / 1M tokens
 			</>
 		),
-		apiProvider === "gemini" && (
-			<span className="italic">
-				{selectedModelId.includes("pro-preview")
-					? t("settings:modelInfo.gemini.billingEstimate")
-					: t("settings:modelInfo.gemini.freeRequests", {
-							count: selectedModelId && selectedModelId.includes("flash") ? 15 : 2,
-						})}{" "}
-				<VSCodeLink href="https://ai.google.dev/pricing" className="text-sm">
-					{t("settings:modelInfo.gemini.pricingDetails")}
-				</VSCodeLink>
-			</span>
-		),
 	].filter(Boolean)
+
+	const infoItems = shouldShowTierPricingTable ? baseInfoItems : [...baseInfoItems, ...priceInfoItems]
 
 	return (
 		<>
@@ -106,6 +118,62 @@ export const ModelInfoView = ({
 					<div key={index}>{item}</div>
 				))}
 			</div>
+
+			{shouldShowTierPricingTable && (
+				<div className="mt-2">
+					<div className="text-xs text-vscode-descriptionForeground mb-1">
+						Pricing by service tier (price per 1M tokens)
+					</div>
+					<div className="border border-vscode-dropdown-border rounded-xs overflow-hidden">
+						<table className="w-full text-sm">
+							<thead className="bg-vscode-dropdown-background">
+								<tr>
+									<th className="text-left px-3 py-1.5">Tier</th>
+									<th className="text-right px-3 py-1.5">Input</th>
+									<th className="text-right px-3 py-1.5">Output</th>
+									<th className="text-right px-3 py-1.5">Cache reads</th>
+								</tr>
+							</thead>
+							<tbody>
+								<tr className="border-t border-vscode-dropdown-border/60">
+									<td className="px-3 py-1.5">Standard</td>
+									<td className="px-3 py-1.5 text-right">{fmt(modelInfo?.inputPrice)}</td>
+									<td className="px-3 py-1.5 text-right">{fmt(modelInfo?.outputPrice)}</td>
+									<td className="px-3 py-1.5 text-right">{fmt(modelInfo?.cacheReadsPrice)}</td>
+								</tr>
+								{allowedTiers.includes("flex") && (
+									<tr className="border-t border-vscode-dropdown-border/60">
+										<td className="px-3 py-1.5">Flex</td>
+										<td className="px-3 py-1.5 text-right">
+											{fmt(tierPricing?.flex?.inputPrice ?? modelInfo?.inputPrice)}
+										</td>
+										<td className="px-3 py-1.5 text-right">
+											{fmt(tierPricing?.flex?.outputPrice ?? modelInfo?.outputPrice)}
+										</td>
+										<td className="px-3 py-1.5 text-right">
+											{fmt(tierPricing?.flex?.cacheReadsPrice ?? modelInfo?.cacheReadsPrice)}
+										</td>
+									</tr>
+								)}
+								{allowedTiers.includes("priority") && (
+									<tr className="border-t border-vscode-dropdown-border/60">
+										<td className="px-3 py-1.5">Priority</td>
+										<td className="px-3 py-1.5 text-right">
+											{fmt(tierPricing?.priority?.inputPrice ?? modelInfo?.inputPrice)}
+										</td>
+										<td className="px-3 py-1.5 text-right">
+											{fmt(tierPricing?.priority?.outputPrice ?? modelInfo?.outputPrice)}
+										</td>
+										<td className="px-3 py-1.5 text-right">
+											{fmt(tierPricing?.priority?.cacheReadsPrice ?? modelInfo?.cacheReadsPrice)}
+										</td>
+									</tr>
+								)}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			)}
 		</>
 	)
 }

--- a/webview-ui/src/components/settings/providers/OpenAI.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAI.tsx
@@ -2,19 +2,21 @@ import { useCallback, useState } from "react"
 import { Checkbox } from "vscrui"
 import { VSCodeTextField } from "@vscode/webview-ui-toolkit/react"
 
-import type { ProviderSettings } from "@roo-code/types"
+import type { ModelInfo, ProviderSettings } from "@roo-code/types"
 
 import { useAppTranslation } from "@src/i18n/TranslationContext"
 import { VSCodeButtonLink } from "@src/components/common/VSCodeButtonLink"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue, StandardTooltip } from "@src/components/ui"
 
 import { inputEventTransform } from "../transforms"
 
 type OpenAIProps = {
 	apiConfiguration: ProviderSettings
 	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
+	selectedModelInfo?: ModelInfo
 }
 
-export const OpenAI = ({ apiConfiguration, setApiConfigurationField }: OpenAIProps) => {
+export const OpenAI = ({ apiConfiguration, setApiConfigurationField, selectedModelInfo }: OpenAIProps) => {
 	const { t } = useAppTranslation()
 
 	const [openAiNativeBaseUrlSelected, setOpenAiNativeBaseUrlSelected] = useState(
@@ -72,6 +74,44 @@ export const OpenAI = ({ apiConfiguration, setApiConfigurationField }: OpenAIPro
 					{t("settings:providers.getOpenAiApiKey")}
 				</VSCodeButtonLink>
 			)}
+
+			{(() => {
+				const allowedTiers = (selectedModelInfo?.allowedServiceTiers || []).filter(
+					(t) => t === "flex" || t === "priority",
+				)
+				if (allowedTiers.length === 0) return null
+
+				return (
+					<div className="flex flex-col gap-1 mt-2" data-testid="openai-service-tier">
+						<div className="flex items-center gap-1">
+							<label className="block font-medium mb-1">Service tier</label>
+							<StandardTooltip content="For faster processing of API requests, try the priority processing service tier. For lower prices with higher latency, try the flex processing tier.">
+								<i className="codicon codicon-info text-vscode-descriptionForeground text-xs" />
+							</StandardTooltip>
+						</div>
+
+						<Select
+							value={apiConfiguration.openAiNativeServiceTier || "default"}
+							onValueChange={(value) =>
+								setApiConfigurationField(
+									"openAiNativeServiceTier",
+									value as ProviderSettings["openAiNativeServiceTier"],
+								)
+							}>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder={t("settings:common.select")} />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="default">Standard</SelectItem>
+								{allowedTiers.includes("flex") && <SelectItem value="flex">Flex</SelectItem>}
+								{allowedTiers.includes("priority") && (
+									<SelectItem value="priority">Priority</SelectItem>
+								)}
+							</SelectContent>
+						</Select>
+					</div>
+				)
+			})()}
 		</>
 	)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue (or explain why it's a follow-up).
- You've reviewed our Contributing Guidelines.
-->

### Related GitHub Issue

Closes: _No linked issue (OpenAI Native service tiers follow-up)_

### Roo Code Task Context (Optional)

_No Roo Code task context for this PR_

### Description

End-to-end support for OpenAI Native service tiers (default, flex, priority):

What’s included:
- Types
  - Add `ServiceTier` and tiered pricing fields to [`ModelInfo`](packages/types/src/model.ts)
  - Allow per-model `allowedServiceTiers` and `serviceTierPricing`
- Provider settings
  - Add `openAiNativeServiceTier` to the OpenAI Native schema in [`provider-settings`](packages/types/src/provider-settings.ts)
- Model catalog
  - Populate `allowedServiceTiers` and `serviceTierPricing` for applicable models in [`openai.ts`](packages/types/src/providers/openai.ts)
- OpenAI Native provider
  - Include `service_tier` in Responses API requests when requested and supported; retry without it on 400 invalid/unsupported tier
  - Capture resolved `response.service_tier` from the stream and derive effective pricing
  - Apply tiered pricing in usage cost computation without changing shared cost logic
  - Include `service_tier` in non‑streaming `completePrompt()` calls
  - Files: [`openai-native.ts`](src/api/providers/openai-native.ts)
- UI (webview)
  - Add “Service tier” dropdown with an info tooltip; shown only when the selected model supports flex/priority
  - Add a tiered pricing table and hide the old single‑line price bullets when the table is shown
  - Files: [`OpenAI.tsx`](webview-ui/src/components/settings/providers/OpenAI.tsx), [`ApiOptions.tsx`](webview-ui/src/components/settings/ApiOptions.tsx), [`ModelInfoView.tsx`](webview-ui/src/components/settings/ModelInfoView.tsx)
- Tests
  - New unit tests covering request body tier inclusion, retry on unsupported tier, capturing `service_tier` from the stream, and tiered pricing cost computation
  - File: [`openai-native-service-tier.spec.ts`](src/api/providers/__tests__/openai-native-service-tier.spec.ts)

Why:
- Enables users to explicitly select “flex” (lower cost, higher latency) or “priority” (faster processing) where supported.
- Ensures usage/cost reporting reflects the actual tier used by OpenAI’s Responses API.

### Test Procedure

Automated:
- Run backend tests:
  - `cd src && npx vitest run api/providers/__tests__/openai-native-service-tier.spec.ts`
- Run UI tests:
  - `cd webview-ui && npx vitest run`

Manual:
1. Settings → select provider “OpenAI (openai-native)”
2. Choose a model with tier support (e.g., `gpt-5-2025-08-07`, `o4-mini`, `o3`)
3. Verify:
   - “Service tier” dropdown is visible and includes only supported non‑standard tiers
   - When table is shown, single-line price bullets are hidden
   - Tiered pricing table shows “Standard”, plus Flex/Priority with per‑1M token prices
4. Choose a model without tier support → no dropdown and no table; single‑line prices remain
5. Make a request and confirm usage cost aligns with chosen/resolved tier.

### Pre-Submission Checklist

- [x] **Scope**: Changes focused on OpenAI Native service tiers end‑to‑end
- [x] **Self-Review**: Code and UX paths verified
- [x] **Testing**: Added/updated unit tests and ran UI tests
- [x] **Docs Impact**: None required in this repo

### Screenshots / Videos

_No screenshots attached_

### Documentation Updates

- [] No documentation updates are required.

### Additional Notes

- Costing relies on `applyServiceTierPricing` to produce an effective `ModelInfo` before calling shared cost helpers.
- Request fallback behavior gracefully handles unsupported/invalid `service_tier`.

### Get in Touch

@username
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for OpenAI Native service tiers, including API handling, UI updates, and pricing logic.
> 
>   - **Behavior**:
>     - Adds `ServiceTier` and pricing fields to `ModelInfo` in `model.ts`.
>     - Adds `openAiNativeServiceTier` to OpenAI Native schema in `provider-settings.ts`.
>     - Handles `service_tier` in API requests and retries on unsupported tiers in `openai-native.ts`.
>     - Captures `response.service_tier` and applies tiered pricing in cost computation.
>   - **UI**:
>     - Adds "Service tier" dropdown and pricing table in `OpenAI.tsx`, `ApiOptions.tsx`, and `ModelInfoView.tsx`.
>     - Hides single-line price bullets when tiered pricing is shown.
>   - **Tests**:
>     - Adds tests for tier inclusion in requests, retry logic, and pricing computation in `openai-native-service-tier.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5d6fc17e1330721f50e82d3790f1565883d612c3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->