### PR TITLE
Revert "Exclude the ID from Roo reasoning details"

### DIFF
--- a/src/api/providers/roo.ts
+++ b/src/api/providers/roo.ts
@@ -169,6 +169,7 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 							text?: string
 							summary?: string
 							data?: string
+							id?: string | null
 							format?: string
 							signature?: string
 							index?: number
@@ -193,6 +194,7 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 									existing.data = (existing.data || "") + detail.data
 								}
 								// Update other fields if provided
+								if (detail.id !== undefined) existing.id = detail.id
 								if (detail.format !== undefined) existing.format = detail.format
 								if (detail.signature !== undefined) existing.signature = detail.signature
 							} else {
@@ -202,6 +204,7 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 									text: detail.text,
 									summary: detail.summary,
 									data: detail.data,
+									id: detail.id,
 									format: detail.format,
 									signature: detail.signature,
 									index,


### PR DESCRIPTION
Reverts RooCodeInc/Roo-Code#9847
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts exclusion of `id` field from reasoning details in `RooHandler` in `roo.ts`.
> 
>   - **Behavior**:
>     - Reverts exclusion of `id` field in reasoning details in `RooHandler` in `roo.ts`.
>     - Updates `createMessage()` and `createStream()` to include `id` in reasoning details.
>   - **Misc**:
>     - Adds `id` field back to reasoning details object structure in `roo.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1a8804a5937e6de8bbe0b7b476ed97cb210c32f4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->