### PR TITLE
fix: display actual API error message instead of generic text on retry

### DIFF
--- a/webview-ui/src/components/chat/ChatRow.tsx
+++ b/webview-ui/src/components/chat/ChatRow.tsx
@@ -1113,8 +1113,9 @@ export const ChatRowContent = ({
 					let retryInfo, code, docsURL
 					if (message.text !== undefined) {
 						// Try to show richer error message for that code, if available
-						if (parseInt(message.text.substring(0, 3)) >= 400) {
-							code = parseInt(message.text)
+						const potentialCode = parseInt(message.text.substring(0, 3))
+						if (potentialCode >= 400) {
+							code = potentialCode
 							const stringForError = `chat:apiRequest.errorMessage.${code}`
 							if (i18n.exists(stringForError)) {
 								body = t(stringForError)
@@ -1134,6 +1135,9 @@ export const ChatRowContent = ({
 									{message.text.substring(4)}
 								</p>
 							)
+						} else {
+							// Non-HTTP-status-code error message - display the actual error text
+							body = message.text
 						}
 					}
 					return (


### PR DESCRIPTION
## Summary
BEFORE
<img width="1242" height="348" alt="image" src="https://github.com/user-attachments/assets/d5799ca2-b37c-4b5c-99d4-bed8bd469d66" />

AFTER
<img width="624" height="198" alt="image" src="https://github.com/user-attachments/assets/64bf167e-9b80-486b-83e6-90be57c2067c" />


Fixes a bug where non-HTTP-status-code error messages (like "Request timed out.") were being replaced with the generic "API Request Failed" text in the retry error display.

## Changes

- Modified `webview-ui/src/components/chat/ChatRow.tsx` to display the actual error message when it doesn't start with an HTTP status code (400+)
- Previously, the error handling code only parsed messages starting with HTTP status codes, causing other error messages to fall through to the generic i18n string

## Testing

- All existing tests pass
- The fix ensures errors like "Request timed out." from the Roo Code Cloud proxy are now displayed to users instead of "API Request Failed"