### PR TITLE
ChatView: smoother stick-to-bottom during streaming

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1453,14 +1453,11 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							increaseViewportBy={{ top: 3_000, bottom: 1000 }}
 							data={groupedMessages}
 							itemContent={itemContent}
-							followOutput="smooth"
+							followOutput={(isAtBottom: boolean) => isAtBottom || stickyFollowRef.current}
 							atBottomStateChange={(isAtBottom: boolean) => {
 								setIsAtBottom(isAtBottom)
+								// Only show the scroll-to-bottom button if not at bottom
 								setShowScrollToBottom(!isAtBottom)
-								if (!isAtBottom && stickyFollowRef.current) {
-									// While in sticky mode, force-pin as streaming increases height
-									scrollToBottomAuto()
-								}
 							}}
 							atBottomThreshold={10}
 							initialTopMostItemIndex={groupedMessages.length - 1}


### PR DESCRIPTION
Fixes issues where sometimes the session would lose its stickyness to the bottom of the window during streaming events. 

BEFORE

https://github.com/user-attachments/assets/4296aba3-2a4b-4213-9ec2-f00efb96ff1c

AFTER

https://github.com/user-attachments/assets/2eeca907-17f7-4737-81bd-56902f17a2d8

Summary
- Smoother, reliable stick-to-bottom during token streaming
- Use Virtuoso followOutput="smooth" + sticky follow mode
- Engage sticky on “scroll to bottom”, auto-disengage on user up-scroll or expanding rows
- All chat tests pass

Key changes
- ChatView: enable followOutput and manage sticky pin: webview-ui/src/components/chat/ChatView.tsx
- Guard textarea and row-height scrolls using isAtBottom

Tests
- webview-ui chat specs: 99/99 passing

Rationale
- Removes after-render debounce jumps and reduces complexity
- Lets Virtuoso own bottom-follow; tiny sticky follow ensures robust pin under fast streams

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves stick-to-bottom behavior in `ChatView.tsx` during streaming using `Virtuoso` with smooth follow mode and updated sticky follow logic.
> 
>   - **Behavior**:
>     - Improved stick-to-bottom behavior during streaming in `ChatView.tsx` using `Virtuoso` with `followOutput` set to "smooth".
>     - Sticky follow mode engages on "scroll to bottom" and disengages on user up-scroll or row expansion.
>   - **State Management**:
>     - Replaced `disableAutoScrollRef` with `stickyFollowRef` to manage sticky follow state.
>     - Updated `isAtBottom` and `showScrollToBottom` state handling to reflect new scroll behavior.
>   - **Event Handling**:
>     - Added `handleWheel` and `onScroll` to disable sticky follow on user scroll actions.
>   - **Misc**:
>     - All chat tests pass, ensuring no regressions in functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 36d6498d8acee63910d47c1379e780a928383e57. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->