### PR TITLE
Fix the type of the list files recursive parameter

### DIFF
--- a/src/core/prompts/tools/native-tools/list_files.ts
+++ b/src/core/prompts/tools/native-tools/list_files.ts
@@ -15,7 +15,7 @@ export default {
 					description: "Directory path to inspect, relative to the workspace",
 				},
 				recursive: {
-					type: ["boolean"],
+					type: "boolean",
 					description: "Set true to list contents recursively; false to show only the top level",
 				},
 			},


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes the type of `recursive` parameter in `list_files.ts` from an array to a boolean.
> 
>   - **Type Correction**:
>     - Fixes the type of `recursive` parameter from `type: ["boolean"]` to `type: "boolean"` in `list_files.ts`.
>     - Ensures correct type usage for recursive file listing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 36b9ece59f783c7f31ccbad8e02166f13a16e9c8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->