### PR TITLE
chore: Remove unsupported Gemini 2.5 Flash Image Preview free model

### DIFF
--- a/src/core/tools/generateImageTool.ts
+++ b/src/core/tools/generateImageTool.ts
@@ -11,7 +11,7 @@ import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { OpenRouterHandler } from "../../api/providers/openrouter"
 
 // Hardcoded list of image generation models for now
-const IMAGE_GENERATION_MODELS = ["google/gemini-2.5-flash-image-preview", "google/gemini-2.5-flash-image-preview:free"]
+const IMAGE_GENERATION_MODELS = ["google/gemini-2.5-flash-image-preview"]
 
 export async function generateImageTool(
 	cline: Task,

--- a/webview-ui/src/components/settings/ImageGenerationSettings.tsx
+++ b/webview-ui/src/components/settings/ImageGenerationSettings.tsx
@@ -14,7 +14,6 @@ interface ImageGenerationSettingsProps {
 // Hardcoded list of image generation models
 const IMAGE_GENERATION_MODELS = [
 	{ value: "google/gemini-2.5-flash-image-preview", label: "Gemini 2.5 Flash Image Preview" },
-	{ value: "google/gemini-2.5-flash-image-preview:free", label: "Gemini 2.5 Flash Image Preview (Free)" },
 	// Add more models as they become available
 ]
 

--- a/webview-ui/src/components/settings/__tests__/ImageGenerationSettings.spec.tsx
+++ b/webview-ui/src/components/settings/__tests__/ImageGenerationSettings.spec.tsx
@@ -41,7 +41,7 @@ describe("ImageGenerationSettings", () => {
 				<ImageGenerationSettings
 					{...defaultProps}
 					openRouterImageApiKey="existing-key"
-					openRouterImageGenerationSelectedModel="google/gemini-2.5-flash-image-preview:free"
+					openRouterImageGenerationSelectedModel="google/gemini-2.5-flash-image-preview"
 				/>,
 			)
 


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: N/A <!-- This is a maintenance task to remove unsupported model endpoint -->

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

_No Roo Code task context for this PR_

### Description

<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

This PR removes the unsupported free version of the Gemini 2.5 Flash Image Preview model from both backend and UI components. The free endpoint is no longer available from the provider, so removing it prevents users from encountering errors when trying to use the non-functional free option.

**Key implementation details:**
- Removed the free model from hardcoded arrays in both backend tool and UI component
- Updated test files to use the paid version instead of the free version
- Maintained backward compatibility - existing users with paid model selected are unaffected
- No breaking changes to the API or user interface

**Areas for reviewer attention:**
- Verify that only the free model was removed and paid model remains functional
- Confirm that all test updates are appropriate and comprehensive

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

**Automated Testing:**
1. Backend tests: `cd src && npx vitest run core/tools/__tests__/generateImageTool.test.ts`
   - All 9 tests pass
   - Tests verify image generation functionality with paid model
2. UI tests: `cd webview-ui && npx vitest run src/components/settings/__tests__/ImageGenerationSettings.spec.tsx`
   - All 5 tests pass
   - Tests verify settings component behavior with paid model

**Manual Testing:**
1. Verify that the UI dropdown in experimental settings only shows the paid model option
2. Confirm that existing configurations with paid model continue to work
3. Check that no references to the free model remain in the codebase

**Verification Commands:**
- `pnpm lint` - All linting passes
- `pnpm check-types` - All type checking passes
- Search for remaining references: `grep -r "google/gemini-2.5-flash-image-preview:free" src/ webview-ui/` should return no results

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR addresses a maintenance task (removing unsupported endpoint).
- [x] **Scope**: My changes are focused on removing the unsupported free model (targeted maintenance).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: All existing tests have been updated and pass (no new functionality added).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

_No visible UI changes - this is a backend model configuration change that removes a non-functional option from the dropdown_

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

- [x] No documentation updates are required.

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

This is a maintenance PR to remove a non-functional model endpoint. The free version of the Gemini 2.5 Flash Image Preview model is no longer supported by the provider, so removing it improves user experience by preventing errors when users try to select the non-working option.

The paid version remains fully functional and available. Users who were already using the paid version will see no changes in functionality.

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

_Contact through GitHub for any questions about this PR_
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unsupported Gemini 2.5 Flash Image Preview free model from backend and UI components.
> 
>   - **Behavior**:
>     - Removed unsupported `google/gemini-2.5-flash-image-preview:free` model from `IMAGE_GENERATION_MODELS` in `generateImageTool.ts` and `ImageGenerationSettings.tsx`.
>     - Updated tests in `ImageGenerationSettings.spec.tsx` to use the paid model.
>     - Ensures backward compatibility; existing users with paid model are unaffected.
>   - **Testing**:
>     - All backend and UI tests pass, confirming functionality with the paid model.
>     - Manual verification ensures no references to the free model remain.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bc50db0035b3c0382da70d18e2a66b869ef7428a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->