### PR TITLE
Fix Marketplace crash by removing wildcard activation event

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -46,7 +46,6 @@
 		"roocode"
 	],
 	"activationEvents": [
-		"onLanguage",
 		"onStartupFinished"
 	],
 	"main": "./dist/extension.js",


### PR DESCRIPTION
### Issue
Clicking on the extension in the VS Code Marketplace causes the window to freeze and crash with Exit Code 5.

### Cause
The `"onLanguage"` wildcard activation event triggers when the Marketplace renders the extension's `README.md`. This causes VS Code to attempt a secondary activation of the extension within the Marketplace's isolated metadata context.
This second activation collides with the already-running main extension instance (loaded via `onStartupFinished`), causing resource deadlocks (e.g. conflicting Cloud/Secret service initialization) that stall the Extension Host and crash the renderer.

### Fix
Removed `"onLanguage"` from `activationEvents` in `package.json` to prevent this unintended secondary activation.

### Impact
The extension no longer crashes when viewing its Marketplace entry. It continues to load correctly at launch via `onStartupFinished`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removes `"onLanguage"` wildcard activation event from `package.json` to fix VS Code Marketplace crash caused by conflicting secondary extension activation.
> 
>   - Removes `"onLanguage"` wildcard from `activationEvents` in `package.json` to fix VS Code Marketplace crash (Exit Code 5).
>   - Prevents secondary extension activation when Marketplace renders `README.md`, which caused resource deadlocks with the main instance loaded via `onStartupFinished`.
>   - Extension now activates only on startup via `onStartupFinished` event.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f0c6ad5e7c6055ddcd796049ff5f62067d085d26. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->