### PR TITLE
Revert "refactor(task): switch to <feedback> wrapper to prevent focus drift after context-management event (condense/truncate)"

### DIFF
--- a/src/core/mentions/__tests__/processUserContentMentions.spec.ts
+++ b/src/core/mentions/__tests__/processUserContentMentions.spec.ts
@@ -31,7 +31,7 @@ describe("processUserContentMentions", () => {
 			const userContent = [
 				{
 					type: "text" as const,
-					text: "<feedback>Read file with limit</feedback>",
+					text: "<task>Read file with limit</task>",
 				},
 			]
 
@@ -45,7 +45,7 @@ describe("processUserContentMentions", () => {
 			})
 
 			expect(parseMentions).toHaveBeenCalledWith(
-				"<feedback>Read file with limit</feedback>",
+				"<task>Read file with limit</task>",
 				"/test",
 				mockUrlContentFetcher,
 				mockFileContextTracker,
@@ -61,7 +61,7 @@ describe("processUserContentMentions", () => {
 			const userContent = [
 				{
 					type: "text" as const,
-					text: "<feedback>Read file without limit</feedback>",
+					text: "<task>Read file without limit</task>",
 				},
 			]
 
@@ -74,7 +74,7 @@ describe("processUserContentMentions", () => {
 			})
 
 			expect(parseMentions).toHaveBeenCalledWith(
-				"<feedback>Read file without limit</feedback>",
+				"<task>Read file without limit</task>",
 				"/test",
 				mockUrlContentFetcher,
 				mockFileContextTracker,
@@ -90,7 +90,7 @@ describe("processUserContentMentions", () => {
 			const userContent = [
 				{
 					type: "text" as const,
-					text: "<feedback>Read unlimited lines</feedback>",
+					text: "<task>Read unlimited lines</task>",
 				},
 			]
 
@@ -104,7 +104,7 @@ describe("processUserContentMentions", () => {
 			})
 
 			expect(parseMentions).toHaveBeenCalledWith(
-				"<feedback>Read unlimited lines</feedback>",
+				"<task>Read unlimited lines</task>",
 				"/test",
 				mockUrlContentFetcher,
 				mockFileContextTracker,
@@ -118,11 +118,11 @@ describe("processUserContentMentions", () => {
 	})
 
 	describe("content processing", () => {
-		it("should process text blocks with <feedback> tags", async () => {
+		it("should process text blocks with <task> tags", async () => {
 			const userContent = [
 				{
 					type: "text" as const,
-					text: "<feedback>Do something</feedback>",
+					text: "<task>Do something</task>",
 				},
 			]
 
@@ -136,7 +136,7 @@ describe("processUserContentMentions", () => {
 			expect(parseMentions).toHaveBeenCalled()
 			expect(result[0]).toEqual({
 				type: "text",
-				text: "parsed: <feedback>Do something</feedback>",
+				text: "parsed: <task>Do something</task>",
 			})
 		})
 
@@ -213,7 +213,7 @@ describe("processUserContentMentions", () => {
 					content: [
 						{
 							type: "text" as const,
-							text: "<feedback>Array task</feedback>",
+							text: "<task>Array task</task>",
 						},
 						{
 							type: "text" as const,
@@ -237,7 +237,7 @@ describe("processUserContentMentions", () => {
 				content: [
 					{
 						type: "text",
-						text: "parsed: <feedback>Array task</feedback>",
+						text: "parsed: <task>Array task</task>",
 					},
 					{
 						type: "text",
@@ -251,7 +251,7 @@ describe("processUserContentMentions", () => {
 			const userContent = [
 				{
 					type: "text" as const,
-					text: "<feedback>First task</feedback>",
+					text: "<task>First task</task>",
 				},
 				{
 					type: "image" as const,
@@ -280,7 +280,7 @@ describe("processUserContentMentions", () => {
 			expect(result).toHaveLength(3)
 			expect(result[0]).toEqual({
 				type: "text",
-				text: "parsed: <feedback>First task</feedback>",
+				text: "parsed: <task>First task</task>",
 			})
 			expect(result[1]).toEqual(userContent[1]) // Image block unchanged
 			expect(result[2]).toEqual({
@@ -296,7 +296,7 @@ describe("processUserContentMentions", () => {
 			const userContent = [
 				{
 					type: "text" as const,
-					text: "<feedback>Test default</feedback>",
+					text: "<task>Test default</task>",
 				},
 			]
 
@@ -308,7 +308,7 @@ describe("processUserContentMentions", () => {
 			})
 
 			expect(parseMentions).toHaveBeenCalledWith(
-				"<feedback>Test default</feedback>",
+				"<task>Test default</task>",
 				"/test",
 				mockUrlContentFetcher,
 				mockFileContextTracker,
@@ -324,7 +324,7 @@ describe("processUserContentMentions", () => {
 			const userContent = [
 				{
 					type: "text" as const,
-					text: "<feedback>Test explicit false</feedback>",
+					text: "<task>Test explicit false</task>",
 				},
 			]
 
@@ -337,7 +337,7 @@ describe("processUserContentMentions", () => {
 			})
 
 			expect(parseMentions).toHaveBeenCalledWith(
-				"<feedback>Test explicit false</feedback>",
+				"<task>Test explicit false</task>",
 				"/test",
 				mockUrlContentFetcher,
 				mockFileContextTracker,

--- a/src/core/mentions/processUserContentMentions.ts
+++ b/src/core/mentions/processUserContentMentions.ts
@@ -30,7 +30,7 @@ export async function processUserContentMentions({
 	// Process userContent array, which contains various block types:
 	// TextBlockParam, ImageBlockParam, ToolUseBlockParam, and ToolResultBlockParam.
 	// We need to apply parseMentions() to:
-	// 1. All TextBlockParam's text (first user message with feedback)
+	// 1. All TextBlockParam's text (first user message with task)
 	// 2. ToolResultBlockParam's content/context text arrays if it contains
 	// "<feedback>" (see formatToolDeniedFeedback, attemptCompletion,
 	// executeCommand, and consecutiveMistakeCount >= 3) or "<answer>"
@@ -40,7 +40,10 @@ export async function processUserContentMentions({
 	return Promise.all(
 		userContent.map(async (block) => {
 			const shouldProcessMentions = (text: string) =>
-				text.includes("<feedback>") || text.includes("<answer>") || text.includes("<user_message>")
+				text.includes("<task>") ||
+				text.includes("<feedback>") ||
+				text.includes("<answer>") ||
+				text.includes("<user_message>")
 
 			if (block.type === "text") {
 				if (shouldProcessMentions(block.text)) {

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1285,7 +1285,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		await this.initiateTaskLoop([
 			{
 				type: "text",
-				text: `<feedback>\n${task}\n</feedback>`,
+				text: `<task>\n${task}\n</task>`,
 			},
 			...imageBlocks,
 		])

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -895,7 +895,7 @@ describe("Cline", () => {
 						} as const,
 						{
 							type: "text",
-							text: "<feedback>Text with 'some/path' (see below for file content) in task tags</feedback>",
+							text: "<task>Text with 'some/path' (see below for file content) in task tags</task>",
 						} as const,
 						{
 							type: "tool_result",
@@ -934,7 +934,7 @@ describe("Cline", () => {
 					// Text within task tags should be processed
 					expect((processedContent[1] as Anthropic.TextBlockParam).text).toContain("processed:")
 					expect((processedContent[1] as Anthropic.TextBlockParam).text).toContain(
-						"<feedback>Text with 'some/path' (see below for file content) in task tags</feedback>",
+						"<task>Text with 'some/path' (see below for file content) in task tags</task>",
 					)
 
 					// Feedback tag content should be processed


### PR DESCRIPTION
Reverts RooCodeInc/Roo-Code#9237

Seemed like GPT 5.1 at least was getting confused by this.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `<feedback>` tags back to `<task>` tags in user content processing and task initiation to resolve confusion.
> 
>   - **Behavior**:
>     - Reverts `<feedback>` tags back to `<task>` tags in `processUserContentMentions.spec.ts`, `processUserContentMentions.ts`, and `Task.ts`.
>     - Affects how user content is processed and tasks are initiated.
>   - **Tests**:
>     - Updates tests in `processUserContentMentions.spec.ts` and `Task.spec.ts` to reflect the reversion to `<task>` tags.
>   - **Functions**:
>     - `processUserContentMentions` function now processes `<task>` tags instead of `<feedback>` tags.
>     - `Task` class initiates tasks using `<task>` tags.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2f8aa6a23992a294636dca20bb76cd7da72c453d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->