### PR TITLE
Consistently use Package.name for better support of the nightly app

### DIFF
--- a/src/api/providers/utils/timeout-config.ts
+++ b/src/api/providers/utils/timeout-config.ts
@@ -1,4 +1,5 @@
 import * as vscode from "vscode"
+import { Package } from "../../../shared/package"
 
 /**
  * Gets the API request timeout from VSCode configuration with validation.
@@ -7,7 +8,7 @@ import * as vscode from "vscode"
  */
 export function getApiRequestTimeout(): number {
 	// Get timeout with validation to ensure it's a valid non-negative number
-	const configTimeout = vscode.workspace.getConfiguration("roo-cline").get<number>("apiRequestTimeout", 600)
+	const configTimeout = vscode.workspace.getConfiguration(Package.name).get<number>("apiRequestTimeout", 600)
 
 	// Validate that it's actually a number and not NaN
 	if (typeof configTimeout !== "number" || isNaN(configTimeout)) {

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -7,6 +7,7 @@ import { TelemetryService } from "@roo-code/telemetry"
 
 import { defaultModeSlug, getModeBySlug } from "../../shared/modes"
 import type { ToolParamName, ToolResponse, ToolUse } from "../../shared/tools"
+import { Package } from "../../shared/package"
 
 import { fetchInstructionsTool } from "../tools/FetchInstructionsTool"
 import { listFilesTool } from "../tools/ListFilesTool"
@@ -279,7 +280,7 @@ export async function presentAssistantMessage(cline: Task) {
 			const pushToolResult = (content: ToolResponse) => {
 				// Check if we're using native tool protocol
 				const toolProtocol = vscode.workspace
-					.getConfiguration("roo-cline")
+					.getConfiguration(Package.name)
 					.get<ToolProtocol>("toolProtocol", "xml")
 				const isNative = isNativeProtocol(toolProtocol)
 
@@ -503,7 +504,7 @@ export async function presentAssistantMessage(cline: Task) {
 
 					// Check if native protocol is enabled - if so, always use single-file class-based tool
 					const toolProtocol = vscode.workspace
-						.getConfiguration("roo-cline")
+						.getConfiguration(Package.name)
 						.get<ToolProtocol>("toolProtocol", "xml")
 					if (isNativeProtocol(toolProtocol)) {
 						await applyDiffToolClass.handle(cline, block as ToolUse<"apply_diff">, {

--- a/src/core/prompts/responses.ts
+++ b/src/core/prompts/responses.ts
@@ -5,6 +5,7 @@ import { RooIgnoreController, LOCK_TEXT_SYMBOL } from "../ignore/RooIgnoreContro
 import { RooProtectedController } from "../protect/RooProtectedController"
 import * as vscode from "vscode"
 import { ToolProtocol, isNativeProtocol } from "@roo-code/types"
+import { Package } from "../../shared/package"
 
 export const formatResponse = {
 	toolDenied: () => `The user denied this operation.`,
@@ -250,6 +251,6 @@ Always ensure you provide all required parameters for the tool you wish to use.`
  */
 function getToolInstructionsReminder(protocol?: ToolProtocol): string {
 	const effectiveProtocol =
-		protocol ?? vscode.workspace.getConfiguration("roo-cline").get<ToolProtocol>("toolProtocol", "xml")
+		protocol ?? vscode.workspace.getConfiguration(Package.name).get<ToolProtocol>("toolProtocol", "xml")
 	return isNativeProtocol(effectiveProtocol) ? toolUseInstructionsReminderNative : toolUseInstructionsReminder
 }

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -9,6 +9,7 @@ import OpenAI from "openai"
 import delay from "delay"
 import pWaitFor from "p-wait-for"
 import { serializeError } from "serialize-error"
+import { Package } from "../../shared/package"
 
 import {
 	type TaskLike,
@@ -2514,7 +2515,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					// we need to remove that message before retrying to avoid having two consecutive
 					// user messages (which would cause tool_result validation errors).
 					const toolProtocol = vscode.workspace
-						.getConfiguration("roo-cline")
+						.getConfiguration(Package.name)
 						.get<ToolProtocol>("toolProtocol", "xml")
 					const isNativeProtocol = toolProtocol === TOOL_PROTOCOL.NATIVE
 
@@ -2695,12 +2696,13 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				{
 					maxConcurrentFileReads: maxConcurrentFileReads ?? 5,
 					todoListEnabled: apiConfiguration?.todoListEnabled ?? true,
-					useAgentRules: vscode.workspace.getConfiguration("roo-cline").get<boolean>("useAgentRules") ?? true,
+					useAgentRules:
+						vscode.workspace.getConfiguration(Package.name).get<boolean>("useAgentRules") ?? true,
 					newTaskRequireTodos: vscode.workspace
-						.getConfiguration("roo-cline")
+						.getConfiguration(Package.name)
 						.get<boolean>("newTaskRequireTodos", false),
 					toolProtocol: vscode.workspace
-						.getConfiguration("roo-cline")
+						.getConfiguration(Package.name)
 						.get<ToolProtocol>("toolProtocol", "xml"),
 				},
 				undefined, // todoList
@@ -2935,7 +2937,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		// Determine if we should include native tools based on:
 		// 1. Tool protocol is set to NATIVE
 		// 2. Model supports native tools
-		const toolProtocol = vscode.workspace.getConfiguration("roo-cline").get<ToolProtocol>("toolProtocol", "xml")
+		const toolProtocol = vscode.workspace.getConfiguration(Package.name).get<ToolProtocol>("toolProtocol", "xml")
 		const modelInfo = this.api.getModel().info
 		const shouldIncludeTools = toolProtocol === TOOL_PROTOCOL.NATIVE && (modelInfo.supportsNativeTools ?? false)
 

--- a/src/core/tools/MultiApplyDiffTool.ts
+++ b/src/core/tools/MultiApplyDiffTool.ts
@@ -18,6 +18,7 @@ import { applyDiffTool as applyDiffToolClass } from "./ApplyDiffTool"
 import { computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import * as vscode from "vscode"
 import { ToolProtocol, isNativeProtocol } from "@roo-code/types"
+import { Package } from "../../shared/package"
 
 interface DiffOperation {
 	path: string
@@ -62,7 +63,7 @@ export async function applyDiffTool(
 	removeClosingTag: RemoveClosingTag,
 ) {
 	// Check if native protocol is enabled - if so, always use single-file class-based tool
-	const toolProtocol = vscode.workspace.getConfiguration("roo-cline").get<ToolProtocol>("toolProtocol", "xml")
+	const toolProtocol = vscode.workspace.getConfiguration(Package.name).get<ToolProtocol>("toolProtocol", "xml")
 	if (isNativeProtocol(toolProtocol)) {
 		return applyDiffToolClass.handle(cline, block as ToolUse<"apply_diff">, {
 			askApproval,

--- a/src/core/webview/generateSystemPrompt.ts
+++ b/src/core/webview/generateSystemPrompt.ts
@@ -8,6 +8,7 @@ import { SYSTEM_PROMPT } from "../prompts/system"
 import { MultiSearchReplaceDiffStrategy } from "../diff/strategies/multi-search-replace"
 import { MultiFileSearchReplaceDiffStrategy } from "../diff/strategies/multi-file-search-replace"
 import { ToolProtocol } from "@roo-code/types"
+import { Package } from "../../shared/package"
 
 import { ClineProvider } from "./ClineProvider"
 
@@ -88,11 +89,11 @@ export const generateSystemPrompt = async (provider: ClineProvider, message: Web
 		{
 			maxConcurrentFileReads: maxConcurrentFileReads ?? 5,
 			todoListEnabled: apiConfiguration?.todoListEnabled ?? true,
-			useAgentRules: vscode.workspace.getConfiguration("roo-cline").get<boolean>("useAgentRules") ?? true,
+			useAgentRules: vscode.workspace.getConfiguration(Package.name).get<boolean>("useAgentRules") ?? true,
 			newTaskRequireTodos: vscode.workspace
-				.getConfiguration("roo-cline")
+				.getConfiguration(Package.name)
 				.get<boolean>("newTaskRequireTodos", false),
-			toolProtocol: vscode.workspace.getConfiguration("roo-cline").get<ToolProtocol>("toolProtocol", "xml"),
+			toolProtocol: vscode.workspace.getConfiguration(Package.name).get<ToolProtocol>("toolProtocol", "xml"),
 		},
 	)
 

--- a/src/services/search/__tests__/file-search.spec.ts
+++ b/src/services/search/__tests__/file-search.spec.ts
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi } from "vitest"
 import * as vscode from "vscode"
 
+// Mock Package
+vi.mock("../../../shared/package", () => ({
+	Package: {
+		name: "roo-cline",
+		publisher: "RooVeterinaryInc",
+		version: "1.0.0",
+		outputChannel: "Roo-Code",
+	},
+}))
+
 // Mock vscode
 vi.mock("vscode", () => ({
 	workspace: {
@@ -50,6 +60,7 @@ describe("file-search", () => {
 		})
 
 		it("should read maximumIndexedFilesForFileSearch configuration", async () => {
+			const { Package } = await import("../../../shared/package")
 			const mockRooConfig = {
 				get: vi.fn((key: string, defaultValue: number) => {
 					if (key === "maximumIndexedFilesForFileSearch") return 50000
@@ -58,28 +69,29 @@ describe("file-search", () => {
 			}
 
 			;(vscode.workspace.getConfiguration as any).mockImplementation((section: string) => {
-				if (section === "roo-cline") return mockRooConfig
+				if (section === Package.name) return mockRooConfig
 				return { get: vi.fn() }
 			})
 
 			// The configuration should be readable
-			const config = vscode.workspace.getConfiguration("roo-cline")
+			const config = vscode.workspace.getConfiguration(Package.name)
 			const limit = config.get("maximumIndexedFilesForFileSearch", 10000)
 
 			expect(limit).toBe(50000)
 		})
 
-		it("should use default limit when configuration is not provided", () => {
+		it("should use default limit when configuration is not provided", async () => {
+			const { Package } = await import("../../../shared/package")
 			const mockRooConfig = {
 				get: vi.fn((key: string, defaultValue: number) => defaultValue),
 			}
 
 			;(vscode.workspace.getConfiguration as any).mockImplementation((section: string) => {
-				if (section === "roo-cline") return mockRooConfig
+				if (section === Package.name) return mockRooConfig
 				return { get: vi.fn() }
 			})
 
-			const config = vscode.workspace.getConfiguration("roo-cline")
+			const config = vscode.workspace.getConfiguration(Package.name)
 			const limit = config.get("maximumIndexedFilesForFileSearch", 10000)
 
 			expect(limit).toBe(10000)

--- a/src/services/search/file-search.ts
+++ b/src/services/search/file-search.ts
@@ -5,6 +5,7 @@ import * as childProcess from "child_process"
 import * as readline from "readline"
 import { byLengthAsc, Fzf } from "fzf"
 import { getBinPath } from "../ripgrep"
+import { Package } from "../../shared/package"
 
 export type FileResult = { path: string; type: "file" | "folder"; label?: string }
 
@@ -116,7 +117,7 @@ export async function executeRipgrepForFiles(
 ): Promise<{ path: string; type: "file" | "folder"; label?: string }[]> {
 	// Get limit from configuration if not provided
 	const effectiveLimit =
-		limit ?? vscode.workspace.getConfiguration("roo-cline").get<number>("maximumIndexedFilesForFileSearch", 10000)
+		limit ?? vscode.workspace.getConfiguration(Package.name).get<number>("maximumIndexedFilesForFileSearch", 10000)
 
 	const args = [
 		"--files",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replace hardcoded configuration string with `Package.name` for consistency across the codebase.
> 
>   - **Configuration**:
>     - Replace hardcoded configuration string `"roo-cline"` with `Package.name` in `getConfiguration()` calls in `timeout-config.ts`, `presentAssistantMessage.ts`, `responses.ts`, `Task.ts`, `MultiApplyDiffTool.ts`, `generateSystemPrompt.ts`, and `file-search.ts`.
>   - **Testing**:
>     - Update `file-search.spec.ts` to mock `Package.name` for configuration tests.
>   - **Misc**:
>     - Import `Package` from `shared/package` in affected files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a5bb123693b25c24e7e8ec1a74df93ee3aa11663. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->