### PR TITLE
fix: auto-sync enableReasoningEffort with reasoning dropdown selection

### DIFF
--- a/webview-ui/src/components/settings/SimpleThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/SimpleThinkingBudget.tsx
@@ -62,9 +62,6 @@ export const SimpleThinkingBudget = ({
 		setApiConfigurationField,
 	])
 
-	// Keep enableReasoningEffort in sync only when enabling is required
-	// - Enable when a non-"none" effort is selected or the model requires it
-	// - Do NOT force-disable when "none" is selected to avoid noisy config writes and to match tests
 	useEffect(() => {
 		if (!isReasoningEffortSupported) return
 		const shouldEnable = isReasoningEffortRequired || currentReasoningEffort !== "none"


### PR DESCRIPTION
## Summary
Fixes reasoning enablement synchronization for Roo provider by automatically setting `enableReasoningEffort` based on dropdown selection.

## Changes
- Add `useEffect` to automatically enable reasoning when:
  - Non-'none' effort is selected in dropdown, OR
  - Model requires reasoning effort
- Only sets flag to `true` when needed (doesn't force-disable for 'none')
- Avoids noisy config writes and aligns with existing tests
- Minor indentation fix for `SelectValue`

## Testing
- All existing tests passing
- Verified behavior with GPT-5 (required reasoning) and Sonnet 4.5 (optional reasoning)

## Related
Addresses issue where reasoning was not showing on the UI due to `enableReasoningEffort` being false even when reasoning effort was selected in the dropdown.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `useEffect` in `SimpleThinkingBudget.tsx` to auto-enable `enableReasoningEffort` based on dropdown selection or model requirements.
> 
>   - **Behavior**:
>     - Adds `useEffect` in `SimpleThinkingBudget.tsx` to auto-enable `enableReasoningEffort` when a non-'none' effort is selected or model requires it.
>     - Does not disable `enableReasoningEffort` for 'none' selection.
>   - **Misc**:
>     - Minor indentation fix for `SelectValue`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e8f6b79c6c2d1451638c3e157950b9d98b47f4b1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->