### PR TITLE
fix: convert line_ranges strings to lineRanges objects in native tool calls

### DIFF
--- a/src/core/assistant-message/__tests__/NativeToolCallParser.spec.ts
+++ b/src/core/assistant-message/__tests__/NativeToolCallParser.spec.ts
@@ -8,7 +8,42 @@ describe("NativeToolCallParser", () => {
 
 	describe("parseToolCall", () => {
 		describe("read_file tool", () => {
-			it("should convert line_ranges strings to lineRanges objects", () => {
+			it("should handle line_ranges as tuples (new format)", () => {
+				const toolCall = {
+					id: "toolu_123",
+					name: "read_file" as const,
+					arguments: JSON.stringify({
+						files: [
+							{
+								path: "src/core/task/Task.ts",
+								line_ranges: [
+									[1920, 1990],
+									[2060, 2120],
+								],
+							},
+						],
+					}),
+				}
+
+				const result = NativeToolCallParser.parseToolCall(toolCall)
+
+				expect(result).not.toBeNull()
+				expect(result?.type).toBe("tool_use")
+				if (result?.type === "tool_use") {
+					expect(result.nativeArgs).toBeDefined()
+					const nativeArgs = result.nativeArgs as {
+						files: Array<{ path: string; lineRanges?: Array<{ start: number; end: number }> }>
+					}
+					expect(nativeArgs.files).toHaveLength(1)
+					expect(nativeArgs.files[0].path).toBe("src/core/task/Task.ts")
+					expect(nativeArgs.files[0].lineRanges).toEqual([
+						{ start: 1920, end: 1990 },
+						{ start: 2060, end: 2120 },
+					])
+				}
+			})
+
+			it("should handle line_ranges as strings (legacy format)", () => {
 				const toolCall = {
 					id: "toolu_123",
 					name: "read_file" as const,

--- a/src/core/prompts/tools/native-tools/read_file.ts
+++ b/src/core/prompts/tools/native-tools/read_file.ts
@@ -15,18 +15,18 @@ export function createReadFileTool(partialReadsEnabled: boolean = true): OpenAI.
 	const baseDescription =
 		READ_FILE_BASE_DESCRIPTION +
 		" Structure: { files: [{ path: 'relative/path.ts'" +
-		(partialReadsEnabled ? ", line_ranges: ['1-50', '100-150']" : "") +
+		(partialReadsEnabled ? ", line_ranges: [[1, 50], [100, 150]]" : "") +
 		" }] }. " +
 		"The 'path' is required and relative to workspace. "
 
 	const optionalRangesDescription = partialReadsEnabled
-		? "The 'line_ranges' is optional for reading specific sections (format: 'start-end', 1-based inclusive). "
+		? "The 'line_ranges' is optional for reading specific sections. Each range is a [start, end] tuple (1-based inclusive). "
 		: ""
 
 	const examples = partialReadsEnabled
 		? "Example single file: { files: [{ path: 'src/app.ts' }] }. " +
-			"Example with line ranges: { files: [{ path: 'src/app.ts', line_ranges: ['1-50', '100-150'] }] }. " +
-			"Example multiple files: { files: [{ path: 'file1.ts', line_ranges: ['1-50'] }, { path: 'file2.ts' }] }"
+			"Example with line ranges: { files: [{ path: 'src/app.ts', line_ranges: [[1, 50], [100, 150]] }] }. " +
+			"Example multiple files: { files: [{ path: 'file1.ts', line_ranges: [[1, 50]] }, { path: 'file2.ts' }] }"
 		: "Example single file: { files: [{ path: 'src/app.ts' }] }. " +
 			"Example multiple files: { files: [{ path: 'file1.ts' }, { path: 'file2.ts' }] }"
 
@@ -45,10 +45,12 @@ export function createReadFileTool(partialReadsEnabled: boolean = true): OpenAI.
 		fileProperties.line_ranges = {
 			type: ["array", "null"],
 			description:
-				"Optional 1-based inclusive ranges to read (format: start-end). Use multiple ranges for non-contiguous sections and keep ranges tight to the needed context.",
+				"Optional line ranges to read. Each range is a [start, end] tuple with 1-based inclusive line numbers. Use multiple ranges for non-contiguous sections.",
 			items: {
-				type: "string",
-				pattern: "^[0-9]+-[0-9]+$",
+				type: "array",
+				items: { type: "integer" },
+				minItems: 2,
+				maxItems: 2,
 			},
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes the `read_file` tool not respecting `line_ranges` when requested by the model in native tool calls mode.

### The Problem

When the model requested specific line ranges in native mode:
```json
{
  "files": [{
    "path": "src/core/task/Task.ts",
    "line_ranges": ["1920-1990", "2060-2120"]
  }]
}
```

The tool was returning the entire file from line 1 instead of the requested ranges, because `NativeToolCallParser` was not converting the `line_ranges` strings to `lineRanges` objects.

### The Solution

1. **Updated tool schema** to use a simpler tuple format: `[[start, end], ...]`
   - Before: `line_ranges: ["1920-1990", "2060-2120"]` 
   - After: `line_ranges: [[1920, 1990], [2060, 2120]]`

2. **Updated `NativeToolCallParser.convertFileEntries()`** to convert API format to internal format, handling all legacy formats for backwards compatibility:
   - New tuple format: `[[1, 50]]` → `[{ start: 1, end: 50 }]`
   - Object format: `[{ start: 1, end: 50 }]` → `[{ start: 1, end: 50 }]`
   - Legacy string format: `["1-50"]` → `[{ start: 1, end: 50 }]`

### Files Changed

- `src/core/prompts/tools/native-tools/read_file.ts` - Updated schema to use tuple format
- `src/core/assistant-message/NativeToolCallParser.ts` - Added `convertFileEntries()` helper
- `src/core/assistant-message/__tests__/NativeToolCallParser.spec.ts` - Added 7 comprehensive tests

### Testing

- All 4278 tests pass
- Manual testing confirms line ranges are now respected in native mode