### PR TITLE
fix: prevent duplicate tool_result blocks in native protocol mode for read_file

### DIFF
--- a/src/core/tools/ReadFileTool.ts
+++ b/src/core/tools/ReadFileTool.ts
@@ -147,7 +147,7 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 								error: errorMsg,
 								xmlContent: `<file><path>${relPath}</path><error>Error reading file: ${errorMsg}</error></file>`,
 							})
-							await handleError(`reading file ${relPath}`, new Error(errorMsg))
+							await task.say("error", `Error reading file ${relPath}: ${errorMsg}`)
 							hasRangeError = true
 							break
 						}
@@ -158,7 +158,7 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 								error: errorMsg,
 								xmlContent: `<file><path>${relPath}</path><error>Error reading file: ${errorMsg}</error></file>`,
 							})
-							await handleError(`reading file ${relPath}`, new Error(errorMsg))
+							await task.say("error", `Error reading file ${relPath}: ${errorMsg}`)
 							hasRangeError = true
 							break
 						}
@@ -363,10 +363,7 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 									error: `Error reading image file: ${errorMsg}`,
 									xmlContent: `<file><path>${relPath}</path><error>Error reading image file: ${errorMsg}</error></file>`,
 								})
-								await handleError(
-									`reading image file ${relPath}`,
-									error instanceof Error ? error : new Error(errorMsg),
-								)
+								await task.say("error", `Error reading image file ${relPath}: ${errorMsg}`)
 								continue
 							}
 						}
@@ -498,7 +495,7 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 						error: `Error reading file: ${errorMsg}`,
 						xmlContent: `<file><path>${relPath}</path><error>Error reading file: ${errorMsg}</error></file>`,
 					})
-					await handleError(`reading file ${relPath}`, error instanceof Error ? error : new Error(errorMsg))
+					await task.say("error", `Error reading file ${relPath}: ${errorMsg}`)
 				}
 			}
 
@@ -570,7 +567,7 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 				})
 			}
 
-			await handleError(`reading file ${relPath}`, error instanceof Error ? error : new Error(errorMsg))
+			await task.say("error", `Error reading file ${relPath}: ${errorMsg}`)
 
 			const xmlResults = fileResults.filter((result) => result.xmlContent).map((result) => result.xmlContent)
 

--- a/src/core/tools/__tests__/readFileTool.spec.ts
+++ b/src/core/tools/__tests__/readFileTool.spec.ts
@@ -1602,10 +1602,7 @@ describe("read_file tool with image support", () => {
 			// Setup - simulate read error
 			mockedFsReadFile.mockRejectedValue(new Error("Failed to read image"))
 
-			// Create a spy for handleError
-			const handleErrorSpy = vi.fn()
-
-			// Execute with the spy
+			// Execute
 			const argsContent = `<file><path>${testImagePath}</path></file>`
 			const toolUse: ReadFileToolUse = {
 				type: "tool_use",
@@ -1616,7 +1613,7 @@ describe("read_file tool with image support", () => {
 
 			await readFileTool.handle(localMockCline, toolUse, {
 				askApproval: localMockCline.ask,
-				handleError: handleErrorSpy, // Use our spy here
+				handleError: vi.fn(),
 				pushToolResult: (result: ToolResponse) => {
 					toolResult = result
 				},
@@ -1625,7 +1622,8 @@ describe("read_file tool with image support", () => {
 
 			// Verify error handling
 			expect(toolResult).toContain("<error>Error reading image file: Failed to read image</error>")
-			expect(handleErrorSpy).toHaveBeenCalled()
+			// Verify that say was called to show error to user
+			expect(localMockCline.say).toHaveBeenCalledWith("error", expect.stringContaining("Failed to read image"))
 		})
 	})
 


### PR DESCRIPTION
## Problem

When using native tool protocol, if `read_file` encountered an error (e.g., file not found), it would create **two tool_result blocks with the same tool_call_id**:

1. `handleError()` internally calls `pushToolResult()` → tool_result \#1
2. Code continues to final `pushToolResult()` with XML → tool_result \#2

This violates the native protocol requirement of exactly one tool_result per tool_use_id, causing 400 errors on subsequent API calls.

## Solution

Replace `handleError()` with `task.say("error", ...)` in error paths within ReadFileTool.

**Agent still receives error details** through the XML in the single final `pushToolResult()` call:
```xml
<file><path>nonexistent.txt</path><error>Error reading file: ENOENT</error></file>
```

## Why This Doesn't Break Anything

### Native Protocol
- ✅ Only ONE `pushToolResult()` call = only ONE tool_result per tool_call_id
- ✅ Agent receives error via XML: `<error>Error reading file: ...</error>`
- ✅ User sees error via `task.say()`

### XML Protocol  
- ✅ Only ONE text block with complete XML (cleaner than before with separate error blocks)
- ✅ Agent receives error via XML (same as native)
- ✅ User sees error via `task.say()` (same as before)

**Both protocols**: Agent error visibility is preserved through XML in the tool result.

## Testing
- ✅ All 44 tests passing in readFileTool.spec.ts
- ✅ All pre-push tests passing (315 test files, 4069 tests)
- ✅ Updated test to verify `say()` is called with error messages