### PR TITLE
hotfix: serialize resumptions to prevent cancel+restore race condition

### DIFF
--- a/src/core/webview/__tests__/ClineProvider.cancelTask.present-ask.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.cancelTask.present-ask.spec.ts
@@ -57,4 +57,28 @@ describe("ClineProvider.cancelTask - schedules presentResumableAsk", () => {
 		await Promise.resolve()
 		expect(mockTask.presentResumableAsk).toHaveBeenCalledTimes(1)
 	})
+
+	it("skips scheduling when suppressResumeAsk is true", async () => {
+		// Arrange
+		provider.setSuppressResumeAsk(true)
+
+		// Act
+		await (provider as any).cancelTask()
+
+		// Assert
+		vi.runAllTimers()
+		await Promise.resolve()
+		expect(mockTask.presentResumableAsk).not.toHaveBeenCalled()
+	})
+
+	it("dedupes multiple cancelTask calls for same taskId", async () => {
+		// Act: call cancel twice rapidly
+		await (provider as any).cancelTask()
+		await (provider as any).cancelTask()
+
+		// Assert
+		vi.runAllTimers()
+		await Promise.resolve()
+		expect(mockTask.presentResumableAsk).toHaveBeenCalledTimes(1)
+	})
 })

--- a/src/core/webview/__tests__/webviewMessageHandler.resume-gating.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.resume-gating.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { webviewMessageHandler } from "../webviewMessageHandler"
+
+describe("webviewMessageHandler - resume gating on checkpointRestore", () => {
+	let mockProvider: any
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+
+		const mockCline = {
+			isInitialized: true,
+			checkpointRestore: vi.fn().mockResolvedValue(undefined),
+		}
+
+		mockProvider = {
+			beginStateTransaction: vi.fn(),
+			endStateTransaction: vi.fn().mockResolvedValue(undefined),
+			setSuppressResumeAsk: vi.fn(),
+			cancelTask: vi.fn().mockResolvedValue(undefined),
+			getCurrentTask: vi.fn(() => mockCline),
+		}
+	})
+
+	it("sets suppressResumeAsk around cancel + restore flow", async () => {
+		await webviewMessageHandler(mockProvider, {
+			type: "checkpointRestore",
+			payload: {
+				commitHash: "abc123",
+				ts: Date.now(),
+				mode: "restore",
+			},
+		} as any)
+
+		// Ensure gating is toggled on then off
+		expect(mockProvider.setSuppressResumeAsk).toHaveBeenCalledWith(true)
+		expect(mockProvider.cancelTask).toHaveBeenCalledTimes(1)
+		expect(mockProvider.endStateTransaction).toHaveBeenCalledTimes(1)
+		expect(mockProvider.setSuppressResumeAsk).toHaveBeenLastCalledWith(false)
+	})
+})

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1034,6 +1034,7 @@ export const webviewMessageHandler = async (
 
 			if (result.success) {
 				// Begin transaction to buffer state updates
+				provider.setSuppressResumeAsk(true)
 				provider.beginStateTransaction()
 
 				try {
@@ -1053,6 +1054,7 @@ export const webviewMessageHandler = async (
 				} finally {
 					// End transaction and post consolidated state
 					await provider.endStateTransaction()
+					provider.setSuppressResumeAsk(false)
 				}
 			}
 


### PR DESCRIPTION
Fixes concurrent resumption flows that can cause two instances behavior when UI cancel schedules presentResumableAsk via setImmediate and webview checkpoint restore calls cancel then restore. Both flows can reset abort flags and call into task loop simultaneously.

Solution: Add suppressResumeAsk flag in ClineProvider to gate scheduling during transactions, plus resumeAskScheduledForTaskId dedupe to prevent multiple asks per task. Wrap checkpoint restore flow with suppression to serialize with cancel path.

Testing: Extended existing tests and added new test for checkpoint restore suppression. All 10 tests across 4 files pass.
Related to: #8986
Addresses PR 8986 recommendations for provider-level resumption serialization.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces suppression and deduplication in `ClineProvider` to prevent concurrent task resumptions, with tests added for validation.
> 
>   - **Behavior**:
>     - Adds `suppressResumeAsk` flag and `resumeAskScheduledForTaskId` in `ClineProvider` to prevent concurrent resumptions.
>     - Wraps checkpoint restore flow in `webviewMessageHandler.ts` with suppression to serialize with cancel path.
>   - **Functions**:
>     - Modifies `cancelTask()` in `ClineProvider` to check `suppressResumeAsk` and deduplicate `presentResumableAsk` scheduling.
>     - Updates `webviewMessageHandler()` to set `suppressResumeAsk` during checkpoint restore.
>   - **Testing**:
>     - Adds tests in `ClineProvider.cancelTask.present-ask.spec.ts` for suppression and deduplication logic.
>     - Adds `webviewMessageHandler.resume-gating.spec.ts` to test suppression during checkpoint restore.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7827cb7a9fc6c4ebd1147eb640caa88b322127f6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->