### PR TITLE
Revert "Revert "Wait to experiment until state is hydrated""

### DIFF
--- a/webview-ui/src/App.tsx
+++ b/webview-ui/src/App.tsx
@@ -86,12 +86,17 @@ const App = () => {
 	const [useProviderSignupView, setUseProviderSignupView] = useState(false)
 
 	// Check PostHog feature flag for provider signup view
+	// Wait for telemetry to be initialized before checking feature flags
 	useEffect(() => {
+		if (!didHydrateState || telemetrySetting === "disabled") {
+			return
+		}
+
 		posthog.onFeatureFlags(function () {
 			// Feature flag for new provider-focused welcome view
 			setUseProviderSignupView(posthog?.getFeatureFlag("welcome-provider-signup") === "test")
 		})
-	}, [])
+	}, [didHydrateState, telemetrySetting])
 
 	// Create a persistent state manager
 	const marketplaceStateManager = useMemo(() => new MarketplaceViewStateManager(), [])


### PR DESCRIPTION
Reverts RooCodeInc/Roo-Code#9491
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts previous change to restore waiting for state hydration before checking feature flags in `App.tsx`, with tests in `App.spec.tsx`.
> 
>   - **Behavior**:
>     - Restores behavior in `App.tsx` to wait for `didHydrateState` and `telemetrySetting` before checking PostHog feature flags.
>     - Updates `useEffect` dependencies to include `didHydrateState` and `telemetrySetting`.
>   - **Tests**:
>     - Adds tests in `App.spec.tsx` to verify feature flags are checked only after state hydration and when telemetry is enabled.
>     - Ensures feature flags are not checked if telemetry is disabled or state is not hydrated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0e2f2cf69911df3d0fc3f3950abd61064953901d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->