### PR TITLE
feat: disable background mode editing when auto-approve write is disabled

### DIFF
--- a/src/core/tools/applyDiffTool.ts
+++ b/src/core/tools/applyDiffTool.ts
@@ -151,10 +151,11 @@ export async function applyDiffToolLegacy(
 			const state = await provider?.getState()
 			const diagnosticsEnabled = state?.diagnosticsEnabled ?? true
 			const writeDelayMs = state?.writeDelayMs ?? DEFAULT_WRITE_DELAY_MS
-			const isPreventFocusDisruptionEnabled = experiments.isEnabled(
-				state?.experiments ?? {},
-				EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION,
-			)
+			// Only use background mode editing if both the experiment is enabled AND write auto-approval is enabled
+			// When auto-approval is disabled, fall back to regular editing with diff view (takes focus)
+			const isPreventFocusDisruptionEnabled =
+				experiments.isEnabled(state?.experiments ?? {}, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION) &&
+				(state?.alwaysAllowWrite ?? false)
 
 			// Check if file is write-protected
 			const isWriteProtected = cline.rooProtectedController?.isWriteProtected(relPath) || false

--- a/src/core/tools/insertContentTool.ts
+++ b/src/core/tools/insertContentTool.ts
@@ -114,10 +114,11 @@ export async function insertContentTool(
 		const state = await provider?.getState()
 		const diagnosticsEnabled = state?.diagnosticsEnabled ?? true
 		const writeDelayMs = state?.writeDelayMs ?? DEFAULT_WRITE_DELAY_MS
-		const isPreventFocusDisruptionEnabled = experiments.isEnabled(
-			state?.experiments ?? {},
-			EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION,
-		)
+		// Only use background mode editing if both the experiment is enabled AND write auto-approval is enabled
+		// When auto-approval is disabled, fall back to regular editing with diff view (takes focus)
+		const isPreventFocusDisruptionEnabled =
+			experiments.isEnabled(state?.experiments ?? {}, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION) &&
+			(state?.alwaysAllowWrite ?? false)
 
 		// Build unified diff for display (normalize EOLs only for diff generation)
 		let unified: string

--- a/src/core/tools/multiApplyDiffTool.ts
+++ b/src/core/tools/multiApplyDiffTool.ts
@@ -563,10 +563,11 @@ ${errorDetails ? `\nTechnical details:\n${errorDetails}\n` : ""}
 				const state = await provider?.getState()
 				const diagnosticsEnabled = state?.diagnosticsEnabled ?? true
 				const writeDelayMs = state?.writeDelayMs ?? DEFAULT_WRITE_DELAY_MS
-				const isPreventFocusDisruptionEnabled = experiments.isEnabled(
-					state?.experiments ?? {},
-					EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION,
-				)
+				// Only use background mode editing if both the experiment is enabled AND write auto-approval is enabled
+				// When auto-approval is disabled, fall back to regular editing with diff view (takes focus)
+				const isPreventFocusDisruptionEnabled =
+					experiments.isEnabled(state?.experiments ?? {}, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION) &&
+					(state?.alwaysAllowWrite ?? false)
 
 				// For batch operations, we've already gotten approval
 				const isWriteProtected = cline.rooProtectedController?.isWriteProtected(relPath) || false

--- a/src/core/tools/writeToFileTool.ts
+++ b/src/core/tools/writeToFileTool.ts
@@ -105,10 +105,11 @@ export async function writeToFileTool(
 			// Check if preventFocusDisruption experiment is enabled
 			const provider = cline.providerRef.deref()
 			const state = await provider?.getState()
-			const isPreventFocusDisruptionEnabled = experiments.isEnabled(
-				state?.experiments ?? {},
-				EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION,
-			)
+			// Only use background mode editing if both the experiment is enabled AND write auto-approval is enabled
+			// When auto-approval is disabled, fall back to regular editing with diff view (takes focus)
+			const isPreventFocusDisruptionEnabled =
+				experiments.isEnabled(state?.experiments ?? {}, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION) &&
+				(state?.alwaysAllowWrite ?? false)
 
 			if (!isPreventFocusDisruptionEnabled) {
 				// update gui message
@@ -167,10 +168,11 @@ export async function writeToFileTool(
 			const state = await provider?.getState()
 			const diagnosticsEnabled = state?.diagnosticsEnabled ?? true
 			const writeDelayMs = state?.writeDelayMs ?? DEFAULT_WRITE_DELAY_MS
-			const isPreventFocusDisruptionEnabled = experiments.isEnabled(
-				state?.experiments ?? {},
-				EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION,
-			)
+			// Only use background mode editing if both the experiment is enabled AND write auto-approval is enabled
+			// When auto-approval is disabled, fall back to regular editing with diff view (takes focus)
+			const isPreventFocusDisruptionEnabled =
+				experiments.isEnabled(state?.experiments ?? {}, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION) &&
+				(state?.alwaysAllowWrite ?? false)
 
 			if (isPreventFocusDisruptionEnabled) {
 				// Direct file write without diff view


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #8736

### Description

This PR modifies file editing tools to disable background mode editing when auto-approve write permissions are disabled, ensuring users can review changes in the diff view when manual approval is required.

**Implementation Details:**
- Added a check for `alwaysAllowWrite` setting in four core editing tools: `writeToFileTool`, `applyDiffTool`, `multiApplyDiffTool`, and `insertContentTool`
- Background mode editing (via `PREVENT_FOCUS_DISRUPTION` experiment) now requires both the experiment to be enabled AND `alwaysAllowWrite` to be true
- When auto-approve is disabled, tools fall back to regular editing behavior that opens the diff view and takes editor focus
- The check is simple and leverages existing approval infrastructure - the UI layer already handles workspace/protection status checks separately

**Reviewers should note:**
- The change is minimal - just adding `&& (state?.alwaysAllowWrite ?? false)` to the existing `isPreventFocusDisruptionEnabled` check
- No changes to approval logic or UI - this only affects whether the diff view is shown during editing

### Test Procedure

**Manual Testing:**
1. Enable the `PREVENT_FOCUS_DISRUPTION` experiment in settings
2. **With auto-approve enabled** (`alwaysAllowWrite: true`):
   - Start a task that writes/edits files
   - Verify files are edited in the background without opening diff view
   - Verify editor focus is not disrupted
3. **With auto-approve disabled** (`alwaysAllowWrite: false`):
   - Start a task that writes/edits files
   - Verify diff view opens for each file edit
   - Verify editor focus switches to the diff view
   - Verify user must manually approve changes
4. Test with all four editing operations:
   - `write_to_file` - creating new files or overwriting existing ones
   - `apply_diff` - applying diffs to existing files
   - `apply_diff` with multiple files - batch operations
   - `insert_content` - inserting content at specific line numbers

**Results:**
- ✅When auto-approve is disabled, background editing is bypassed regardless of experiment setting
- ✅When auto-approve is disabled, users see the diff view and can review/approve changes before they're applied
- ✅When auto-approve is enabled, background mode works as before

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.

### Get in Touch

Discord: `@ocean.smith`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Disables background mode editing in core tools when auto-approve is disabled, requiring diff view for manual approval.
> 
>   - **Behavior**:
>     - Disables background mode editing in `applyDiffTool`, `insertContentTool`, `multiApplyDiffTool`, and `writeToFileTool` when `alwaysAllowWrite` is false.
>     - Requires both `PREVENT_FOCUS_DISRUPTION` experiment and `alwaysAllowWrite` to be true for background mode.
>     - Falls back to regular editing with diff view when auto-approve is disabled.
>   - **Implementation**:
>     - Adds `&& (state?.alwaysAllowWrite ?? false)` to `isPreventFocusDisruptionEnabled` check in the four tools.
>   - **Testing**:
>     - Manual tests confirm diff view opens and requires user approval when auto-approve is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 16a8d47935acf1abe5810e496dd60d63b2e25b6b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->