### PR TITLE
fix: always show checkpoint restore options regardless of change detection

### DIFF
--- a/webview-ui/src/components/chat/checkpoints/CheckpointMenu.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointMenu.tsx
@@ -11,7 +11,6 @@ import { Checkpoint } from "./schema"
 type CheckpointMenuBaseProps = {
 	ts: number
 	commitHash: string
-	currentHash?: string
 	checkpoint: Checkpoint
 }
 type CheckpointMenuControlledProps = {
@@ -24,14 +23,7 @@ type CheckpointMenuUncontrolledProps = {
 }
 type CheckpointMenuProps = CheckpointMenuBaseProps & (CheckpointMenuControlledProps | CheckpointMenuUncontrolledProps)
 
-export const CheckpointMenu = ({
-	ts,
-	commitHash,
-	currentHash: _currentHash,
-	checkpoint,
-	open,
-	onOpenChange,
-}: CheckpointMenuProps) => {
+export const CheckpointMenu = ({ ts, commitHash, checkpoint, open, onOpenChange }: CheckpointMenuProps) => {
 	const { t } = useTranslation()
 	const [internalOpen, setInternalOpen] = useState(false)
 	const [isConfirming, setIsConfirming] = useState(false)

--- a/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
+++ b/webview-ui/src/components/chat/checkpoints/CheckpointSaved.tsx
@@ -13,9 +13,9 @@ type CheckpointSavedProps = {
 	checkpoint?: Record<string, unknown>
 }
 
-export const CheckpointSaved = ({ checkpoint, ...props }: CheckpointSavedProps) => {
+export const CheckpointSaved = ({ checkpoint, currentHash, ...props }: CheckpointSavedProps) => {
 	const { t } = useTranslation()
-	const isCurrent = props.currentHash === props.commitHash
+	const isCurrent = currentHash === props.commitHash
 	const [isPopoverOpen, setIsPopoverOpen] = useState(false)
 	const [isClosing, setIsClosing] = useState(false)
 	const closeTimer = useRef<number | null>(null)


### PR DESCRIPTION
## Problem
Previously, checkpoint restore options were hidden when the system detected no changes (). This caused the checkpoint menu popover to appear empty for current checkpoints, as shown in the user's screenshot.

## Solution
Removed all conditional rendering that hid restore options based on the  flag. Now both 'Restore Files' and 'Restore Files & Task' options are always visible in the checkpoint menu popover.

## Changes
- **CheckpointMenu.tsx**: Removed  conditional wrappers around both restore options
- **CheckpointMenu.tsx**: Prefixed unused  parameter with underscore to satisfy linter
- **App.tsx**: Removed conditional rendering that only showed CheckpointRestoreDialog when hasCheckpoint was true
- **CheckpointRestoreDialog.tsx**: Removed conditional rendering of 'Restore to Checkpoint' button
- **CheckpointRestoreDialog.spec.tsx**: Updated tests to expect restore button always visible

## Testing
- ✅ All checkpoint menu tests passing (3/3)
- ✅ All checkpoint restore dialog tests passing (18/18)
- ✅ Linting passes
- ✅ Manual testing confirmed popover now shows options for all checkpoints

## Impact
Users can now always restore to any checkpoint, even when the system's change detection indicates no differences. This ensures checkpoint functionality is always accessible and prevents confusion when popovers appear empty.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Always show checkpoint restore options in `CheckpointMenu.tsx`, removing conditional rendering based on change detection.
> 
>   - **Behavior**:
>     - Always show 'Restore Files' and 'Restore Files & Task' options in `CheckpointMenu.tsx` regardless of change detection.
>     - Remove conditional rendering of `CheckpointRestoreDialog` in `App.tsx`.
>     - Always display 'Restore to Checkpoint' button in `CheckpointRestoreDialog.tsx`.
>   - **Testing**:
>     - Update `CheckpointRestoreDialog.spec.tsx` to expect restore button always visible.
>     - All tests passing (21/21).
>   - **Misc**:
>     - Prefix unused `currentHash` parameter with underscore in `CheckpointMenu.tsx` to satisfy linter.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 52cb1fa81599bd200b842384b212f44251e97a6d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->