### PR TITLE
fix: resolve 400 error with native tools on OpenRouter

### DIFF
--- a/src/core/assistant-message/NativeToolCallParser.ts
+++ b/src/core/assistant-message/NativeToolCallParser.ts
@@ -81,7 +81,7 @@ export class NativeToolCallParser {
 			switch (toolCall.name) {
 				case "read_file":
 					if (args.files && Array.isArray(args.files)) {
-						nativeArgs = args.files as NativeArgsFor<TName>
+						nativeArgs = { files: args.files } as NativeArgsFor<TName>
 					}
 					break
 

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -178,8 +178,8 @@ export async function presentAssistantMessage(cline: Task) {
 							return getSimpleReadFileToolDescription(block.name, block.params)
 						} else {
 							// Prefer native typed args when available; fall back to legacy params
-							// Check if nativeArgs exists and is an array (native protocol)
-							if (Array.isArray(block.nativeArgs)) {
+							// Check if nativeArgs exists (native protocol)
+							if (block.nativeArgs) {
 								return readFileTool.getReadFileToolDescription(block.name, block.nativeArgs)
 							}
 							return readFileTool.getReadFileToolDescription(block.name, block.params)

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -2450,11 +2450,14 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 						// Get the tool call ID that was stored during parsing
 						const toolCallId = (toolUse as any).id
 						if (toolCallId) {
+							// nativeArgs is already in the correct API format for all tools
+							const input = toolUse.nativeArgs || toolUse.params
+
 							assistantContent.push({
 								type: "tool_use" as const,
 								id: toolCallId,
 								name: toolUse.name,
-								input: toolUse.nativeArgs || toolUse.params,
+								input,
 							})
 						}
 					}

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -82,7 +82,7 @@ export type ToolProtocol = "xml" | "native"
  * Tools not listed here will fall back to `any` for backward compatibility.
  */
 export type NativeToolArgs = {
-	read_file: FileEntry[]
+	read_file: { files: FileEntry[] }
 	attempt_completion: { result: string }
 	execute_command: { command: string; cwd?: string }
 	insert_content: { path: string; line: number; content: string }


### PR DESCRIPTION
Fixes 400 error "messages.3.content.0.tool_use.input: Input should be a valid dictionary" when using native tools with OpenRouter routing to Anthropic.

**Root Cause:**
`read_file`'s `nativeArgs` was stored as `FileEntry[]` instead of `{files: FileEntry[]}`, causing `tool_use.input` to be an array instead of an object in the API conversation history.

**Changes:**
- Updated `NativeToolArgs.read_file` to `{files: FileEntry[]}` matching API schema
- Updated parser, tool implementation, and call sites accordingly
- Added debug logging to OpenRouter provider

All tools now store `nativeArgs` in their exact API-compatible format, eliminating special-case handling.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 400 error by updating `read_file` tool's `nativeArgs` to match API schema, ensuring correct handling across the codebase.
> 
>   - **Behavior**:
>     - Fixes 400 error by updating `NativeToolArgs.read_file` to `{files: FileEntry[]}` in `tools.ts`.
>     - Ensures `tool_use.input` is an object, not an array, in `Task.ts` and `NativeToolCallParser.ts`.
>   - **Implementation**:
>     - Updates `ReadFileTool` methods to handle `{files: FileEntry[]}` format.
>     - Adjusts `presentAssistantMessage()` in `presentAssistantMessage.ts` to use updated `nativeArgs`.
>   - **Misc**:
>     - Adds debug logging to OpenRouter provider for better error tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b09338cd58f8908ec0491b4d23669949b6835d86. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->