### PR TITLE
fix: respect nested .gitignore files in search_files

### DIFF
--- a/src/services/ripgrep/index.ts
+++ b/src/services/ripgrep/index.ts
@@ -150,7 +150,15 @@ export async function regexSearchFiles(
 		throw new Error("Could not find ripgrep binary")
 	}
 
-	const args = ["--json", "-e", regex, "--glob", filePattern || "*", "--context", "1", "--no-messages", directoryPath]
+	const args = ["--json", "-e", regex]
+
+	// Only add --glob if a specific file pattern is provided
+	// Using --glob "*" overrides .gitignore behavior, so we omit it when no pattern is specified
+	if (filePattern) {
+		args.push("--glob", filePattern)
+	}
+
+	args.push("--context", "1", "--no-messages", directoryPath)
 
 	let output: string
 	try {


### PR DESCRIPTION
## Problem

The `search_files` tool was returning results from directories/files that nested `.gitignore` files mark as ignored. This occurred because ripgrep was being invoked with `--glob '*'` by default, which overrides ripgrep's native .gitignore handling.

## Root Cause

In `src/services/ripgrep/index.ts`, the code unconditionally added `--glob` flag with a default value:
```typescript
const args = ["--json", "-e", regex, "--glob", filePattern || "*", ...]
```

When no file pattern is specified, this defaults to `--glob '*'`, which tells ripgrep to override .gitignore rules.

## Solution

Made the `--glob` flag conditional - only adding it when a specific file pattern is provided by the user:

```typescript
const args = ["--json", "-e", regex]

if (filePattern) {
    args.push("--glob", filePattern)
}

args.push("--context", "1", "--no-messages", directoryPath)
```

This leverages ripgrep's built-in .gitignore support, which works correctly when no glob patterns are specified.

## Testing

Verified with test directory containing:
- Root `.gitignore`
- Nested `src/build/.gitignore` with pattern `*` (ignore everything)
- Test files in both directories

**Before fix:** Files in `src/build/` appeared in search results ❌
**After fix:** Files in `src/build/` correctly excluded ✅

Note: Ripgrep only respects .gitignore files when the directory is inside a git repository (has a .git folder).

Closes #7921
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `regexSearchFiles` in `index.ts` to respect nested `.gitignore` files by conditionally adding `--glob` flag only when `filePattern` is specified.
> 
>   - **Behavior**:
>     - Fixes `regexSearchFiles` in `index.ts` to respect nested `.gitignore` files by conditionally adding `--glob` flag only when `filePattern` is specified.
>     - Ensures ripgrep's native `.gitignore` handling is leveraged when no glob pattern is provided.
>   - **Testing**:
>     - Verified with a test directory containing root and nested `.gitignore` files.
>     - Confirmed files in ignored directories are excluded from search results after the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5d9ff1985cfbef2c66847e56a36f688afb3777d8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->