### PR TITLE
Fix caching logic in Roo provider

### DIFF
--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -598,7 +598,12 @@ export const getApiProtocol = (provider: ProviderName | undefined, modelId?: str
 	}
 
 	// Vercel AI Gateway uses anthropic protocol for anthropic models.
-	if (provider && provider === "vercel-ai-gateway" && modelId && modelId.toLowerCase().startsWith("anthropic/")) {
+	if (
+		provider &&
+		["vercel-ai-gateway", "roo"].includes(provider) &&
+		modelId &&
+		modelId.toLowerCase().startsWith("anthropic/")
+	) {
 		return "anthropic"
 	}
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix caching logic in `RooHandler` to yield last usage data and update `getApiProtocol` for "roo" provider.
> 
>   - **Behavior**:
>     - Update `getApiProtocol` in `provider-settings.ts` to include "roo" for anthropic protocol handling.
>     - Modify `createMessage` in `RooHandler` in `roo.ts` to yield last usage data after stream processing.
>   - **Misc**:
>     - Initialize `lastUsage` in `RooHandler` in `roo.ts` to ensure usage data is captured correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 097e09ee8ccf688d7728fa99571c1dcc7688a3c0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->