### PR TITLE
feat: enable native tool support for DeepSeek and Doubao models

### DIFF
--- a/packages/types/src/providers/deepseek.ts
+++ b/packages/types/src/providers/deepseek.ts
@@ -11,6 +11,7 @@ export const deepSeekModels = {
 		contextWindow: 128_000,
 		supportsImages: false,
 		supportsPromptCache: true,
+		supportsNativeTools: true,
 		inputPrice: 0.56, // $0.56 per million tokens (cache miss) - Updated Sept 5, 2025
 		outputPrice: 1.68, // $1.68 per million tokens - Updated Sept 5, 2025
 		cacheWritesPrice: 0.56, // $0.56 per million tokens (cache miss) - Updated Sept 5, 2025
@@ -22,6 +23,7 @@ export const deepSeekModels = {
 		contextWindow: 128_000,
 		supportsImages: false,
 		supportsPromptCache: true,
+		supportsNativeTools: true,
 		inputPrice: 0.56, // $0.56 per million tokens (cache miss) - Updated Sept 5, 2025
 		outputPrice: 1.68, // $1.68 per million tokens - Updated Sept 5, 2025
 		cacheWritesPrice: 0.56, // $0.56 per million tokens (cache miss) - Updated Sept 5, 2025

--- a/packages/types/src/providers/doubao.ts
+++ b/packages/types/src/providers/doubao.ts
@@ -8,6 +8,7 @@ export const doubaoModels = {
 		contextWindow: 128_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsNativeTools: true,
 		inputPrice: 0.0001, // $0.0001 per million tokens (cache miss)
 		outputPrice: 0.0004, // $0.0004 per million tokens
 		cacheWritesPrice: 0.0001, // $0.0001 per million tokens (cache miss)
@@ -19,6 +20,7 @@ export const doubaoModels = {
 		contextWindow: 128_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsNativeTools: true,
 		inputPrice: 0.0002, // $0.0002 per million tokens
 		outputPrice: 0.0008, // $0.0008 per million tokens
 		cacheWritesPrice: 0.0002, // $0.0002 per million
@@ -30,6 +32,7 @@ export const doubaoModels = {
 		contextWindow: 128_000,
 		supportsImages: true,
 		supportsPromptCache: true,
+		supportsNativeTools: true,
 		inputPrice: 0.00015, // $0.00015 per million tokens
 		outputPrice: 0.0006, // $0.0006 per million tokens
 		cacheWritesPrice: 0.00015, // $0.00015 per million


### PR DESCRIPTION
## Summary

Enable native OpenAI-compatible tool calling for DeepSeek and Doubao providers by adding `supportsNativeTools: true` to their model definitions.

## Changes

- **packages/types/src/providers/deepseek.ts**: Added `supportsNativeTools: true` to `deepseek-chat` and `deepseek-reasoner` models
- **packages/types/src/providers/doubao.ts**: Added `supportsNativeTools: true` to all Doubao models (`Doubao-1.5-pro-256k`, `Doubao-1.5-pro-32k`, `Doubao-1.5-lite-32k`)

## Why This Works

Both DeepSeek and Doubao already extend `OpenAiHandler` which has built-in support for native tools:
- Sends tools via the OpenAI-compatible `tools` parameter
- Handles `tool_call_partial` streaming chunks
- Processes complete `tool_call` responses

No code changes were needed in the provider handlers - only the model definitions needed to be updated.

## Test Plan

- All existing tests pass
- Users can now set `toolProtocol: 'native'` in their provider profile to use native tools with DeepSeek and Doubao models
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds native tool support to DeepSeek and Doubao models by updating model definitions to include `supportsNativeTools: true`.
> 
>   - **Model Definitions**:
>     - Added `supportsNativeTools: true` to `deepseek-chat` and `deepseek-reasoner` in `deepseek.ts`.
>     - Added `supportsNativeTools: true` to all models in `doubao.ts` (`doubao-seed-1-6-250615`, `doubao-seed-1-6-thinking-250715`, `doubao-seed-1-6-flash-250715`).
>   - **Functionality**:
>     - Enables native tool support for DeepSeek and Doubao models using existing OpenAI-compatible `tools` parameter.
>     - No changes to provider handlers; only model definitions updated.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c448349b69f16ed7eac057c3c781da614c2dd67e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->