### PR TITLE
fix: format tool responses for native protocol

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -10,7 +10,8 @@ import delay from "delay"
 import pWaitFor from "p-wait-for"
 import { serializeError } from "serialize-error"
 import { Package } from "../../shared/package"
-import { getCurrentToolProtocol, formatToolInvocation, isNativeProtocol } from "../tools/helpers/toolResultFormatting"
+import { isNativeProtocol } from "@roo-code/types"
+import { getCurrentToolProtocol, formatToolInvocation } from "../tools/helpers/toolResultFormatting"
 
 import {
 	type TaskLike,

--- a/src/core/tools/ReadFileTool.ts
+++ b/src/core/tools/ReadFileTool.ts
@@ -1,6 +1,7 @@
 import path from "path"
 import { isBinaryFile } from "isbinaryfile"
 import type { FileEntry, LineRange } from "@roo-code/types"
+import { isNativeProtocol } from "@roo-code/types"
 
 import { Task } from "../task/Task"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
@@ -14,7 +15,7 @@ import { readLines } from "../../integrations/misc/read-lines"
 import { extractTextFromFile, addLineNumbers, getSupportedBinaryFormats } from "../../integrations/misc/extract-text"
 import { parseSourceCodeDefinitionsForFile } from "../../services/tree-sitter"
 import { parseXml } from "../../utils/xml"
-import { getCurrentToolProtocol, isNativeProtocol } from "./helpers/toolResultFormatting"
+import { getCurrentToolProtocol } from "./helpers/toolResultFormatting"
 import {
 	DEFAULT_MAX_IMAGE_FILE_SIZE_MB,
 	DEFAULT_MAX_TOTAL_IMAGE_SIZE_MB,

--- a/src/core/tools/helpers/__tests__/toolResultFormatting.spec.ts
+++ b/src/core/tools/helpers/__tests__/toolResultFormatting.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import * as vscode from "vscode"
-import { formatToolInvocation, isNativeProtocol, getCurrentToolProtocol } from "../toolResultFormatting"
-import { TOOL_PROTOCOL } from "@roo-code/types"
+import { TOOL_PROTOCOL, isNativeProtocol } from "@roo-code/types"
+import { formatToolInvocation, getCurrentToolProtocol } from "../toolResultFormatting"
 
 vi.mock("vscode", () => ({
 	workspace: {
@@ -36,18 +36,11 @@ describe("toolResultFormatting", () => {
 	})
 
 	describe("isNativeProtocol", () => {
-		it("should return true for native protocol from config", () => {
-			mockGetConfiguration.mockReturnValue(TOOL_PROTOCOL.NATIVE)
-			expect(isNativeProtocol()).toBe(true)
-		})
-
-		it("should return false for XML protocol from config", () => {
-			mockGetConfiguration.mockReturnValue("xml")
-			expect(isNativeProtocol()).toBe(false)
-		})
-
-		it("should accept protocol parameter", () => {
+		it("should return true for native protocol", () => {
 			expect(isNativeProtocol(TOOL_PROTOCOL.NATIVE)).toBe(true)
+		})
+
+		it("should return false for XML protocol", () => {
 			expect(isNativeProtocol("xml")).toBe(false)
 		})
 	})

--- a/src/core/tools/helpers/toolResultFormatting.ts
+++ b/src/core/tools/helpers/toolResultFormatting.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode"
 import { Package } from "../../../shared/package"
-import { TOOL_PROTOCOL, ToolProtocol } from "@roo-code/types"
+import { TOOL_PROTOCOL, ToolProtocol, isNativeProtocol } from "@roo-code/types"
 
 /**
  * Gets the current tool protocol from workspace configuration.
@@ -10,19 +10,12 @@ export function getCurrentToolProtocol(): ToolProtocol {
 }
 
 /**
- * Checks if the current protocol is native.
- */
-export function isNativeProtocol(protocol?: ToolProtocol): boolean {
-	const effectiveProtocol = protocol ?? getCurrentToolProtocol()
-	return effectiveProtocol === TOOL_PROTOCOL.NATIVE
-}
-
-/**
  * Formats tool invocation parameters for display based on protocol.
  * Used for legacy conversation history conversion.
  */
 export function formatToolInvocation(toolName: string, params: Record<string, any>, protocol?: ToolProtocol): string {
-	if (isNativeProtocol(protocol)) {
+	const effectiveProtocol = protocol ?? getCurrentToolProtocol()
+	if (isNativeProtocol(effectiveProtocol)) {
 		// Native protocol: readable format
 		const paramsList = Object.entries(params)
 			.map(([key, value]) => `${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`)


### PR DESCRIPTION
Fixes XML confusion when toolProtocol is set to native by making ReadFileTool format its own results.

## Changes
- Added toolResultFormatting utilities for protocol detection
- ReadFileTool builds both XML and native formats, selects based on protocol
- Native format returns clean text without XML tags
- Legacy conversation history conversion is protocol-aware

## Testing
✅ 55 tests passing (11 formatting + 44 ReadFileTool)
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> `ReadFileTool` now supports both XML and native protocols, with utilities for protocol detection and formatting, and includes tests for these changes.
> 
>   - **Behavior**:
>     - `ReadFileTool` now formats results in both XML and native formats, selecting based on current protocol.
>     - Native format outputs plain text without XML tags.
>     - Legacy conversation history conversion is now protocol-aware in `Task.ts`.
>   - **Utilities**:
>     - Adds `getCurrentToolProtocol()` and `formatToolInvocation()` in `toolResultFormatting.ts` for protocol detection and formatting.
>   - **Testing**:
>     - New tests in `toolResultFormatting.spec.ts` for protocol utilities.
>     - 55 tests passing (11 formatting + 44 ReadFileTool).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for af90a8cea5135efa752f43cda13800257b244ed6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->