### PR TITLE
fix: make line_ranges optional in read_file tool schema

### DIFF
--- a/src/core/prompts/tools/native-tools/read_file.ts
+++ b/src/core/prompts/tools/native-tools/read_file.ts
@@ -30,7 +30,7 @@ export const read_file = {
 								},
 							},
 						},
-						required: ["path", "line_ranges"],
+						required: ["path"],
 						additionalProperties: false,
 					},
 					minItems: 1,


### PR DESCRIPTION
## Problem

The OpenAI tool schema required both `path` and `line_ranges` in FileEntry, but the TypeScript type definition marks `lineRanges` as optional. This caused the AI to fail when trying to read files without specifying line_ranges.

## Root Cause

**TypeScript Type** (`packages/types/src/tool-params.ts`):
```typescript
export interface FileEntry {
    path: string
    lineRanges?: LineRange[]  // Optional
}
```

**OpenAI Tool Schema** (before fix):
```typescript
required: ["path", "line_ranges"]  // Both required!
```

With OpenAI's `strict: true` mode, the AI was forced to always provide `line_ranges` even though the implementation treats it as optional throughout.

## Solution

Updated `src/core/prompts/tools/native-tools/read_file.ts`:
```typescript
required: ["path"]  // Only path is required now
```

This aligns the OpenAI tool schema with:
- The TypeScript type definition (optional `lineRanges?`)
- The implementation behavior (treats as optional, initializes to `[]`)
- The parser behavior (doesn't enforce structure)

## Testing

The tool now works correctly - the AI can call `read_file` without providing `line_ranges`, and when provided, they can be `null` or an array of range strings.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `line_ranges` optional in `read_file.ts` schema to align with TypeScript definition and implementation.
> 
>   - **Schema Update**:
>     - In `read_file.ts`, `line_ranges` is no longer required in the OpenAI tool schema, aligning with TypeScript's optional `lineRanges`.
>   - **Behavior**:
>     - AI can call `read_file` without `line_ranges`. When provided, `line_ranges` can be `null` or an array.
>   - **Testing**:
>     - Ensures AI functionality without `line_ranges` and handles `null` or array inputs correctly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 830b6faddbed1204fc29a1516b2e09a575a6f49f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->