### PR TITLE
feat: add conditional test running to pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -18,6 +18,16 @@ fi
 
 $pnpm_cmd run check-types
 
+# Load .env.local if it exists
+if [ -f ".env.local" ]; then
+  export $(grep -v '^#' .env.local | xargs)
+fi
+
+# Run tests if RUN_TESTS_ON_PUSH is set to true
+if [ "$RUN_TESTS_ON_PUSH" = "true" ]; then
+  $pnpm_cmd run test
+fi
+
 # Check for new changesets.
 NEW_CHANGESETS=$(find .changeset -name "*.md" ! -name "README.md" | wc -l | tr -d ' ')
 echo "Changeset files: $NEW_CHANGESETS"


### PR DESCRIPTION
## Summary

Adds the ability to conditionally run tests during the pre-push hook using a `.env.local` environment variable.

## Changes

- Modified `.husky/pre-push` to load `.env.local` if it exists
- Added conditional test execution when `RUN_TESTS_ON_PUSH=true`
- Uses existing `pnpm run test` command (turbo) to run all tests across the monorepo
- Tests are skipped by default when `RUN_TESTS_ON_PUSH` is not set or false

## Usage

Create or update `.env.local`:
```bash
# Enable tests on push
RUN_TESTS_ON_PUSH=true

# Disable tests on push (default)  
RUN_TESTS_ON_PUSH=false
```

## Benefits

- Developers can choose whether to run tests during push based on their workflow
- Uses the existing comprehensive test suite via turbo
- No verbose logging - clean output
- Backwards compatible (tests disabled by default)