### PR TITLE
Revert "Wait to experiment until state is hydrated"

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -86,17 +86,12 @@ const App = () => {
 	const [useProviderSignupView, setUseProviderSignupView] = useState(false)
 
 	// Check PostHog feature flag for provider signup view
-	// Wait for telemetry to be initialized before checking feature flags
 	useEffect(() => {
-		if (!didHydrateState || telemetrySetting === "disabled") {
-			return
-		}
-
 		posthog.onFeatureFlags(function () {
 			// Feature flag for new provider-focused welcome view
 			setUseProviderSignupView(posthog?.getFeatureFlag("welcome-provider-signup") === "test")
 		})
-	}, [didHydrateState, telemetrySetting])
+	}, [])
 
 	// Create a persistent state manager
 	const marketplaceStateManager = useMemo(() => new MarketplaceViewStateManager(), [])

--- a/webview-ui/src/__tests__/App.spec.tsx
+++ b/webview-ui/src/__tests__/App.spec.tsx
@@ -2,17 +2,8 @@
 
 import React from "react"
 import { render, screen, act, cleanup } from "@/utils/test-utils"
-import posthog from "posthog-js"
 
 import AppWithProviders from "../App"
-
-// Mock posthog
-vi.mock("posthog-js", () => ({
-	default: {
-		onFeatureFlags: vi.fn(),
-		getFeatureFlag: vi.fn(),
-	},
-}))
 
 vi.mock("@src/utils/vscode", () => ({
 	vscode: {
@@ -198,7 +189,6 @@ describe("App", () => {
 			shouldShowAnnouncement: false,
 			experiments: {},
 			language: "en",
-			telemetrySetting: "enabled",
 		})
 	})
 
@@ -347,55 +337,5 @@ describe("App", () => {
 		const chatView = screen.getByTestId("chat-view")
 		expect(chatView.getAttribute("data-hidden")).toBe("false")
 		expect(screen.queryByTestId("marketplace-view")).not.toBeInTheDocument()
-	})
-
-	describe("PostHog feature flag initialization", () => {
-		it("waits for state hydration before checking feature flags", () => {
-			mockUseExtensionState.mockReturnValue({
-				didHydrateState: false,
-				showWelcome: false,
-				shouldShowAnnouncement: false,
-				experiments: {},
-				language: "en",
-				telemetrySetting: "enabled",
-			})
-
-			render(<AppWithProviders />)
-
-			// PostHog feature flag check should not be called before hydration
-			expect(posthog.onFeatureFlags).not.toHaveBeenCalled()
-		})
-
-		it("checks feature flags after state hydration when telemetry is enabled", () => {
-			mockUseExtensionState.mockReturnValue({
-				didHydrateState: true,
-				showWelcome: false,
-				shouldShowAnnouncement: false,
-				experiments: {},
-				language: "en",
-				telemetrySetting: "enabled",
-			})
-
-			render(<AppWithProviders />)
-
-			// PostHog feature flag check should be called after hydration
-			expect(posthog.onFeatureFlags).toHaveBeenCalled()
-		})
-
-		it("does not check feature flags when telemetry is disabled", () => {
-			mockUseExtensionState.mockReturnValue({
-				didHydrateState: true,
-				showWelcome: false,
-				shouldShowAnnouncement: false,
-				experiments: {},
-				language: "en",
-				telemetrySetting: "disabled",
-			})
-
-			render(<AppWithProviders />)
-
-			// PostHog feature flag check should not be called when telemetry is disabled
-			expect(posthog.onFeatureFlags).not.toHaveBeenCalled()
-		})
 	})
 })


### PR DESCRIPTION
Reverts RooCodeInc/Roo-Code#9488
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts waiting for state hydration before checking PostHog feature flags in `App.tsx` and updates related tests.
> 
>   - **Behavior**:
>     - Reverts waiting for `didHydrateState` before checking PostHog feature flags in `App.tsx`.
>     - Removes dependency on `telemetrySetting` for feature flag checks.
>   - **Tests**:
>     - Removes tests related to state hydration and telemetry setting checks in `App.spec.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 21a339cdb0729cd6c24d8189b79302fcb6298989. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->