### PR TITLE
fix: preserve chat input when queued messages are sent (#7861)

### DIFF
--- a/webview-ui/src/components/chat/__tests__/ChatView.queuedMessages.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.queuedMessages.spec.tsx
@@ -1,0 +1,213 @@
+import React from "react"
+import { render, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { vi } from "vitest"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import "@testing-library/jest-dom"
+
+// Mock dependencies before importing components
+vi.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+vi.mock("use-sound", () => ({
+	default: () => [vi.fn()],
+}))
+
+// Mock the extension state hook
+vi.mock("@src/context/ExtensionStateContext", async () => {
+	const actual = await vi.importActual("@src/context/ExtensionStateContext")
+	return {
+		...actual,
+		useExtensionState: vi.fn(() => ({
+			clineMessages: [],
+			taskHistory: [],
+			apiConfiguration: { apiProvider: "test" },
+			messageQueue: [],
+			mode: "code",
+			customModes: [],
+			setMode: vi.fn(),
+		})),
+	}
+})
+
+// Now import components after all mocks are set up
+import ChatView from "../ChatView"
+import { ExtensionStateContextProvider, useExtensionState } from "@src/context/ExtensionStateContext"
+import { vscode } from "@src/utils/vscode"
+
+// Set up global mock
+;(global as any).acquireVsCodeApi = () => ({
+	postMessage: vi.fn(),
+	getState: () => ({}),
+	setState: vi.fn(),
+})
+
+const queryClient = new QueryClient({
+	defaultOptions: {
+		queries: { retry: false },
+		mutations: { retry: false },
+	},
+})
+
+const renderChatView = () => {
+	return render(
+		<ExtensionStateContextProvider>
+			<QueryClientProvider client={queryClient}>
+				<ChatView isHidden={false} showAnnouncement={false} hideAnnouncement={vi.fn()} />
+			</QueryClientProvider>
+		</ExtensionStateContextProvider>,
+	)
+}
+
+describe("ChatView - Queued Messages", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("should preserve input text when processing queued messages", async () => {
+		// Mock the state with a queued message
+		const mockUseExtensionState = useExtensionState as any
+		mockUseExtensionState.mockReturnValue({
+			clineMessages: [],
+			taskHistory: [],
+			apiConfiguration: { apiProvider: "test" },
+			messageQueue: [
+				{
+					id: "queue-1",
+					text: "Queued message",
+					images: [],
+					timestamp: Date.now(),
+				},
+			],
+			mode: "code",
+			customModes: [],
+			setMode: vi.fn(),
+		})
+
+		const { container } = renderChatView()
+
+		// Find the textarea
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement
+		expect(textarea).toBeTruthy()
+
+		// User types new text while message is queued
+		await userEvent.type(textarea, "New text typed by user")
+		expect(textarea.value).toBe("New text typed by user")
+
+		// Simulate backend processing the queued message by sending invoke message
+		const invokeMessage = new MessageEvent("message", {
+			data: {
+				type: "invoke",
+				invoke: "sendMessage",
+				text: "Queued message",
+				images: [],
+			},
+		})
+		window.dispatchEvent(invokeMessage)
+
+		// Wait for any async operations
+		await waitFor(() => {
+			// The input should still contain the user's typed text
+			expect(textarea.value).toBe("New text typed by user")
+		})
+
+		// Verify the queued message was sent
+		expect(vscode.postMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: expect.stringMatching(/newTask|askResponse/),
+			}),
+		)
+	})
+
+	it("should clear input when sending a regular message (not from queue)", async () => {
+		// Mock the state with no queued messages
+		const mockUseExtensionState = useExtensionState as any
+		mockUseExtensionState.mockReturnValue({
+			clineMessages: [],
+			taskHistory: [],
+			apiConfiguration: { apiProvider: "test" },
+			messageQueue: [], // No queued messages
+			mode: "code",
+			customModes: [],
+			setMode: vi.fn(),
+		})
+
+		const { container } = renderChatView()
+
+		// Find the textarea
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement
+		expect(textarea).toBeTruthy()
+
+		// User types text
+		await userEvent.type(textarea, "Regular message")
+		expect(textarea.value).toBe("Regular message")
+
+		// Simulate backend sending invoke message for a non-queued message
+		const invokeMessage = new MessageEvent("message", {
+			data: {
+				type: "invoke",
+				invoke: "sendMessage",
+				text: "Different message not in queue",
+				images: [],
+			},
+		})
+		window.dispatchEvent(invokeMessage)
+
+		// Wait for any async operations
+		await waitFor(() => {
+			// The input should be cleared since this is not a queued message
+			expect(textarea.value).toBe("")
+		})
+	})
+
+	it("should handle messages with images correctly", async () => {
+		// Mock the state with a queued message with image
+		const mockUseExtensionState = useExtensionState as any
+		mockUseExtensionState.mockReturnValue({
+			clineMessages: [],
+			taskHistory: [],
+			apiConfiguration: { apiProvider: "test" },
+			messageQueue: [
+				{
+					id: "queue-2",
+					text: "Message with image",
+					images: ["data:image/png;base64,abc123"],
+					timestamp: Date.now(),
+				},
+			],
+			mode: "code",
+			customModes: [],
+			setMode: vi.fn(),
+		})
+
+		const { container } = renderChatView()
+
+		// Find the textarea
+		const textarea = container.querySelector("textarea") as HTMLTextAreaElement
+		expect(textarea).toBeTruthy()
+
+		// User types new text
+		await userEvent.type(textarea, "User typing while image message queued")
+		expect(textarea.value).toBe("User typing while image message queued")
+
+		// Simulate backend processing the queued message with image
+		const invokeMessage = new MessageEvent("message", {
+			data: {
+				type: "invoke",
+				invoke: "sendMessage",
+				text: "Message with image",
+				images: ["data:image/png;base64,abc123"],
+			},
+		})
+		window.dispatchEvent(invokeMessage)
+
+		// Wait for any async operations
+		await waitFor(() => {
+			// The input should still contain the user's typed text
+			expect(textarea.value).toBe("User typing while image message queued")
+		})
+	})
+})


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #7861 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

