### PR TITLE
Fix read_file ranges for gemini

### DIFF
--- a/src/core/prompts/tools/native-tools/read_file.ts
+++ b/src/core/prompts/tools/native-tools/read_file.ts
@@ -43,7 +43,7 @@ export function createReadFileTool(partialReadsEnabled: boolean = true): OpenAI.
 	// Only include line_ranges if partial reads are enabled
 	if (partialReadsEnabled) {
 		fileProperties.line_ranges = {
-			type: ["array", "null"],
+			type: "array",
 			description:
 				"Optional line ranges to read. Each range is a [start, end] tuple with 1-based inclusive line numbers. Use multiple ranges for non-contiguous sections.",
 			items: {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Changes `line_ranges` type to `array` in `createReadFileTool()` for strict mode handling when `partialReadsEnabled` is true.
> 
>   - **Behavior**:
>     - Changes `line_ranges` type from `['array', 'null']` to `array` in `createReadFileTool()` when `partialReadsEnabled` is true.
>     - Ensures `line_ranges` is always an array if present, affecting strict mode handling of optional properties.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c05f2eaa5db47dca08627ad753745f22a11554b7. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->