### PR TITLE
Wait to experiment until state is hydrated

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -86,12 +86,17 @@ const App = () => {
 	const [useProviderSignupView, setUseProviderSignupView] = useState(false)
 
 	// Check PostHog feature flag for provider signup view
+	// Wait for telemetry to be initialized before checking feature flags
 	useEffect(() => {
+		if (!didHydrateState || telemetrySetting === "disabled") {
+			return
+		}
+
 		posthog.onFeatureFlags(function () {
 			// Feature flag for new provider-focused welcome view
 			setUseProviderSignupView(posthog?.getFeatureFlag("welcome-provider-signup") === "test")
 		})
-	}, [])
+	}, [didHydrateState, telemetrySetting])
 
 	// Create a persistent state manager
 	const marketplaceStateManager = useMemo(() => new MarketplaceViewStateManager(), [])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Delays PostHog feature flag checks in `App.tsx` until extension state is hydrated and telemetry is enabled, with corresponding tests.
> 
>   - **Feature Flag Check Timing**: Delays PostHog `onFeatureFlags()` call in `App.tsx` until `didHydrateState` is `true` and `telemetrySetting` is not `"disabled"`.
>   - **Effect Dependencies**: Updates `useEffect` dependencies from `[]` to `[didHydrateState, telemetrySetting]` to re-run when these values change.
>   - **Tests**: Adds 3 tests in `App.spec.tsx` verifying feature flags are not checked before hydration, are checked after hydration when telemetry is enabled, and are not checked when telemetry is disabled.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1b3c8093001a6a7fd555025e4f03b798510730ad. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->