### PR TITLE
fix: Gate auth-driven Roo model refresh to active provider only

### DIFF
--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -440,12 +440,13 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 	// Watch for authentication state changes and refresh Roo models
 	useEffect(() => {
 		const currentAuth = state.cloudIsAuthenticated ?? false
-		if (!prevCloudIsAuthenticated && currentAuth) {
-			// User just authenticated - refresh Roo models with the new auth token
+		const currentProvider = state.apiConfiguration?.apiProvider
+		if (!prevCloudIsAuthenticated && currentAuth && currentProvider === "roo") {
+			// User just authenticated and Roo is the active provider - refresh Roo models
 			vscode.postMessage({ type: "requestRooModels" })
 		}
 		setPrevCloudIsAuthenticated(currentAuth)
-	}, [state.cloudIsAuthenticated, prevCloudIsAuthenticated])
+	}, [state.cloudIsAuthenticated, prevCloudIsAuthenticated, state.apiConfiguration?.apiProvider])
 
 	const contextValue: ExtensionStateContextType = {
 		...state,

--- a/webview-ui/src/context/__tests__/ExtensionStateContext.roo-auth-gate.spec.tsx
+++ b/webview-ui/src/context/__tests__/ExtensionStateContext.roo-auth-gate.spec.tsx
@@ -1,0 +1,75 @@
+import { render, waitFor } from "@/utils/test-utils"
+import React from "react"
+
+vi.mock("@src/utils/vscode", () => ({
+	vscode: {
+		postMessage: vi.fn(),
+	},
+}))
+
+import { ExtensionStateContextProvider } from "@src/context/ExtensionStateContext"
+import { vscode } from "@src/utils/vscode"
+
+describe("ExtensionStateContext Roo auth gate", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	function postStateMessage(state: any) {
+		window.dispatchEvent(
+			new MessageEvent("message", {
+				data: {
+					type: "state",
+					state,
+				},
+			}),
+		)
+	}
+
+	it("does not post requestRooModels when auth flips and provider !== 'roo'", async () => {
+		render(
+			<ExtensionStateContextProvider>
+				<div />
+			</ExtensionStateContextProvider>,
+		)
+
+		// Flip auth to true with a non-roo provider (anthropic)
+		postStateMessage({
+			cloudIsAuthenticated: true,
+			apiConfiguration: { apiProvider: "anthropic" },
+		})
+
+		// Should NOT fire auth-driven Roo refresh
+		await waitFor(() => {
+			const calls = (vscode.postMessage as any).mock.calls as any[][]
+			const hasRequest = calls.some((c) => c[0]?.type === "requestRooModels")
+			expect(hasRequest).toBe(false)
+		})
+	})
+
+	it("posts requestRooModels when auth flips and provider === 'roo'", async () => {
+		render(
+			<ExtensionStateContextProvider>
+				<div />
+			</ExtensionStateContextProvider>,
+		)
+
+		// Ensure prev false (explicit)
+		postStateMessage({
+			cloudIsAuthenticated: false,
+			apiConfiguration: { apiProvider: "roo" },
+		})
+
+		vi.clearAllMocks()
+
+		// Flip to true with provider roo - should trigger
+		postStateMessage({
+			cloudIsAuthenticated: true,
+			apiConfiguration: { apiProvider: "roo" },
+		})
+
+		await waitFor(() => {
+			expect(vscode.postMessage).toHaveBeenCalledWith({ type: "requestRooModels" })
+		})
+	})
+})


### PR DESCRIPTION
## Problem

Part of the webview memory mitigation effort. When auth state changes (login/logout), the extension was triggering `requestRooModels` regardless of which provider was active. This caused unnecessary router model fetches and cache reconciliation even when using non-Roo providers.

## Solution

Gate the auth-driven `requestRooModels` effect to only fire when:
1. `cloudIsAuthenticated` transitions to true, AND
2. Current provider === "roo"

## Changes

- **ExtensionStateContext**: Added provider check before posting `requestRooModels`
- **Test**: Added comprehensive test coverage for auth gating behavior

## Impact

**Before**: Auth changes triggered Roo model fetches for all providers
**After**: Roo models only fetched when Roo is the active provider

## Files Changed

- `webview-ui/src/context/ExtensionStateContext.tsx`
- `webview-ui/src/context/__tests__/ExtensionStateContext.roo-auth-gate.spec.tsx` (new)

## Testing

- ✅ New test verifies auth transitions only trigger `requestRooModels` when provider === "roo"
- ✅ All webview UI tests passing

## Part of

This is the first PR in a series to reduce webview memory usage. Follow-up PRs will add:
- Backend provider filtering support
- Frontend provider-scoped fetches
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `requestRooModels` to trigger only for 'roo' provider in `ExtensionStateContext.tsx`, with tests added in `ExtensionStateContext.roo-auth-gate.spec.tsx`.
> 
>   - **Behavior**:
>     - `requestRooModels` in `ExtensionStateContext.tsx` now only triggers when `cloudIsAuthenticated` is true and `apiProvider` is 'roo'.
>   - **Testing**:
>     - Added `ExtensionStateContext.roo-auth-gate.spec.tsx` to test `requestRooModels` behavior when auth state changes.
>     - Tests ensure `requestRooModels` is not called for non-'roo' providers.
>   - **Impact**:
>     - Reduces unnecessary model fetches and cache reconciliation for non-'roo' providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8708abfabf047cb06d8d9d501791b31fb7a2448e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->