### PR TITLE
fix: pass tool protocol parameter to lineCountTruncationError

### DIFF
--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -18,6 +18,7 @@ import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { convertNewFileToUnifiedDiff, computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
 import type { ToolUse } from "../../shared/tools"
+import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 
 interface WriteToFileParams {
 	path: string
@@ -109,6 +110,8 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 				const actualLineCount = newContent.split("\n").length
 				const isNewFile = !fileExists
 				const diffStrategyEnabled = !!task.diffStrategy
+				const modelInfo = task.api.getModel().info
+				const toolProtocol = resolveToolProtocol(task.apiConfiguration, modelInfo)
 
 				await task.say(
 					"error",
@@ -119,7 +122,12 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 
 				pushToolResult(
 					formatResponse.toolError(
-						formatResponse.lineCountTruncationError(actualLineCount, isNewFile, diffStrategyEnabled),
+						formatResponse.lineCountTruncationError(
+							actualLineCount,
+							isNewFile,
+							diffStrategyEnabled,
+							toolProtocol,
+						),
 					),
 				)
 				await task.diffViewProvider.revertChanges()


### PR DESCRIPTION
Fixes a bug where the `lineCountTruncationError` message was always showing XML tool instructions even when native tool protocol was enabled.

## Problem

`WriteToFileTool.ts` was calling `formatResponse.lineCountTruncationError()` without passing the `protocol` parameter, causing it to default to XML protocol and display incorrect tool instructions.

## Solution

- Import `resolveToolProtocol` in `WriteToFileTool.ts`
- Resolve the current tool protocol before calling `lineCountTruncationError()`
- Pass the resolved protocol as the 4th parameter

## Testing

All existing tests pass. The function now correctly displays native tool instructions when using native protocol.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `WriteToFileTool.ts` by resolving and passing the tool protocol to `lineCountTruncationError()` to ensure correct tool instructions are displayed.
> 
>   - **Behavior**:
>     - Fixes bug in `WriteToFileTool.ts` where `lineCountTruncationError` defaulted to XML instructions.
>     - Resolves tool protocol using `resolveToolProtocol` and passes it to `lineCountTruncationError()`.
>   - **Testing**:
>     - All existing tests pass, confirming correct display of native tool instructions when using native protocol.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 79298160493155cec535feb558870d39fc8ffb38. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->