### PR TITLE
fix: include mcpServers in getState() for auto-approval

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -2220,6 +2220,7 @@ export class ClineProvider
 			language: stateValues.language ?? formatLanguage(vscode.env.language),
 			mcpEnabled: stateValues.mcpEnabled ?? true,
 			enableMcpServerCreation: stateValues.enableMcpServerCreation ?? true,
+			mcpServers: this.mcpHub?.getAllServers() ?? [],
 			alwaysApproveResubmit: stateValues.alwaysApproveResubmit ?? false,
 			requestDelaySeconds: Math.max(5, stateValues.requestDelaySeconds ?? 10),
 			currentApiConfigName: stateValues.currentApiConfigName ?? "default",


### PR DESCRIPTION
## Problem

MCP auto-approval was not working even when both `alwaysAllowMcp` and tool-specific `alwaysAllow` flags were enabled.

## Root Cause

During the auto-approval refactor in #9157, `ClineProvider.getState()` was missing the `mcpServers` property that `getStateToPostToWebview()` includes. This caused `isMcpToolAlwaysAllowed()` to receive `undefined` for the servers list, always returning `false`.

## Fix

Added `mcpServers: this.mcpHub?.getAllServers() ?? []` to the `getState()` method return value, matching the implementation in `getStateToPostToWebview()`.

## Testing

Verified with debug logging that:
- Before fix: `state.mcpServers` was undefined (count: 0)  
- After fix: `state.mcpServers` contains configured servers with tools

Fixes #9190
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ClineProvider.getState()` to include `mcpServers`, resolving auto-approval issues.
> 
>   - **Behavior**:
>     - Fixes `ClineProvider.getState()` in `ClineProvider.ts` to include `mcpServers` property, aligning it with `getStateToPostToWebview()`.
>     - Ensures `isMcpToolAlwaysAllowed()` receives the correct servers list, fixing the auto-approval issue.
>   - **Testing**:
>     - Verified `state.mcpServers` was undefined before the fix and contains configured servers after the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a89ce926bd0eeb2a843b669e608ee6aadcb4d79d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->