### PR TITLE
Track cloud synced messages

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -809,6 +809,15 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 		this.clineMessages = newMessages
 		restoreTodoListForTask(this)
 		await this.saveClineMessages()
+
+		// When overwriting messages (e.g., during task resume), repopulate the cloud sync tracking Set
+		// with timestamps from all non-partial messages to prevent re-syncing previously synced messages
+		this.cloudSyncedMessageTimestamps.clear()
+		for (const msg of newMessages) {
+			if (msg.partial !== true) {
+				this.cloudSyncedMessageTimestamps.add(msg.ts)
+			}
+		}
 	}
 
 	private async updateClineMessage(message: ClineMessage) {


### PR DESCRIPTION
Hopefully this fixes an issue where we were getting multiple copies of reasoning messages synced
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds tracking of cloud-synced message timestamps in `Task.ts` to prevent duplicate syncing of messages.
> 
>   - **Behavior**:
>     - Adds `cloudSyncedMessageTimestamps` set to `Task` class in `Task.ts` to track timestamps of cloud-synced messages.
>     - Updates `addToClineMessages()` and `updateClineMessage()` to add message timestamps to the set after syncing to cloud.
>     - Modifies `overwriteClineMessages()` to clear and repopulate the set with non-partial message timestamps during task resume.
>   - **Misc**:
>     - Minor logic adjustments in `updateClineMessage()` to check if a message has already been synced before syncing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 12e33abe0e8495e9e622c2ed430ca76c77670317. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->