### PR TITLE
Show the prompt for image gen

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1004,10 +1004,14 @@ export const ChatRowContent = ({
 						</div>
 						{message.type === "ask" && (
 							<div className="pl-6">
-								<div className="px-3 py-2 bg-vscode-editor-background border border-vscode-editorGroup-border rounded">
-									<div className="mb-2 break-words">{tool.content}</div>
-									<div className="text-xs text-vscode-descriptionForeground">{tool.path}</div>
-								</div>
+								<ToolUseBlock>
+									<div className="p-2">
+										<div className="mb-2 break-words">{tool.content}</div>
+										<div className="flex items-center gap-1 text-xs text-vscode-descriptionForeground">
+											{tool.path}
+										</div>
+									</div>
+								</ToolUseBlock>
 							</div>
 						)}
 					</>


### PR DESCRIPTION
Before:
<img width="601" height="536" alt="Screenshot 2025-11-22 at 10 34 01 AM" src="https://github.com/user-attachments/assets/451e4874-5983-4d31-b39f-a5925e296d45" />

After:
<img width="607" height="572" alt="Screenshot 2025-11-22 at 10 33 47 AM" src="https://github.com/user-attachments/assets/d4fcc5d9-1449-467c-bacd-001c0be0e4b8" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Replaces `CodeAccordian` with `ToolUseBlock` for displaying image generation prompts in `ChatRow.tsx`, enhancing readability and structure.
> 
>   - **Behavior**:
>     - Replaces `CodeAccordian` with `ToolUseBlock` for 'generateImage' prompts in `ChatRow.tsx`.
>     - Displays prompt content and path in a more structured format for 'ask' type messages.
>   - **UI**:
>     - Adjusts padding and text styles for better readability of image generation prompts.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2681d69a5662dc69bb7d2bc87ec3ed81150fabfd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->