### PR TITLE
fix: preserve tool_use blocks in summary message during condensing with native tools

### DIFF
--- a/src/core/context-management/__tests__/context-management.spec.ts
+++ b/src/core/context-management/__tests__/context-management.spec.ts
@@ -589,6 +589,7 @@ describe("Context Management", () => {
 				true,
 				undefined, // customCondensingPrompt
 				undefined, // condensingApiHandler
+				undefined, // useNativeTools
 			)
 
 			// Verify the result contains the summary information
@@ -760,6 +761,7 @@ describe("Context Management", () => {
 				true,
 				undefined, // customCondensingPrompt
 				undefined, // condensingApiHandler
+				undefined, // useNativeTools
 			)
 
 			// Verify the result contains the summary information

--- a/src/core/context-management/index.ts
+++ b/src/core/context-management/index.ts
@@ -86,6 +86,7 @@ export type ContextManagementOptions = {
 	condensingApiHandler?: ApiHandler
 	profileThresholds: Record<string, number>
 	currentProfileId: string
+	useNativeTools?: boolean
 }
 
 export type ContextManagementResult = SummarizeResponse & { prevContextTokens: number }
@@ -110,6 +111,7 @@ export async function manageContext({
 	condensingApiHandler,
 	profileThresholds,
 	currentProfileId,
+	useNativeTools,
 }: ContextManagementOptions): Promise<ContextManagementResult> {
 	let error: string | undefined
 	let cost = 0
@@ -163,6 +165,7 @@ export async function manageContext({
 				true, // automatic trigger
 				customCondensingPrompt,
 				condensingApiHandler,
+				useNativeTools,
 			)
 			if (result.error) {
 				error = result.error


### PR DESCRIPTION
## Summary
Fixes the 400 error when native tools are enabled during condensing: "The number of toolResult blocks at messages.2.content exceeds the number of toolUse blocks of previous turn."

## Root Cause
When condensing conversation history with native tools enabled, the conversation is restructured as:
1. Original first user message (the task)
2. Summary message (assistant role)
3. Last N kept messages

The error occurs when the **first kept message** (in position 3) is a user message containing `tool_result` blocks - responses to tools the assistant called. The API requires that whenever a user message has `tool_result` blocks, the immediately preceding assistant message must contain matching `tool_use` blocks. Since the summary message is now the preceding assistant message, it must include those `tool_use` blocks.

## Solution
Added `useNativeTools` parameter that, when true:
- Detects if the first kept message has `tool_result` blocks
- Extracts corresponding `tool_use` blocks from the message before the kept messages
- Appends those `tool_use` blocks to the summary message content

## Files Changed
- `src/core/condense/index.ts` - Added `useNativeTools` parameter and `getKeepMessagesWithToolBlocks()` helper
- `src/core/context-management/index.ts` - Added `useNativeTools` to options interface
- `src/core/task/Task.ts` - Pass `useNativeTools` flag based on resolved tool protocol
- `src/core/condense/__tests__/index.spec.ts` - Updated test
- `src/core/context-management/__tests__/context-management.spec.ts` - Updated test expectations

## Test Plan
- All 4229 tests pass
- Specific tests added for tool_use block preservation in native tools mode
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 400 error by preserving `tool_use` blocks in summaries when native tools are enabled, adding `useNativeTools` parameter to handle native tool protocols.
> 
>   - **Behavior**:
>     - Fixes 400 error by preserving `tool_use` blocks in summary messages when native tools are enabled.
>     - Introduces `useNativeTools` parameter in `summarizeConversation()` and `manageContext()` to handle native tool protocols.
>   - **Functions**:
>     - Adds `getKeepMessagesWithToolBlocks()` in `index.ts` to extract and preserve `tool_use` blocks.
>     - Updates `summarizeConversation()` in `index.ts` to append `tool_use` blocks to summary messages.
>   - **Files**:
>     - `index.ts`: Implements `useNativeTools` logic and updates summarization process.
>     - `Task.ts`: Passes `useNativeTools` flag to `summarizeConversation()` and `manageContext()`.
>     - `context-management/index.ts`: Adds `useNativeTools` to `ContextManagementOptions` and updates `manageContext()`.
>   - **Tests**:
>     - Updates `index.spec.ts` and `context-management.spec.ts` to test `tool_use` block preservation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4e017ed3c42fa97182e99d00e298db10831e6fd0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->