### PR TITLE
Look for a tag in the Roo provider to default the model to native tool calling

### DIFF
--- a/src/api/providers/fetchers/__tests__/roo.spec.ts
+++ b/src/api/providers/fetchers/__tests__/roo.spec.ts
@@ -543,4 +543,106 @@ describe("getRooModels", () => {
 
 		expect(models["test/model-no-temp"].defaultTemperature).toBeUndefined()
 	})
+
+	it("should set defaultToolProtocol to native when default-native-tools tag is present", async () => {
+		const mockResponse = {
+			object: "list",
+			data: [
+				{
+					id: "test/native-tools-model",
+					object: "model",
+					created: 1234567890,
+					owned_by: "test",
+					name: "Native Tools Model",
+					description: "Model with native tool calling default",
+					context_window: 128000,
+					max_tokens: 8192,
+					type: "language",
+					tags: ["tool-use", "default-native-tools"],
+					pricing: {
+						input: "0.0001",
+						output: "0.0002",
+					},
+				},
+			],
+		}
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockResponse,
+		})
+
+		const models = await getRooModels(baseUrl, apiKey)
+
+		expect(models["test/native-tools-model"].supportsNativeTools).toBe(true)
+		expect(models["test/native-tools-model"].defaultToolProtocol).toBe("native")
+	})
+
+	it("should imply supportsNativeTools when default-native-tools tag is present without tool-use tag", async () => {
+		const mockResponse = {
+			object: "list",
+			data: [
+				{
+					id: "test/implicit-native-tools",
+					object: "model",
+					created: 1234567890,
+					owned_by: "test",
+					name: "Implicit Native Tools Model",
+					description: "Model with default-native-tools but no tool-use tag",
+					context_window: 128000,
+					max_tokens: 8192,
+					type: "language",
+					tags: ["default-native-tools"], // Only default-native-tools, no tool-use
+					pricing: {
+						input: "0.0001",
+						output: "0.0002",
+					},
+				},
+			],
+		}
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockResponse,
+		})
+
+		const models = await getRooModels(baseUrl, apiKey)
+
+		expect(models["test/implicit-native-tools"].supportsNativeTools).toBe(true)
+		expect(models["test/implicit-native-tools"].defaultToolProtocol).toBe("native")
+	})
+
+	it("should not set defaultToolProtocol when default-native-tools tag is not present", async () => {
+		const mockResponse = {
+			object: "list",
+			data: [
+				{
+					id: "test/non-native-model",
+					object: "model",
+					created: 1234567890,
+					owned_by: "test",
+					name: "Non-Native Tools Model",
+					description: "Model without native tool calling default",
+					context_window: 128000,
+					max_tokens: 8192,
+					type: "language",
+					tags: ["tool-use"],
+					pricing: {
+						input: "0.0001",
+						output: "0.0002",
+					},
+				},
+			],
+		}
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockResponse,
+		})
+
+		const models = await getRooModels(baseUrl, apiKey)
+
+		expect(models["test/non-native-model"].supportsNativeTools).toBe(true)
+		expect(models["test/non-native-model"].defaultToolProtocol).toBeUndefined()
+	})
 })

--- a/src/api/providers/fetchers/roo.ts
+++ b/src/api/providers/fetchers/roo.ts
@@ -107,8 +107,13 @@ export async function getRooModels(baseUrl: string, apiKey?: string): Promise<Mo
 				// Determine if the model requires reasoning effort based on tags
 				const requiredReasoningEffort = tags.includes("reasoning-required")
 
+				// Determine if native tool calling should be the default protocol for this model
+				const hasDefaultNativeTools = tags.includes("default-native-tools")
+				const defaultToolProtocol = hasDefaultNativeTools ? ("native" as const) : undefined
+
 				// Determine if the model supports native tool calling based on tags
-				const supportsNativeTools = tags.includes("tool-use")
+				// default-native-tools implies tool-use support
+				const supportsNativeTools = tags.includes("tool-use") || hasDefaultNativeTools
 
 				// Parse pricing (API returns strings, convert to numbers)
 				const inputPrice = parseApiPrice(pricing.input)
@@ -133,6 +138,7 @@ export async function getRooModels(baseUrl: string, apiKey?: string): Promise<Mo
 					deprecated: model.deprecated || false,
 					isFree: tags.includes("free"),
 					defaultTemperature: model.default_temperature,
+					defaultToolProtocol,
 				}
 
 				// Apply model-specific defaults (e.g., defaultToolProtocol)


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Set `defaultToolProtocol` to `native` in `getRooModels()` when `default-native-tools` tag is present, with tests added for various scenarios.
> 
>   - **Behavior**:
>     - In `getRooModels()` in `roo.ts`, set `defaultToolProtocol` to `native` if `default-native-tools` tag is present.
>     - `supportsNativeTools` is true if `tool-use` or `default-native-tools` tag is present.
>   - **Tests**:
>     - Add test in `roo.spec.ts` to check `defaultToolProtocol` is `native` when `default-native-tools` tag is present.
>     - Add test to imply `supportsNativeTools` when `default-native-tools` tag is present without `tool-use` tag.
>     - Add test to ensure `defaultToolProtocol` is not set when `default-native-tools` tag is absent.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2808ed95b015d342d2fe89d5b9fc4d16e47c88db. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->