### PR TITLE
feat: Add provider filtering support to router models backend

### DIFF
--- a/src/core/webview/__tests__/webviewMessageHandler.routerModels.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.routerModels.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { webviewMessageHandler } from "../webviewMessageHandler"
+import type { ClineProvider } from "../ClineProvider"
+
+// Mock vscode (minimal)
+vi.mock("vscode", () => ({
+	window: {
+		showErrorMessage: vi.fn(),
+		showWarningMessage: vi.fn(),
+		showInformationMessage: vi.fn(),
+	},
+	workspace: {
+		workspaceFolders: undefined,
+		getConfiguration: vi.fn(() => ({
+			get: vi.fn(),
+			update: vi.fn(),
+		})),
+	},
+	env: {
+		clipboard: { writeText: vi.fn() },
+		openExternal: vi.fn(),
+	},
+	commands: {
+		executeCommand: vi.fn(),
+	},
+	Uri: {
+		parse: vi.fn((s: string) => ({ toString: () => s })),
+		file: vi.fn((p: string) => ({ fsPath: p })),
+	},
+	ConfigurationTarget: {
+		Global: 1,
+		Workspace: 2,
+		WorkspaceFolder: 3,
+	},
+}))
+
+// Mock modelCache getModels/flushModels used by the handler
+const getModelsMock = vi.fn()
+vi.mock("../../../api/providers/fetchers/modelCache", () => ({
+	getModels: (...args: any[]) => getModelsMock(...args),
+	flushModels: vi.fn(),
+}))
+
+describe("webviewMessageHandler - requestRouterModels providers filter", () => {
+	let mockProvider: ClineProvider & {
+		postMessageToWebview: ReturnType<typeof vi.fn>
+		getState: ReturnType<typeof vi.fn>
+		contextProxy: any
+		log: ReturnType<typeof vi.fn>
+	}
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		mockProvider = {
+			// Only methods used by this code path
+			postMessageToWebview: vi.fn(),
+			getState: vi.fn().mockResolvedValue({ apiConfiguration: {} }),
+			contextProxy: {
+				getValue: vi.fn(),
+				setValue: vi.fn(),
+				globalStorageUri: { fsPath: "/mock/storage" },
+			},
+			log: vi.fn(),
+		} as any
+
+		// Default mock: return distinct model maps per provider so we can verify keys
+		getModelsMock.mockImplementation(async (options: any) => {
+			switch (options?.provider) {
+				case "roo":
+					return { "roo/sonnet": { contextWindow: 8192, supportsPromptCache: false } }
+				case "openrouter":
+					return { "openrouter/qwen2.5": { contextWindow: 32768, supportsPromptCache: false } }
+				case "requesty":
+					return { "requesty/model": { contextWindow: 8192, supportsPromptCache: false } }
+				case "deepinfra":
+					return { "deepinfra/model": { contextWindow: 8192, supportsPromptCache: false } }
+				case "glama":
+					return { "glama/model": { contextWindow: 8192, supportsPromptCache: false } }
+				case "unbound":
+					return { "unbound/model": { contextWindow: 8192, supportsPromptCache: false } }
+				case "vercel-ai-gateway":
+					return { "vercel/model": { contextWindow: 8192, supportsPromptCache: false } }
+				case "io-intelligence":
+					return { "io/model": { contextWindow: 8192, supportsPromptCache: false } }
+				case "litellm":
+					return { "litellm/model": { contextWindow: 8192, supportsPromptCache: false } }
+				default:
+					return {}
+			}
+		})
+	})
+
+	it("fetches only requested provider when values.providers is present (['roo'])", async () => {
+		await webviewMessageHandler(
+			mockProvider as any,
+			{
+				type: "requestRouterModels",
+				values: { providers: ["roo"] },
+			} as any,
+		)
+
+		// Should post a single routerModels message
+		expect(mockProvider.postMessageToWebview).toHaveBeenCalledWith(
+			expect.objectContaining({ type: "routerModels", routerModels: expect.any(Object) }),
+		)
+
+		const call = (mockProvider.postMessageToWebview as any).mock.calls.find(
+			(c: any[]) => c[0]?.type === "routerModels",
+		)
+		expect(call).toBeTruthy()
+		const payload = call[0]
+		const routerModels = payload.routerModels as Record<string, Record<string, any>>
+
+		// Only "roo" key should be present
+		const keys = Object.keys(routerModels)
+		expect(keys).toEqual(["roo"])
+		expect(Object.keys(routerModels.roo || {})).toContain("roo/sonnet")
+
+		// getModels should have been called exactly once for roo
+		const providersCalled = getModelsMock.mock.calls.map((c: any[]) => c[0]?.provider)
+		expect(providersCalled).toEqual(["roo"])
+	})
+
+	it("defaults to aggregate fetching when no providers filter is sent", async () => {
+		await webviewMessageHandler(
+			mockProvider as any,
+			{
+				type: "requestRouterModels",
+			} as any,
+		)
+
+		const call = (mockProvider.postMessageToWebview as any).mock.calls.find(
+			(c: any[]) => c[0]?.type === "routerModels",
+		)
+		expect(call).toBeTruthy()
+		const routerModels = call[0].routerModels as Record<string, Record<string, any>>
+
+		// Aggregate handler initializes many known routers - ensure a few expected keys exist
+		expect(routerModels).toHaveProperty("openrouter")
+		expect(routerModels).toHaveProperty("roo")
+		expect(routerModels).toHaveProperty("requesty")
+	})
+
+	it("supports filtering another single provider (['openrouter'])", async () => {
+		await webviewMessageHandler(
+			mockProvider as any,
+			{
+				type: "requestRouterModels",
+				values: { providers: ["openrouter"] },
+			} as any,
+		)
+
+		const call = (mockProvider.postMessageToWebview as any).mock.calls.find(
+			(c: any[]) => c[0]?.type === "routerModels",
+		)
+		expect(call).toBeTruthy()
+		const routerModels = call[0].routerModels as Record<string, Record<string, any>>
+		const keys = Object.keys(routerModels)
+
+		expect(keys).toEqual(["openrouter"])
+		expect(Object.keys(routerModels.openrouter || {})).toContain("openrouter/qwen2.5")
+
+		const providersCalled = getModelsMock.mock.calls.map((c: any[]) => c[0]?.provider)
+		expect(providersCalled).toEqual(["openrouter"])
+	})
+})

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -757,20 +757,38 @@ export const webviewMessageHandler = async (
 		case "requestRouterModels":
 			const { apiConfiguration } = await provider.getState()
 
-			const routerModels: Record<RouterName, ModelRecord> = {
-				openrouter: {},
-				"vercel-ai-gateway": {},
-				huggingface: {},
-				litellm: {},
-				deepinfra: {},
-				"io-intelligence": {},
-				requesty: {},
-				unbound: {},
-				glama: {},
-				ollama: {},
-				lmstudio: {},
-				roo: {},
-			}
+			// Optional providers filter coming from the webview
+			const providersFilterRaw = Array.isArray(message?.values?.providers) ? message.values.providers : undefined
+			const requestedProviders = providersFilterRaw
+				?.filter((p: unknown) => typeof p === "string")
+				.map((p: string) => {
+					try {
+						return toRouterName(p)
+					} catch {
+						return undefined
+					}
+				})
+				.filter((p): p is RouterName => !!p)
+
+			const hasFilter = !!requestedProviders && requestedProviders.length > 0
+			const requestedSet = new Set<RouterName>(requestedProviders || [])
+
+			const routerModels: Record<RouterName, ModelRecord> = hasFilter
+				? ({} as Record<RouterName, ModelRecord>)
+				: {
+						openrouter: {},
+						"vercel-ai-gateway": {},
+						huggingface: {},
+						litellm: {},
+						deepinfra: {},
+						"io-intelligence": {},
+						requesty: {},
+						unbound: {},
+						glama: {},
+						ollama: {},
+						lmstudio: {},
+						roo: {},
+					}
 
 			const safeGetModels = async (options: GetModelsOptions): Promise<ModelRecord> => {
 				try {
@@ -785,7 +803,8 @@ export const webviewMessageHandler = async (
 				}
 			}
 
-			const modelFetchPromises: { key: RouterName; options: GetModelsOptions }[] = [
+			// Base candidates (only those handled by this aggregate fetcher)
+			const candidates: { key: RouterName; options: GetModelsOptions }[] = [
 				{ key: "openrouter", options: { provider: "openrouter" } },
 				{
 					key: "requesty",
@@ -818,28 +837,27 @@ export const webviewMessageHandler = async (
 				},
 			]
 
-			// Add IO Intelligence if API key is provided.
-			const ioIntelligenceApiKey = apiConfiguration.ioIntelligenceApiKey
-
-			if (ioIntelligenceApiKey) {
-				modelFetchPromises.push({
+			// IO Intelligence is conditional on api key
+			if (apiConfiguration.ioIntelligenceApiKey) {
+				candidates.push({
 					key: "io-intelligence",
-					options: { provider: "io-intelligence", apiKey: ioIntelligenceApiKey },
+					options: { provider: "io-intelligence", apiKey: apiConfiguration.ioIntelligenceApiKey },
 				})
 			}
 
-			// Don't fetch Ollama and LM Studio models by default anymore.
-			// They have their own specific handlers: requestOllamaModels and requestLmStudioModels.
-
+			// LiteLLM is conditional on baseUrl+apiKey
 			const litellmApiKey = apiConfiguration.litellmApiKey || message?.values?.litellmApiKey
 			const litellmBaseUrl = apiConfiguration.litellmBaseUrl || message?.values?.litellmBaseUrl
 
 			if (litellmApiKey && litellmBaseUrl) {
-				modelFetchPromises.push({
+				candidates.push({
 					key: "litellm",
 					options: { provider: "litellm", apiKey: litellmApiKey, baseUrl: litellmBaseUrl },
 				})
 			}
+
+			// Apply providers filter (if any)
+			const modelFetchPromises = candidates.filter(({ key }) => (!hasFilter ? true : requestedSet.has(key)))
 
 			const results = await Promise.allSettled(
 				modelFetchPromises.map(async ({ key, options }) => {
@@ -854,18 +872,7 @@ export const webviewMessageHandler = async (
 				if (result.status === "fulfilled") {
 					routerModels[routerName] = result.value.models
 
-					// Ollama and LM Studio settings pages still need these events.
-					if (routerName === "ollama" && Object.keys(result.value.models).length > 0) {
-						provider.postMessageToWebview({
-							type: "ollamaModels",
-							ollamaModels: result.value.models,
-						})
-					} else if (routerName === "lmstudio" && Object.keys(result.value.models).length > 0) {
-						provider.postMessageToWebview({
-							type: "lmStudioModels",
-							lmStudioModels: result.value.models,
-						})
-					}
+					// Ollama and LM Studio settings pages still need these events. They are not fetched here.
 				} else {
 					// Handle rejection: Post a specific error message for this provider.
 					const errorMessage = result.reason instanceof Error ? result.reason.message : String(result.reason)


### PR DESCRIPTION
## Problem

Part of the webview memory mitigation effort. The backend was always fetching and returning all router models from all providers, even when the frontend only needed models from a specific provider. This resulted in unnecessarily large payloads being cached and reconciled in the webview.

## Solution

Add support for provider filtering in the `requestRouterModels` handler. The frontend can now send a `providers` filter via `message.values.providers`, and the backend will only fetch and return models for those specific providers.

## Changes

- **webviewMessageHandler**: Honor `message.values.providers` filter
  - When filter is present and non-empty, only fetch requested providers
  - Maintain backward compatibility - fetch all providers when no filter provided
- **Test**: Comprehensive test coverage for provider filtering logic

## Impact

**Before**: Backend always returned all router models (openrouter, roo, litellm, etc.) regardless of which provider was needed

**After**: Backend can return filtered subset (e.g., only Roo models when `providers: ["roo"]` is requested)

**Payload size reduction**: Instead of 8+ provider catalogs, can return just 1

## Files Changed

- `src/core/webview/webviewMessageHandler.ts`
- `src/core/webview/__tests__/webviewMessageHandler.routerModels.spec.ts` (new)

## Testing

- ✅ Test verifies provider filtering returns only requested providers
- ✅ Test verifies backward compatibility with no filter
- ✅ All backend tests passing

## Part of

This is the second PR in a series to reduce webview memory usage:
1. ✅ PR #8915 - Gate auth-driven Roo model refresh
2. **This PR** - Backend provider filtering
3. Next: Frontend provider-scoped fetches

## Dependencies

This PR is independent and can be merged before or after #8915. However, it enables the frontend filtering in PR #3 to work effectively.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds provider filtering to `webviewMessageHandler` for `requestRouterModels`, reducing payload size by fetching only specified providers.
> 
>   - **Behavior**:
>     - `webviewMessageHandler` now supports provider filtering for `requestRouterModels` using `message.values.providers`.
>     - Fetches models only for specified providers; defaults to all if no filter is provided.
>   - **Testing**:
>     - New test file `webviewMessageHandler.routerModels.spec.ts` added.
>     - Tests for provider filtering and backward compatibility.
>   - **Impact**:
>     - Reduces payload size by fetching only necessary provider models.
>     - Maintains backward compatibility by fetching all models if no filter is specified.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 03549249feb19e5417bdab5cd62ea8fc015b8c70. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->