### PR TITLE
fix: add tooltips to display full file paths on truncated filenames in chatview

### DIFF
--- a/webview-ui/src/components/chat/BatchFilePermission.tsx
+++ b/webview-ui/src/components/chat/BatchFilePermission.tsx
@@ -36,7 +36,7 @@ export const BatchFilePermission = memo(({ files = [], onPermissionResponse, ts 
 								<ToolUseBlockHeader
 									onClick={() => vscode.postMessage({ type: "openFile", text: file.content })}>
 									{file.path?.startsWith(".") && <span>.</span>}
-									<StandardTooltip content={file.path} side="top" align="start" className="text-wrap max-w-[min(300px,100vw)]">
+									<StandardTooltip content={removeLeadingNonAlphanumeric(file.path ?? "") + "\u200E" + (file.lineSnippet ? ` ${file.lineSnippet}` : "")} side="top" align="start" className="text-wrap max-w-[min(300px,100vw)]">
 										<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
 											{removeLeadingNonAlphanumeric(file.path ?? "") + "\u200E"}
 											{file.lineSnippet && ` ${file.lineSnippet}`}

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -601,7 +601,7 @@ export const ChatRowContent = ({
 									className="group"
 									onClick={() => vscode.postMessage({ type: "openFile", text: tool.content })}>
 									{tool.path?.startsWith(".") && <span>.</span>}
-									<StandardTooltip content={tool.path} side="top" align="start" className="text-wrap max-w-[min(300px,100vw)]">
+									<StandardTooltip content={removeLeadingNonAlphanumeric(tool.path ?? "") + "\u200E" + (tool.reason || "")} side="top" align="start" className="text-wrap max-w-[min(300px,100vw)]">
 										<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
 											{removeLeadingNonAlphanumeric(tool.path ?? "") + "\u200E"}
 											{tool.reason}

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -59,7 +59,7 @@ const CodeAccordian = ({
 					) : (
 						<>
 							{path?.startsWith(".") && <span>.</span>}
-							<StandardTooltip content={path} side="top" align="start" className="text-wrap max-w-[min(300px,100vw)]">
+							<StandardTooltip content={removeLeadingNonAlphanumeric(path ?? "") + "\u200E"} side="top" align="start" className="text-wrap max-w-[min(300px,100vw)]">
 								<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
 									{removeLeadingNonAlphanumeric(path ?? "") + "\u200E"}
 								</span>


### PR DESCRIPTION
### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #8278

### Description

This PR fixes the filename truncation issue in file editing/reading notices by adding tooltips that display the full file path on hover.

**Implementation details:**
- Added `StandardTooltip` components wrapping file path displays in three locations:
  - `CodeAccordian.tsx` - General file path headers and custom headers
  - `ChatRow.tsx` - Single file read/edit operations
  - `BatchFilePermission.tsx` - Batch file permission requests
- Configured tooltips with `className="text-wrap max-w-[min(300px,100vw)]"` to:
  - Override the default `text-balance` CSS (which was causing excessive whitespace)
  - Use responsive max-width that adapts to panel size (300px max on wide panels, 100vw on narrow)
  - Leverage existing `break-words` CSS for natural line breaking at path separators

**Key design choices:**
- Chose to use `text-wrap` instead of `text-balance` to minimize whitespace while maintaining readability
- Used `max-w-[min(300px,100vw)]` instead of a fixed width to prevent tooltip cutoff in narrow panels while maintaining a reasonable max width

**Reviewers should note:**
- The tooltip styling is consistent with other tooltips in the extension (using the existing `TooltipProvider` and `StandardTooltip` components)

### Test Procedure

**Manual testing steps:**

1. **Test truncated paths show tooltips:**
    - Open Roo Code and start a chat session
    - Ask Roo to read or edit a file with a long path (e.g., `src/components/chat/file/with/deeply/nested/structure.tsx`)
    - Narrow the chat panel until the filename truncates (shows ellipsis)
    - Hover over the truncated filename in the notice
    - ✅ Verify: Tooltip appears showing the full file path
    - ✅ Verify: Tooltip wraps text to multiple lines without being cut off

2. **Test all tooltip locations:**
	- Test tooltips on:
		- Single file read operations
		- Single file edit operations
		- Batch file read operations
		- Batch file edit operations
		- Directory listing operations (listFilesTopLevel, listFilesRecursive tools)
		- Search operations (searchFiles, listCodeDefinitionNames tools)
		- ✅ Verify: All locations show tooltips with consistent behavior

**Testing environment:**
- Tested on narrow panel widths (200px - 400px)
- Tested on standard panel widths (400px - 800px)
- Tested with various file path lengths

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

**Before:** Filename truncated, no tooltip on hover.

<img width="279" height="328" alt="before" src="https://github.com/user-attachments/assets/dad2670d-86ac-415d-9155-44d2a526a353" />

**After:** Tooltip on hover.

<img width="280" height="329" alt="after" src="https://github.com/user-attachments/assets/4571d39b-333c-4de9-9ab9-6b1075d13dd7" />

### Documentation Updates

- [x] No documentation updates are required.

### Get in Touch

Discord: `@ocean.smith`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds tooltips to display full file paths on truncated filenames in `CodeAccordian.tsx`, `ChatRow.tsx`, and `BatchFilePermission.tsx`, ensuring responsive and consistent styling.
> 
>   - **Behavior**:
>     - Adds `StandardTooltip` to display full file paths on hover for truncated filenames in `CodeAccordian.tsx`, `ChatRow.tsx`, and `BatchFilePermission.tsx`.
>     - Tooltips are styled with `text-wrap` and `max-w-[min(300px,100vw)]` for responsive width and minimal whitespace.
>   - **Design**:
>     - Uses `text-wrap` instead of `text-balance` to reduce whitespace.
>     - Ensures tooltip width adapts to panel size, preventing cutoff in narrow panels.
>   - **Consistency**:
>     - Tooltip styling aligns with existing tooltips using `TooltipProvider` and `StandardTooltip`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 643090cb43ab617fb1d04e513f21765b30be5571. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->