### PR TITLE
fix: flush LiteLLM cache when credentials change on refresh

### DIFF
--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -882,6 +882,12 @@ export const webviewMessageHandler = async (
 			const litellmBaseUrl = apiConfiguration.litellmBaseUrl || message?.values?.litellmBaseUrl
 
 			if (litellmApiKey && litellmBaseUrl) {
+				// If explicit credentials are provided in message.values (from Refresh Models button),
+				// flush the cache first to ensure we fetch fresh data with the new credentials
+				if (message?.values?.litellmApiKey || message?.values?.litellmBaseUrl) {
+					await flushModels("litellm", true)
+				}
+
 				candidates.push({
 					key: "litellm",
 					options: { provider: "litellm", apiKey: litellmApiKey, baseUrl: litellmBaseUrl },


### PR DESCRIPTION
## Problem
When changing the LiteLLM API key or base URL in settings and clicking 'Refresh Models', the model list wasn't updating. Users had to manually delete cache directories or restart VS Code to see the updated models.

## Root Cause
The caching system uses only the provider name as the cache key. When credentials change, cached models for the old credentials remain and are served instead of fetching new models with the updated credentials.

## Solution
This PR modifies the `requestRouterModels` handler to detect when explicit LiteLLM credentials are provided via the 'Refresh Models' button and flushes the cache before fetching.

The fix distinguishes between two scenarios:
1. **Explicit 'Refresh Models' button click** - Includes credentials in `message.values`, cache is flushed
2. **Automatic/debounced refresh** - No credentials, uses cached models for better performance

This approach is consistent with how Ollama and LMStudio handle explicit model refreshes.

## Changes
- Modified `webviewMessageHandler.ts` to flush LiteLLM cache when credentials are provided in the message
- Added comprehensive tests to verify cache flushing behavior

## Testing
- ✅ All 5 router models tests pass
- ✅ All 20 existing LiteLLM tests pass  
- ✅ All 17 webview message handler tests pass
- ✅ Manual testing: changing API key and clicking 'Refresh Models' now shows updated model list

## Impact
- Users can now change their LiteLLM API key or base URL and immediately see the updated model list
- No need to manually delete cache directories or restart VS Code
- Automatic refreshes still benefit from caching for faster UI loading
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Flush LiteLLM cache in `webviewMessageHandler.ts` when credentials change, ensuring updated models are fetched immediately.
> 
>   - **Behavior**:
>     - In `webviewMessageHandler.ts`, flush LiteLLM cache when new credentials are provided in `requestRouterModels` message.
>     - Distinguishes between explicit refresh (flush cache) and automatic refresh (use cache).
>   - **Testing**:
>     - Added tests in `webviewMessageHandler.routerModels.spec.ts` to verify cache flushing when credentials change.
>     - Ensures cache is not flushed when using stored credentials.
>   - **Impact**:
>     - Users see updated LiteLLM models immediately after changing API key or base URL.
>     - No need to manually clear cache or restart VS Code.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f0b1d13767b16f164be7b08cbc130874bf899d9f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->