### PR TITLE
fix: preserve tool_use blocks in summary for parallel tool calls

### DIFF
--- a/src/core/condense/index.ts
+++ b/src/core/condense/index.ts
@@ -172,8 +172,13 @@ export async function summarizeConversation(
 		? getKeepMessagesWithToolBlocks(messages, N_MESSAGES_TO_KEEP)
 		: { keepMessages: messages.slice(-N_MESSAGES_TO_KEEP), toolUseBlocksToPreserve: [] }
 
+	const keepStartIndex = Math.max(messages.length - N_MESSAGES_TO_KEEP, 0)
+	const includeFirstKeptMessageInSummary = toolUseBlocksToPreserve.length > 0
+	const summarySliceEnd = includeFirstKeptMessageInSummary ? keepStartIndex + 1 : keepStartIndex
+	const messagesBeforeKeep = summarySliceEnd > 0 ? messages.slice(0, summarySliceEnd) : []
+
 	// Get messages to summarize, including the first message and excluding the last N messages
-	const messagesToSummarize = getMessagesSinceLastSummary(messages.slice(0, -N_MESSAGES_TO_KEEP))
+	const messagesToSummarize = getMessagesSinceLastSummary(messagesBeforeKeep)
 
 	if (messagesToSummarize.length <= 1) {
 		const error =


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #9700 

### Roo Code Task Context (Optional)
N/A 

<!--
If you used Roo Code to help create this PR, you can share public task links here.
This helps reviewers understand your development process and provides additional context.
Example: https://app.roocode.com/share/task-id
-->

### Description
 Fix native-tool context condensation so tool_use blocks always have the matching tool_result message in the summarization request. Also preserve all parallel tool calls when appending tool_use blocks to the summary message.  
<!--
Briefly summarize the changes in this PR and how they address the linked issue.
The issue should cover the "what" and "why"; this section should focus on:
- The "how": key implementation details, design choices, or trade-offs made.
- Anything specific reviewers should pay attention to in this PR.
-->

### Test Procedure
 1. pnpm vitest src/core/condense/__tests__/index.spec.ts
<!--
Detail the steps to test your changes. This helps reviewers verify your work.
- How did you test this specific implementation? (e.g., unit tests, manual testing steps)
- How can reviewers reproduce your tests or verify the fix/feature?
- Include relevant testing environment details if applicable.
-->

### Pre-Submission Checklist

<!-- Go through this checklist before marking your PR as ready for review. -->

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos
<img width="1204" height="256" alt="image" src="https://github.com/user-attachments/assets/673a0c59-2ba3-446a-af64-3f395005be75" />
The screenshot shows the failure. After fixing it, I resumed the conversation, and the context compression started working correctly.
<!--
For UI changes, please provide before-and-after screenshots or a short video of the *actual results*.
This greatly helps in understanding the visual impact of your changes.
-->

### Documentation Updates
No documentation changes are required. 

<!--
Does this PR necessitate updates to user-facing documentation?
- [ ] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).
-->

### Additional Notes
Test command cannot be executed in the current environment because the vitest CLI is unavailable; please run the suite in the standard dev setup. 
<!-- Add any other context, questions, or information for reviewers here. -->

### Get in Touch
N/A
<!--
Please provide your Discord username for reviewers or maintainers to reach you if they have questions about your PR
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `summarizeConversation` to preserve `tool_use` blocks and handle parallel tool calls in conversation summaries.
> 
>   - **Behavior**:
>     - Fixes `summarizeConversation` in `index.ts` to preserve `tool_use` blocks with matching `tool_result` messages.
>     - Ensures all parallel `tool_use` blocks are appended to summary messages.
>   - **Tests**:
>     - Adds tests in `index.spec.ts` for preserving `tool_use` blocks and handling parallel tool calls.
>     - Verifies inclusion of `tool_result` messages in summary requests.
>   - **Functions**:
>     - Modifies `getKeepMessagesWithToolBlocks` to handle `tool_use` block preservation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5a881a1aec095f8d74464e627c1bda7a0a3e06b8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->