### PR TITLE
Handle zsh process substitution correctly

### DIFF
--- a/webview-ui/src/utils/command-validation.ts
+++ b/webview-ui/src/utils/command-validation.ts
@@ -71,6 +71,7 @@ type ShellToken = string | { op: string } | { command: string }
  * - ${var=value} with escape sequences - Can embed commands via \140 (backtick), \x60, or \u0060
  * - ${!var} - Indirect variable references
  * - <<<$(...) or <<<`...` - Here-strings with command substitution
+ * - =(...) - Zsh process substitution that executes commands
  *
  * @param source - The command string to analyze
  * @returns true if dangerous substitution patterns are detected, false otherwise
@@ -100,9 +101,17 @@ export function containsDangerousSubstitution(source: string): boolean {
 	// <<<$(...) or <<<`...` can execute commands
 	const hereStringWithSubstitution = /<<<\s*(\$\(|`)/.test(source)
 
+	// Check for zsh process substitution =(...) which executes commands
+	// =(...) creates a temporary file containing the output of the command, but executes it
+	const zshProcessSubstitution = /=\([^)]+\)/.test(source)
+
 	// Return true if any dangerous pattern is detected
 	return (
-		dangerousParameterExpansion || parameterAssignmentWithEscapes || indirectExpansion || hereStringWithSubstitution
+		dangerousParameterExpansion ||
+		parameterAssignmentWithEscapes ||
+		indirectExpansion ||
+		hereStringWithSubstitution ||
+		zshProcessSubstitution
 	)
 }
 


### PR DESCRIPTION
Thanks @maccarita for reporting this issue.

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add detection for zsh process substitution in command validation to flag as dangerous.
> 
>   - **Behavior**:
>     - `containsDangerousSubstitution` in `command-validation.ts` now detects zsh process substitution `=()` as dangerous.
>     - Commands with zsh process substitution are flagged to require user approval.
>   - **Tests**:
>     - Added tests in `command-validation.spec.ts` to verify detection of zsh process substitution patterns like `ls =(open -a Calculator)`.
>     - Ensures various forms of zsh process substitution are correctly identified as dangerous.
>     - Tests confirm that commands with these patterns are not auto-approved.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e05098e0aabca5aea122809ca83bec33eff21327. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->