### PR TITLE
Fix #8628. Avoid using templates on git init

### DIFF
--- a/src/services/checkpoints/ShadowCheckpointService.ts
+++ b/src/services/checkpoints/ShadowCheckpointService.ts
@@ -106,7 +106,7 @@ export abstract class ShadowCheckpointService extends EventEmitter {
 			this.baseHash = await git.revparse(["HEAD"])
 		} else {
 			this.log(`[${this.constructor.name}#initShadowGit] creating shadow git repo at ${this.checkpointsDir}`)
-			await git.init()
+			await git.init({ "--template": "" })
 			await git.addConfig("core.worktree", this.workspaceDir) // Sets the working tree to the current workspace.
 			await git.addConfig("commit.gpgSign", "false") // Disable commit signing for shadow repo.
 			await git.addConfig("user.name", "Roo Code")


### PR DESCRIPTION
### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #8629 

### Description

`git init` without options can use templates that trigger commit hooks.
This patch forces `ShadowCheckpointService` to use `git init --template=`
instead of  just `git init`.

### Test Procedure

#8629 defines the steps to recreate the bug. With the patch, the bug does not happen.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Get in Touch

@x_verges

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `ShadowCheckpointService` to use `git init --template=""` to prevent template-triggered commit hooks.
> 
>   - **Behavior**:
>     - Modify `git.init()` in `ShadowCheckpointService` to use `git init --template=""`, preventing template usage that triggers commit hooks.
>   - **Testing**:
>     - Bug #8629 steps confirm the fix; the issue no longer occurs with this patch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 203549f729ee872044bc6834d9b778b4fba8dc6b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->