### PR TITLE
chore: add changeset for v3.28.12

### DIFF
--- a/.changeset/v3.28.12.md
+++ b/.changeset/v3.28.12.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+- Fix: Correct Anthropic Sonnet 4.5 model ID and add Bedrock 1M context checkbox (thanks @daniel-lxs!)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds changeset for v3.28.12 with a fix for Anthropic Sonnet 4.5 model ID and a new Bedrock 1M context checkbox.
> 
>   - **Changeset**:
>     - Adds changeset file `v3.28.12.md` for version `v3.28.12`.
>     - Fixes Anthropic Sonnet 4.5 model ID.
>     - Adds Bedrock 1M context checkbox.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5b46f378c613d7c44245f345956b11d7d45fd7ee. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->