### PR TITLE
fix: restore content undefined check in WriteToFileTool.handlePartial()

### DIFF
--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -290,7 +290,7 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 		const relPath: string | undefined = block.params.path
 		let newContent: string | undefined = block.params.content
 
-		if (!relPath) {
+		if (!relPath || newContent === undefined) {
 			return
 		}
 


### PR DESCRIPTION
## Summary
Fixes error 'Error handling partial write_to_file' when native tools are not enabled.

## Root Cause
PR #9542 unintentionally removed the `newContent === undefined` check from `handlePartial()`, causing errors during XML protocol streaming when content arrives incrementally.

## Changes
- Restored the early return check: `if (!relPath || newContent === undefined)`
- This prevents the method from attempting file operations with incomplete data

## Testing
- All 19 existing tests in `writeToFileTool.spec.ts` pass
- Test at line 357-361 specifically validates this behavior: "returns early when content is undefined in partial block"

## Context
During XML protocol streaming (when native tools are NOT enabled), the parser emits partial ToolUse blocks as parameters arrive. For `write_to_file`, you might see:
1. First: `<write_to_file><path>src/file.txt</path>` (path arrives, content still undefined)
2. Then: `<content>some content...` (content starts streaming)

Without the early return, the code attempts file operations with undefined content, triggering the error caught by `BaseTool.handle()` and logged as "Error handling partial write_to_file".

Fixes #9611

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores `newContent === undefined` check in `WriteToFileTool.handlePartial()` to prevent errors during XML protocol streaming with undefined content.
> 
>   - **Behavior**:
>     - Restores `newContent === undefined` check in `WriteToFileTool.handlePartial()` to prevent file operations with undefined content.
>     - Ensures early return when `relPath` or `newContent` is undefined, avoiding errors during XML protocol streaming.
>   - **Testing**:
>     - All 19 tests in `writeToFileTool.spec.ts` pass.
>     - Test at line 357-361 specifically checks early return behavior when content is undefined.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c7c09966cf2e6c45d94f489bce7c681d0d604754. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->