### PR TITLE
Remove the Roo model defaults

### DIFF
--- a/packages/types/src/providers/roo.ts
+++ b/packages/types/src/providers/roo.ts
@@ -1,7 +1,6 @@
 import { z } from "zod"
 
 import type { ModelInfo } from "../model.js"
-import { TOOL_PROTOCOL } from "../tool.js"
 
 /**
  * Roo Code Cloud is a dynamic provider - models are loaded from the /v1/models API endpoint.
@@ -14,38 +13,6 @@ export const rooDefaultModelId = "xai/grok-code-fast-1"
  * All model data comes dynamically from the API.
  */
 export const rooModels = {} as const satisfies Record<string, ModelInfo>
-
-/**
- * Model-specific defaults for Roo provider models.
- * These defaults are merged with dynamically fetched model data.
- *
- * Use this to configure model-specific settings like defaultToolProtocol.
- *
- * Example usage:
- * ```typescript
- * export const rooModelDefaults: Record<string, Partial<ModelInfo>> = {
- *   "anthropic/claude-3-5-sonnet-20241022": {
- *     defaultToolProtocol: "xml",
- *   },
- *   "openai/gpt-4o": {
- *     defaultToolProtocol: "native",
- *   },
- *   "xai/grok-code-fast-1": {
- *     defaultToolProtocol: "native",
- *   },
- * }
- * ```
- */
-export const rooModelDefaults: Record<string, Partial<ModelInfo>> = {
-	// Add model-specific defaults below.
-	// You can configure defaultToolProtocol and other ModelInfo fields for specific model IDs.
-	"anthropic/claude-haiku-4.5": {
-		defaultToolProtocol: TOOL_PROTOCOL.NATIVE,
-	},
-	"minimax/minimax-m2:free": {
-		defaultToolProtocol: TOOL_PROTOCOL.NATIVE,
-	},
-}
 
 /**
  * Roo Code Cloud API response schemas

--- a/src/api/providers/fetchers/roo.ts
+++ b/src/api/providers/fetchers/roo.ts
@@ -1,4 +1,4 @@
-import { RooModelsResponseSchema, rooModelDefaults } from "@roo-code/types"
+import { RooModelsResponseSchema } from "@roo-code/types"
 
 import type { ModelRecord } from "../../../shared/api"
 import { parseApiPrice } from "../../../shared/cost"
@@ -119,10 +119,7 @@ export async function getRooModels(baseUrl: string, apiKey?: string): Promise<Mo
 					isFree: tags.includes("free"),
 				}
 
-				// Merge with model-specific defaults if they exist
-				// Defaults take precedence over dynamically fetched data for specified fields
-				const modelDefaults = rooModelDefaults[modelId]
-				models[modelId] = modelDefaults ? { ...baseModelInfo, ...modelDefaults } : baseModelInfo
+				models[modelId] = baseModelInfo
 			}
 
 			return models

--- a/src/api/providers/roo.ts
+++ b/src/api/providers/roo.ts
@@ -1,7 +1,7 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 
-import { rooDefaultModelId, rooModelDefaults, getApiProtocol } from "@roo-code/types"
+import { rooDefaultModelId, getApiProtocol } from "@roo-code/types"
 import { CloudService } from "@roo-code/cloud"
 
 import type { ApiHandlerOptions, ModelRecord } from "../../shared/api"
@@ -274,8 +274,7 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 		}
 
 		// Return the requested model ID even if not found, with fallback info.
-		// Check if there are model-specific defaults configured
-		const baseModelInfo = {
+		const fallbackInfo = {
 			maxTokens: 16_384,
 			contextWindow: 262_144,
 			supportsImages: false,
@@ -286,10 +285,6 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 			outputPrice: 0,
 			isFree: false,
 		}
-
-		// Merge with model-specific defaults if they exist
-		const modelDefaults = rooModelDefaults[modelId]
-		const fallbackInfo = modelDefaults ? { ...baseModelInfo, ...modelDefaults } : baseModelInfo
 
 		return {
 			id: modelId,


### PR DESCRIPTION
I think we can just load this from the API instead
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `rooModelDefaults`, relying solely on API data for Roo model configurations.
> 
>   - **Behavior**:
>     - Removes `rooModelDefaults` from `providers/roo.ts` and `fetchers/roo.ts`, which were used to set model-specific defaults.
>     - Models are now solely loaded from the `/v1/models` API endpoint without merging defaults.
>   - **Functions**:
>     - `getRooModels` in `fetchers/roo.ts` no longer merges model-specific defaults with fetched data.
>     - `RooHandler` in `providers/roo.ts` uses only API data for model information, removing fallback to defaults.
>   - **Misc**:
>     - Removes import of `TOOL_PROTOCOL` from `providers/roo.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cff76a713a998bb861416b9a1db9d3b34be4f657. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->