### PR TITLE
feat: Reposition History button from overflow to main toolbar

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -224,23 +224,23 @@
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
-					"command": "roo-cline.marketplaceButtonClicked",
+					"command": "roo-cline.historyButtonClicked",
 					"group": "navigation@2",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
-					"command": "roo-cline.settingsButtonClicked",
+					"command": "roo-cline.marketplaceButtonClicked",
 					"group": "navigation@3",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
-					"command": "roo-cline.cloudButtonClicked",
+					"command": "roo-cline.settingsButtonClicked",
 					"group": "navigation@4",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
-					"command": "roo-cline.historyButtonClicked",
-					"group": "overflow@1",
+					"command": "roo-cline.cloudButtonClicked",
+					"group": "navigation@5",
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
@@ -266,23 +266,23 @@
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
-					"command": "roo-cline.marketplaceButtonClicked",
+					"command": "roo-cline.historyButtonClicked",
 					"group": "navigation@2",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
-					"command": "roo-cline.settingsButtonClicked",
+					"command": "roo-cline.marketplaceButtonClicked",
 					"group": "navigation@3",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
-					"command": "roo-cline.cloudButtonClicked",
+					"command": "roo-cline.settingsButtonClicked",
 					"group": "navigation@4",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
-					"command": "roo-cline.historyButtonClicked",
-					"group": "overflow@1",
+					"command": "roo-cline.cloudButtonClicked",
+					"group": "navigation@5",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{


### PR DESCRIPTION
## Changes
Modified menu contributions in src/package.json:
- Repositioned historyButtonClicked from overflow@1 to navigation@2
- Adjusted navigation positions: marketplace@3, settings@4, cloud@5
- Applied to both view/title and editor/title contexts

## Testing
- Backend tests: 290 files, 3778 passing
- UI tests: 86 files, 1032 passing  
- Type checking: passing
- Linting: passing

## Technical Details
Line modifications in src/package.json:
- Lines 227, 269: historyButtonClicked group change
- Lines 228-230, 270-272: navigation item position adjustments

Fixes #7887
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reposition `historyButtonClicked` to main toolbar in `src/package.json`, adjusting other navigation items accordingly, with all tests passing.
> 
>   - **Behavior**:
>     - Reposition `historyButtonClicked` from `overflow@1` to `navigation@2` in `src/package.json`.
>     - Adjust `marketplaceButtonClicked`, `settingsButtonClicked`, and `cloudButtonClicked` positions to `navigation@3`, `navigation@4`, and `navigation@5` respectively.
>     - Changes apply to both `view/title` and `editor/title` contexts.
>   - **Testing**:
>     - Backend tests: 3778 passing.
>     - UI tests: 1032 passing.
>     - Type checking and linting: passing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c2c136a664c216e18f81beefe8a7384a5769a518. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->