### PR TITLE
Include tool format in environment details

### DIFF
--- a/src/core/environment/getEnvironmentDetails.ts
+++ b/src/core/environment/getEnvironmentDetails.ts
@@ -8,6 +8,7 @@ import delay from "delay"
 import type { ExperimentId } from "@roo-code/types"
 import { DEFAULT_TERMINAL_OUTPUT_CHARACTER_LIMIT } from "@roo-code/types"
 
+import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 import { EXPERIMENT_IDS, experiments as Experiments } from "../../shared/experiments"
 import { formatLanguage } from "../../shared/language"
 import { defaultModeSlug, getFullModeDetails, getModeBySlug, isToolAllowedForMode } from "../../shared/modes"
@@ -235,10 +236,15 @@ export async function getEnvironmentDetails(cline: Task, includeFileDetails: boo
 		language: language ?? formatLanguage(vscode.env.language),
 	})
 
+	// Resolve and add tool protocol information
+	const modelInfo = cline.api.getModel().info
+	const toolProtocol = resolveToolProtocol(state?.apiConfiguration ?? {}, modelInfo)
+
 	details += `\n\n# Current Mode\n`
 	details += `<slug>${currentMode}</slug>\n`
 	details += `<name>${modeDetails.name}</name>\n`
 	details += `<model>${modelId}</model>\n`
+	details += `<tool_format>${toolProtocol}</tool_format>\n`
 
 	if (Experiments.isEnabled(experiments ?? {}, EXPERIMENT_IDS.POWER_STEERING)) {
 		details += `<role>${modeDetails.roleDefinition}</role>\n`


### PR DESCRIPTION
This seems to help the model make the right decision when switching between xml and native tool calls.

Tested by asking the model "ask me a question" in xml mode and then switching to native tool calls and asking "ask me another question". Without this, the model outputs xml even when it's supposed to use native tool calls (at least when testing with sonnet).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds tool format information to environment details in `getEnvironmentDetails()` using `resolveToolProtocol()`.
> 
>   - **Behavior**:
>     - Adds tool format information to environment details in `getEnvironmentDetails()`.
>     - Uses `resolveToolProtocol()` to determine tool format based on `apiConfiguration` and `modelInfo`.
>     - Appends `<tool_format>` tag with resolved tool protocol to the details string.
>   - **Imports**:
>     - Adds import for `resolveToolProtocol` in `getEnvironmentDetails.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 66bd7b5a6361f5ff1154058f56e0a8ac387fa3a7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->