### PR TITLE
Fix the download count on the homepage

### DIFF
--- a/apps/web-roo-code/src/lib/stats.ts
+++ b/apps/web-roo-code/src/lib/stats.ts
@@ -106,7 +106,7 @@ export async function getVSCodeDownloads() {
 function formatNumber(num: number): string {
 	// if number is 1 million or more, format as millions
 	if (num >= 1000000) {
-		const truncated = Math.floor((num / 1000000) * 10) / 10
+		const truncated = Math.floor((num / 1000000) * 100) / 100
 		return truncated.toFixed(2) + "M"
 	}
 
@@ -115,8 +115,8 @@ function formatNumber(num: number): string {
 	return truncated.toFixed(1) + "k"
 
 	// examples:
-	// console.log(formatNumber(1033400)) -> "1.0M"
-	// console.log(formatNumber(2500000)) -> "2.5M"
+	// console.log(formatNumber(1033400)) -> "1.03M"
+	// console.log(formatNumber(2500000)) -> "2.50M"
 	// console.log(formatNumber(337231)) -> "337.2k"
 	// console.log(formatNumber(23233)) -> "23.2k"
 	// console.log(formatNumber(2322)) -> "2.3k"


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update `formatNumber` in `stats.ts` to display millions with two decimal places for download counts.
> 
>   - **Behavior**:
>     - Update `formatNumber` in `stats.ts` to format numbers in millions with two decimal places instead of one.
>     - Affects display of download counts on the homepage.
>   - **Examples**:
>     - Changes output of `formatNumber(1033400)` from `1.0M` to `1.03M`.
>     - Changes output of `formatNumber(2500000)` from `2.5M` to `2.50M`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for aeab33692c4e9286d28c4a02f2b0f965021e3898. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->