### PR TITLE
Fix preserveReasoning flag to control API reasoning inclusion

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -3432,8 +3432,6 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 					continue
 				} else if (hasPlainTextReasoning) {
-					const reasoningBlock = first as any
-
 					// Check if the model's preserveReasoning flag is set
 					// If true, include the reasoning block in API requests
 					// If false/undefined, strip it out (stored for history only, not sent back to API)


### PR DESCRIPTION
## Problem

The `preserveReasoning` flag was not being used correctly:
- Reasoning was being hardcoded as `<think>` tags in the assistant message during streaming
- This caused reasoning to be duplicated (both in text and as a structured block)
- The flag wasn't being checked in `buildCleanConversationHistory` to control whether reasoning should be sent back to the API

## Solution

### 1. Removed hardcoded reasoning logic during streaming
- Removed lines 2650-2655 in `Task.ts` that prepended `<think>` tags
- Now passes `reasoningMessage` as a parameter to `addToApiConversationHistory()` for proper structured storage

### 2. Updated `buildCleanConversationHistory()` to respect `preserveReasoning` flag
- **When `preserveReasoning: true`**: Full content array (including reasoning block) is sent to API
  - Needed for Moonshot/Minimax models
- **When `preserveReasoning: false/undefined`**: Reasoning is stripped from API requests
  - Used for Anthropic/Gemini/Mistral/etc models
- Reasoning is stored in conversation history for all cases

### 3. Added temporary debug logs
- Added to `base-openai-compatible-provider.ts` to verify reasoning blocks are being sent correctly
- Shows preserveReasoning flag value, incoming reasoning blocks, and converted messages

## Testing

✅ All 4,148 tests pass including 6 specific reasoning preservation tests
✅ Verified with Minimax model that debug logs show proper reasoning handling

## Next Steps

The temporary debug logs can be removed once verified in production.