### PR TITLE
Add BFL models to openrouter

### DIFF
--- a/packages/types/src/image-generation.ts
+++ b/packages/types/src/image-generation.ts
@@ -20,10 +20,17 @@ export const IMAGE_GENERATION_MODELS: ImageGenerationModel[] = [
 	{ value: "google/gemini-3-pro-image-preview", label: "Gemini 3 Pro Image Preview", provider: "openrouter" },
 	{ value: "openai/gpt-5-image", label: "GPT-5 Image", provider: "openrouter" },
 	{ value: "openai/gpt-5-image-mini", label: "GPT-5 Image Mini", provider: "openrouter" },
+	{ value: "black-forest-labs/flux.2-flex", label: "Black Forest Labs FLUX.2 Flex", provider: "openrouter" },
+	{ value: "black-forest-labs/flux.2-pro", label: "Black Forest Labs FLUX.2 Pro", provider: "openrouter" },
 	// Roo Code Cloud models
 	{ value: "google/gemini-2.5-flash-image", label: "Gemini 2.5 Flash Image", provider: "roo" },
 	{ value: "google/gemini-3-pro-image", label: "Gemini 3 Pro Image", provider: "roo" },
-	{ value: "bfl/flux-2-pro:free", label: "BFL Flux 2 Pro (Free)", provider: "roo", apiMethod: "images_api" },
+	{
+		value: "bfl/flux-2-pro:free",
+		label: "Black Forest Labs FLUX.2 Pro (Free)",
+		provider: "roo",
+		apiMethod: "images_api",
+	},
 ]
 
 /**


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add Black Forest Labs models to `IMAGE_GENERATION_MODELS` in `image-generation.ts`.
> 
>   - **Models**:
>     - Add `black-forest-labs/flux.2-flex` and `black-forest-labs/flux.2-pro` to `IMAGE_GENERATION_MODELS` in `image-generation.ts` with `openrouter` as the provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 38828b0cbd19c29316196ef2003cd6b4aa000548. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->