### PR TITLE
Fix cost and token tracking between provider styles

### DIFF
--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -230,17 +230,19 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		}
 
 		if (inputTokens > 0 || outputTokens > 0 || cacheWriteTokens > 0 || cacheReadTokens > 0) {
+			const { totalCost } = calculateApiCostAnthropic(
+				this.getModel().info,
+				inputTokens,
+				outputTokens,
+				cacheWriteTokens,
+				cacheReadTokens,
+			)
+
 			yield {
 				type: "usage",
 				inputTokens: 0,
 				outputTokens: 0,
-				totalCost: calculateApiCostAnthropic(
-					this.getModel().info,
-					inputTokens,
-					outputTokens,
-					cacheWriteTokens,
-					cacheReadTokens,
-				),
+				totalCost,
 			}
 		}
 	}

--- a/src/api/providers/cerebras.ts
+++ b/src/api/providers/cerebras.ts
@@ -331,6 +331,7 @@ export class CerebrasHandler extends BaseProvider implements SingleCompletionHan
 		const { info } = this.getModel()
 		// Use actual token usage from the last request
 		const { inputTokens, outputTokens } = this.lastUsage
-		return calculateApiCostOpenAI(info, inputTokens, outputTokens)
+		const { totalCost } = calculateApiCostOpenAI(info, inputTokens, outputTokens)
+		return totalCost
 	}
 }

--- a/src/api/providers/deepinfra.ts
+++ b/src/api/providers/deepinfra.ts
@@ -131,9 +131,9 @@ export class DeepInfraHandler extends RouterProvider implements SingleCompletion
 		const cacheWriteTokens = usage?.prompt_tokens_details?.cache_write_tokens || 0
 		const cacheReadTokens = usage?.prompt_tokens_details?.cached_tokens || 0
 
