### PR TITLE
fix: make code index initialization non-blocking at activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -110,13 +110,13 @@ export async function activate(context: vscode.ExtensionContext) {
 			if (manager) {
 				codeIndexManagers.push(manager)
 
-				try {
-					await manager.initialize(contextProxy)
-				} catch (error) {
+				// Initialize in background; do not block extension activation
+				void manager.initialize(contextProxy).catch((error) => {
+					const message = error instanceof Error ? error.message : String(error)
 					outputChannel.appendLine(
-						`[CodeIndexManager] Error during background CodeIndexManager configuration/indexing for ${folder.uri.fsPath}: ${error.message || error}`,
+						`[CodeIndexManager] Error during background CodeIndexManager configuration/indexing for ${folder.uri.fsPath}: ${message}`,
 					)
-				}
+				})
 
 				context.subscriptions.push(manager)
 			}


### PR DESCRIPTION
Fixes #8777

Extension activation no longer waits for Code Index embedder validation. Initialization runs in background with fire-and-forget pattern, preventing UI hangs when embedders are unreachable or slow.

**Changes:**
- Use  in activation loop to prevent blocking
- Errors logged to output channel and captured in telemetry
- All tests pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `CodeIndexManager` initialization non-blocking in `activate()` in `extension.ts` to prevent UI hangs.
> 
>   - **Behavior**:
>     - `CodeIndexManager` initialization in `activate()` in `extension.ts` is now non-blocking, using a fire-and-forget pattern.
>     - Errors during initialization are logged to the output channel and captured in telemetry.
>   - **Misc**:
>     - All tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b835b44dc5dbc66a53be0e0ec5df3dc2393b1559. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->