### PR TITLE
Exclude the ID from Roo reasoning details

### DIFF
--- a/src/api/providers/roo.ts
+++ b/src/api/providers/roo.ts
@@ -169,7 +169,6 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 							text?: string
 							summary?: string
 							data?: string
-							id?: string | null
 							format?: string
 							signature?: string
 							index?: number
@@ -194,7 +193,6 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 									existing.data = (existing.data || "") + detail.data
 								}
 								// Update other fields if provided
-								if (detail.id !== undefined) existing.id = detail.id
 								if (detail.format !== undefined) existing.format = detail.format
 								if (detail.signature !== undefined) existing.signature = detail.signature
 							} else {
@@ -204,7 +202,6 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 									text: detail.text,
 									summary: detail.summary,
 									data: detail.data,
-									id: detail.id,
 									format: detail.format,
 									signature: detail.signature,
 									index,


### PR DESCRIPTION
Another attempt at https://github.com/RooCodeInc/Roo-Code/pull/9839
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `id` field from reasoning details in `RooHandler` class in `roo.ts`.
> 
>   - **Behavior**:
>     - Remove `id` field from reasoning details in `RooHandler` class in `roo.ts`.
>     - Affects accumulation and storage of reasoning details, but not other functionalities.
>   - **Misc**:
>     - No changes to other fields or functionalities in `RooHandler`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 44759b7828e0d8eefb90d2b80a95f702fa0c41a5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->