### PR TITLE
Always enabled reasoning for models that require it

### DIFF
--- a/src/api/transform/reasoning.ts
+++ b/src/api/transform/reasoning.ts
@@ -57,12 +57,9 @@ export const getRooReasoning = ({
 	}
 
 	if (model.requiredReasoningEffort) {
-		const effort: GetModelReasoningOptions["reasoningEffort"] = reasoningEffort ?? "medium"
-		const validEfforts: ReasoningEffortExtended[] = ["low", "medium", "high"]
-
 		// Honor the provided effort if it's valid, otherwise let the model choose.
-		if (validEfforts.includes(effort as ReasoningEffortExtended)) {
-			return { enabled: true, effort: effort as ReasoningEffortExtended }
+		if (reasoningEffort && reasoningEffort !== "disable" && reasoningEffort !== "minimal") {
+			return { enabled: true, effort: reasoningEffort }
 		} else {
 			return { enabled: true }
 		}


### PR DESCRIPTION
I'm worried about the cascading effects of ensuring that "reasoningEffort" is set to "medium" instead of "undefined" by default, so this feels like a safe fix, though maybe there's other work to be done on the "reasoningEffort" default.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Ensure models with `requiredReasoningEffort` in `getRooReasoning` are always enabled with valid effort or default to model's choice.
> 
>   - **Behavior**:
>     - In `getRooReasoning` in `reasoning.ts`, models with `requiredReasoningEffort` are always enabled with a valid `reasoningEffort` or default to model's choice.
>     - Handles `reasoningEffort` values: ignores `disable` and `minimal`, defaults to model's choice if invalid.
>   - **Misc**:
>     - No changes to other reasoning functions like `getOpenRouterReasoning`, `getAnthropicReasoning`, `getOpenAiReasoning`, and `getGeminiReasoning`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1a11b9948081f086bb848929fd7be9f14c1f26de. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->