### PR TITLE
FIX: Reopen parent task if subtask is terminated by the user

### DIFF
--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -634,7 +634,20 @@ export const webviewMessageHandler = async (
 			// Clear task resets the current session. Delegation flows are
 			// handled via metadata; parent resumption occurs through
 			// reopenParentFromDelegation, not via finishSubTask.
-			await provider.clearTask()
+			const task = provider.getCurrentTask()
+			if (task?.parentTaskId) {
+				const completionResultMessage = task.clineMessages.filter(
+					(msg) => msg.say === "completion_result" || msg.ask === "completion_result",
+				)
+				const lastCompletionMessage = completionResultMessage[completionResultMessage.length - 1]?.text
+				await provider.reopenParentFromDelegation({
+					parentTaskId: task.parentTaskId,
+					childTaskId: task.taskId,
+					completionResultSummary: lastCompletionMessage || t("common:tasks.canceled"),
+				})
+			} else {
+				await provider.clearTask()
+			}
 			await provider.postStateToWebview()
 			break
 		case "didShowAnnouncement":


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: #9886 <!-- Replace with the issue number, e.g., Closes: #123 -->

### Description

This PR fixes an issue where a parent task would not be reopened if the user explicitly terminated a delegated child task

The fix introduces a check to see if the current task has a `parentTaskId` If it does, instead of clearing the task, it now calls `reopenParentFromDelegation` with a summary. This summary is derived from the last `completion_result` message in the child task's history, or defaults to "Canceled" if no completion message is found i.e the user clicked the `Terminate` button.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix task handling in `webviewMessageHandler.ts` to reopen parent task with a summary if a subtask is terminated by the user.
> 
>   - **Behavior**:
>     - In `webviewMessageHandler.ts`, modify `clearTask` handling to check for `parentTaskId`.
>     - If `parentTaskId` exists, call `reopenParentFromDelegation` with a summary from the last `completion_result` message or default to "Canceled".
>     - If no `parentTaskId`, proceed with `clearTask` as usual.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4d45424dc38c258e7b237c0013144e54cb90b517. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->