### PR TITLE
Remove double todo list

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -160,7 +160,6 @@ export const ChatRowContent = ({
 	onSuggestionClick,
 	onFollowUpUnmount,
 	onBatchFileResponse,
-	editable,
 	isFollowUpAnswered,
 }: ChatRowContentProps) => {
 	const { t } = useTranslation()
@@ -540,21 +539,7 @@ export const ChatRowContent = ({
 				// Get previous todos from the latest todos in the task context
 				const previousTodos = getPreviousTodos(clineMessages, message.ts)
 
-				return (
-					<>
-						<TodoChangeDisplay previousTodos={previousTodos} newTodos={todos} />
-						<UpdateTodoListToolBlock
-							todos={todos}
-							content={(tool as any).content}
-							onChange={(updatedTodos) => {
-								if (typeof vscode !== "undefined" && vscode?.postMessage) {
-									vscode.postMessage({ type: "updateTodoList", payload: { todos: updatedTodos } })
-								}
-							}}
-							editable={!!(editable && isLast)}
-						/>
-					</>
-				)
+				return <TodoChangeDisplay previousTodos={previousTodos} newTodos={todos} />
 			}
 			case "newFileCreated":
 				return (


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove redundant `UpdateTodoListToolBlock` rendering in `ChatRowContent` for `updateTodoList` tool, simplifying the component.
> 
>   - **Behavior**:
>     - Removes `UpdateTodoListToolBlock` rendering in `ChatRowContent` for `updateTodoList` tool, leaving only `TodoChangeDisplay`.
>   - **Props**:
>     - Removes `editable` prop from `ChatRowContent` and `ChatRowContentProps`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 277029bb38930636694ed32f396cf8606c8b8eb0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->