### PR TITLE
fix: defer XML parser initialization to avoid race condition with async model loading

### DIFF
--- a/packages/telemetry/src/TelemetryService.ts
+++ b/packages/telemetry/src/TelemetryService.ts
@@ -158,6 +158,26 @@ export class TelemetryService {
 	}
 
 	/**
+	 * Captures protocol mismatch when XML parser exists but native protocol is expected
+	 * @param taskId The task ID
+	 * @param properties Protocol mismatch diagnostic information (no sensitive data)
+	 */
+	public captureProtocolMismatch(
+		taskId: string,
+		properties: {
+			expectedProtocol: string
+			parserExists: boolean
+			supportsNativeTools?: boolean
+			defaultToolProtocol?: string
+			userToolProtocol?: string
+			apiProvider?: string
+			modelId: string
+		},
+	): void {
+		this.captureEvent(TelemetryEventName.PROTOCOL_MISMATCH, { taskId, ...properties })
+	}
+
+	/**
 	 * Captures when a tab is shown due to user action
 	 * @param tab The tab that was shown
 	 */

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -71,6 +71,7 @@ export enum TelemetryEventName {
 	SHELL_INTEGRATION_ERROR = "Shell Integration Error",
 	CONSECUTIVE_MISTAKE_ERROR = "Consecutive Mistake Error",
 	CODE_INDEX_ERROR = "Code Index Error",
+	PROTOCOL_MISMATCH = "Protocol Mismatch",
 	TELEMETRY_SETTINGS_CHANGED = "Telemetry Settings Changed",
 }
 
@@ -196,6 +197,7 @@ export const rooCodeTelemetryEventSchema = z.discriminatedUnion("type", [
 			TelemetryEventName.SHELL_INTEGRATION_ERROR,
 			TelemetryEventName.CONSECUTIVE_MISTAKE_ERROR,
 			TelemetryEventName.CODE_INDEX_ERROR,
+			TelemetryEventName.PROTOCOL_MISMATCH,
 			TelemetryEventName.CONTEXT_CONDENSED,
 			TelemetryEventName.SLIDING_WINDOW_TRUNCATION,
 			TelemetryEventName.TAB_SHOWN,


### PR DESCRIPTION
## Problem

Router providers (Unbound, OpenRouter) load model information asynchronously, but the Task constructor was calling `resolveToolProtocol()` immediately before model info finished loading. This caused the protocol to be determined with incomplete model info, leading to XML parser being active when native protocol should be used.

## Solution

Defer parser initialization until stream start, when model info is guaranteed to be fully loaded. Parser is now created/reset at the perfect moment - right before streaming begins with accurate model info.

## Changes

- Remove parser initialization from constructor
- Initialize/reset parser at stream start based on fully-loaded model info  
- Simplify `updateApiConfiguration` (no longer manages parser)
- Remove unnecessary `reset()` when discarding parser for native protocol

## Testing

All 4131 tests pass, including tool history and assistant message parsing tests.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Defer XML parser initialization in `Task` class to avoid race condition, ensuring correct protocol usage and adding telemetry for protocol mismatches.
> 
>   - **Behavior**:
>     - Defer XML parser initialization in `Task` class until stream start when model info is fully loaded.
>     - Remove parser initialization from `Task` constructor.
>     - Simplify `updateApiConfiguration()` in `Task` by removing parser management.
>     - Add telemetry logging for protocol mismatches in `TelemetryService`.
>   - **Telemetry**:
>     - Add `captureProtocolMismatch()` in `TelemetryService` to log protocol mismatch events.
>     - Add `PROTOCOL_MISMATCH` to `TelemetryEventName` in `telemetry.ts`.
>   - **Testing**:
>     - All 4131 tests pass, including tool history and assistant message parsing tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1df364706ab787f34cc88887d4d86df321e1978f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->