### PR TITLE
Safer tool call json parsing

### DIFF
--- a/src/core/assistant-message/NativeToolCallParser.ts
+++ b/src/core/assistant-message/NativeToolCallParser.ts
@@ -559,8 +559,9 @@ export class NativeToolCallParser {
 		}
 
 		try {
-			// Parse the arguments JSON string
-			const args = JSON.parse(toolCall.arguments)
+			// Parse the arguments JSON string using partial-json to handle malformed JSON
+			// (e.g., unescaped tab characters that strict JSON.parse would reject)
+			const args = parseJSON(toolCall.arguments)
 
 			// Build legacy params object for backward compatibility with XML protocol and UI.
 			// Native execution path uses nativeArgs instead, which has proper typing.
@@ -805,8 +806,9 @@ export class NativeToolCallParser {
 	 */
 	public static parseDynamicMcpTool(toolCall: { id: string; name: string; arguments: string }): McpToolUse | null {
 		try {
-			// Parse the arguments - these are the actual tool arguments passed directly
-			const args = JSON.parse(toolCall.arguments || "{}")
+			// Parse the arguments using partial-json to handle malformed JSON
+			// (e.g., unescaped tab characters that strict JSON.parse would reject)
+			const args = parseJSON(toolCall.arguments || "{}")
 
 			// Extract server_name and tool_name from the tool name itself
 			// Format: mcp_serverName_toolName


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Replaces `JSON.parse` with `parseJSON` in `NativeToolCallParser.ts` to handle malformed JSON.
> 
>   - **Behavior**:
>     - Replaces `JSON.parse` with `parseJSON` from `partial-json` in `NativeToolCallParser` to handle malformed JSON (e.g., unescaped tabs).
>     - Affects `parseToolCall()` and `parseDynamicMcpTool()` methods.
>   - **Imports**:
>     - Adds `parseJSON` import from `partial-json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 04d27da70d09d9967a8be93e58c4d3a0615432e4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->