### PR TITLE
Tweaks to baseten model definitions

### DIFF
--- a/packages/types/src/providers/baseten.ts
+++ b/packages/types/src/providers/baseten.ts
@@ -5,7 +5,7 @@ import type { ModelInfo } from "../model.js"
 
 export const basetenModels = {
 	"moonshotai/Kimi-K2-Thinking": {
-		maxTokens: 163_800,
+		maxTokens: 16_384,
 		contextWindow: 262_000,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -17,7 +17,7 @@ export const basetenModels = {
 		description: "Kimi K2 Thinking - A model with enhanced reasoning capabilities from Kimi K2",
 	},
 	"zai-org/GLM-4.6": {
-		maxTokens: 200_000,
+		maxTokens: 16_384,
 		contextWindow: 200_000,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -29,7 +29,7 @@ export const basetenModels = {
 		description: "Frontier open model with advanced agentic, reasoning and coding capabilities",
 	},
 	"deepseek-ai/DeepSeek-R1": {
-		maxTokens: 131_072,
+		maxTokens: 16_384,
 		contextWindow: 163_840,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -40,7 +40,7 @@ export const basetenModels = {
 		description: "DeepSeek's first-generation reasoning model",
 	},
 	"deepseek-ai/DeepSeek-R1-0528": {
-		maxTokens: 131_072,
+		maxTokens: 16_384,
 		contextWindow: 163_840,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -51,7 +51,7 @@ export const basetenModels = {
 		description: "The latest revision of DeepSeek's first-generation reasoning model",
 	},
 	"deepseek-ai/DeepSeek-V3-0324": {
-		maxTokens: 131_072,
+		maxTokens: 16_384,
 		contextWindow: 163_840,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -62,7 +62,7 @@ export const basetenModels = {
 		description: "Fast general-purpose LLM with enhanced reasoning capabilities",
 	},
 	"deepseek-ai/DeepSeek-V3.1": {
-		maxTokens: 131_072,
+		maxTokens: 16_384,
 		contextWindow: 163_840,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -74,10 +74,11 @@ export const basetenModels = {
 			"Extremely capable general-purpose LLM with hybrid reasoning capabilities and advanced tool calling",
 	},
 	"deepseek-ai/DeepSeek-V3.2": {
-		maxTokens: 131_072,
+		maxTokens: 16_384,
 		contextWindow: 163_840,
 		supportsImages: false,
 		supportsPromptCache: false,
+		supportsNativeTools: true,
 		inputPrice: 0.3,
 		outputPrice: 0.45,
 		cacheWritesPrice: 0,
@@ -86,7 +87,7 @@ export const basetenModels = {
 			"DeepSeek's hybrid reasoning model with efficient long context scaling with GPT-5 level performance",
 	},
 	"Qwen/Qwen3-235B-A22B-Instruct-2507": {
-		maxTokens: 262_144,
+		maxTokens: 16_384,
 		contextWindow: 262_144,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -97,7 +98,7 @@ export const basetenModels = {
 		description: "Mixture-of-experts LLM with math and reasoning capabilities",
 	},
 	"Qwen/Qwen3-Coder-480B-A35B-Instruct": {
-		maxTokens: 262_144,
+		maxTokens: 16_384,
 		contextWindow: 262_144,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -108,7 +109,7 @@ export const basetenModels = {
 		description: "Mixture-of-experts LLM with advanced coding and reasoning capabilities",
 	},
 	"openai/gpt-oss-120b": {
-		maxTokens: 128_072,
+		maxTokens: 16_384,
 		contextWindow: 128_072,
 		supportsImages: false,
 		supportsPromptCache: false,
@@ -120,7 +121,7 @@ export const basetenModels = {
 		description: "Extremely capable general-purpose LLM with strong, controllable reasoning capabilities",
 	},
 	"moonshotai/Kimi-K2-Instruct-0905": {
-		maxTokens: 168_000,
+		maxTokens: 16_384,
 		contextWindow: 262_000,
 		supportsImages: false,
 		supportsPromptCache: false,


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Reduces `maxTokens` to 16,384 for multiple models in `baseten.ts` and adds `supportsNativeTools` to `deepseek-ai/DeepSeek-V3.2`.
> 
>   - **Behavior**:
>     - Reduces `maxTokens` to 16,384 for models in `baseten.ts`, including `moonshotai/Kimi-K2-Thinking`, `zai-org/GLM-4.6`, and `deepseek-ai/DeepSeek-R1`, among others.
>     - Adds `supportsNativeTools: true` to `deepseek-ai/DeepSeek-V3.2` in `baseten.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 32cc0a220065b7a62761714961db9544d3aed216. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->