### PR TITLE
fix: cache tool protocol to prevent race conditions during profile changes

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -39,7 +39,6 @@ import { codebaseSearchTool } from "../tools/CodebaseSearchTool"
 import { experiments, EXPERIMENT_IDS } from "../../shared/experiments"
 import { applyDiffTool as applyDiffToolClass } from "../tools/ApplyDiffTool"
 import { isNativeProtocol } from "@roo-code/types"
-import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 
 /**
  * Processes and presents assistant message content to the user interface.

--- a/src/core/tools/MultiApplyDiffTool.ts
+++ b/src/core/tools/MultiApplyDiffTool.ts
@@ -17,7 +17,6 @@ import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { applyDiffTool as applyDiffToolClass } from "./ApplyDiffTool"
 import { computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import { isNativeProtocol } from "@roo-code/types"
-import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 
 interface DiffOperation {
 	path: string
@@ -62,14 +61,13 @@ export async function applyDiffTool(
 	removeClosingTag: RemoveClosingTag,
 ) {
 	// Check if native protocol is enabled - if so, always use single-file class-based tool
-	const toolProtocol = resolveToolProtocol(cline.apiConfiguration, cline.api.getModel().info)
-	if (isNativeProtocol(toolProtocol)) {
+	if (isNativeProtocol(cline.toolProtocol)) {
 		return applyDiffToolClass.handle(cline, block as ToolUse<"apply_diff">, {
 			askApproval,
 			handleError,
 			pushToolResult,
 			removeClosingTag,
-			toolProtocol,
+			toolProtocol: cline.toolProtocol,
 		})
 	}
 
@@ -89,7 +87,7 @@ export async function applyDiffTool(
 				handleError,
 				pushToolResult,
 				removeClosingTag,
-				toolProtocol,
+				toolProtocol: cline.toolProtocol,
 			})
 		}
 	}
@@ -737,10 +735,9 @@ ${errorDetails ? `\nTechnical details:\n${errorDetails}\n` : ""}
 		}
 
 		// Check protocol for notice formatting
-		const toolProtocol = resolveToolProtocol(cline.apiConfiguration, cline.api.getModel().info)
 		const singleBlockNotice =
 			totalSearchBlocks === 1
-				? isNativeProtocol(toolProtocol)
+				? isNativeProtocol(cline.toolProtocol)
 					? "\n" +
 						JSON.stringify({
 							notice: "Making multiple related changes in a single apply_diff is more efficient. If other changes are needed in this file, please include them as additional SEARCH/REPLACE blocks.",

--- a/src/core/tools/ReadFileTool.ts
+++ b/src/core/tools/ReadFileTool.ts
@@ -15,7 +15,6 @@ import { readLines } from "../../integrations/misc/read-lines"
 import { extractTextFromFile, addLineNumbers, getSupportedBinaryFormats } from "../../integrations/misc/extract-text"
 import { parseSourceCodeDefinitionsForFile } from "../../services/tree-sitter"
 import { parseXml } from "../../utils/xml"
-import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 import {
 	DEFAULT_MAX_IMAGE_FILE_SIZE_MB,
 	DEFAULT_MAX_TOTAL_IMAGE_SIZE_MB,
@@ -109,8 +108,7 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 		const { handleError, pushToolResult, toolProtocol } = callbacks
 		const fileEntries = params.files
 		const modelInfo = task.api.getModel().info
-		const protocol = resolveToolProtocol(task.apiConfiguration, modelInfo)
-		const useNative = isNativeProtocol(protocol)
+		const useNative = isNativeProtocol(task.toolProtocol)
 
 		if (!fileEntries || fileEntries.length === 0) {
 			task.consecutiveMistakeCount++

--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -18,7 +18,6 @@ import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { convertNewFileToUnifiedDiff, computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import { BaseTool, ToolCallbacks } from "./BaseTool"
 import type { ToolUse } from "../../shared/tools"
-import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 
 interface WriteToFileParams {
 	path: string
@@ -110,8 +109,6 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 				const actualLineCount = newContent.split("\n").length
 				const isNewFile = !fileExists
 				const diffStrategyEnabled = !!task.diffStrategy
-				const modelInfo = task.api.getModel().info
-				const toolProtocol = resolveToolProtocol(task.apiConfiguration, modelInfo)
 
 				await task.say(
 					"error",
@@ -126,7 +123,7 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 							actualLineCount,
 							isNewFile,
 							diffStrategyEnabled,
-							toolProtocol,
+							task.toolProtocol,
 						),
 					),
 				)

--- a/src/core/tools/__tests__/applyDiffTool.experiment.spec.ts
+++ b/src/core/tools/__tests__/applyDiffTool.experiment.spec.ts
@@ -68,6 +68,10 @@ describe("applyDiffTool experiment routing", () => {
 				}),
 			},
 			processQueuedMessages: vi.fn(),
+			// Add toolProtocol getter that returns XML by default
+			get toolProtocol() {
+				return TOOL_PROTOCOL.XML
+			},
 		} as any
 
 		mockBlock = {
@@ -168,6 +172,12 @@ describe("applyDiffTool experiment routing", () => {
 				supportsNativeTools: true, // Model supports native tools
 				defaultToolProtocol: "native", // Model defaults to native protocol
 			},
+		})
+
+		// Update mockCline to return native protocol
+		Object.defineProperty(mockCline, "toolProtocol", {
+			get: () => TOOL_PROTOCOL.NATIVE,
+			configurable: true,
 		})
 
 		mockProvider.getState.mockResolvedValue({

--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -13,7 +13,6 @@ import { diagnosticsToProblemsString, getNewDiagnostics } from "../diagnostics"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { Task } from "../../core/task/Task"
 import { DEFAULT_WRITE_DELAY_MS, isNativeProtocol } from "@roo-code/types"
-import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 
 import { DecorationController } from "./DecorationController"
 
@@ -326,9 +325,8 @@ export class DiffViewProvider {
 			await task.say("user_feedback_diff", JSON.stringify(say))
 		}
 
-		// Check which protocol we're using
-		const toolProtocol = resolveToolProtocol(task.apiConfiguration, task.api.getModel().info)
-		const useNative = isNativeProtocol(toolProtocol)
+		// Check which protocol we're using (cached to avoid race conditions)
+		const useNative = isNativeProtocol(task.toolProtocol)
 
 		// Build notices array
 		const notices = [


### PR DESCRIPTION
## Problem

The XML parser was incorrectly activating when it shouldn't be due to race conditions in `resolveToolProtocol`. Multiple calls throughout the task lifecycle could return different values during profile transitions, causing the parser to be in an inconsistent state.

## Solution

Implemented protocol caching in the Task class:
- Cache is initialized in constructor
- Cache updates automatically via existing ProviderProfileChanged listener
- All direct `resolveToolProtocol()` calls replaced with cached `task.toolProtocol` getter

This ensures consistent protocol state throughout the task lifecycle and eliminates race conditions when switching profiles or models.

## Testing

- All existing tests pass
- Updated test mocks to include toolProtocol getter
- Verified protocol stays synchronized during profile changes