### PR TITLE
fix: process finish_reason to emit tool_call_end events

### DIFF
--- a/src/api/providers/__tests__/openrouter.spec.ts
+++ b/src/api/providers/__tests__/openrouter.spec.ts
@@ -283,6 +283,79 @@ describe("OpenRouterHandler", () => {
 			const generator = handler.createMessage("test", [])
 			await expect(generator.next()).rejects.toThrow("OpenRouter API Error 500: API Error")
 		})
+
+		it("yields tool_call_end events when finish_reason is tool_calls", async () => {
+			// Import NativeToolCallParser to set up state
+			const { NativeToolCallParser } = await import("../../../core/assistant-message/NativeToolCallParser")
+
+			// Clear any previous state
+			NativeToolCallParser.clearRawChunkState()
+
+			const handler = new OpenRouterHandler(mockOptions)
+
+			const mockStream = {
+				async *[Symbol.asyncIterator]() {
+					yield {
+						id: "test-id",
+						choices: [
+							{
+								delta: {
+									tool_calls: [
+										{
+											index: 0,
+											id: "call_openrouter_test",
+											function: { name: "read_file", arguments: '{"path":"test.ts"}' },
+										},
+									],
+								},
+								index: 0,
+							},
+						],
+					}
+					yield {
+						id: "test-id",
+						choices: [
+							{
+								delta: {},
+								finish_reason: "tool_calls",
+								index: 0,
+							},
+						],
+						usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+					}
+				},
+			}
+
+			const mockCreate = vitest.fn().mockResolvedValue(mockStream)
+			;(OpenAI as any).prototype.chat = {
+				completions: { create: mockCreate },
+			} as any
+
+			const generator = handler.createMessage("test", [])
+			const chunks = []
+
+			for await (const chunk of generator) {
+				// Simulate what Task.ts does: when we receive tool_call_partial,
+				// process it through NativeToolCallParser to populate rawChunkTracker
+				if (chunk.type === "tool_call_partial") {
+					NativeToolCallParser.processRawChunk({
+						index: chunk.index,
+						id: chunk.id,
+						name: chunk.name,
+						arguments: chunk.arguments,
+					})
+				}
+				chunks.push(chunk)
+			}
+
+			// Should have tool_call_partial and tool_call_end
+			const partialChunks = chunks.filter((chunk) => chunk.type === "tool_call_partial")
+			const endChunks = chunks.filter((chunk) => chunk.type === "tool_call_end")
+
+			expect(partialChunks).toHaveLength(1)
+			expect(endChunks).toHaveLength(1)
+			expect(endChunks[0].id).toBe("call_openrouter_test")
+		})
 	})
 
 	describe("completePrompt", () => {

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -9,6 +9,8 @@ import {
 	DEEP_SEEK_DEFAULT_TEMPERATURE,
 } from "@roo-code/types"
 
+import { NativeToolCallParser } from "../../core/assistant-message/NativeToolCallParser"
+
 import type { ApiHandlerOptions, ModelRecord } from "../../shared/api"
 
 import { convertToOpenAiMessages } from "../transform/openai-format"
@@ -338,6 +340,15 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 
 				if (delta.content) {
 					yield { type: "text", text: delta.content }
+				}
+			}
+
+			// Process finish_reason to emit tool_call_end events
+			// This ensures tool calls are finalized even if the stream doesn't properly close
+			if (finishReason) {
+				const endEvents = NativeToolCallParser.processFinishReason(finishReason)
+				for (const event of endEvents) {
+					yield event
 				}
 			}
 


### PR DESCRIPTION
## Summary

When using native tool calling, if an API returns `finish_reason: "tool_calls"` but delays or fails to send the `[DONE]` stream termination signal, the stream would hang indefinitely waiting for tool calls to be finalized.

## Root Cause

The `NativeToolCallParser.processFinishReason()` method was created to handle this scenario but was never wired up to the providers. The `finishReason` was being captured but not processed:

```typescript
const finishReason = chunk.choices[0]?.finish_reason  // ← Read but never used!
```

## Fix

This PR:
- Imports `NativeToolCallParser` in both `roo.ts` and `openrouter.ts` providers
- Processes `finish_reason` during streaming to immediately emit `tool_call_end` events
- Ensures tool calls are finalized as soon as `finish_reason` is received, without waiting for `[DONE]`

## Before (Bug)
1. API sends `tool_call_partial` chunks → yielded
2. API sends `finish_reason: "tool_calls"` → **IGNORED**
3. API hangs or never sends `[DONE]` → stream hangs forever
4. Tool calls stuck in partial state

## After (Fixed)
1. API sends `tool_call_partial` chunks → yielded
2. Task.ts processes them via `NativeToolCallParser.processRawChunk()` → populates `rawChunkTracker`
3. API sends `finish_reason: "tool_calls"` → provider calls `NativeToolCallParser.processFinishReason()`
4. Provider yields `tool_call_end` events for all tracked tool calls
5. Tool calls are finalized **immediately** - no need to wait for `[DONE]`

## Testing

- Added tests for both `roo.ts` and `openrouter.ts` to verify `tool_call_end` events are emitted when `finish_reason: "tool_calls"` is received
- All 54 provider tests pass
- All 4536 tests pass in full test suite
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Integrates `NativeToolCallParser` to process `finish_reason` and emit `tool_call_end` events in `openrouter.ts` and `roo.ts`, with tests verifying functionality.
> 
>   - **Behavior**:
>     - Integrates `NativeToolCallParser` in `openrouter.ts` and `roo.ts` to process `finish_reason` and emit `tool_call_end` events.
>     - Ensures tool calls are finalized immediately upon receiving `finish_reason`, without waiting for `[DONE]`.
>   - **Testing**:
>     - Adds tests in `openrouter.spec.ts` and `roo.spec.ts` to verify `tool_call_end` events are emitted when `finish_reason: "tool_calls"` is received.
>     - All provider tests pass, ensuring robust functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3562b8fcb4268a4f892bc2f82670f39c60e7e672. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->