### PR TITLE
chore: hide parallel tool calls experiment and disable feature

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -478,13 +478,9 @@ export async function presentAssistantMessage(cline: Task) {
 			const toolCallId = (block as any).id
 			const toolProtocol = toolCallId ? TOOL_PROTOCOL.NATIVE : TOOL_PROTOCOL.XML
 
-			// Check experimental setting for multiple native tool calls
-			const provider = cline.providerRef.deref()
-			const state = await provider?.getState()
-			const isMultipleNativeToolCallsEnabled = experiments.isEnabled(
-				state?.experiments ?? {},
-				EXPERIMENT_IDS.MULTIPLE_NATIVE_TOOL_CALLS,
-			)
+			// Multiple native tool calls feature is on hold - always disabled
+			// Previously resolved from experiments.isEnabled(..., EXPERIMENT_IDS.MULTIPLE_NATIVE_TOOL_CALLS)
+			const isMultipleNativeToolCallsEnabled = false
 
 			const pushToolResult = (content: ToolResponse) => {
 				if (toolProtocol === TOOL_PROTOCOL.NATIVE) {

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -3610,11 +3610,9 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			})
 		}
 
-		// Resolve parallel tool calls setting from experiment (will move to per-API-profile setting later)
-		const parallelToolCallsEnabled = experiments.isEnabled(
-			state?.experiments ?? {},
-			EXPERIMENT_IDS.MULTIPLE_NATIVE_TOOL_CALLS,
-		)
+		// Parallel tool calls are disabled - feature is on hold
+		// Previously resolved from experiments.isEnabled(..., EXPERIMENT_IDS.MULTIPLE_NATIVE_TOOL_CALLS)
+		const parallelToolCallsEnabled = false
 
 		const metadata: ApiHandlerCreateMessageMetadata = {
 			mode: mode,

--- a/webview-ui/src/components/settings/ExperimentalSettings.tsx
+++ b/webview-ui/src/components/settings/ExperimentalSettings.tsx
@@ -55,6 +55,8 @@ export const ExperimentalSettings = ({
 			<Section>
 				{Object.entries(experimentConfigsMap)
 					.filter(([key]) => key in EXPERIMENT_IDS)
+					// Hide MULTIPLE_NATIVE_TOOL_CALLS - feature is on hold
+					.filter(([key]) => key !== "MULTIPLE_NATIVE_TOOL_CALLS")
 					.map((config) => {
 						if (config[0] === "MULTI_FILE_APPLY_DIFF") {
 							return (


### PR DESCRIPTION
## Summary
Hides the parallel tool calling experimental setting from the UI and ensures it's ignored even for users who have it set. Will add it back with improvements after full native tool call migration is complete.

## Changes
- Hide `MULTIPLE_NATIVE_TOOL_CALLS` from experimental settings UI by filtering it out
- Force `parallelToolCallsEnabled` to `false` in Task.ts (line 3612)
- Force `isMultipleNativeToolCallsEnabled` to `false` in presentAssistantMessage.ts (line 480)

## Notes
- The experiment still exists in the schema (`src/shared/experiments.ts`) to avoid breaking changes for users who had it set
- The setting is simply hidden from the UI and forced to `false` at both usage points
- All existing tests pass since they only verify the default value is `false`

## Testing
- `src/shared/__tests__/experiments.spec.ts` - 5 passing tests
- `webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx` - 9 passing tests
- `src/core/assistant-message/__tests__/presentAssistantMessage-images.spec.ts` - 8 passing tests
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable and hide the `MULTIPLE_NATIVE_TOOL_CALLS` feature in both UI and backend logic, ensuring it is set to `false` and not displayed.
> 
>   - **Behavior**:
>     - Hide `MULTIPLE_NATIVE_TOOL_CALLS` from UI in `ExperimentalSettings` by filtering it out.
>     - Force `parallelToolCallsEnabled` to `false` in `Task` class.
>     - Force `isMultipleNativeToolCallsEnabled` to `false` in `presentAssistantMessage()`.
>   - **Testing**:
>     - `ChatView.spec.tsx` and `experiments.spec.ts` confirm no UI or logic errors with 9 and 5 passing tests respectively.
>   - **Notes**:
>     - Experiment remains in `experiments.ts` schema to avoid breaking changes for existing users.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dc70cdbfbbd3fe6958c7ad4e065c8afc9e5469e1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->