### PR TITLE
A couple more sonnet 4.5 fixes

### DIFF
--- a/packages/types/src/providers/bedrock.ts
+++ b/packages/types/src/providers/bedrock.ts
@@ -457,7 +457,6 @@ export const BEDROCK_REGIONS = [
 	{ value: "us-gov-west-1", label: "us-gov-west-1" },
 ].sort((a, b) => a.value.localeCompare(b.value))
 
-export const BEDROCK_CLAUDE_SONNET_4_MODEL_ID = "anthropic.claude-sonnet-4-20250514-v1:0"
 export const BEDROCK_1M_CONTEXT_MODEL_IDS = [
 	"anthropic.claude-sonnet-4-20250514-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",

--- a/src/api/providers/__tests__/bedrock.spec.ts
+++ b/src/api/providers/__tests__/bedrock.spec.ts
@@ -25,7 +25,7 @@ vi.mock("@aws-sdk/client-bedrock-runtime", () => {
 
 import { AwsBedrockHandler } from "../bedrock"
 import { ConverseStreamCommand, BedrockRuntimeClient } from "@aws-sdk/client-bedrock-runtime"
-import { BEDROCK_CLAUDE_SONNET_4_MODEL_ID } from "@roo-code/types"
+import { BEDROCK_1M_CONTEXT_MODEL_IDS } from "@roo-code/types"
 
 import type { Anthropic } from "@anthropic-ai/sdk"
 
@@ -569,7 +569,7 @@ describe("AwsBedrockHandler", () => {
 	describe("1M context beta feature", () => {
 		it("should enable 1M context window when awsBedrock1MContext is true for Claude Sonnet 4", () => {
 			const handler = new AwsBedrockHandler({
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsAccessKey: "test",
 				awsSecretKey: "test",
 				awsRegion: "us-east-1",
@@ -584,7 +584,7 @@ describe("AwsBedrockHandler", () => {
 
 		it("should use default context window when awsBedrock1MContext is false for Claude Sonnet 4", () => {
 			const handler = new AwsBedrockHandler({
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsAccessKey: "test",
 				awsSecretKey: "test",
 				awsRegion: "us-east-1",
@@ -614,7 +614,7 @@ describe("AwsBedrockHandler", () => {
 
 		it("should include anthropic_beta parameter when 1M context is enabled", async () => {
 			const handler = new AwsBedrockHandler({
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsAccessKey: "test",
 				awsSecretKey: "test",
 				awsRegion: "us-east-1",
@@ -644,7 +644,7 @@ describe("AwsBedrockHandler", () => {
 
 		it("should not include anthropic_beta parameter when 1M context is disabled", async () => {
 			const handler = new AwsBedrockHandler({
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsAccessKey: "test",
 				awsSecretKey: "test",
 				awsRegion: "us-east-1",
@@ -698,7 +698,7 @@ describe("AwsBedrockHandler", () => {
 
 		it("should enable 1M context window with cross-region inference for Claude Sonnet 4", () => {
 			const handler = new AwsBedrockHandler({
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsAccessKey: "test",
 				awsSecretKey: "test",
 				awsRegion: "us-east-1",
@@ -711,12 +711,12 @@ describe("AwsBedrockHandler", () => {
 			// Should have 1M context window even with cross-region prefix
 			expect(model.info.contextWindow).toBe(1_000_000)
 			// Model ID should have cross-region prefix
-			expect(model.id).toBe(`us.${BEDROCK_CLAUDE_SONNET_4_MODEL_ID}`)
+			expect(model.id).toBe(`us.${BEDROCK_1M_CONTEXT_MODEL_IDS[0]}`)
 		})
 
 		it("should include anthropic_beta parameter with cross-region inference for Claude Sonnet 4", async () => {
 			const handler = new AwsBedrockHandler({
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsAccessKey: "test",
 				awsSecretKey: "test",
 				awsRegion: "us-east-1",
@@ -746,7 +746,7 @@ describe("AwsBedrockHandler", () => {
 			// Should not include anthropic_version since thinking is not enabled
 			expect(commandArg.additionalModelRequestFields.anthropic_version).toBeUndefined()
 			// Model ID should have cross-region prefix
-			expect(commandArg.modelId).toBe(`us.${BEDROCK_CLAUDE_SONNET_4_MODEL_ID}`)
+			expect(commandArg.modelId).toBe(`us.${BEDROCK_1M_CONTEXT_MODEL_IDS[0]}`)
 		})
 	})
 })

--- a/src/api/providers/bedrock.ts
+++ b/src/api/providers/bedrock.ts
@@ -21,7 +21,6 @@ import {
 	BEDROCK_MAX_TOKENS,
 	BEDROCK_DEFAULT_CONTEXT,
 	AWS_INFERENCE_PROFILE_MAPPING,
-	BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
 	BEDROCK_1M_CONTEXT_MODEL_IDS,
 } from "@roo-code/types"
 
@@ -373,7 +372,7 @@ export class AwsBedrockHandler extends BaseProvider implements SingleCompletionH
 			maxTokens: modelConfig.maxTokens || (modelConfig.info.maxTokens as number),
 			temperature: modelConfig.temperature ?? (this.options.modelTemperature as number),
 		}
-	
+
 		// Check if 1M context is enabled for Claude Sonnet 4
 		// Use parseBaseModelId to handle cross-region inference prefixes
 		const baseModelId = this.parseBaseModelId(modelConfig.id)

--- a/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
+++ b/webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { renderHook } from "@testing-library/react"
 import type { Mock } from "vitest"
 
-import { ProviderSettings, ModelInfo, BEDROCK_CLAUDE_SONNET_4_MODEL_ID } from "@roo-code/types"
+import { ProviderSettings, ModelInfo, BEDROCK_1M_CONTEXT_MODEL_IDS } from "@roo-code/types"
 
 import { useSelectedModel } from "../useSelectedModel"
 import { useRouterModels } from "../useRouterModels"
@@ -474,28 +474,28 @@ describe("useSelectedModel", () => {
 		it("should enable 1M context window for Bedrock Claude Sonnet 4 when awsBedrock1MContext is true", () => {
 			const apiConfiguration: ProviderSettings = {
 				apiProvider: "bedrock",
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsBedrock1MContext: true,
 			}
 
 			const wrapper = createWrapper()
 			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
 
-			expect(result.current.id).toBe(BEDROCK_CLAUDE_SONNET_4_MODEL_ID)
+			expect(result.current.id).toBe(BEDROCK_1M_CONTEXT_MODEL_IDS[0])
 			expect(result.current.info?.contextWindow).toBe(1_000_000)
 		})
 
 		it("should use default context window for Bedrock Claude Sonnet 4 when awsBedrock1MContext is false", () => {
 			const apiConfiguration: ProviderSettings = {
 				apiProvider: "bedrock",
-				apiModelId: BEDROCK_CLAUDE_SONNET_4_MODEL_ID,
+				apiModelId: BEDROCK_1M_CONTEXT_MODEL_IDS[0],
 				awsBedrock1MContext: false,
 			}
 
 			const wrapper = createWrapper()
 			const { result } = renderHook(() => useSelectedModel(apiConfiguration), { wrapper })
 
-			expect(result.current.id).toBe(BEDROCK_CLAUDE_SONNET_4_MODEL_ID)
+			expect(result.current.id).toBe(BEDROCK_1M_CONTEXT_MODEL_IDS[0])
 			expect(result.current.info?.contextWindow).toBe(200_000)
 		})
 

--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -367,11 +367,11 @@ function getSelectedModel({
 			// Apply 1M context beta tier pricing for Claude Sonnet 4
 			if (
 				provider === "anthropic" &&
-				id === "claude-sonnet-4-20250514" &&
+				(id === "claude-sonnet-4-20250514" || id === "claude-sonnet-4-5") &&
 				apiConfiguration.anthropicBeta1MContext &&
 				baseInfo
 			) {
-				// Type assertion since we know claude-sonnet-4-20250514 has tiers
+				// Type assertion since we know claude-sonnet-4-20250514 and claude-sonnet-4-5 have tiers
 				const modelWithTiers = baseInfo as typeof baseInfo & {
 					tiers?: Array<{
 						contextWindow: number


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor Claude Sonnet 4 model handling to use `BEDROCK_1M_CONTEXT_MODEL_IDS` for 1M context window support.
> 
>   - **Behavior**:
>     - Removed `BEDROCK_CLAUDE_SONNET_4_MODEL_ID` constant from `bedrock.ts`.
>     - Updated `AwsBedrockHandler` in `bedrock.ts` to use `BEDROCK_1M_CONTEXT_MODEL_IDS[0]` for 1M context window logic.
>     - Updated `getSelectedModel()` in `useSelectedModel.ts` to handle 1M context for Claude Sonnet 4 using `BEDROCK_1M_CONTEXT_MODEL_IDS`.
>   - **Tests**:
>     - Updated tests in `bedrock.spec.ts` to use `BEDROCK_1M_CONTEXT_MODEL_IDS[0]` instead of `BEDROCK_CLAUDE_SONNET_4_MODEL_ID`.
>     - Updated tests in `useSelectedModel.spec.ts` to reflect changes in model ID handling for 1M context.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e056367c1f6893918807b48555b39e806896a459. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->