### PR TITLE
Ignore input to the execa terminal process

### DIFF
--- a/src/integrations/terminal/ExecaTerminalProcess.ts
+++ b/src/integrations/terminal/ExecaTerminalProcess.ts
@@ -42,6 +42,8 @@ export class ExecaTerminalProcess extends BaseTerminalProcess {
 				shell: true,
 				cwd: this.terminal.getCurrentWorkingDirectory(),
 				all: true,
+				// Ignore stdin to ensure non-interactive mode and prevent hanging
+				stdin: "ignore",
 				env: {
 					...process.env,
 					// Ensure UTF-8 encoding for Ruby, CocoaPods, etc.


### PR DESCRIPTION
This addresses an issue where the inline terminal would hang if a command required input. You can test by having it run the command `read`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set `stdin: "ignore"` in `ExecaTerminalProcess` to prevent terminal hanging on input-requiring commands.
> 
>   - **Behavior**:
>     - In `ExecaTerminalProcess.ts`, set `stdin: "ignore"` in `execa` options to prevent terminal hanging on input-requiring commands.
>   - **Misc**:
>     - Comment added to explain ignoring stdin to ensure non-interactive mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4165066830a3aab52a8b69b07053ed167e825ab6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->