### PR TITLE
Capture the reasoning content in base-openai-compatible for GLM 4.6

### DIFF
--- a/src/api/providers/base-openai-compatible-provider.ts
+++ b/src/api/providers/base-openai-compatible-provider.ts
@@ -115,6 +115,10 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 				}
 			}
 
+			if (delta && "reasoning_content" in delta && delta.reasoning_content) {
+				yield { type: "reasoning", text: (delta.reasoning_content as string | undefined) || "" }
+			}
+
 			if (chunk.usage) {
 				yield {
 					type: "usage",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add handling for `reasoning_content` in `createMessage()` in `base-openai-compatible-provider.ts`, yielding reasoning data when present.
> 
>   - **Behavior**:
>     - In `createMessage()` in `base-openai-compatible-provider.ts`, added handling for `reasoning_content` in response `delta`.
>     - Yields `{ type: "reasoning", text: delta.reasoning_content }` when `reasoning_content` is present.
>   - **Misc**:
>     - No changes to existing functionality, only addition of new data handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d53a35d787adbde3fe8725018e3b40a186500759. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->