### PR TITLE
Remove unused slack notif

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -89,19 +89,3 @@ jobs:
             - name: Run integration tests
               working-directory: apps/vscode-e2e
               run: xvfb-run -a pnpm test:ci
-
-    notify-slack-on-failure:
-        runs-on: ubuntu-latest
-        needs: [check-translations, knip, compile, unit-test, integration-test]
-        if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && contains(needs.*.result, 'failure') }}
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
-
-            - name: Send Slack notification on failure
-              uses: ./.github/actions/slack-notify
-              with:
-                  webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-                  channel: "#ci"
-                  workflow-name: "Code QA"
-                  failed-jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove unused Slack notification job from `code-qa.yml` workflow.
> 
>   - **Removal**:
>     - Removed `notify-slack-on-failure` job from `.github/workflows/code-qa.yml`.
>     - This job was responsible for sending Slack notifications on failure of specific jobs (`check-translations`, `knip`, `compile`, `unit-test`, `integration-test`).
>     - Removed steps related to Slack notification, including checkout and Slack webhook usage.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e58d260e073e3e49b28dfeff8849ca55410364ae. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->