### PR TITLE
fix: prevent command_output ask from blocking in cloud/headless environments

### DIFF
--- a/packages/types/src/message.ts
+++ b/packages/types/src/message.ts
@@ -46,7 +46,21 @@ export type ClineAsk = z.infer<typeof clineAskSchema>
 
 // Needs classification:
 // - `followup`
-// - `command_output
+
+/**
+ * NonBlockingAsk
+ *
+ * Asks that should not block task execution. These are informational or optional
+ * asks where the task can proceed even without an immediate user response.
+ */
+
+export const nonBlockingAsks = ["command_output"] as const satisfies readonly ClineAsk[]
+
+export type NonBlockingAsk = (typeof nonBlockingAsks)[number]
+
+export function isNonBlockingAsk(ask: ClineAsk): ask is NonBlockingAsk {
+	return (nonBlockingAsks as readonly ClineAsk[]).includes(ask)
+}
 
 /**
  * IdleAsk


### PR DESCRIPTION
Classifies command_output as NonBlockingAsk to prevent task timeouts when auto-approve is enabled in cloud/headless environments.

## Problem
After v3.30.0 changed the default terminal to inline (execa), command output streams immediately, causing onLine callbacks to fire early and create command_output asks. In cloud/headless with no user to respond, these asks would block indefinitely, causing task timeouts.

## Root Cause
- Inline terminal (execa) streams output immediately → onLine fires early
- Multiple rapid onLine calls create concurrent command_output asks  
- Asks race: "Current ask promise was ignored" errors
- command_output was unclassified (not Interactive/Idle/Resumable)
- In cloud/headless, if an ask succeeded in blocking, no one could answer it → timeout

## Solution
Classify command_output as **NonBlockingAsk** - a new ask category that doesn't block task execution.

## Changes
- **packages/types/src/message.ts**: Add NonBlockingAsk classification
- **src/core/task/Task.ts**: Return immediately for non-blocking asks, skip status mutation
- **src/core/tools/executeCommandTool.ts**: Prevent concurrent asks with hasAskedForCommandOutput flag

## Behavior
**Cloud/Headless**: Ask created, returns immediately, command completes without blocking
**Interactive**: Ask shown in UI, returns immediately, command completes (user response ignored since ask already returned)

## Testing
- All existing tests pass
- Type checking passes
- Linting passes

Fixes the issue where cloud tasks would timeout waiting for approval even when auto-approve for command execution was enabled.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Classifies `command_output` as `NonBlockingAsk` to prevent blocking in cloud/headless environments, ensuring tasks return immediately without waiting for user response.
> 
>   - **Behavior**:
>     - Classifies `command_output` as `NonBlockingAsk` to prevent blocking in cloud/headless environments.
>     - Tasks return immediately for non-blocking asks, skipping status mutation in `Task.ts`.
>     - Prevents concurrent asks in `executeCommandTool.ts` using `hasAskedForCommandOutput` flag.
>   - **Changes**:
>     - Adds `NonBlockingAsk` classification in `message.ts`.
>     - Modifies `ask()` in `Task.ts` to handle non-blocking asks by returning immediately.
>     - Updates `executeCommand()` in `executeCommandTool.ts` to prevent multiple asks.
>   - **Testing**:
>     - All existing tests pass.
>     - Type checking and linting pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 15ec2bec7ada2b3e328aa225edd1ca9ce1873391. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->