### PR TITLE
fix(focus): stabilize focus across sidebar/tab; remove race in plus button path

### DIFF
--- a/src/activate/registerCommands.ts
+++ b/src/activate/registerCommands.ts
@@ -97,9 +97,6 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 		await visibleProvider.removeClineFromStack()
 		await visibleProvider.refreshWorkspace()
 		await visibleProvider.postMessageToWebview({ type: "action", action: "chatButtonClicked" })
-		// Send focusInput action immediately after chatButtonClicked
-		// This ensures the focus happens after the view has switched
-		await visibleProvider.postMessageToWebview({ type: "action", action: "focusInput" })
 	},
 	mcpButtonClicked: () => {
 		const visibleProvider = getVisibleProviderOrLog(outputChannel)
@@ -197,9 +194,13 @@ const getCommandsMap = ({ context, outputChannel, provider }: RegisterCommandOpt
 		try {
 			await focusPanel(tabPanel, sidebarPanel)
 
-			// Send focus input message only for sidebar panels
-			if (sidebarPanel && getPanel() === sidebarPanel) {
-				provider.postMessageToWebview({ type: "action", action: "focusInput" })
+			// Send focus input message to webview after panel becomes focusable
+			// Use setTimeout to defer until after the panel reveal/focus completes
+			const activePanel = getPanel()
+			if (activePanel) {
+				setTimeout(() => {
+					provider.postMessageToWebview({ type: "action", action: "focusInput" })
+				}, 0)
 			}
 		} catch (error) {
 			outputChannel.appendLine(`Error focusing input: ${error}`)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -787,11 +787,15 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					switch (message.action!) {
 						case "didBecomeVisible":
 							if (!isHidden && !sendingDisabled && !enableButtons) {
-								textAreaRef.current?.focus()
+								requestAnimationFrame(() => {
+									textAreaRef.current?.focus()
+								})
 							}
 							break
 						case "focusInput":
-							textAreaRef.current?.focus()
+							requestAnimationFrame(() => {
+								textAreaRef.current?.focus()
+							})
 							break
 					}
 					break


### PR DESCRIPTION
Problem
Random focus loss to the editor occurs due to a timing race introduced by sending action: focusInput immediately after switching views via the plus button path. VS Code’s panel reveal/focus and the webview’s own focus compete.

Changes
- Remove eager focusInput right after chatButtonClicked in the plus button path [plusButtonClicked](src/activate/registerCommands.ts:88).
- Make focus symmetric: after focusPanel completes, send action: focusInput for both sidebar and tab panels [focusInput](src/activate/registerCommands.ts:196).
- Defer webview focus to the next frame for stability on both didBecomeVisible and focusInput handlers [ChatView.tsx](webview-ui/src/components/chat/ChatView.tsx:785), [ChatView.tsx](webview-ui/src/components/chat/ChatView.tsx:793).

Impact
- Eliminates focus races during view transitions; input reliably keeps focus.
- “Add to Context” remains unaffected: it still inserts text and explicitly posts action: focusInput from provider [ClineProvider.handleCodeAction()](src/core/webview/ClineProvider.ts:680).

Tests
- Webview: 1108 passed, 6 skipped
- Extension: 3958 passed, 48 skipped
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Stabilizes focus handling across sidebar and tab panels by deferring focus actions and ensuring symmetric focus behavior in `registerCommands.ts` and `ChatView.tsx`.
> 
>   - **Behavior**:
>     - Removes immediate `focusInput` action after `chatButtonClicked` in `plusButtonClicked` in `registerCommands.ts`.
>     - Makes focus handling symmetric by sending `focusInput` after `focusPanel` completes for both sidebar and tab panels in `registerCommands.ts`.
>     - Defers webview focus to the next frame using `requestAnimationFrame` in `didBecomeVisible` and `focusInput` handlers in `ChatView.tsx`.
>   - **Impact**:
>     - Resolves focus races during view transitions, ensuring input retains focus.
>     - "Add to Context" functionality remains unchanged, still posting `focusInput` from `ClineProvider.handleCodeAction()`.
>   - **Tests**:
>     - Webview: 1108 passed, 6 skipped
>     - Extension: 3958 passed, 48 skipped
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 96e499c96528aaac4dabd469b11b96cb93156cb1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->