### PR TITLE
web: Leftover white bg

### DIFF
--- a/apps/web-roo-code/src/app/cloud/page.tsx
+++ b/apps/web-roo-code/src/app/cloud/page.tsx
@@ -152,7 +152,7 @@ export default function CloudPage() {
 							</div>
 						</div>
 						<div className="flex items-center justify-end mx-auto h-full mt-8 lg:mt-0">
-							<div className="md:w-[900px] md:h-[700px]  dark:bg-white relative rounded-md overflow-clip">
+							<div className="md:w-[900px] md:h-[700px] relative rounded-md overflow-clip">
 								<div className="block">
 									<Image
 										src={screenshotDark}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove `dark:bg-white` class in `page.tsx` to fix white background in dark mode.
> 
>   - **Visual Fix**:
>     - Removed `dark:bg-white` class from a `div` in `page.tsx` to fix leftover white background in dark mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 95266b72b3d49d5b9de36c9b38e802371e9149f2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->