### PR TITLE
Remove request content from UI messages

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1793,9 +1793,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			await this.say(
 				"api_req_started",
 				JSON.stringify({
-					request:
-						currentUserContent.map((block) => formatContentBlockToMarkdown(block)).join("\n\n") +
-						"\n\nLoading...",
 					apiProtocol,
 				}),
 			)
@@ -1835,7 +1832,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			const lastApiReqIndex = findLastIndex(this.clineMessages, (m) => m.say === "api_req_started")
 
 			this.clineMessages[lastApiReqIndex].text = JSON.stringify({
-				request: finalUserContent.map((block) => formatContentBlockToMarkdown(block)).join("\n\n"),
 				apiProtocol,
 			} satisfies ClineApiReqInfo)
 

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -704,7 +704,6 @@ describe("Cline", () => {
 							tokensOut: 50,
 							cacheWrites: 0,
 							cacheReads: 0,
-							request: "test request",
 						}),
 					},
 				]
@@ -829,7 +828,6 @@ describe("Cline", () => {
 							tokensOut: 50,
 							cacheWrites: 0,
 							cacheReads: 0,
-							request: "test request",
 						}),
 					},
 				]

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -46,8 +46,6 @@ import { ChatTextArea } from "./ChatTextArea"
 import { MAX_IMAGES_PER_MESSAGE } from "./ChatView"
 import { useSelectedModel } from "../ui/hooks/useSelectedModel"
 import {
-	ChevronRight,
-	ChevronDown,
 	Eye,
 	FileDiff,
 	ListTree,
@@ -289,11 +287,7 @@ export const ChatRowContent = ({
 							getIconSpan("error", errorColor)
 						)
 					) : cost !== null && cost !== undefined ? (
-						isExpanded ? (
-							<ChevronDown className="w-4 shrink-0" />
-						) : (
-							<ChevronRight className="w-4 shrink-0" />
-						)
+						getIconSpan("arrow-swap", normalColor)
 					) : apiRequestFailedMessage ? (
 						getIconSpan("error", errorColor)
 					) : (
@@ -325,17 +319,7 @@ export const ChatRowContent = ({
 			default:
 				return [null, null]
 		}
-	}, [
-		type,
-		isCommandExecuting,
-		message,
-		isMcpServerResponding,
-		apiReqCancelReason,
-		cost,
-		apiRequestFailedMessage,
-		t,
-		isExpanded,
-	])
+	}, [type, isCommandExecuting, message, isMcpServerResponding, apiReqCancelReason, cost, apiRequestFailedMessage, t])
 
 	const headerStyle: React.CSSProperties = {
 		display: "flex",
@@ -1062,13 +1046,7 @@ export const ChatRowContent = ({
 											? 10
 											: 0,
 									justifyContent: "space-between",
-									cursor: "pointer",
-									userSelect: "none",
-									WebkitUserSelect: "none",
-									MozUserSelect: "none",
-									msUserSelect: "none",
-								}}
-								onClick={handleToggleExpand}>
+								}}>
 								<div style={{ display: "flex", alignItems: "center", gap: "10px", flexGrow: 1 }}>
 									{icon}
 									{title}
@@ -1100,17 +1078,6 @@ export const ChatRowContent = ({
 										) : undefined
 									}
 								/>
-							)}
-
-							{isExpanded && (
-								<div className="ml-6" style={{ marginTop: "10px" }}>
-									<CodeAccordian
-										code={safeJsonParse<any>(message.text)?.request}
-										language="markdown"
-										isExpanded={true}
-										onToggleExpand={handleToggleExpand}
-									/>
-								</div>
 							)}
 						</>
 					)


### PR DESCRIPTION
Trying out another approach to #8692 - not sure any of this content is actually very important to include in the UI messages, especially if it causes gray screens?

Before:
<img width="459" height="734" alt="Screenshot 2025-10-17 at 1 12 22 AM" src="https://github.com/user-attachments/assets/05e96883-46c7-4a4b-8bc5-7d9ae63cdf25" />

After:
<img width="462" height="383" alt="Screenshot 2025-10-17 at 1 13 26 AM" src="https://github.com/user-attachments/assets/6a1fb8bd-2e9a-41a0-9605-6f881bbb3c75" />
Fixes https://github.com/RooCodeInc/Roo-Code/issues/8690
Fixes https://github.com/RooCodeInc/Roo-Code/issues/5601
Fixes https://github.com/RooCodeInc/Roo-Code/issues/8594
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove request content from `api_req_started` and `api_req_finished` messages to prevent UI issues, updating `Task.ts`, `Task.spec.ts`, and `ChatRow.tsx` accordingly.
> 
>   - **Behavior**:
>     - Removed request content from `api_req_started` and `api_req_finished` messages in `Task.ts` to prevent UI issues.
>     - Adjusted `ChatRow.tsx` to handle absence of request content in UI rendering.
>   - **Tests**:
>     - Updated `Task.spec.ts` to remove references to request content in tests for `api_req_started` and `api_req_finished` messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3afc7da39c16d3e69e37a85856980820d62f7c83. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->