### PR TITLE
feat: add file path tooltips with centralized PathTooltip component

### DIFF
--- a/webview-ui/src/components/chat/BatchFilePermission.tsx
+++ b/webview-ui/src/components/chat/BatchFilePermission.tsx
@@ -2,7 +2,8 @@ import { memo } from "react"
 
 import { ToolUseBlock, ToolUseBlockHeader } from "../common/ToolUseBlock"
 import { vscode } from "@src/utils/vscode"
-import { removeLeadingNonAlphanumeric } from "@src/utils/removeLeadingNonAlphanumeric"
+import { formatPathTooltip } from "@src/utils/formatPathTooltip"
+import { PathTooltip } from "../ui/PathTooltip"
 
 interface FilePermissionItem {
 	path: string
@@ -35,10 +36,18 @@ export const BatchFilePermission = memo(({ files = [], onPermissionResponse, ts 
 								<ToolUseBlockHeader
 									onClick={() => vscode.postMessage({ type: "openFile", text: file.content })}>
 									{file.path?.startsWith(".") && <span>.</span>}
-									<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
-										{removeLeadingNonAlphanumeric(file.path ?? "") + "\u200E"}
-										{file.lineSnippet && ` ${file.lineSnippet}`}
-									</span>
+									<PathTooltip
+										content={formatPathTooltip(
+											file.path,
+											file.lineSnippet ? ` ${file.lineSnippet}` : undefined,
+										)}>
+										<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
+											{formatPathTooltip(
+												file.path,
+												file.lineSnippet ? ` ${file.lineSnippet}` : undefined,
+											)}
+										</span>
+									</PathTooltip>
 									<div className="flex-grow"></div>
 									<span className="codicon codicon-link-external text-[13.5px] my-[1px]" />
 								</ToolUseBlockHeader>

--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -14,7 +14,7 @@ import { safeJsonParse } from "@roo/safeJsonParse"
 import { useExtensionState } from "@src/context/ExtensionStateContext"
 import { findMatchingResourceOrTemplate } from "@src/utils/mcp"
 import { vscode } from "@src/utils/vscode"
-import { removeLeadingNonAlphanumeric } from "@src/utils/removeLeadingNonAlphanumeric"
+import { formatPathTooltip } from "@src/utils/formatPathTooltip"
 import { getLanguageFromPath } from "@src/utils/getLanguageFromPath"
 
 import { ToolUseBlock, ToolUseBlockHeader } from "../common/ToolUseBlock"
@@ -61,6 +61,7 @@ import {
 	MessageCircle,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { PathTooltip } from "../ui/PathTooltip"
 
 interface ChatRowProps {
 	message: ClineMessage
@@ -552,10 +553,11 @@ export const ChatRowContent = ({
 									className="group"
 									onClick={() => vscode.postMessage({ type: "openFile", text: tool.content })}>
 									{tool.path?.startsWith(".") && <span>.</span>}
-									<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
-										{removeLeadingNonAlphanumeric(tool.path ?? "") + "\u200E"}
-										{tool.reason}
-									</span>
+									<PathTooltip content={formatPathTooltip(tool.path, tool.reason)}>
+										<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
+											{formatPathTooltip(tool.path, tool.reason)}
+										</span>
+									</PathTooltip>
 									<div style={{ flexGrow: 1 }}></div>
 									<SquareArrowOutUpRight
 										className="w-4 shrink-0 codicon codicon-link-external opacity-0 group-hover:opacity-100 transition-opacity"

--- a/webview-ui/src/components/common/CodeAccordian.tsx
+++ b/webview-ui/src/components/common/CodeAccordian.tsx
@@ -2,10 +2,11 @@ import { memo, useMemo } from "react"
 import { VSCodeProgressRing } from "@vscode/webview-ui-toolkit/react"
 import { type ToolProgressStatus } from "@roo-code/types"
 import { getLanguageFromPath } from "@src/utils/getLanguageFromPath"
-import { removeLeadingNonAlphanumeric } from "@src/utils/removeLeadingNonAlphanumeric"
+import { formatPathTooltip } from "@src/utils/formatPathTooltip"
 
 import { ToolUseBlock, ToolUseBlockHeader } from "./ToolUseBlock"
 import CodeBlock from "./CodeBlock"
+import { PathTooltip } from "../ui/PathTooltip"
 
 interface CodeAccordianProps {
 	path?: string
@@ -44,7 +45,9 @@ const CodeAccordian = ({
 					{header ? (
 						<div className="flex items-center">
 							<span className="codicon codicon-server mr-1.5"></span>
-							<span className="whitespace-nowrap overflow-hidden text-ellipsis mr-2">{header}</span>
+							<PathTooltip content={header}>
+								<span className="whitespace-nowrap overflow-hidden text-ellipsis mr-2">{header}</span>
+							</PathTooltip>
 						</div>
 					) : isFeedback ? (
 						<div className="flex items-center">
@@ -56,9 +59,11 @@ const CodeAccordian = ({
 					) : (
 						<>
 							{path?.startsWith(".") && <span>.</span>}
-							<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
-								{removeLeadingNonAlphanumeric(path ?? "") + "\u200E"}
-							</span>
+							<PathTooltip content={formatPathTooltip(path)}>
+								<span className="whitespace-nowrap overflow-hidden text-ellipsis text-left mr-2 rtl">
+									{formatPathTooltip(path)}
+								</span>
+							</PathTooltip>
 						</>
 					)}
 					<div className="flex-grow-1" />

--- a/webview-ui/src/components/ui/PathTooltip.tsx
+++ b/webview-ui/src/components/ui/PathTooltip.tsx
@@ -1,0 +1,54 @@
+import { ReactNode } from "react"
+import { StandardTooltip } from "./standard-tooltip"
+
+interface PathTooltipProps {
+	/** The file path or content to display in the tooltip */
+	content: string
+	/** The element(s) that trigger the tooltip */
+	children: ReactNode
+	/** The preferred side of the trigger to render the tooltip */
+	side?: "top" | "right" | "bottom" | "left"
+	/** The preferred alignment against the trigger */
+	align?: "start" | "center" | "end"
+	/** Distance in pixels from the trigger */
+	sideOffset?: number
+	/** Whether the trigger should be rendered as a child */
+	asChild?: boolean
+}
+
+/**
+ * PathTooltip component specifically designed for displaying file paths with appropriate
+ * wrapping and responsive width behavior. Use this for truncated file paths that need
+ * tooltips to show the full path.
+ *
+ * Features:
+ * - Responsive max-width that adapts to panel size (max 300px on wide panels, 100vw on narrow)
+ * - Uses text-wrap instead of text-balance to minimize whitespace
+ * - Leverages existing break-words CSS for natural line breaking at path separators
+ *
+ * @example
+ * <PathTooltip content="/very/long/file/path.tsx">
+ *   <span className="truncate">...path.tsx</span>
+ * </PathTooltip>
+ */
+export function PathTooltip({
+	content,
+	children,
+	side = "top",
+	align = "start",
+	sideOffset = 4,
+	asChild = true,
+}: PathTooltipProps) {
+	return (
+		<StandardTooltip
+			content={content}
+			side={side}
+			align={align}
+			sideOffset={sideOffset}
+			className="[text-wrap:wrap]"
+			maxWidth="min(300px,100vw)"
+			asChild={asChild}>
+			{children}
+		</StandardTooltip>
+	)
+}

--- a/webview-ui/src/utils/formatPathTooltip.ts
+++ b/webview-ui/src/utils/formatPathTooltip.ts
@@ -1,0 +1,28 @@
+import { removeLeadingNonAlphanumeric } from "./removeLeadingNonAlphanumeric"
+
+/**
+ * Formats a file path for display in tooltips with consistent formatting.
+ *
+ * @param path - The file path to format
+ * @param additionalContent - Optional additional content to append (e.g., line snippets, reasons)
+ * @returns Formatted string ready for tooltip display
+ *
+ * @example
+ * formatPathTooltip("/src/components/MyComponent.tsx")
+ * // Returns: "src/components/MyComponent.tsx" + U+200E
+ *
+ * @example
+ * formatPathTooltip("/src/utils/helper.ts", ":42-45")
+ * // Returns: "src/utils/helper.ts:42-45" + U+200E
+ */
+export function formatPathTooltip(path?: string, additionalContent?: string): string {
+	if (!path) return ""
+
+	const formattedPath = removeLeadingNonAlphanumeric(path) + "\u200E"
+
+	if (additionalContent) {
+		return formattedPath + additionalContent
+	}
+
+	return formattedPath
+}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #8278

### Description

This PR adds tooltips to display full file paths on truncated filenames in file editing/reading notices throughout the chat interface.

**Implementation details:**
- Added `PathTooltip` component that wraps `StandardTooltip` with appropriate styling
- Used `maxWidth="min(300px,100vw)"` via inline style to reliably override defaults  
- Applied `[text-wrap:wrap]` class to override text-balance behavior
- Added `formatPathTooltip` helper for consistent path content formatting
- Updated `CodeAccordian.tsx`, `ChatRow.tsx`, and `BatchFilePermission.tsx` to use `PathTooltip`
- Centralizes tooltip behavior and reduces code duplication

**Key design choices:**
- Uses inline style for max-width to deterministically override the default `max-w-[300px]` in `TooltipContent`
- Uses `[text-wrap:wrap]` arbitrary property to reliably override the default `text-balance` CSS
- Centralizes all path tooltip logic in reusable components

**Testing:**
- All existing tests pass
- Tooltip styling is consistent with other tooltips in the extension
- Responsive width adapts to panel size while preventing tooltip cutoff

### Test Procedure

**Manual testing steps:**

1. **Test truncated paths show tooltips:**
    - Open Roo Code and start a chat session
    - Ask Roo to read or edit a file with a long path (e.g., `src/components/chat/file/with/deeply/nested/structure.tsx`)
    - Narrow the chat panel until the filename truncates (shows ellipsis)
    - Hover over the truncated filename in the notice
    - ✅ Verify: Tooltip appears showing the full file path
    - ✅ Verify: Tooltip wraps text to multiple lines without being cut off

2. **Test all tooltip locations:**
	- Test tooltips on:
		- Single file read operations
		- Single file edit operations  
		- Batch file read operations
		- Batch file edit operations
		- Directory listing operations
		- Search operations
		- ✅ Verify: All locations show tooltips with consistent behavior

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: All existing tests pass and functionality works as expected.
- [x] **Documentation Impact**: No documentation updates required.
- [x] **Contribution Guidelines**: I have read and agree to the Contributor Guidelines.

### Screenshot
<img width="397" height="306" alt="2025-11-04_12-50-19" src="https://github.com/user-attachments/assets/51a1e68e-ad84-4841-91ba-32f9a24f79f2" />

Supersedes PR #8797.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces `PathTooltip` component to centralize and standardize file path tooltips across the application, reducing code duplication and ensuring consistent behavior.
> 
>   - **Components**:
>     - Introduces `PathTooltip` in `PathTooltip.tsx` for displaying full file paths.
>     - Replaces inline path tooltip logic with `PathTooltip` in `BatchFilePermission.tsx`, `ChatRow.tsx`, and `CodeAccordian.tsx`.
>   - **Utilities**:
>     - Adds `formatPathTooltip` in `formatPathTooltip.ts` for consistent path formatting.
>   - **Behavior**:
>     - Centralizes tooltip logic, ensuring consistent display and behavior across components.
>     - Tooltips adapt to panel size, preventing cutoff and ensuring readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fcb9dbe10ccf94c733a6ee398b9d83736f628f10. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->