### PR TITLE
Add test execution to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -17,6 +17,7 @@ else
 fi
 
 $pnpm_cmd run check-types
+$pnpm_cmd run test
 
 # Check for new changesets.
 NEW_CHANGESETS=$(find .changeset -name "*.md" ! -name "README.md" | wc -l | tr -d ' ')


### PR DESCRIPTION
Ensures all tests pass before pushing, preventing broken code from entering the repository.

- Added `$pnpm_cmd run test` to `.husky/pre-push`
- Tests run after type checking and before changeset validation  
- Uses Turbo to execute tests across all packages in the monorepo