### PR TITLE
feat(openai-native): add abort controller for request cancellation

### DIFF
--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -159,6 +159,9 @@ describe("OpenAiNativeHandler", () => {
 						},
 					],
 				}),
+				expect.objectContaining({
+					signal: expect.any(Object),
+				}),
 			)
 		})
 
@@ -1135,6 +1138,9 @@ describe("GPT-5 streaming event coverage (additional)", () => {
 					model: "codex-mini-latest",
 					stream: false,
 					store: false,
+				}),
+				expect.objectContaining({
+					signal: expect.any(Object),
 				}),
 			)
 		})


### PR DESCRIPTION
## Summary
Adds abort controller support to the OpenAI Native provider to enable proper stream cancellation when tasks are cancelled.

## Changes
- Add instance-level abort controller property for external cancellation
- Pass abort signal to SDK and fetch requests
- Check abort signal in streaming loops to stop yielding immediately
- Update tests to expect abort signal parameter

## Testing
- All tests pass (32/32 for openai-native.spec.ts)
- Follows same pattern as Bedrock provider but with instance-level controller for external cancellation support

Fixes issue where OpenAI Native provider continues yielding after task cancellation.