### PR TITLE
Add support for multi-line git commit messages in auto-approve

### DIFF
--- a/webview-ui/src/utils/__tests__/command-validation-quote-protection.spec.ts
+++ b/webview-ui/src/utils/__tests__/command-validation-quote-protection.spec.ts
@@ -1,5 +1,3 @@
-// kilocode_change new file
-
 // npx vitest src/utils/__tests__/command-validation-quote-protection.spec.ts
 
 import {

--- a/webview-ui/src/utils/__tests__/command-validation.spec.ts
+++ b/webview-ui/src/utils/__tests__/command-validation.spec.ts
@@ -110,7 +110,6 @@ describe("Command Validation", () => {
 				])
 			})
 
-			// kilocode_change start allowed newlines within quotes
 			it("preserves newlines within quotes", () => {
 				// Newlines inside quoted strings should be preserved as part of the command
 				// Using template literal to create actual newline
@@ -120,7 +119,6 @@ git status`
 				// The newlines inside quotes are preserved, so we get two commands
 				expect(parseCommand(commandWithNewlineInQuotes)).toEqual(['echo "Hello\nWorld"', "git status"])
 			})
-			// kilocode_change end
 
 			it("handles quoted strings on single line", () => {
 				// When quotes are on the same line, they are preserved
@@ -1084,7 +1082,6 @@ describe("Unified Command Decision Functions", () => {
 			expect(getCommandDecision("dangerous", allowed, denied)).toBe("ask_user")
 			expect(getCommandDecision("npm install && dangerous", allowed, denied)).toBe("ask_user")
 		})
-		// kilocode_change start
 		// Real-world regression: multi-line git commit message in quotes should be treated as a single command
 		describe("real-world: multi-line git commit message", () => {
 			it("auto-approves when commit message is single-line", () => {
@@ -1121,7 +1118,6 @@ describe("Unified Command Decision Functions", () => {
 				expect(parsed[0]).toContain("- point b")
 			})
 		})
-		// kilocode_change end
 	})
 
 	describe("CommandValidator Integration Tests", () => {

--- a/webview-ui/src/utils/command-validation-quote-protection.ts
+++ b/webview-ui/src/utils/command-validation-quote-protection.ts
@@ -1,5 +1,3 @@
-// kilocode_change new file
-
 /**
  * Placeholders used to protect newlines within quoted strings during command parsing.
  * These constants are used by the protectNewlinesInQuotes function to temporarily replace

--- a/webview-ui/src/utils/command-validation.ts
+++ b/webview-ui/src/utils/command-validation.ts
@@ -1,11 +1,9 @@
 import { parse } from "shell-quote"
-// kilocode_change start
 import {
 	protectNewlinesInQuotes,
 	NEWLINE_PLACEHOLDER,
 	CARRIAGE_RETURN_PLACEHOLDER,
 } from "./command-validation-quote-protection"
-// kilocode_change end
 
 type ShellToken = string | { op: string } | { command: string }
 
@@ -129,7 +127,6 @@ export function containsDangerousSubstitution(source: string): boolean {
 	)
 }
 
-// kilocode_change start added exception for quoted newlines
 /**
  * Split a command string into individual sub-commands by
  * chaining operators (&&, ||, ;, |, or &) and newlines.
@@ -145,7 +142,6 @@ export function containsDangerousSubstitution(source: string): boolean {
 export function parseCommand(command: string): string[] {
 	if (!command?.trim()) return []
 
-	// kilocode_change start
 	// First, protect newlines inside quoted strings by replacing them with placeholders
 	// This prevents splitting multi-line quoted strings (e.g., git commit -m "multi\nline")
 	const protectedCommand = protectNewlinesInQuotes(command, NEWLINE_PLACEHOLDER, CARRIAGE_RETURN_PLACEHOLDER)
@@ -153,7 +149,6 @@ export function parseCommand(command: string): string[] {
 	// Split by newlines (handle different line ending formats)
 	// This regex splits on \r\n (Windows), \n (Unix), or \r (old Mac)
 	const lines = protectedCommand.split(/\r\n|\r|\n/)
-	// kilocode_change end
 	const allCommands: string[] = []
 
 	for (const line of lines) {
@@ -165,14 +160,12 @@ export function parseCommand(command: string): string[] {
 		allCommands.push(...lineCommands)
 	}
 
-	// kilocode_change start
 	// Restore newlines and carriage returns in quoted strings
 	return allCommands.map((cmd) =>
 		cmd
 			.replace(new RegExp(NEWLINE_PLACEHOLDER, "g"), "\n")
 			.replace(new RegExp(CARRIAGE_RETURN_PLACEHOLDER, "g"), "\r"),
 	)
-	// kilocode_change end
 }
 
 /**


### PR DESCRIPTION
Fixes this problem
<img width="831" height="339" alt="CleanShot 2025-10-21 at 09 17 44" src="https://github.com/user-attachments/assets/3abc008c-f546-4cc6-aca7-5d189d8b905d" />

<img width="918" height="515" alt="CleanShot 2025-10-21 at 09 17 59" src="https://github.com/user-attachments/assets/dadce0d5-2ad2-420a-bd10-34b5e852dc3a" />

After:
<img width="806" height="668" alt="CleanShot 2025-10-23 at 10 32 26@2x" src="https://github.com/user-attachments/assets/382abba2-cd82-4f6d-b647-8b4ee24621e1" />

upstreamed from kilo ( https://github.com/Kilo-Org/kilocode/pull/3104 ); 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for multi-line git commit messages by handling newlines within quotes in command parsing and validation.
> 
>   - **Behavior**:
>     - Adds `protectNewlinesInQuotes()` in `command-validation-quote-protection.ts` to replace newlines in quotes with placeholders.
>     - Updates `parseCommand()` in `command-validation.ts` to use `protectNewlinesInQuotes()` for handling multi-line commands.
>     - Ensures multi-line git commit messages are treated as single commands in `getCommandDecision()`.
>   - **Tests**:
>     - Adds `command-validation-quote-protection.spec.ts` to test newline protection in quotes.
>     - Updates `command-validation.spec.ts` to test multi-line command handling and validation logic.
>   - **Misc**:
>     - Introduces placeholders `NEWLINE_PLACEHOLDER` and `CARRIAGE_RETURN_PLACEHOLDER` for newline handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7bdd67beefc41eb89187cfdb5c48c9f0f2a04ac0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->