### PR TITLE
Release v3.35.5

### DIFF
--- a/.changeset/v3.35.5.md
+++ b/.changeset/v3.35.5.md
@@ -1,0 +1,8 @@
+---
+"roo-cline": patch
+---
+
+- Feat: Add provider routing selection for OpenRouter embeddings (#9144 by @SannidhyaSah, PR #9693 by @SannidhyaSah)
+- Default Minimax M2 to native tool calling (PR #9778 by @mrubens)
+- Sanitize the native tool calls to fix a bug with Gemini (PR #9769 by @mrubens)
+- UX: Updates to CloudView (PR #9776 by @roomote)


### PR DESCRIPTION
Release preparation for v3.35.5. This PR includes the changeset and any necessary documentation updates.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Release v3.35.5 includes provider routing for OpenRouter, Minimax M2 tool calling, Gemini bug fix, and CloudView UX updates.
> 
>   - **Features**:
>     - Add provider routing selection for OpenRouter embeddings.
>     - Default Minimax M2 to native tool calling.
>   - **Bug Fixes**:
>     - Sanitize native tool calls to fix a bug with Gemini.
>   - **UX**:
>     - Updates to CloudView.
>   - **Documentation**:
>     - New changeset file `v3.35.5.md` added for release notes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 46efee0ed2c0b7a04bdba1805717528f463352e4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->