### PR TITLE
Make single file read only apply to xml tools

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -808,8 +808,9 @@ export async function presentAssistantMessage(cline: Task) {
 					break
 				case "read_file":
 					// Check if this model should use the simplified single-file read tool
+					// Only use simplified tool for XML protocol - native protocol works with standard tool
 					const modelId = cline.api.getModel().id
-					if (shouldUseSingleFileRead(modelId)) {
+					if (shouldUseSingleFileRead(modelId) && toolProtocol !== TOOL_PROTOCOL.NATIVE) {
 						await simpleReadFileTool(
 							cline,
 							block,


### PR DESCRIPTION
Grok Code Fast was failing to read files with native tools on
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adjust `presentAssistantMessage` to use `simpleReadFileTool` only for XML protocol, not native protocol.
> 
>   - **Behavior**:
>     - In `presentAssistantMessage` function, `read_file` tool now uses `simpleReadFileTool` only for XML protocol, not for native protocol.
>     - Ensures native protocol uses standard `readFileTool`.
>   - **Misc**:
>     - Adds a comment explaining the protocol-specific tool usage logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 0573cdb93856eb5c1aca799d128fb63f813d7cab. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->