### PR TITLE
Remove GPT‑5 instructions/reasoning_summary from UI message metadata to prevent ui_messages.json bloat

### DIFF
--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -221,8 +221,6 @@ export const clineMessageSchema = z.object({
 			gpt5: z
 				.object({
 					previous_response_id: z.string().optional(),
-					instructions: z.string().optional(),
-					reasoning_summary: z.string().optional(),
 				})
 				.optional(),
 		})

--- a/src/core/task-persistence/__tests__/taskMessages.spec.ts
+++ b/src/core/task-persistence/__tests__/taskMessages.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as os from "os"
+import * as path from "path"
+import * as fs from "fs/promises"
+
+// Mocks (use hoisted to avoid initialization ordering issues)
+const hoisted = vi.hoisted(() => ({
+	safeWriteJsonMock: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock("../../../utils/safeWriteJson", () => ({
+	safeWriteJson: hoisted.safeWriteJsonMock,
+}))
+
+// Import after mocks
+import { saveTaskMessages } from "../taskMessages"
+
+let tmpBaseDir: string
+
+beforeEach(async () => {
+	hoisted.safeWriteJsonMock.mockClear()
+	// Create a unique, writable temp directory to act as globalStoragePath
+	tmpBaseDir = await fs.mkdtemp(path.join(os.tmpdir(), "roo-test-"))
+})
+
+describe("taskMessages.saveTaskMessages", () => {
+	beforeEach(() => {
+		hoisted.safeWriteJsonMock.mockClear()
+	})
+
+	it("persists messages as-is", async () => {
+		const messages: any[] = [
+			{
+				role: "assistant",
+				content: "Hello",
+				metadata: {
+					gpt5: {
+						previous_response_id: "resp_123",
+					},
+					other: "keep",
+				},
+			},
+			{ role: "user", content: "Do thing" },
+		]
+
+		await saveTaskMessages({
+			messages,
+			taskId: "task-1",
+			globalStoragePath: tmpBaseDir,
+		})
+
+		expect(hoisted.safeWriteJsonMock).toHaveBeenCalledTimes(1)
+		const [, persisted] = hoisted.safeWriteJsonMock.mock.calls[0]
+		expect(persisted).toEqual(messages)
+	})
+
+	it("persists messages without modification when no metadata", async () => {
+		const messages: any[] = [
+			{ role: "assistant", content: "Hi" },
+			{ role: "user", content: "Yo" },
+		]
+
+		await saveTaskMessages({
+			messages,
+			taskId: "task-2",
+			globalStoragePath: tmpBaseDir,
+		})
+
+		const [, persisted] = hoisted.safeWriteJsonMock.mock.calls[0]
+		expect(persisted).toEqual(messages)
+	})
+})

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -2267,7 +2267,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					}
 				}
 
-				await this.persistGpt5Metadata(reasoningMessage)
+				await this.persistGpt5Metadata()
 				await this.saveClineMessages()
 				await this.providerRef.deref()?.postStateToWebview()
 
@@ -2853,10 +2853,12 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	/**
-	 * Persist GPT-5 per-turn metadata (previous_response_id, instructions, reasoning_summary)
+	 * Persist GPT-5 per-turn metadata (previous_response_id only)
 	 * onto the last complete assistant say("text") message.
+	 *
+	 * Note: We do not persist system instructions or reasoning summaries.
 	 */
-	private async persistGpt5Metadata(reasoningMessage?: string): Promise<void> {
+	private async persistGpt5Metadata(): Promise<void> {
 		try {
 			const modelId = this.api.getModel().id
 			if (!modelId || !modelId.startsWith("gpt-5")) return
@@ -2875,9 +2877,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				}
 				const gpt5Metadata: Gpt5Metadata = {
 					...(msg.metadata.gpt5 ?? {}),
-					previous_response_id: lastResponseId,
-					instructions: this.lastUsedInstructions,
-					reasoning_summary: (reasoningMessage ?? "").trim() || undefined,
+					...(lastResponseId ? { previous_response_id: lastResponseId } : {}),
 				}
 				msg.metadata.gpt5 = gpt5Metadata
 			}

--- a/src/core/task/types.ts
+++ b/src/core/task/types.ts
@@ -12,18 +12,6 @@ export interface Gpt5Metadata {
 	 * Used to maintain conversation continuity in subsequent requests
 	 */
 	previous_response_id?: string
-
-	/**
-	 * The system instructions/prompt used for this response
-	 * Stored to track what instructions were active when the response was generated
-	 */
-	instructions?: string
-
-	/**
-	 * The reasoning summary from GPT-5's reasoning process
-	 * Contains the model's internal reasoning if reasoning mode was enabled
-	 */
-	reasoning_summary?: string
 }
 
 /**


### PR DESCRIPTION
# Remove GPT‑5 instructions/reasoning_summary from UI message metadata

## Problem statement
- ui_messages.json was getting bloated with unused or duplicated content.
- Specifically: metadata.gpt5.instructions (system prompt) and metadata.gpt5.reasoning_summary.

## Root cause
- In an earlier implementation of the OpenAI-native Responses API provider we persisted system instructions and a reasoning summary into per-message metadata.
- 'instructions' are already sent as top-level request instructions in the Responses API and recomputed each call.
- Reasoning summaries are surfaced live via streaming events and are not read from storage.

## Changes in this PR
- Stop writing instructions and reasoning_summary to message metadata. Keep only previous_response_id for GPT‑5 continuity.
- Update types: remove instructions and reasoning_summary from Gpt5Metadata.
- Update schema (packages/types): clineMessage.metadata.gpt5 now only allows previous_response_id.
- Persistence remains passthrough (no sanitizer) since the source no longer writes these fields.

## Impact & migration
- Reduces unnecessary data in ui_messages.json significantly.
- No behavioral change to request construction; OpenAI-native provider still sends system prompt via top-level instructions.
- Existing tasks with older metadata fields are ignored by schema and cause no issues.

## Verification
- Full vitest suite passed.
- Type checks across packages pass.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `instructions` and `reasoning_summary` from GPT-5 metadata to reduce `ui_messages.json` bloat, retaining only `previous_response_id`.
> 
>   - **Behavior**:
>     - Stop persisting `instructions` and `reasoning_summary` in `Gpt5Metadata` within `clineMessageSchema` in `message.ts`.
>     - Only `previous_response_id` is retained for GPT-5 continuity.
>   - **Schema and Types**:
>     - Update `Gpt5Metadata` in `types.ts` to remove `instructions` and `reasoning_summary`.
>     - Modify `clineMessageSchema` in `message.ts` to reflect these changes.
>   - **Persistence Logic**:
>     - Update `persistGpt5Metadata()` in `Task.ts` to only handle `previous_response_id`.
>     - Ensure `saveTaskMessages()` in `taskMessages.spec.ts` persists messages without modification.
>   - **Testing**:
>     - Add tests in `taskMessages.spec.ts` to verify message persistence without unnecessary metadata.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f6326ab25ef6aa602f8abe12cee94f73822e0abd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->