### PR TITLE
fix: Apply updated API profile settings when provider/model unchanged (#9208)

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1301,14 +1301,22 @@ export class ClineProvider
 	// Provider Profile Management
 
 	/**
-	 * Updates the current task's API handler if the provider or model has changed.
-	 * Also synchronizes the task.apiConfiguration so subsequent comparisons and logic
-	 * (protocol selection, reasoning display, model metadata) use the latest profile.
+	 * Updates the current task's API handler.
+	 * Rebuilds when:
+	 * - provider or model changes, OR
+	 * - explicitly forced (e.g., user-initiated profile switch/save to apply changed settings like headers/baseUrl/tier).
+	 * Always synchronizes task.apiConfiguration with latest provider settings.
 	 * @param providerSettings The new provider settings to apply
+	 * @param options.forceRebuild Force rebuilding the API handler regardless of provider/model equality
 	 */
-	private updateTaskApiHandlerIfNeeded(providerSettings: ProviderSettings): void {
+	private updateTaskApiHandlerIfNeeded(
+		providerSettings: ProviderSettings,
+		options: { forceRebuild?: boolean } = {},
+	): void {
 		const task = this.getCurrentTask()
 		if (!task) return
+
+		const { forceRebuild = false } = options
 
 		// Determine if we need to rebuild using the previous configuration snapshot
 		const prevConfig = task.apiConfiguration
@@ -1317,7 +1325,7 @@ export class ClineProvider
 		const newProvider = providerSettings.apiProvider
 		const newModelId = getModelId(providerSettings)
 
-		if (prevProvider !== newProvider || prevModelId !== newModelId) {
+		if (forceRebuild || prevProvider !== newProvider || prevModelId !== newModelId) {
 			task.api = buildApiHandler(providerSettings)
 		}
 
@@ -1373,7 +1381,7 @@ export class ClineProvider
 
 				// Change the provider for the current task.
 				// TODO: We should rename `buildApiHandler` for clarity (e.g. `getProviderClient`).
-				this.updateTaskApiHandlerIfNeeded(providerSettings)
+				this.updateTaskApiHandlerIfNeeded(providerSettings, { forceRebuild: true })
 			} else {
 				await this.updateGlobalState("listApiConfigMeta", await this.providerSettingsManager.listConfig())
 			}
@@ -1428,9 +1436,8 @@ export class ClineProvider
 		if (id) {
 			await this.providerSettingsManager.setModeConfig(mode, id)
 		}
-
 		// Change the provider for the current task.
-		this.updateTaskApiHandlerIfNeeded(providerSettings)
+		this.updateTaskApiHandlerIfNeeded(providerSettings, { forceRebuild: true })
 
 		await this.postStateToWebview()
 


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

Closes: #9208

### Roo Code Task Context (Optional)

_No Roo Code task context for this PR_

### Description

This PR fixes a bug where switching to an API Profile that keeps the same provider/model did not apply changed settings (e.g., headers, baseUrl, service tier, reasoning tokens/budget). Previously, the API client (task.api) was only rebuilt when provider or model changed.

Implementation details:
- Added an options parameter with forceRebuild to the helper that updates the task API client. Now explicit profile switch/save forces a rebuild to apply all non-model-affecting settings immediately.
- Invocations from explicit profile activation and profile save paths pass forceRebuild: true.
- Task.apiConfiguration is still fully synchronized with the selected profile.

Key changes:
- [src/core/webview/ClineProvider.ts](src/core/webview/ClineProvider.ts)
  - Added forceRebuild option to updateTaskApiHandlerIfNeeded()
  - Force rebuild on:
    - upsertProviderProfile() activation path
    - activateProviderProfile() path
- Tests updated to reflect new behavior:
  - [src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts](src/core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts)

Why this approach:
- User-initiated profile switches or saves are explicit intent to use the new configuration. Rebuilding the client ensures runtime parameters (headers/baseUrl/tier/reasoning, etc.) take effect even when provider/model are unchanged.

### Test Procedure

Automated tests:
- Run targeted spec:
  - cd src && npx vitest run core/webview/__tests__/ClineProvider.apiHandlerRebuild.spec.ts
- Run full suite:
  - cd src && npx vitest run

What’s covered:
- Rebuild occurs when provider/model unchanged but settings differ during explicit activation/save
- Rebuild still occurs when provider or model changes
- Task.apiConfiguration is fully synchronized on every switch

Observed results locally:
- Targeted: 1 file, all tests passed
- Full suite: all tests passed (skipped tests unchanged)

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

_No UI changes in this PR_

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

_No additional notes_

### Get in Touch

@hannesrudolph