### PR TITLE
fix: use foreground color for context-management icons

### DIFF
--- a/webview-ui/src/components/chat/context-management/CondensationResultRow.tsx
+++ b/webview-ui/src/components/chat/context-management/CondensationResultRow.tsx
@@ -32,7 +32,7 @@ export function CondensationResultRow({ data }: CondensationResultRowProps) {
 				className="flex items-center justify-between cursor-pointer select-none"
 				onClick={() => setIsExpanded(!isExpanded)}>
 				<div className="flex items-center gap-2 flex-grow">
-					<FoldVertical size={16} className="text-blue-400" />
+					<FoldVertical size={16} className="text-vscode-foreground" />
 					<span className="font-bold text-vscode-foreground">
 						{t("chat:contextManagement.condensation.title")}
 					</span>

--- a/webview-ui/src/components/chat/context-management/TruncationResultRow.tsx
+++ b/webview-ui/src/components/chat/context-management/TruncationResultRow.tsx
@@ -33,7 +33,7 @@ export function TruncationResultRow({ data }: TruncationResultRowProps) {
 				className="flex items-center justify-between cursor-pointer select-none"
 				onClick={() => setIsExpanded(!isExpanded)}>
 				<div className="flex items-center gap-2 flex-grow">
-					<FoldVertical size={16} className="text-blue-400" />
+					<FoldVertical size={16} className="text-vscode-foreground" />
 					<span className="font-bold text-vscode-foreground">
 						{t("chat:contextManagement.truncation.title")}
 					</span>


### PR DESCRIPTION
## Summary

Changes the context-management icons (condensation and truncation) to use the VSCode foreground color instead of a hardcoded blue color, making them match the theme.

## Changes

- Updated `CondensationResultRow.tsx` to use `text-vscode-foreground` instead of `text-blue-400`
- Updated `TruncationResultRow.tsx` to use `text-vscode-foreground` instead of `text-blue-400`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change context-management icon color to match VSCode theme in `CondensationResultRow.tsx` and `TruncationResultRow.tsx`.
> 
>   - **Behavior**:
>     - Change icon color in `CondensationResultRow.tsx` and `TruncationResultRow.tsx` from `text-blue-400` to `text-vscode-foreground` to match VSCode theme.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 92461cd1f7a1a7528232b7ff8553997fb87e51e8. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->