### PR TITLE
[FIX] Prevent OpenAI Native parallel tool calls for native tool calling

### DIFF
--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -244,6 +244,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 				strict?: boolean
 			}>
 			tool_choice?: any
+			parallel_tool_calls?: boolean
 		}
 
 		// Validate requested tier against model support; if not supported, omit.
@@ -300,6 +301,12 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 					})),
 			}),
 			...(metadata?.tool_choice && { tool_choice: metadata.tool_choice }),
+		}
+
+		// For native tool protocol, explicitly disable parallel tool calls.
+		// For XML or when protocol is unset, omit the field entirely so the API default applies.
+		if (metadata?.toolProtocol === "native") {
+			body.parallel_tool_calls = false
 		}
 
 		// Include text.verbosity only when the model explicitly supports it


### PR DESCRIPTION
<img width="1010" height="256" alt="image" src="https://github.com/user-attachments/assets/5360fb3d-5c2a-4b74-b42f-7bc7b89276de" />

### Summary

Fixes an issue where using the **OpenAI Native** provider together with **Native Tool Calling** could cause OpenAI’s Responses API to fail with errors like:

> Invalid request to Responses API. Please check your input parameters. – No tool output found for function call …

We now explicitly disable parallel tool calls for the OpenAI Native provider when Native Tool Calling is enabled, so each tool call is handled sequentially and the Responses API no longer complains about missing tool outputs.

### User Impact

- Native Tool Calling with OpenAI Native becomes stable and reliable.
- You should no longer see the "No tool output found for function call" Responses API error when tools are invoked.
