### PR TITLE
Safe navigation access for simple thinking options

### DIFF
--- a/webview-ui/src/components/settings/SimpleThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/SimpleThinkingBudget.tsx
@@ -81,7 +81,7 @@ export const SimpleThinkingBudget = ({
 	}
 	// If persisted value isn't supported by capability (e.g., "minimal" while supports=true), don't show it
 	const normalizedCurrent: ReasoningSelectValue | undefined =
-		current && (availableOptions as readonly any[]).includes(current) ? current : undefined
+		current && (availableOptions as readonly any[])?.includes(current) ? current : undefined
 
 	// Default when required: set to model default on mount (no synthetic "None")
 	useEffect(() => {
@@ -109,9 +109,9 @@ export const SimpleThinkingBudget = ({
 			<Select
 				value={normalizedCurrent}
 				onValueChange={(value: ReasoningSelectValue) => {
-				if (value === "disable") {
-					setApiConfigurationField("enableReasoningEffort", false, true)
-					setApiConfigurationField("reasoningEffort", "disable" as any, true)
+					if (value === "disable") {
+						setApiConfigurationField("enableReasoningEffort", false, true)
+						setApiConfigurationField("reasoningEffort", "disable" as any, true)
 					} else {
 						setApiConfigurationField("enableReasoningEffort", true, true)
 						setApiConfigurationField("reasoningEffort", value as any, true)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add safe navigation for `availableOptions` in `SimpleThinkingBudget.tsx` to prevent runtime errors.
> 
>   - **Behavior**:
>     - Use optional chaining for `availableOptions` in `SimpleThinkingBudget.tsx` to safely check if `current` is included.
>   - **Misc**:
>     - Minor formatting changes in `SimpleThinkingBudget.tsx` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c8ce6ccbab04f3d43644b6927b959ffacc77bca4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->