### PR TITLE
fix: Enable Google Ads conversion tracking with consent mode

### DIFF
--- a/apps/web-roo-code/src/components/providers/google-analytics-provider.tsx
+++ b/apps/web-roo-code/src/components/providers/google-analytics-provider.tsx
@@ -57,7 +57,6 @@ export function GoogleAnalyticsProvider({ children }: { children: React.ReactNod
 				functionality_storage: "denied",
 				personalization_storage: "denied",
 				security_storage: "granted", // Always granted for security
-				wait_for_update: 500, // Wait 500ms for consent before sending data
 			})
 
 			// Enable cookieless pings for Google Ads
@@ -76,6 +75,9 @@ export function GoogleAnalyticsProvider({ children }: { children: React.ReactNod
 				functionality_storage: "granted",
 				personalization_storage: "granted",
 			})
+
+			// Re-initialize config to flush queued events and enable tracking
+			window.gtag("config", GTM_ID)
 		}
 	}
 


### PR DESCRIPTION
## Problem
Google Ads conversions were not being tracked in production. The `window.gtag()` function executed but sent no network requests to Google servers.

## Root Cause Analysis
Two issues were preventing conversion tracking:

1. **`wait_for_update: 500` was blocking all events**
   - gtag waited 500ms for consent updates
   - When no update arrived and all consent was denied, all events were dropped
   - Result: Zero network requests, even for cookieless conversion pings

2. **Missing config re-initialization after consent granted**
   - When users accepted cookies, consent was updated to 'granted'
   - However, `gtag('config')` was never called again to flush queued events
   - Result: Events remained queued but never sent

## Solution
This PR implements two critical fixes:

### 1. Remove `wait_for_update` parameter
Removed the `wait_for_update: 500` parameter from consent defaults. This allows gtag to send anonymized conversion pings immediately, even when consent is denied.

### 2. Re-initialize config after consent granted
Added `window.gtag('config', GTM_ID)` call in `updateConsentGranted()` function. When users accept cookies, this flushes any queued events and enables full conversion tracking.

## Expected Behavior After Fix

**WITHOUT user consent:**
- ✅ Anonymized conversion pings are sent to Google
- ✅ No user data or cookies are used
- ✅ Enables Google's conversion modeling
- ✅ GDPR compliant

**WITH user consent:**
- ✅ Full conversion tracking enabled
- ✅ User data and cookies used for attribution
- ✅ Complete conversion funnel tracking

## Testing
To verify the fix works:
1. Load /reviewer page
2. Open DevTools → Network tab → Filter by 'google'
3. You should now see requests to `googleads.g.doubleclick.net` 
4. Click 'Start 14-day Free Trial' button
5. Verify conversion event is sent

## Files Changed
- `apps/web-roo-code/src/components/providers/google-analytics-provider.tsx`

## Related Issues
Fixes the issue where Google Ads conversion tracking appeared to execute but sent no network requests in production.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Google Ads conversion tracking by removing `wait_for_update` and re-initializing config after consent in `google-analytics-provider.tsx`.
> 
>   - **Behavior**:
>     - Removed `wait_for_update: 500` from consent defaults in `google-analytics-provider.tsx` to allow immediate anonymized conversion pings.
>     - Added `window.gtag('config', GTM_ID)` in `updateConsentGranted()` to flush queued events after consent is granted.
>   - **Testing**:
>     - Verified by checking network requests to `googleads.g.doubleclick.net` on `/reviewer` page and after clicking 'Start 14-day Free Trial'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 276d1ff33c11d3e4d1ce7b6d942443a09eec84ae. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->