### PR TITLE
feat: Add Claude Sonnet 4.5 1M context window support for Claude Code…

### DIFF
--- a/packages/types/src/providers/claude-code.ts
+++ b/packages/types/src/providers/claude-code.ts
@@ -48,6 +48,15 @@ export const claudeCodeModels = {
 		supportsReasoningBudget: false,
 		requiredReasoningBudget: false,
 	},
+	"claude-sonnet-4-5-20250929[1m]": {
+		...anthropicModels["claude-sonnet-4-5"],
+		contextWindow: 1_000_000, // 1M token context window (requires [1m] suffix)
+		supportsImages: false,
+		supportsPromptCache: true, // Claude Code does report cache tokens
+		supportsReasoningEffort: false,
+		supportsReasoningBudget: false,
+		requiredReasoningBudget: false,
+	},
 	"claude-sonnet-4-20250514": {
 		...anthropicModels["claude-sonnet-4-20250514"],
 		supportsImages: false,


### PR DESCRIPTION
# feat: Add Claude Sonnet 4.5 1M context window support for Claude Code provider

<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #8585

### Roo Code Task Context (Optional)

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

### Description

Adds support for Claude Sonnet 4.5 with 1M token context window to the Claude Code provider.

**Changes made in `packages/types/src/providers/claude-code.ts`:**
- Added new model ID: `claude-sonnet-4-5-20250929[1m]`
- Set `contextWindow: 1_000_000` (overrides default 200K from base anthropic model)
- All other properties inherited from base `claude-sonnet-4-5` model

**Implementation Details:**
This follows the same pattern used by Bedrock and Anthropic API providers for 1M context support:
1. The model definition spreads properties from the base anthropic model (which has `contextWindow: 200_000`)
2. Our explicit `contextWindow: 1_000_000` overrides the inherited value
3. The ClaudeCodeHandler's `getModel()` method returns the full ModelInfo object with the overridden contextWindow
4. The sliding window truncation logic in `src/core/sliding-window/index.ts` uses this contextWindow value to determine when to truncate messages

**When users select this model via `/model sonnet[1m]` in Claude Code:**
- The system retrieves the model definition with `contextWindow: 1_000_000`
- Messages won't be auto-truncated until they exceed 1M tokens (instead of 200K)
- The truncation calculation respects the full 1M token context window

### Test Procedure

**Manual Verification:**
1. Select the model using `/model sonnet[1m]` in Claude Code
2. Verify the model is loaded with correct contextWindow in developer tools
3. Create a conversation with context approaching 1M tokens
4. Confirm truncation doesn't occur until exceeding 1M tokens (previously would truncate at ~200K)

**Code Review:**
- Verified model definition follows TypeScript type constraints (`satisfies Record<string, ModelInfo>`)
- Confirmed contextWindow override pattern matches existing 1M implementations in:
  - `webview-ui/src/components/ui/hooks/useSelectedModel.ts` (lines 203-211 for Bedrock)
  - `webview-ui/src/components/ui/hooks/useSelectedModel.ts` (lines 367-397 for Anthropic)
- Confirmed the spread operator pattern correctly overrides the contextWindow property

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

N/A - This is a backend model configuration change with no UI modifications.

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

- [ ] Yes, documentation updates may be helpful to inform users about the new 1M context model availability via the `[1m]` suffix in Claude Code.

### Additional Notes

This implementation adds the model definition but relies on the existing infrastructure:
- The `ClaudeCodeHandler.getModel()` method already properly returns model info with all properties
- The sliding window truncation logic already uses the `contextWindow` property from model info
- No additional changes needed to support the 1M context - the existing code paths handle it automatically

### Get in Touch

<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

Discord: <!-- Add your Discord username here -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `claude-sonnet-4-5-20250929[1m]` model with 1M token context window to Claude Code provider, overriding default 200K token limit.
> 
>   - **Behavior**:
>     - Adds support for `claude-sonnet-4-5-20250929[1m]` model with 1M token context window in `claude-code.ts`.
>     - Overrides default `contextWindow` of 200K tokens to 1M tokens.
>     - Truncation logic in `src/core/sliding-window/index.ts` respects the 1M token limit.
>   - **Implementation**:
>     - Model inherits properties from `claude-sonnet-4-5` and overrides `contextWindow`.
>     - `getModel()` method in `ClaudeCodeHandler` returns model info with updated context window.
>   - **Testing**:
>     - Manual verification includes loading model and checking truncation at 1M tokens.
>     - Code review confirms TypeScript type constraints and contextWindow override pattern.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e0140432193107afcbb05e7c7d3957db0c2fb510. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->