### PR TITLE
feat(groq): enable native tool support for models that support function calling

### DIFF
--- a/.changeset/groq-native-tools.md
+++ b/.changeset/groq-native-tools.md
@@ -1,5 +1,0 @@
----
-"@roo-code/types": patch
----
-
-Enable native tool support for Groq models that support function calling: llama-3.1-8b-instant, llama-3.3-70b-versatile, llama-4-scout, qwen3-32b, kimi-k2-instruct-0905, gpt-oss-120b, and gpt-oss-20b


### PR DESCRIPTION
## Summary
Enable native tool call support for Groq models that support OpenAI-compatible function calling.

## Changes
Added `supportsNativeTools: true` to the following Groq models:
- `llama-3.1-8b-instant`
- `llama-3.3-70b-versatile`
- `meta-llama/llama-4-scout-17b-16e-instruct`
- `qwen/qwen3-32b`
- `moonshotai/kimi-k2-instruct-0905`
- `openai/gpt-oss-120b`
- `openai/gpt-oss-20b`

## Background
The `BaseOpenAiCompatibleProvider` already supports native tool calling, but Groq models were not flagged with `supportsNativeTools: true`, preventing the application from enabling this feature by default.

## Testing
All existing tests pass. The changes are additive and only enable functionality that was already implemented in the base provider.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enable native tool support for specific Groq models by setting `supportsNativeTools: true` in `groq.ts`.
> 
>   - **Behavior**:
>     - Set `supportsNativeTools: true` for Groq models in `groq.ts`: `llama-3.1-8b-instant`, `llama-3.3-70b-versatile`, `meta-llama/llama-4-scout-17b-16e-instruct`, `qwen/qwen3-32b`, `moonshotai/kimi-k2-instruct-0905`, `openai/gpt-oss-120b`, `openai/gpt-oss-20b`.
>   - **Background**:
>     - `BaseOpenAiCompatibleProvider` supports native tool calling, but Groq models were not flagged to enable this feature by default.
>   - **Testing**:
>     - All existing tests pass; changes are additive and align with existing functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9acad02cfbf2d84a487aca1b5b64061b87567f09. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->