### PR TITLE
Change baseten default model to glm for now

### DIFF
--- a/packages/types/src/providers/baseten.ts
+++ b/packages/types/src/providers/baseten.ts
@@ -10,7 +10,6 @@ export const basetenModels = {
 		supportsImages: false,
 		supportsPromptCache: false,
 		supportsNativeTools: true,
-		defaultToolProtocol: "native",
 		inputPrice: 0.6,
 		outputPrice: 2.5,
 		cacheWritesPrice: 0,
@@ -124,4 +123,4 @@ export const basetenModels = {
 
 export type BasetenModelId = keyof typeof basetenModels
 
-export const basetenDefaultModelId = "moonshotai/Kimi-K2-Thinking" satisfies BasetenModelId
+export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change default Baseten model to `zai-org/GLM-4.6` and remove `defaultToolProtocol` from `moonshotai/Kimi-K2-Thinking` in `baseten.ts`.
> 
>   - **Behavior**:
>     - Change default model ID from `moonshotai/Kimi-K2-Thinking` to `zai-org/GLM-4.6` in `baseten.ts`.
>     - Removes `defaultToolProtocol: "native"` from `basetenModels` entry for `moonshotai/Kimi-K2-Thinking`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7f3431e54298e4db2bcbb55be6698f6f04f70f70. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->