### PR TITLE
feat: configure tool preferences for xAI models

### DIFF
--- a/packages/types/src/providers/xai.ts
+++ b/packages/types/src/providers/xai.ts
@@ -17,6 +17,8 @@ export const xaiModels = {
 		cacheWritesPrice: 0.02,
 		cacheReadsPrice: 0.02,
 		description: "xAI's Grok Code Fast model with 256K context window",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 	"grok-4-1-fast-reasoning": {
 		maxTokens: 65_536,
@@ -30,6 +32,8 @@ export const xaiModels = {
 		cacheReadsPrice: 0.05,
 		description:
 			"xAI's Grok 4.1 Fast model with 2M context window, optimized for high-performance agentic tool calling with reasoning",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 	"grok-4-1-fast-non-reasoning": {
 		maxTokens: 65_536,
@@ -43,6 +47,8 @@ export const xaiModels = {
 		cacheReadsPrice: 0.05,
 		description:
 			"xAI's Grok 4.1 Fast model with 2M context window, optimized for high-performance agentic tool calling",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 	"grok-4-fast-reasoning": {
 		maxTokens: 65_536,
@@ -56,6 +62,8 @@ export const xaiModels = {
 		cacheReadsPrice: 0.05,
 		description:
 			"xAI's Grok 4 Fast model with 2M context window, optimized for high-performance agentic tool calling with reasoning",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 	"grok-4-fast-non-reasoning": {
 		maxTokens: 65_536,
@@ -69,6 +77,8 @@ export const xaiModels = {
 		cacheReadsPrice: 0.05,
 		description:
 			"xAI's Grok 4 Fast model with 2M context window, optimized for high-performance agentic tool calling",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 	"grok-4-0709": {
 		maxTokens: 8192,
@@ -81,6 +91,8 @@ export const xaiModels = {
 		cacheWritesPrice: 0.75,
 		cacheReadsPrice: 0.75,
 		description: "xAI's Grok-4 model with 256K context window",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 	"grok-3-mini": {
 		maxTokens: 8192,
@@ -95,6 +107,8 @@ export const xaiModels = {
 		description: "xAI's Grok-3 mini model with 128K context window",
 		supportsReasoningEffort: ["low", "high"],
 		reasoningEffort: "low",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 	"grok-3": {
 		maxTokens: 8192,
@@ -107,5 +121,7 @@ export const xaiModels = {
 		cacheWritesPrice: 0.75,
 		cacheReadsPrice: 0.75,
 		description: "xAI's Grok-3 model with 128K context window",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
 	},
 } as const satisfies Record<string, ModelInfo>


### PR DESCRIPTION
## Summary

Configure tool preferences for all xAI Grok models to optimize file editing operations.

## Changes

- Add `includedTools: ["search_replace"]` to enable search_replace tool for better file editing compatibility
- Add `excludedTools: ["apply_diff"]` to disable apply_diff tool which may not work well with these models
- Applied to all 8 xAI models: grok-code-fast, grok-4-1-fast-reasoning, grok-4-1-fast-non-reasoning, grok-4-fast-reasoning, grok-4-fast-non-reasoning, grok-4-0709, grok-3-mini, and grok-3