### PR TITLE
fix: defer new_task tool_result until subtask completes for native protocol

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -938,6 +938,7 @@ export async function presentAssistantMessage(cline: Task) {
 						pushToolResult,
 						removeClosingTag,
 						toolProtocol,
+						toolCallId: block.id,
 					})
 					break
 				case "attempt_completion": {

--- a/src/core/tools/BaseTool.ts
+++ b/src/core/tools/BaseTool.ts
@@ -18,6 +18,7 @@ export interface ToolCallbacks {
 	pushToolResult: PushToolResult
 	removeClosingTag: RemoveClosingTag
 	toolProtocol: ToolProtocol
+	toolCallId?: string
 }
 
 /**

--- a/src/core/tools/NewTaskTool.ts
+++ b/src/core/tools/NewTaskTool.ts
@@ -30,7 +30,7 @@ export class NewTaskTool extends BaseTool<"new_task"> {
 
 	async execute(params: NewTaskParams, task: Task, callbacks: ToolCallbacks): Promise<void> {
 		const { mode, message, todos } = params
-		const { askApproval, handleError, pushToolResult, toolProtocol } = callbacks
+		const { askApproval, handleError, pushToolResult, toolProtocol, toolCallId } = callbacks
 
 		try {
 			// Validate required parameters.
@@ -133,9 +133,20 @@ export class NewTaskTool extends BaseTool<"new_task"> {
 				return
 			}
 
-			pushToolResult(
-				`Successfully created new task in ${targetMode.name} mode with message: ${unescapedMessage} and ${todoItems.length} todo items`,
-			)
+			// For native protocol, defer the tool_result until the subtask completes.
+			// The actual result (including what the subtask accomplished) will be pushed
+			// by completeSubtask. This gives the parent task useful information about
+			// what the subtask actually did.
+			if (toolProtocol === "native" && toolCallId) {
+				task.pendingNewTaskToolCallId = toolCallId
+				// Don't push tool_result here - it will come from completeSubtask with the actual result.
+				// The task loop will stay alive because isPaused is true (see Task.ts stack push condition).
+			} else {
+				// For XML protocol, push the result immediately (existing behavior)
+				pushToolResult(
+					`Successfully created new task in ${targetMode.name} mode with message: ${unescapedMessage} and ${todoItems.length} todo items`,
+				)
+			}
 
 			return
 		} catch (error) {


### PR DESCRIPTION
## Problem

For native tools, the API requires strict message ordering: `User > Assistant > Tool Call > Tool Result`. The `new_task` tool was causing 400 errors because:

1. **NewTaskTool** pushed a `tool_result` immediately with a generic message ("Successfully created new task...")
2. Parent task paused, waited for subtask
3. **completeSubtask** added a **separate user message** for the subtask result
4. This resulted in consecutive user messages which broke the ordering

Additionally, the parent task couldn't see what the subtask actually accomplished since the tool_result only said "Successfully created new task..." rather than the actual result.

## Solution

For native protocol, defer the `tool_result` until the subtask completes:

- **NewTaskTool** stores `pendingNewTaskToolCallId` but doesn't push tool_result (native only)
- Task loop stays alive via `isPaused` condition in stack push
- **completeSubtask** pushes the actual `tool_result` with subtask's real result
- After `waitForSubtask`, content is copied to `currentUserContent`

## Benefits

- ✅ No more 400 errors with native tools
- ✅ Parent task now sees what the subtask actually accomplished
- ✅ XML protocol behavior is unchanged
- ✅ All 4274 tests pass

## Native Protocol Flow (After Fix)

```
User: (initial request)
Assistant: tool_use (new_task, id="xyz")
→ NewTaskTool stores pendingNewTaskToolCallId, starts subtask, NO tool_result yet
→ Task loop continues because isPaused is true (stack push condition)
→ Next iteration: pop empty item, check isPaused → wait for subtask
→ Subtask runs and completes: "The random word is: elephant"
→ completeSubtask pushes: tool_result (tool_use_id="xyz", content="[new_task completed] Result: The random word is: elephant")
→ waitForSubtask returns, copies userMessageContent to currentUserContent
→ Continue iteration, send tool_result to API
```

## Files Changed

- `src/core/tools/NewTaskTool.ts` - Defer tool_result for native protocol
- `src/core/task/Task.ts` - Handle deferred tool_result in completeSubtask and task loop
- `src/core/tools/BaseTool.ts` - Add toolCallId to callbacks
- `src/core/assistant-message/presentAssistantMessage.ts` - Pass toolCallId to NewTaskTool
- `src/core/task/__tests__/Task.spec.ts` - Tests for new behavior
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Defers `tool_result` in `NewTaskTool` for native protocol until subtask completion to prevent 400 errors and ensure correct message ordering.
> 
>   - **Behavior**:
>     - Defers `tool_result` in `NewTaskTool` for native protocol until subtask completion.
>     - `completeSubtask` in `Task.ts` pushes actual `tool_result` with subtask result.
>     - Maintains task loop via `isPaused` condition.
>   - **Files Changed**:
>     - `NewTaskTool.ts`: Stores `pendingNewTaskToolCallId`, defers `tool_result`.
>     - `Task.ts`: Handles deferred `tool_result` in `completeSubtask` and task loop.
>     - `BaseTool.ts`: Adds `toolCallId` to `ToolCallbacks`.
>     - `presentAssistantMessage.ts`: Passes `toolCallId` to `NewTaskTool`.
>     - `Task.spec.ts`: Adds tests for new behavior.
>   - **Benefits**:
>     - Prevents 400 errors with native tools.
>     - Parent task sees actual subtask results.
>     - XML protocol behavior unchanged.
>     - All tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ce71beff0b13293841f6e60f2e373ecb66d695b0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->