### PR TITLE
feat: add dynamic settings support for Roo models from API

### DIFF
--- a/packages/types/src/providers/roo.ts
+++ b/packages/types/src/providers/roo.ts
@@ -39,6 +39,9 @@ export const RooModelSchema = z.object({
 	pricing: RooPricingSchema,
 	deprecated: z.boolean().optional(),
 	default_temperature: z.number().optional(),
+	// Dynamic settings that map directly to ModelInfo properties
+	// Allows the API to configure model-specific defaults like includedTools, excludedTools, reasoningEffort, etc.
+	settings: z.record(z.string(), z.unknown()).optional(),
 })
 
 export const RooModelsResponseSchema = z.object({

--- a/src/api/providers/__tests__/roo.spec.ts
+++ b/src/api/providers/__tests__/roo.spec.ts
@@ -439,12 +439,12 @@ describe("RooHandler", () => {
 			}
 		})
 
-		it("should not override existing properties when applying MODEL_DEFAULTS", () => {
+		it("should return cached model info with settings applied from API", () => {
 			const handlerWithMinimax = new RooHandler({
 				apiModelId: "minimax/minimax-m2:free",
 			})
 			const modelInfo = handlerWithMinimax.getModel()
-			// The defaults should be merged, but not overwrite existing cached values
+			// The settings from API should already be applied in the cached model info
 			expect(modelInfo.info.supportsNativeTools).toBe(true)
 			expect(modelInfo.info.inputPrice).toBe(0.15)
 			expect(modelInfo.info.outputPrice).toBe(0.6)

--- a/src/api/providers/fetchers/roo.ts
+++ b/src/api/providers/fetchers/roo.ts
@@ -5,31 +5,6 @@ import { parseApiPrice } from "../../../shared/cost"
 
 import { DEFAULT_HEADERS } from "../constants"
 
-// Model-specific defaults that should be applied even when models come from API cache
-// These override API-provided values for specific models
-// Exported so RooHandler.getModel() can also apply these for fallback cases
-export const MODEL_DEFAULTS: Record<string, Partial<ModelInfo>> = {
-	"minimax/minimax-m2:free": {
-		includedTools: ["search_and_replace"],
-		excludedTools: ["apply_diff"],
-	},
-	"openai/gpt-5.1": {
-		includedTools: ["apply_patch"],
-		excludedTools: ["apply_diff", "write_to_file"],
-		reasoningEffort: "medium",
-	},
-	"openai/gpt-5": {
-		includedTools: ["apply_patch"],
-		excludedTools: ["apply_diff", "write_to_file"],
-		reasoningEffort: "medium",
-	},
-	"openai/gpt-5-mini": {
-		includedTools: ["apply_patch"],
-		excludedTools: ["apply_diff", "write_to_file"],
-		reasoningEffort: "medium",
-	},
-}
-
 /**
  * Fetches available models from the Roo Code Cloud provider
  *
@@ -150,9 +125,12 @@ export async function getRooModels(baseUrl: string, apiKey?: string): Promise<Mo
 					isStealthModel: isStealthModel || undefined,
 				}
 
-				// Apply model-specific defaults (e.g., defaultToolProtocol)
-				const modelDefaults = MODEL_DEFAULTS[modelId]
-				models[modelId] = modelDefaults ? { ...baseModelInfo, ...modelDefaults } : baseModelInfo
+				// Apply API-provided settings on top of base model info
+				// Settings allow the proxy to dynamically configure model-specific options
+				// like includedTools, excludedTools, reasoningEffort, etc.
+				const apiSettings = model.settings as Partial<ModelInfo> | undefined
+
+				models[modelId] = apiSettings ? { ...baseModelInfo, ...apiSettings } : baseModelInfo
 			}
 
 			return models

--- a/src/api/providers/roo.ts
+++ b/src/api/providers/roo.ts
@@ -15,7 +15,6 @@ import { getRooReasoning } from "../transform/reasoning"
 import type { ApiHandlerCreateMessageMetadata } from "../index"
 import { BaseOpenAiCompatibleProvider } from "./base-openai-compatible-provider"
 import { getModels, getModelsFromCache } from "../providers/fetchers/modelCache"
-import { MODEL_DEFAULTS } from "../providers/fetchers/roo"
 import { handleOpenAIError } from "./utils/openai-error-handler"
 import { generateImageWithProvider, generateImageWithImagesApi, ImageGenerationResult } from "./utils/image-generation"
 import { t } from "../../i18n"
@@ -335,17 +334,12 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 	override getModel() {
 		const modelId = this.options.apiModelId || rooDefaultModelId
 
-		// Get models from shared cache
+		// Get models from shared cache (settings are already applied by the fetcher)
 		const models = getModelsFromCache("roo") || {}
 		const modelInfo = models[modelId]
 
-		// Get model-specific defaults if they exist
-		const modelDefaults = MODEL_DEFAULTS[modelId]
-
 		if (modelInfo) {
-			// Merge model-specific defaults with cached model info
-			const mergedInfo = modelDefaults ? { ...modelInfo, ...modelDefaults } : modelInfo
-			return { id: modelId, info: mergedInfo }
+			return { id: modelId, info: modelInfo }
 		}
 
 		// Return the requested model ID even if not found, with fallback info.


### PR DESCRIPTION
## Summary

This PR adds support for dynamic model settings from the Roo Code Cloud API, replacing hardcoded model defaults.

## Changes

- **packages/types/src/providers/roo.ts**: Added optional `settings` field to `RooModelSchema` that maps directly to ModelInfo properties
- **src/api/providers/fetchers/roo.ts**: Removed hardcoded `MODEL_DEFAULTS` constant; now applies API-provided settings from `model.settings` field
- **src/api/providers/roo.ts**: Removed `MODEL_DEFAULTS` import; simplified `getModel()` since settings are applied by the fetcher
- **Tests**: Updated test descriptions and added two new tests for API-provided settings functionality

## Why

Previously, model-specific defaults (like `includedTools`, `excludedTools`, `reasoningEffort`) were hardcoded in the extension. This change allows the proxy to dynamically configure these options via the API, enabling:
- Faster iteration on model configurations without extension updates
- Centralized model configuration management
- Support for arbitrary model-specific settings

## Testing

All 64 tests pass.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds dynamic settings support for Roo models, removing hardcoded defaults and applying configurations from the API.
> 
>   - **Behavior**:
>     - Adds `settings` field to `RooModelSchema` in `providers/roo.ts` for dynamic model settings.
>     - Removes `MODEL_DEFAULTS` in `fetchers/roo.ts`; settings now applied from API.
>     - Simplifies `getModel()` in `roo.ts` by removing `MODEL_DEFAULTS` logic.
>   - **Tests**:
>     - Updates test cases in `roo.spec.ts` and `fetchers/roo.spec.ts` to validate API-provided settings.
>     - Adds tests for handling arbitrary settings properties dynamically.
>   - **Misc**:
>     - Removes hardcoded model defaults, enabling dynamic configuration via API.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7d221fce9573b995e912b2676a2401fe800de4b6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->