### PR TITLE
Allow models to contain default temperature

### DIFF
--- a/packages/types/src/providers/roo.ts
+++ b/packages/types/src/providers/roo.ts
@@ -38,6 +38,7 @@ export const RooModelSchema = z.object({
 	tags: z.array(z.string()).optional(),
 	pricing: RooPricingSchema,
 	deprecated: z.boolean().optional(),
+	default_temperature: z.number().optional(),
 })
 
 export const RooModelsResponseSchema = z.object({

--- a/src/api/providers/fetchers/__tests__/roo.spec.ts
+++ b/src/api/providers/fetchers/__tests__/roo.spec.ts
@@ -478,4 +478,69 @@ describe("getRooModels", () => {
 			"Failed to fetch Roo Code Cloud models: No response from server",
 		)
 	})
+
+	it("should parse default_temperature from API response", async () => {
+		const mockResponse = {
+			object: "list",
+			data: [
+				{
+					id: "test/model-with-temp",
+					object: "model",
+					created: 1234567890,
+					owned_by: "test",
+					name: "Model with Default Temperature",
+					description: "Model with custom default temperature",
+					context_window: 128000,
+					max_tokens: 8192,
+					type: "language",
+					pricing: {
+						input: "0.0001",
+						output: "0.0002",
+					},
+					default_temperature: 0.6,
+				},
+			],
+		}
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockResponse,
+		})
+
+		const models = await getRooModels(baseUrl, apiKey)
+
+		expect(models["test/model-with-temp"].defaultTemperature).toBe(0.6)
+	})
+
+	it("should handle models without default_temperature", async () => {
+		const mockResponse = {
+			object: "list",
+			data: [
+				{
+					id: "test/model-no-temp",
+					object: "model",
+					created: 1234567890,
+					owned_by: "test",
+					name: "Model without Default Temperature",
+					description: "Model without custom default temperature",
+					context_window: 128000,
+					max_tokens: 8192,
+					type: "language",
+					pricing: {
+						input: "0.0001",
+						output: "0.0002",
+					},
+				},
+			],
+		}
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockResponse,
+		})
+
+		const models = await getRooModels(baseUrl, apiKey)
+
+		expect(models["test/model-no-temp"].defaultTemperature).toBeUndefined()
+	})
 })

--- a/src/api/providers/fetchers/roo.ts
+++ b/src/api/providers/fetchers/roo.ts
@@ -132,6 +132,7 @@ export async function getRooModels(baseUrl: string, apiKey?: string): Promise<Mo
 					description: model.description || model.name,
 					deprecated: model.deprecated || false,
 					isFree: tags.includes("free"),
+					defaultTemperature: model.default_temperature,
 				}
 
 				// Apply model-specific defaults (e.g., defaultToolProtocol)

--- a/src/api/transform/__tests__/model-params.spec.ts
+++ b/src/api/transform/__tests__/model-params.spec.ts
@@ -87,6 +87,38 @@ describe("getModelParams", () => {
 			expect(result.temperature).toBe(0.5)
 		})
 
+		it("should use model defaultTemperature over provider defaultTemperature", () => {
+			const modelWithDefaultTemp: ModelInfo = {
+				...baseModel,
+				defaultTemperature: 0.8,
+			}
+
+			const result = getModelParams({
+				...anthropicParams,
+				settings: {},
+				model: modelWithDefaultTemp,
+				defaultTemperature: 0.5,
+			})
+
+			expect(result.temperature).toBe(0.8)
+		})
+
+		it("should prefer settings temperature over model defaultTemperature", () => {
+			const modelWithDefaultTemp: ModelInfo = {
+				...baseModel,
+				defaultTemperature: 0.8,
+			}
+
+			const result = getModelParams({
+				...anthropicParams,
+				settings: { modelTemperature: 0.3 },
+				model: modelWithDefaultTemp,
+				defaultTemperature: 0.5,
+			})
+
+			expect(result.temperature).toBe(0.3)
+		})
+
 		it("should use model maxTokens when available", () => {
 			const model: ModelInfo = {
 				...baseModel,

--- a/src/api/transform/model-params.ts
+++ b/src/api/transform/model-params.ts
@@ -95,7 +95,7 @@ export function getModelParams({
 		format,
 	})
 
-	let temperature = customTemperature ?? defaultTemperature
+	let temperature = customTemperature ?? model.defaultTemperature ?? defaultTemperature
 	let reasoningBudget: ModelParams["reasoningBudget"] = undefined
 	let reasoningEffort: ModelParams["reasoningEffort"] = undefined
 	let verbosity: VerbosityLevel | undefined = customVerbosity


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add `default_temperature` to model schema and update logic to handle it in `getRooModels` and `getModelParams`.
> 
>   - **Schema Changes**:
>     - Add `default_temperature` as an optional field to `RooModelSchema` in `roo.ts`.
>   - **Functionality**:
>     - Update `getRooModels` in `roo.ts` to include `defaultTemperature` from `default_temperature`.
>     - Modify `getModelParams` in `model-params.ts` to prioritize `customTemperature`, then `model.defaultTemperature`, then `defaultTemperature`.
>   - **Tests**:
>     - Add tests in `roo.spec.ts` to verify parsing of `default_temperature` and handling when absent.
>     - Add tests in `model-params.spec.ts` to check temperature precedence logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4840f255de2e0a18b578f3e916303cf55f2b9780. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->