### PR TITLE
Fix broken share button

### DIFF
--- a/webview-ui/src/components/chat/LucideIconButton.tsx
+++ b/webview-ui/src/components/chat/LucideIconButton.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { cn } from "@src/lib/utils"
 import { Button, StandardTooltip } from "@src/components/ui"
 import { Loader2, LucideIcon } from "lucide-react"
@@ -11,40 +12,35 @@ interface LucideIconButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEle
 	style?: React.CSSProperties
 }
 
-export const LucideIconButton: React.FC<LucideIconButtonProps> = ({
-	icon,
-	title,
-	className,
-	disabled,
-	tooltip = true,
-	isLoading,
-	onClick,
-	style,
-	...props
-}) => {
-	const Icon = icon
-	return (
-		<StandardTooltip content={tooltip ? title : undefined}>
-			<Button
-				aria-label={title}
-				className={cn(
-					"relative inline-flex items-center justify-center",
-					"bg-transparent border-none p-1.5",
-					"rounded-full",
-					"text-vscode-foreground opacity-85",
-					"transition-all duration-150",
-					"focus:outline-none focus-visible:ring-1 focus-visible:ring-vscode-focusBorder",
-					"active:bg-[rgba(255,255,255,0.1)]",
-					!disabled && "cursor-pointer hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)]",
-					disabled && "cursor-not-allowed opacity-40 hover:bg-transparent active:bg-transparent",
-					className,
-				)}
-				disabled={disabled}
-				onClick={!disabled ? onClick : undefined}
-				style={{ fontSize: 16.5, ...style }}
-				{...props}>
-				{isLoading ? <Loader2 className="size-2.5 animate-spin" /> : <Icon className="size-2.5" />}
-			</Button>
-		</StandardTooltip>
-	)
-}
+export const LucideIconButton = forwardRef<HTMLButtonElement, LucideIconButtonProps>(
+	({ icon, title, className, disabled, tooltip = true, isLoading, onClick, style, ...props }, ref) => {
+		const Icon = icon
+		return (
+			<StandardTooltip content={tooltip ? title : undefined}>
+				<Button
+					ref={ref}
+					aria-label={title}
+					className={cn(
+						"relative inline-flex items-center justify-center",
+						"bg-transparent border-none p-1.5",
+						"rounded-full",
+						"text-vscode-foreground opacity-85",
+						"transition-all duration-150",
+						"focus:outline-none focus-visible:ring-1 focus-visible:ring-vscode-focusBorder",
+						"active:bg-[rgba(255,255,255,0.1)]",
+						!disabled && "cursor-pointer hover:opacity-100 hover:bg-[rgba(255,255,255,0.03)]",
+						disabled && "cursor-not-allowed opacity-40 hover:bg-transparent active:bg-transparent",
+						className,
+					)}
+					disabled={disabled}
+					onClick={!disabled ? onClick : undefined}
+					style={{ fontSize: 16.5, ...style }}
+					{...props}>
+					{isLoading ? <Loader2 className="size-2.5 animate-spin" /> : <Icon className="size-2.5" />}
+				</Button>
+			</StandardTooltip>
+		)
+	},
+)
+
+LucideIconButton.displayName = "LucideIconButton"


### PR DESCRIPTION
This PR wires up the Share button popover by converting LucideIconButton to forwardRef so Radix PopoverTrigger(asChild) gets a proper ref. This fixes the issue where the share popover did not open and no messages were sent.

Implementation:
- Update [webview-ui/src/components/chat/LucideIconButton.tsx](webview-ui/src/components/chat/LucideIconButton.tsx) to use React.forwardRef and pass ref to underlying Button.
- Share UI and extension wiring already existed ([src/core/webview/webviewMessageHandler.ts](src/core/webview/webviewMessageHandler.ts:670)); now the trigger works.

Tests:
- Ran webview-ui ShareButton and TaskActions test suites (Vitest): all passing.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Convert `LucideIconButton` to use `forwardRef`, fixing share popover trigger issue.
> 
>   - **Behavior**:
>     - Convert `LucideIconButton` to use `forwardRef` in `LucideIconButton.tsx`, fixing share popover trigger issue.
>     - Ensures `Radix PopoverTrigger(asChild)` receives a proper ref.
>   - **Tests**:
>     - Ran `ShareButton` and `TaskActions` test suites with Vitest: all tests passing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fa28b8661cd2ff0fd799c594b627c7f0ca1dd57f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->