### PR TITLE
Be safer about large file reads

### DIFF
--- a/src/core/tools/ReadFileTool.ts
+++ b/src/core/tools/ReadFileTool.ts
@@ -1,11 +1,12 @@
 import path from "path"
 import { isBinaryFile } from "isbinaryfile"
 import type { FileEntry, LineRange } from "@roo-code/types"
-import { isNativeProtocol } from "@roo-code/types"
+import { isNativeProtocol, ANTHROPIC_DEFAULT_MAX_TOKENS } from "@roo-code/types"
 
 import { Task } from "../task/Task"
 import { ClineSayTool } from "../../shared/ExtensionMessage"
 import { formatResponse } from "../prompts/responses"
+import { getModelMaxOutputTokens } from "../../shared/api"
 import { t } from "../../i18n"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
@@ -480,11 +481,22 @@ export class ReadFileTool extends BaseTool<"read_file"> {
 						continue
 					}
 
-					const modelInfo = task.api.getModel().info
+					const { id: modelId, info: modelInfo } = task.api.getModel()
 					const { contextTokens } = task.getTokenUsage()
 					const contextWindow = modelInfo.contextWindow
 
-					const budgetResult = await validateFileTokenBudget(fullPath, contextWindow, contextTokens || 0)
+					const maxOutputTokens =
+						getModelMaxOutputTokens({
+							modelId,
+							model: modelInfo,
+							settings: task.apiConfiguration,
+						}) ?? ANTHROPIC_DEFAULT_MAX_TOKENS
+
+					const budgetResult = await validateFileTokenBudget(
+						fullPath,
+						contextWindow - maxOutputTokens,
+						contextTokens || 0,
+					)
 
 					let content = await extractTextFromFile(fullPath)
 					let xmlInfo = ""

--- a/src/core/tools/__tests__/readFileTool.spec.ts
+++ b/src/core/tools/__tests__/readFileTool.spec.ts
@@ -210,6 +210,7 @@ function createMockCline(): any {
 		// CRITICAL: Always ensure image support is enabled
 		api: {
 			getModel: vi.fn().mockReturnValue({
+				id: "test-model",
 				info: {
 					supportsImages: true,
 					contextWindow: 200000,
@@ -228,6 +229,7 @@ function createMockCline(): any {
 function setImageSupport(mockCline: any, supportsImages: boolean | undefined): void {
 	mockCline.api = {
 		getModel: vi.fn().mockReturnValue({
+			id: "test-model",
 			info: { supportsImages },
 		}),
 	}


### PR DESCRIPTION
`validateFileTokenBudget` wasn't being called considering the output budget.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `ReadFileTool` to consider output token budget in `validateFileTokenBudget` and adjust tests accordingly.
> 
>   - **Behavior**:
>     - Update `ReadFileTool` in `ReadFileTool.ts` to call `validateFileTokenBudget` with adjusted context window considering output token budget.
>     - Calculate `maxOutputTokens` using `getModelMaxOutputTokens()` or default to `ANTHROPIC_DEFAULT_MAX_TOKENS`.
>   - **Tests**:
>     - Add `id: "test-model"` to mock model in `readFileTool.spec.ts` to support new logic.
>     - Ensure tests cover scenarios with adjusted token budgets.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a764b28c346eec71bc2b9d9ac5cefc2a62251b9e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->