### PR TITLE
fix: Exclude XML tool examples from MODES section when native protocol enabled

### DIFF
--- a/src/core/prompts/sections/modes.ts
+++ b/src/core/prompts/sections/modes.ts
@@ -5,7 +5,10 @@ import type { ModeConfig } from "@roo-code/types"
 import { getAllModesWithPrompts } from "../../../shared/modes"
 import { ensureSettingsDirectoryExists } from "../../../utils/globalContext"
 
-export async function getModesSection(context: vscode.ExtensionContext): Promise<string> {
+export async function getModesSection(
+	context: vscode.ExtensionContext,
+	skipXmlExamples: boolean = false,
+): Promise<string> {
 	// Make sure path gets created
 	await ensureSettingsDirectoryExists(context)
 
@@ -31,12 +34,18 @@ ${allModes
 	})
 	.join("\n")}`
 
-	modesContent += `
+	if (!skipXmlExamples) {
+		modesContent += `
 If the user asks you to create or edit a new mode for this project, you should read the instructions by using the fetch_instructions tool, like this:
 <fetch_instructions>
 <task>create_mode</task>
 </fetch_instructions>
 `
+	} else {
+		modesContent += `
+If the user asks you to create or edit a new mode for this project, you should read the instructions by using the fetch_instructions tool.
+`
+	}
 
 	return modesContent
 }

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -86,7 +86,7 @@ async function generatePrompt(
 	const effectiveProtocol = getEffectiveProtocol(settings?.toolProtocol)
 
 	const [modesSection, mcpServersSection] = await Promise.all([
-		getModesSection(context),
+		getModesSection(context, isNativeProtocol(effectiveProtocol)),
 		shouldIncludeMcp
 			? getMcpServersSection(
 					mcpHub,


### PR DESCRIPTION
This PR updates the MODES section in system prompts to exclude XML tool usage examples when the native tool calling protocol is enabled, preventing confusion and ensuring the model uses the correct protocol.