### PR TITLE
Fix cerebras test: update expected default model to gpt-oss-120b

### DIFF
--- a/src/api/providers/__tests__/cerebras.spec.ts
+++ b/src/api/providers/__tests__/cerebras.spec.ts
@@ -56,7 +56,7 @@ describe("CerebrasHandler", () => {
 		it("should fallback to default model when apiModelId is not provided", () => {
 			const handlerWithoutModel = new CerebrasHandler({ cerebrasApiKey: "test" })
 			const { id } = handlerWithoutModel.getModel()
-			expect(id).toBe("qwen-3-coder-480b") // cerebrasDefaultModelId (routed)
+			expect(id).toBe("gpt-oss-120b") // cerebrasDefaultModelId
 		})
 	})
 


### PR DESCRIPTION
This PR fixes the failing CI test in PR #8897.

## Problem
The test in src/api/providers/__tests__/cerebras.spec.ts was failing because it expected the default Cerebras model to be qwen-3-coder-480b, but PR #8897 changed the default to gpt-oss-120b.

## Solution
Updated the test expectation to match the new default model ID (gpt-oss-120b).

## Testing
- Ran the test locally and verified it passes
- All 14 tests in the cerebras.spec.ts file pass

Fixes the failing CI test in #8897