### PR TITLE
fix: exclude XML tool examples from MODES section when native protocol enabled

### DIFF
--- a/src/core/prompts/sections/modes.ts
+++ b/src/core/prompts/sections/modes.ts
@@ -5,7 +5,10 @@ import type { ModeConfig } from "@roo-code/types"
 import { getAllModesWithPrompts } from "../../../shared/modes"
 import { ensureSettingsDirectoryExists } from "../../../utils/globalContext"
 
-export async function getModesSection(context: vscode.ExtensionContext): Promise<string> {
+export async function getModesSection(
+	context: vscode.ExtensionContext,
+	skipXmlExamples: boolean = false,
+): Promise<string> {
 	// Make sure path gets created
 	await ensureSettingsDirectoryExists(context)
 
@@ -31,12 +34,18 @@ ${allModes
 	})
 	.join("\n")}`
 
-	modesContent += `
+	if (!skipXmlExamples) {
+		modesContent += `
 If the user asks you to create or edit a new mode for this project, you should read the instructions by using the fetch_instructions tool, like this:
 <fetch_instructions>
 <task>create_mode</task>
 </fetch_instructions>
 `
+	} else {
+		modesContent += `
+If the user asks you to create or edit a new mode for this project, you should read the instructions by using the fetch_instructions tool.
+`
+	}
 
 	return modesContent
 }

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -86,7 +86,7 @@ async function generatePrompt(
 	const effectiveProtocol = getEffectiveProtocol(settings?.toolProtocol)
 
 	const [modesSection, mcpServersSection] = await Promise.all([
-		getModesSection(context),
+		getModesSection(context, isNativeProtocol(effectiveProtocol)),
 		shouldIncludeMcp
 			? getMcpServersSection(
 					mcpHub,


### PR DESCRIPTION
Excludes XML tool call examples from the MODES section when native tool protocol is enabled to avoid confusing the model with XML syntax when it should use native tool calling.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Excludes XML tool examples from MODES section when native protocol is enabled by checking tool call IDs.
> 
>   - **Behavior**:
>     - Excludes XML tool examples from MODES section when native protocol is enabled in `modes.ts`.
>     - Determines protocol by checking for tool call ID in `presentAssistantMessage.ts`.
>   - **Functions**:
>     - Updates `getModesSection()` in `modes.ts` to accept `skipXmlExamples` parameter.
>     - Modifies `generatePrompt()` in `system.ts` to pass `isNativeProtocol` to `getModesSection()`.
>   - **Misc**:
>     - Adjusts logic in `presentAssistantMessage()` in `presentAssistantMessage.ts` to use tool call ID for protocol determination.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b360ba2c496e89f7ef993b241b476192ebd720d7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->