### PR TITLE
Add zai glm model

### DIFF
--- a/packages/types/src/providers/cerebras.ts
+++ b/packages/types/src/providers/cerebras.ts
@@ -3,7 +3,7 @@ import type { ModelInfo } from "../model.js"
 // https://inference-docs.cerebras.ai/api-reference/chat-completions
 export type CerebrasModelId = keyof typeof cerebrasModels
 
-export const cerebrasDefaultModelId: CerebrasModelId = "zai-glm-4.6"
+export const cerebrasDefaultModelId: CerebrasModelId = "gpt-oss-120b"
 
 export const cerebrasModels = {
 	"zai-glm-4.6": {


### PR DESCRIPTION
Added zai-glm-4.6 as a Cerebras model. It will become available on the platform November 5th.

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

<!--
Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `zai-glm-4.6` model to Cerebras and set it as default in `cerebras.ts`.
> 
>   - **Models**:
>     - Add `zai-glm-4.6` to `cerebrasModels` in `cerebras.ts` with attributes: `maxTokens: 40000`, `contextWindow: 128000`, `supportsImages: false`, `supportsPromptCache: false`, `inputPrice: 0`, `outputPrice: 0`, `description: "Highly intelligent general-purpose model with ~2000 tokens/s"`.
>     - Set `cerebrasDefaultModelId` to `zai-glm-4.6` in `cerebras.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7e7c7fe25c1a7570831f13e33ac64132ae72b482. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->