_No Roo Code task context for this PR_

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

This PR fixes a bug where the chat input was being cleared when queued messages were sent, even if the user had typed new text in the meantime.

**Key Changes:**
- Added a `fromQueue` parameter to `handleSendMessage` to distinguish between user-initiated sends and queue-processed messages
- Modified the invoke handler to detect when a message is being sent from the queue
- Only clear the input when `fromQueue` is false, preserving user input for queued messages

**Implementation Details:**
- When the backend processes a queued message, it sends an "invoke sendMessage" to the frontend
- The fix checks if the invoked message matches any message in the queue to determine if it's from the queue
- This ensures the input is preserved when processing queued messages but still cleared for normal message sends

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

**Automated Tests:**
- Added comprehensive unit tests in `ChatView.queuedMessages.spec.tsx`
- Tests verify that input is preserved when processing queued messages
- Tests verify that input is cleared for normal message sends
- All existing tests continue to pass

**Manual Testing:**
1. Open Roo Code extension
2. Start a task that causes sending to be disabled (e.g., during approval waiting)
3. Queue a message while sending is disabled
4. Type new text in the chatbox (do not send)
5. Wait for the queued message to be processed
6. Verify that your typed text remains in the chatbox

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

_No UI changes in this PR - the fix is behavioral (preserving input text)_

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

- [x] No documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

This bug affected users who had messages queued (e.g., while approval is pending) and then typed new text before the queue processed. The fix ensures a better user experience by preserving their typed content.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

_Available via GitHub for questions_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes chat input clearing issue by adding `fromQueue` parameter to `handleSendMessage` in `ChatView.tsx`, preserving input for queued messages.
> 
>   - **Behavior**:
>     - Adds `fromQueue` parameter to `handleSendMessage` in `ChatView.tsx` to differentiate between user-initiated and queue-processed messages.
>     - Modifies message handling to preserve input when `fromQueue` is true.
>   - **Testing**:
>     - Adds `ChatView.queuedMessages.spec.tsx` to test input preservation for queued messages and clearing for regular messages.
>     - Tests include scenarios with and without images.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9784d0773953378b93b0a1e3761f4f8261412c6a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->