### PR TITLE
fix: suppress 'ask promise was ignored' error in handleError

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -9,6 +9,7 @@ import { defaultModeSlug, getModeBySlug } from "../../shared/modes"
 import type { ToolParamName, ToolResponse, ToolUse, McpToolUse } from "../../shared/tools"
 import { Package } from "../../shared/package"
 import { t } from "../../i18n"
+import { AskIgnoredError } from "../task/AskIgnoredError"
 
 import { fetchInstructionsTool } from "../tools/FetchInstructionsTool"
 import { listFilesTool } from "../tools/ListFilesTool"
@@ -224,9 +225,9 @@ export async function presentAssistantMessage(cline: Task) {
 			}
 
 			const handleError = async (action: string, error: Error) => {
-				// Silently ignore "ask promise was ignored" errors - this is an internal control flow
+				// Silently ignore AskIgnoredError - this is an internal control flow
 				// signal, not an actual error. It occurs when a newer ask supersedes an older one.
-				if (error.message?.includes("ask promise was ignored")) {
+				if (error instanceof AskIgnoredError) {
 					return
 				}
 				const errorString = `Error ${action}: ${JSON.stringify(serializeError(error))}`
@@ -615,9 +616,9 @@ export async function presentAssistantMessage(cline: Task) {
 			}
 
 			const handleError = async (action: string, error: Error) => {
-				// Silently ignore "ask promise was ignored" errors - this is an internal control flow
+				// Silently ignore AskIgnoredError - this is an internal control flow
 				// signal, not an actual error. It occurs when a newer ask supersedes an older one.
-				if (error.message?.includes("ask promise was ignored")) {
+				if (error instanceof AskIgnoredError) {
 					return
 				}
 				const errorString = `Error ${action}: ${JSON.stringify(serializeError(error))}`

--- a/src/core/task/AskIgnoredError.ts
+++ b/src/core/task/AskIgnoredError.ts
@@ -1,0 +1,15 @@
+/**
+ * Error thrown when an ask promise is superseded by a newer one.
+ *
+ * This is used as an internal control flow signal - not an actual error.
+ * It occurs when multiple asks are sent in rapid succession and an older
+ * ask is invalidated by a newer one (e.g., during streaming updates).
+ */
+export class AskIgnoredError extends Error {
+	constructor(reason?: string) {
+		super(reason ? `Ask ignored: ${reason}` : "Ask ignored")
+		this.name = "AskIgnoredError"
+		// Maintains proper prototype chain for instanceof checks
+		Object.setPrototypeOf(this, AskIgnoredError.prototype)
+	}
+}

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -4,6 +4,8 @@ import os from "os"
 import crypto from "crypto"
 import EventEmitter from "events"
 
+import { AskIgnoredError } from "./AskIgnoredError"
+
 import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 import delay from "delay"
@@ -983,7 +985,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					// whole array in new listener.
 					this.updateClineMessage(lastMessage)
 					// console.log("Task#ask: current ask promise was ignored (#1)")
-					throw new Error("Current ask promise was ignored (#1)")
+					throw new AskIgnoredError("updating existing partial")
 				} else {
 					// This is a new partial message, so add it with partial
 					// state.
@@ -992,7 +994,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					console.log(`Task#ask: new partial ask -> ${type} @ ${askTs}`)
 					await this.addToClineMessages({ ts: askTs, type: "ask", ask: type, text, partial, isProtected })
 					// console.log("Task#ask: current ask promise was ignored (#2)")
-					throw new Error("Current ask promise was ignored (#2)")
+					throw new AskIgnoredError("new partial")
 				}
 			} else {
 				if (isUpdatingPreviousPartial) {
@@ -1146,7 +1148,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			// command_output. It's important that when we know an ask could
 			// fail, it is handled gracefully.
 			console.log("Task#ask: current ask promise was ignored")
-			throw new Error("Current ask promise was ignored")
+			throw new AskIgnoredError("superseded")
 		}
 
 		const result = { response: this.askResponse!, text: this.askResponseText, images: this.askResponseImages }


### PR DESCRIPTION
## Summary

The `Task.ask()` method throws `"Current ask promise was ignored"` as a control flow mechanism for:
1. **Partial UI updates** (fire-and-forget progress messages)
2. **Superseded asks** (when a newer ask invalidates an older one)

While callers already handle this with `.catch(() => {})`, the error was leaking through `handleError()` in `presentAssistantMessage.ts`, causing it to be reported to the LLM and confuse the conversation.

## Changes

Modified `handleError()` callbacks in `presentAssistantMessage.ts` to silently ignore this expected control flow error.

## Why This Approach

The "proper" fix would be to refactor `Task.ask()` to return `undefined` instead of throwing, then update all 21+ callers to handle the return value instead of using `.catch(() => {})`. However, this is a large refactor with risk of introducing regressions.

The `handleError()` suppression is a targeted, safe fix because:
- The error is intentional and expected (all callers already catch and ignore it)
- The error does nothing useful when caught (no state reset, no cleanup)
- The fix prevents the symptom (error leaking to LLM) without architectural risk

## Testing

- All 4534 tests pass
- Verified the fix prevents the error from appearing in tool results
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Suppress 'ask promise was ignored' error in `presentAssistantMessage.ts` by introducing `AskIgnoredError` and updating `Task.ask()` in `Task.ts`.
> 
>   - **Error Handling**:
>     - Introduce `AskIgnoredError` in `AskIgnoredError.ts` for control flow in `Task.ask()`.
>     - Modify `handleError()` in `presentAssistantMessage.ts` to ignore `AskIgnoredError`.
>   - **Task Class**:
>     - Replace generic error with `AskIgnoredError` in `Task.ask()` in `Task.ts` for partial and superseded asks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 057104bab67ce485c58ff908a7338dd86cd4b12d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->