### PR TITLE
Prevent a noisy cloud agent exception

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1820,7 +1820,9 @@ export class ClineProvider
 		let cloudOrganizations: CloudOrganizationMembership[] = []
 
 		try {
-			cloudOrganizations = await CloudService.instance.getOrganizationMemberships()
+			if (!CloudService.instance.isCloudAgent) {
+				cloudOrganizations = await CloudService.instance.getOrganizationMemberships()
+			}
 		} catch (error) {
 			console.error(
 				`[getStateToPostToWebview] failed to get cloud organizations: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
The cloud agent logs are filled with:
```
4|controller  | 2025-10-08T20:50:35: [303:1009/034932.692959:INFO:CONSOLE:34] "%c  ERR color: #f33 [Extension Host] [getStateToPostToWebview] failed to get cloud organizations: Authentication methods are disabled in StaticTokenAuthService", source: vscode-file://vscode-app/data/vscode/resources/app/out/vs/workbench/workbench.desktop.main.js (34)
4|controller  | 2025-10-08T20:50:35: [303:1009/034932.692999:INFO:CONSOLE:523] "%c[Extension Host] %c[getStateToPostToWebview] failed to get cloud organizations: Authentication methods are disabled in StaticTokenAuthService %c(at console.<anonymous> (file:///data/vscode/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:201:30974)) color: blue color:  color: grey", source: vscode-file://vscode-app/data/vscode/resources/app/out/vs/workbench/workbench.desktop.main.js (523)
4|controller  | 2025-10-08T20:50:35: Task has not finished or aborted yet
4|controller  | 2025-10-08T20:50:35: [303:1009/034940.171445:INFO:CONSOLE:34] "%c  ERR color: #f33 [Extension Host] [getStateToPostToWebview] failed to get cloud organizations: Authentication methods are disabled in StaticTokenAuthService", source: vscode-file://vscode-app/data/vscode/resources/app/out/vs/workbench/workbench.desktop.main.js (34)
4|controller  | 2025-10-08T20:50:35: [303:1009/034940.171480:INFO:CONSOLE:523] "%c[Extension Host] %c[getStateToPostToWebview] failed to get cloud organizations: Authentication methods are disabled in StaticTokenAuthService %c(at console.<anonymous> (file:///data/vscode/resources/app/out/vs/workbench/api/node/extensionHostProcess.js:201:30974)) color: blue color:  color: grey", source: vscode-file://vscode-app/data/vscode/resources/app/out/vs/workbench/workbench.desktop.main.js (523)
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevents logging errors in `ClineProvider.ts` when cloud agent is active by checking `CloudService.instance.isCloudAgent` before retrieving cloud organizations.
> 
>   - **Behavior**:
>     - Prevents logging of cloud organization retrieval errors when `CloudService.instance.isCloudAgent` is true in `getStateToPostToWebview()` in `ClineProvider.ts`.
>     - Specifically addresses error: "failed to get cloud organizations: Authentication methods are disabled in StaticTokenAuthService".
>   - **Misc**:
>     - Adds a conditional check for `CloudService.instance.isCloudAgent` before calling `getOrganizationMemberships()` in `ClineProvider.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2dfecc1c003e040b9575547ebbd31b60e97166ba. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->