-		const totalCost = modelInfo
+		const { totalCost } = modelInfo
 			? calculateApiCostOpenAI(modelInfo, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
-			: 0
+			: { totalCost: 0 }
 
 		return {
 			type: "usage",

--- a/src/api/providers/groq.ts
+++ b/src/api/providers/groq.ts
@@ -64,7 +64,7 @@ export class GroqHandler extends BaseOpenAiCompatibleProvider<GroqModelId> {
 		const cacheWriteTokens = 0
 
 		// Calculate cost using OpenAI-compatible cost calculation
-		const totalCost = calculateApiCostOpenAI(info, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
+		const { totalCost } = calculateApiCostOpenAI(info, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
 
 		yield {
 			type: "usage",

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -165,21 +165,22 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 					(lastUsage as any).prompt_cache_hit_tokens ||
 					0
 
+				const { totalCost } = calculateApiCostOpenAI(
+					info,
+					lastUsage.prompt_tokens || 0,
+					lastUsage.completion_tokens || 0,
+					cacheWriteTokens,
+					cacheReadTokens,
+				)
+
 				const usageData: ApiStreamUsageChunk = {
 					type: "usage",
 					inputTokens: lastUsage.prompt_tokens || 0,
 					outputTokens: lastUsage.completion_tokens || 0,
 					cacheWriteTokens: cacheWriteTokens > 0 ? cacheWriteTokens : undefined,
 					cacheReadTokens: cacheReadTokens > 0 ? cacheReadTokens : undefined,
+					totalCost,
 				}
-
-				usageData.totalCost = calculateApiCostOpenAI(
-					info,
-					usageData.inputTokens,
-					usageData.outputTokens,
-					usageData.cacheWriteTokens || 0,
-					usageData.cacheReadTokens || 0,
-				)
 
 				yield usageData
 			}

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -99,8 +99,8 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 		const effectiveInfo = this.applyServiceTierPricing(model.info, effectiveTier)
 
 		// Pass total input tokens directly to calculateApiCostOpenAI
-		// The function handles subtracting both cache reads and writes internally (see shared/cost.ts:46)
-		const totalCost = calculateApiCostOpenAI(
+		// The function handles subtracting both cache reads and writes internally
+		const { totalCost } = calculateApiCostOpenAI(
 			effectiveInfo,
 			totalInputTokens,
 			totalOutputTokens,

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -85,9 +85,9 @@ export class RequestyHandler extends BaseProvider implements SingleCompletionHan
 		const outputTokens = requestyUsage?.completion_tokens || 0
 		const cacheWriteTokens = requestyUsage?.prompt_tokens_details?.caching_tokens || 0
 		const cacheReadTokens = requestyUsage?.prompt_tokens_details?.cached_tokens || 0
-		const totalCost = modelInfo
+		const { totalCost } = modelInfo
 			? calculateApiCostOpenAI(modelInfo, inputTokens, outputTokens, cacheWriteTokens, cacheReadTokens)
-			: 0
+			: { totalCost: 0 }
 
 		return {
 			type: "usage",

--- a/src/shared/cost.ts
+++ b/src/shared/cost.ts
@@ -1,18 +1,31 @@
 import type { ModelInfo } from "@roo-code/types"
 
+export interface ApiCostResult {
+	totalInputTokens: number
+	totalOutputTokens: number
+	totalCost: number
+}
+
 function calculateApiCostInternal(
 	modelInfo: ModelInfo,
 	inputTokens: number,
 	outputTokens: number,
 	cacheCreationInputTokens: number,
 	cacheReadInputTokens: number,
-): number {
+	totalInputTokens: number,
+	totalOutputTokens: number,
+): ApiCostResult {
 	const cacheWritesCost = ((modelInfo.cacheWritesPrice || 0) / 1_000_000) * cacheCreationInputTokens
 	const cacheReadsCost = ((modelInfo.cacheReadsPrice || 0) / 1_000_000) * cacheReadInputTokens
 	const baseInputCost = ((modelInfo.inputPrice || 0) / 1_000_000) * inputTokens
 	const outputCost = ((modelInfo.outputPrice || 0) / 1_000_000) * outputTokens
 	const totalCost = cacheWritesCost + cacheReadsCost + baseInputCost + outputCost
-	return totalCost
+
+	return {
+		totalInputTokens,
+		totalOutputTokens,
+		totalCost,
+	}
 }
 
 // For Anthropic compliant usage, the input tokens count does NOT include the
@@ -23,13 +36,22 @@ export function calculateApiCostAnthropic(
 	outputTokens: number,
 	cacheCreationInputTokens?: number,
 	cacheReadInputTokens?: number,
-): number {
+): ApiCostResult {
+	const cacheCreation = cacheCreationInputTokens || 0
+	const cacheRead = cacheReadInputTokens || 0
+
+	// For Anthropic: inputTokens does NOT include cached tokens
+	// Total input = base input + cache creation + cache reads
+	const totalInputTokens = inputTokens + cacheCreation + cacheRead
+
 	return calculateApiCostInternal(
 		modelInfo,
 		inputTokens,
 		outputTokens,
-		cacheCreationInputTokens || 0,
-		cacheReadInputTokens || 0,
+		cacheCreation,
+		cacheRead,
+		totalInputTokens,
+		outputTokens,
 	)
 }
 
@@ -40,17 +62,21 @@ export function calculateApiCostOpenAI(
 	outputTokens: number,
 	cacheCreationInputTokens?: number,
 	cacheReadInputTokens?: number,
-): number {
+): ApiCostResult {
 	const cacheCreationInputTokensNum = cacheCreationInputTokens || 0
 	const cacheReadInputTokensNum = cacheReadInputTokens || 0
 	const nonCachedInputTokens = Math.max(0, inputTokens - cacheCreationInputTokensNum - cacheReadInputTokensNum)
 
+	// For OpenAI: inputTokens ALREADY includes all tokens (cached + non-cached)
+	// So we pass the original inputTokens as the total
 	return calculateApiCostInternal(
 		modelInfo,
 		nonCachedInputTokens,
 		outputTokens,
 		cacheCreationInputTokensNum,
 		cacheReadInputTokensNum,
+		inputTokens,
+		outputTokens,
 	)
 }
 

--- a/src/shared/getApiMetrics.ts
+++ b/src/shared/getApiMetrics.ts
@@ -80,15 +80,12 @@ export function getApiMetrics(messages: ClineMessage[]) {
 		if (message.type === "say" && message.say === "api_req_started" && message.text) {
 			try {
 				const parsedText: ParsedApiReqStartedTextType = JSON.parse(message.text)
-				const { tokensIn, tokensOut, cacheWrites, cacheReads, apiProtocol } = parsedText
+				const { tokensIn, tokensOut } = parsedText
 
-				// Calculate context tokens based on API protocol.
-				if (apiProtocol === "anthropic") {
-					result.contextTokens = (tokensIn || 0) + (tokensOut || 0) + (cacheWrites || 0) + (cacheReads || 0)
-				} else {
-					// For OpenAI (or when protocol is not specified).
-					result.contextTokens = (tokensIn || 0) + (tokensOut || 0)
-				}
+				// Since tokensIn now stores TOTAL input tokens (including cache tokens),
+				// we no longer need to add cacheWrites and cacheReads separately.
+				// This applies to both Anthropic and OpenAI protocols.
+				result.contextTokens = (tokensIn || 0) + (tokensOut || 0)
 			} catch (error) {
 				console.error("Error parsing JSON:", error)
 				continue


### PR DESCRIPTION
Before:
<img width="616" height="274" alt="Screenshot 2025-10-31 at 10 53 41 AM" src="https://github.com/user-attachments/assets/a028e229-2bca-4f78-b64c-e984000e6887" />

After:
<img width="513" height="278" alt="Screenshot 2025-10-31 at 10 53 56 AM" src="https://github.com/user-attachments/assets/2a6f305a-223f-41de-970c-abff72c3e8d1" />

This also fixes the real-time stats and telemetry sent to cloud.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor cost and token tracking across provider handlers to ensure consistent and accurate reporting for Anthropic and OpenAI protocols.
> 
>   - **Cost Calculation**:
>     - Refactor `calculateApiCostAnthropic` and `calculateApiCostOpenAI` in `cost.ts` to return `ApiCostResult` with `totalInputTokens`, `totalOutputTokens`, and `totalCost`.
>     - Update cost calculation logic in `calculateApiCostInternal()` to handle both Anthropic and OpenAI protocols.
>   - **Provider Handlers**:
>     - Update `AnthropicHandler`, `CerebrasHandler`, `DeepInfraHandler`, `GroqHandler`, `LiteLLMHandler`, `OpenAiNativeHandler`, and `RequestyHandler` to use the new cost calculation functions.
>     - Ensure `totalCost` is extracted and used consistently across handlers.
>   - **Token Usage Tracking**:
>     - Modify `getApiMetrics()` in `getApiMetrics.ts` to calculate `contextTokens` using `tokensIn` and `tokensOut`.
>     - Update `Task.ts` to handle cost and token tracking using the new `ApiCostResult` structure.
>   - **Testing**:
>     - Update tests in `cost.spec.ts` to validate new cost calculation logic for both Anthropic and OpenAI.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6be9762b05a6690979668c21abd7f9766901f39b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->