### PR TITLE
fix(modes): custom modes under custom path not showing

### DIFF
--- a/src/core/prompts/instructions/create-mode.ts
+++ b/src/core/prompts/instructions/create-mode.ts
@@ -2,11 +2,12 @@ import * as path from "path"
 import * as vscode from "vscode"
 
 import { GlobalFileNames } from "../../../shared/globalFileNames"
+import { getSettingsDirectoryPath } from "../../../utils/storage"
 
 export async function createModeInstructions(context: vscode.ExtensionContext | undefined): Promise<string> {
 	if (!context) throw new Error("Missing VSCode Extension Context")
 
-	const settingsDir = path.join(context.globalStorageUri.fsPath, "settings")
+	const settingsDir = await getSettingsDirectoryPath(context.globalStorageUri.fsPath)
 	const customModesPath = path.join(settingsDir, GlobalFileNames.customModes)
 
 	return `

--- a/src/core/prompts/sections/modes.ts
+++ b/src/core/prompts/sections/modes.ts
@@ -1,14 +1,13 @@
-import * as path from "path"
 import * as vscode from "vscode"
-import { promises as fs } from "fs"
 
 import type { ModeConfig } from "@roo-code/types"
 
 import { getAllModesWithPrompts } from "../../../shared/modes"
+import { ensureSettingsDirectoryExists } from "../../../utils/globalContext"
 
 export async function getModesSection(context: vscode.ExtensionContext): Promise<string> {
-	const settingsDir = path.join(context.globalStorageUri.fsPath, "settings")
-	await fs.mkdir(settingsDir, { recursive: true })
+	// Make sure path gets created
+	await ensureSettingsDirectoryExists(context)
 
 	// Get all modes with their overrides from extension state
 	const allModes = await getAllModesWithPrompts(context)

--- a/src/utils/globalContext.ts
+++ b/src/utils/globalContext.ts
@@ -1,13 +1,7 @@
-import { mkdir } from "fs/promises"
-import { join } from "path"
 import { ExtensionContext } from "vscode"
-
-export async function getGlobalFsPath(context: ExtensionContext): Promise<string> {
-	return context.globalStorageUri.fsPath
-}
+import { getSettingsDirectoryPath } from "./storage"
 
 export async function ensureSettingsDirectoryExists(context: ExtensionContext): Promise<string> {
-	const settingsDir = join(context.globalStorageUri.fsPath, "settings")
-	await mkdir(settingsDir, { recursive: true })
-	return settingsDir
+	// getSettingsDirectoryPath already handles the custom storage path setting
+	return await getSettingsDirectoryPath(context.globalStorageUri.fsPath)
 }

--- a/src/utils/migrateSettings.ts
+++ b/src/utils/migrateSettings.ts
@@ -3,6 +3,7 @@ import * as path from "path"
 import * as fs from "fs/promises"
 import { fileExistsAtPath } from "./fs"
 import { GlobalFileNames } from "../shared/globalFileNames"
+import { getSettingsDirectoryPath } from "./storage"
 import * as yaml from "yaml"
 
 const deprecatedCustomModesJSONFilename = "custom_modes.json"
@@ -26,7 +27,7 @@ export async function migrateSettings(
 	]
 
 	try {
-		const settingsDir = path.join(context.globalStorageUri.fsPath, "settings")
+		const settingsDir = await getSettingsDirectoryPath(context.globalStorageUri.fsPath)
 
 		// Check if settings directory exists first
 		if (!(await fileExistsAtPath(settingsDir))) {


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #8122

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

### Description

Upon setting custom storage path, custom modes didn't show up. This PR fixes it by replacing hardcoded global storage path to the one set by the user.

### Test Procedure

<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

1. Set custom global storage path
2. Create a new mode
3. Restart, it should still show the custom modes we've defined earlier in the custom directory.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes

<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch

@elianiva
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue with custom modes not showing by using user-defined storage path instead of hardcoded path.
> 
>   - **Behavior**:
>     - Replaces hardcoded global storage path with user-defined path in `createModeInstructions()` in `create-mode.ts` and `getModesSection()` in `modes.ts`.
>     - Ensures settings directory is created using `ensureSettingsDirectoryExists()` in `modes.ts`.
>   - **Utilities**:
>     - Updates `ensureSettingsDirectoryExists()` in `globalContext.ts` to use `getSettingsDirectoryPath()` for custom path handling.
>     - Modifies `migrateSettings()` in `migrateSettings.ts` to use `getSettingsDirectoryPath()` for determining settings directory.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9e93dd8feeea15058067fe0670ee238eb3335bf7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->