### PR TITLE
Remove a very verbose error for cloud agents

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1822,9 +1822,7 @@ export class ClineProvider
 		try {
 			cloudOrganizations = await CloudService.instance.getOrganizationMemberships()
 		} catch (error) {
-			console.error(
-				`[getStateToPostToWebview] failed to get cloud organizations: ${error instanceof Error ? error.message : String(error)}`,
-			)
+			// Ignore this error.
 		}
 
 		const telemetryKey = process.env.POSTHOG_API_KEY


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove verbose error logging for cloud organization fetch failures in `ClineProvider.ts`.
> 
>   - **Behavior**:
>     - Removed verbose error logging in `ClineProvider.ts` when failing to get cloud organizations in `getStateToPostToWebview()`.
>     - Error is now ignored silently without logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f6fab91b04f4f37cb29f425b4b0f013bb2284010. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->