### PR TITLE
OpenAI Native: gate encrypted_content include; remove gpt-5-chat-latest verbosity flag (fixes #9225)

### DIFF
--- a/packages/types/src/providers/openai.ts
+++ b/packages/types/src/providers/openai.ts
@@ -16,7 +16,6 @@ export const openAiNativeModels = {
 		outputPrice: 10.0,
 		cacheReadsPrice: 0.13,
 		description: "GPT-5 Chat Latest: Optimized for conversational AI and non-reasoning tasks",
-		supportsVerbosity: true,
 	},
 	"gpt-5-2025-08-07": {
 		maxTokens: 128000,

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -216,7 +216,8 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 			// Unlike Chat Completions, system/developer roles in input have no special semantics here.
 			// The official way to set system behavior is the top-level `instructions` field.
 			instructions: systemPrompt,
-			include: ["reasoning.encrypted_content"],
+			// Only include encrypted reasoning content when reasoning effort is set
+			...(reasoningEffort ? { include: ["reasoning.encrypted_content"] } : {}),
 			...(reasoningEffort
 				? {
 						reasoning: {
@@ -1098,7 +1099,8 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 				],
 				stream: false, // Non-streaming for completePrompt
 				store: false, // Don't store prompt completions
-				include: ["reasoning.encrypted_content"],
+				// Only include encrypted reasoning content when reasoning effort is set
+				...(reasoningEffort ? { include: ["reasoning.encrypted_content"] } : {}),
 			}
 
 			// Include service tier if selected and supported


### PR DESCRIPTION
Reason
- When include: ["reasoning.encrypted_content"] is sent for models without reasoning, OpenAI Responses API returns: Invalid request to Responses API. Please check your input parameters. - Encrypted content is not supported with this model.
- Also, gpt-5-chat-latest only supports medium verbosity; setting low/high triggers: Invalid request to Responses API. Please check your input parameters. - Unsupported value: 'low' is not supported with the 'gpt-5-chat-latest' model. Supported values are: 'medium'.

Changes
- Gate encrypted include only when reasoning effort is set:
  - [OpenAiNativeHandler.buildRequestBody()](src/api/providers/openai-native.ts:180)
  - [OpenAiNativeHandler.completePrompt()](src/api/providers/openai-native.ts:1082)
- Remove supportsVerbosity from gpt-5-chat-latest:
  - [openai.ts](packages/types/src/providers/openai.ts:9)

Fixes #9225
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Gate `encrypted_content` inclusion to when `reasoningEffort` is set and remove verbosity support for `gpt-5-chat-latest`.
> 
>   - **Behavior**:
>     - Gate `encrypted_content` inclusion to when `reasoningEffort` is set in `OpenAiNativeHandler.buildRequestBody()` and `OpenAiNativeHandler.completePrompt()`.
>     - Remove `supportsVerbosity` from `gpt-5-chat-latest` in `openai.ts`.
>   - **Verification**:
>     - Unit tests in `openai-native.spec.ts` pass.
>     - Full test suite passes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 46fc2e14fed5631fa6288ffd8919ca2e4d870d89. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->