### PR TITLE
fix: create parent directories early in write_to_file to prevent ENOENT errors

### DIFF
--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -7,7 +7,7 @@ import { Task } from "../task/Task"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { formatResponse } from "../prompts/responses"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
-import { fileExistsAtPath } from "../../utils/fs"
+import { fileExistsAtPath, createDirectoriesForFile } from "../../utils/fs"
 import { stripLineNumbers, everyLineHasLineNumbers } from "../../integrations/misc/extract-text"
 import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
@@ -70,13 +70,19 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 		const isWriteProtected = task.rooProtectedController?.isWriteProtected(relPath) || false
 
 		let fileExists: boolean
+		const absolutePath = path.resolve(task.cwd, relPath)
 
 		if (task.diffViewProvider.editType !== undefined) {
 			fileExists = task.diffViewProvider.editType === "modify"
 		} else {
-			const absolutePath = path.resolve(task.cwd, relPath)
 			fileExists = await fileExistsAtPath(absolutePath)
 			task.diffViewProvider.editType = fileExists ? "modify" : "create"
+		}
+
+		// Create parent directories early for new files to prevent ENOENT errors
+		// in subsequent operations (e.g., diffViewProvider.open, fs.readFile)
+		if (!fileExists) {
+			await createDirectoriesForFile(absolutePath)
 		}
 
 		if (newContent.startsWith("```")) {
@@ -307,16 +313,23 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 		}
 
 		let fileExists: boolean
+		const absolutePath = path.resolve(task.cwd, relPath)
+
 		if (task.diffViewProvider.editType !== undefined) {
 			fileExists = task.diffViewProvider.editType === "modify"
 		} else {
-			const absolutePath = path.resolve(task.cwd, relPath)
 			fileExists = await fileExistsAtPath(absolutePath)
 			task.diffViewProvider.editType = fileExists ? "modify" : "create"
 		}
 
+		// Create parent directories early for new files to prevent ENOENT errors
+		// in subsequent operations (e.g., diffViewProvider.open)
+		if (!fileExists) {
+			await createDirectoriesForFile(absolutePath)
+		}
+
 		const isWriteProtected = task.rooProtectedController?.isWriteProtected(relPath) || false
-		const fullPath = path.resolve(task.cwd, relPath)
+		const fullPath = absolutePath
 		const isOutsideWorkspace = isPathOutsideWorkspace(fullPath)
 
 		const sharedMessageProps: ClineSayTool = {


### PR DESCRIPTION
## Problem
Fixes #9634

When creating a file in a non-existent subdirectory, the `write_to_file` tool would fail with ENOENT errors because directories were only created later when `diffViewProvider.open()` was called.

## Root Cause
- The `execute()` and `handlePartial()` methods check if a file exists and set `editType`
- Directories are only created inside `diffViewProvider.open()` or `diffViewProvider.saveDirectly()`
- If `diffViewProvider.isEditing` was already true from a previous operation, `open()` would be skipped and directories would never be created
- This caused ENOENT errors for subsequent file operations

## Solution
Create parent directories **immediately** after determining a file doesn't exist, before any other operations that might depend on them:

1. Added `createDirectoriesForFile` import from `utils/fs`
2. In `execute()` method: Create directories when `!fileExists` before file operations
3. In `handlePartial()` method: Same fix to prevent ENOENT during partial streaming

## Testing
- Added comprehensive tests for the new directory creation behavior
- All 4315 tests pass
- TypeScript compilation successful

## Test Scenarios Covered
- Creates parent directories early when file does not exist (execute)
- Creates parent directories early when file does not exist (partial)
- Does not create directories when file exists
- Does not create directories when editType is cached as modify
- Creates directories when editType is cached as create
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes ENOENT errors in `WriteToFileTool.ts` by creating parent directories early, with comprehensive tests added.
> 
>   - **Behavior**:
>     - Fixes ENOENT errors by creating parent directories early in `execute()` and `handlePartial()` in `WriteToFileTool.ts`.
>     - Uses `createDirectoriesForFile` from `utils/fs` to ensure directories exist before file operations.
>   - **Testing**:
>     - Adds tests in `writeToFileTool.spec.ts` to verify early directory creation for non-existent files in both `execute` and `partial` modes.
>     - Tests ensure directories are not created if file exists or `editType` is cached as modify.
>     - All tests pass, including scenarios for directory creation, file existence detection, and error handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e0e38d8b588bea8620de01c40b9554d281fc1404. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->