### PR TITLE
fix: correct OpenRouter Mistral model dimension from 3072 to 1536

### DIFF
--- a/src/shared/embeddingModels.ts
+++ b/src/shared/embeddingModels.ts
@@ -86,7 +86,7 @@ export const EMBEDDING_MODEL_PROFILES: EmbeddingModelProfiles = {
 		"google/gemini-embedding-001": { dimension: 3072, scoreThreshold: 0.4 },
 		// Mistral models via OpenRouter
 		"mistralai/mistral-embed-2312": { dimension: 1024, scoreThreshold: 0.4 },
-		"mistralai/codestral-embed-2505": { dimension: 3072, scoreThreshold: 0.4 },
+		"mistralai/codestral-embed-2505": { dimension: 1536, scoreThreshold: 0.4 },
 		// Qwen models via OpenRouter
 		"qwen/qwen3-embedding-8b": { dimension: 4096, scoreThreshold: 0.4 },
 	},


### PR DESCRIPTION
Fixes dimension mismatch causing 'Vector dimension error: expected dim: 3072, got 1536' when using OpenRouter provider with mistralai/codestral-embed-2505 model.

- Updated model profile dimension to match actual API response (1536)
- Fixed related test cases
- Enables automatic Qdrant collection recreation with correct dimensions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes dimension mismatch for OpenRouter Mistral model, ensuring correct dimension handling and updating related tests.
> 
>   - **Behavior**:
>     - Fixes dimension mismatch for `mistralai/codestral-embed-2505` model in `embeddingModels.ts` from 3072 to 1536.
>     - Ensures correct dimension handling for OpenRouter provider, preventing 'Vector dimension error'.
>     - Enables automatic Qdrant collection recreation with correct dimensions.
>   - **Tests**:
>     - Updates test cases in `config-manager.spec.ts` to verify correct dimension handling across restarts.
>     - Adds tests to ensure no restart is required when model dimensions remain the same.
>     - Adds tests to ensure restart is required when model dimensions change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5537dd04b2b054a65c461adc840f33c2bd001e52. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->