### PR TITLE
fix: prevent shell injection in pre-push hook environment loading

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -18,14 +18,17 @@ fi
 
 $pnpm_cmd run check-types
 
-# Load .env.local if it exists
+# Use dotenvx to securely load .env.local and run commands that depend on it
 if [ -f ".env.local" ]; then
-  export $(grep -v '^#' .env.local | xargs)
-fi
-
-# Run tests if RUN_TESTS_ON_PUSH is set to true
-if [ "$RUN_TESTS_ON_PUSH" = "true" ]; then
-  $pnpm_cmd run test
+  # Check if RUN_TESTS_ON_PUSH is set to true and run tests with dotenvx
+  if npx dotenvx get RUN_TESTS_ON_PUSH -f .env.local 2>/dev/null | grep -q "^true$"; then
+    npx dotenvx run -f .env.local -- $pnpm_cmd run test
+  fi
+else
+  # Fallback: run tests if RUN_TESTS_ON_PUSH is set in regular environment
+  if [ "$RUN_TESTS_ON_PUSH" = "true" ]; then
+    $pnpm_cmd run test
+  fi
 fi
 
 # Check for new changesets.


### PR DESCRIPTION
Fixes shell injection vulnerability in pre-push hook environment loading.

**Problem:**
The original `export $(grep -v '^\#' .env.local | xargs)` pattern was vulnerable to shell injection. Malicious content in .env.local like `RUN_TESTS_ON_PUSH=true; rm -rf /` could execute arbitrary commands.

**Solution:**
Uses the existing `@dotenvx/dotenvx` dependency to securely parse .env.local without shell evaluation:
- `npx dotenvx get` safely extracts specific variables 
- `npx dotenvx run` executes commands with environment loaded securely
- Eliminates shell injection attack vectors while maintaining functionality

**Security Benefits:**
- No shell evaluation of .env.local contents
- Prevents execution of embedded commands or scripts
- Uses established, secure dotenv parsing library
- Maintains backward compatibility with existing behavior