### PR TITLE
Make it clear that BFL Flux 2 is free

### DIFF
--- a/packages/types/src/image-generation.ts
+++ b/packages/types/src/image-generation.ts
@@ -23,7 +23,7 @@ export const IMAGE_GENERATION_MODELS: ImageGenerationModel[] = [
 	// Roo Code Cloud models
 	{ value: "google/gemini-2.5-flash-image", label: "Gemini 2.5 Flash Image", provider: "roo" },
 	{ value: "google/gemini-3-pro-image", label: "Gemini 3 Pro Image", provider: "roo" },
-	{ value: "bfl/flux-2-pro", label: "BFL Flux 2 Pro", provider: "roo", apiMethod: "images_api" },
+	{ value: "bfl/flux-2-pro:free", label: "BFL Flux 2 Pro (Free)", provider: "roo", apiMethod: "images_api" },
 ]
 
 /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Clarifies that `BFL Flux 2 Pro` model is free in `image-generation.ts`.
> 
>   - **Behavior**:
>     - Updated `value` of `bfl/flux-2-pro` to `bfl/flux-2-pro:free` in `IMAGE_GENERATION_MODELS` in `image-generation.ts` to indicate it is free.
>     - Updated `label` to "BFL Flux 2 Pro (Free)" for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c9d3be4a5d743dfb23bc81213362fcc9e6b9a85b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->