### PR TITLE
Revert "feat: change defaultToolProtocol default from xml to native"

### DIFF
--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -981,7 +981,6 @@ describe("Cline", () => {
 					getState: vi.fn().mockResolvedValue({
 						apiConfiguration: mockApiConfig,
 					}),
-					getMcpHub: vi.fn().mockReturnValue(undefined),
 					say: vi.fn(),
 					postStateToWebview: vi.fn().mockResolvedValue(undefined),
 					postMessageToWebview: vi.fn().mockResolvedValue(undefined),

--- a/src/utils/__tests__/resolveToolProtocol.spec.ts
+++ b/src/utils/__tests__/resolveToolProtocol.spec.ts
@@ -139,24 +139,18 @@ describe("resolveToolProtocol", () => {
 		})
 	})
 
-	describe("Precedence Level 3: Native Fallback", () => {
-		it("should use Native fallback when no model default is specified and model supports native", () => {
+	describe("Precedence Level 3: XML Fallback", () => {
+		it("should use XML fallback when no model default is specified", () => {
 			const settings: ProviderSettings = {
 				apiProvider: "anthropic",
 			}
-			const modelInfo: ModelInfo = {
-				maxTokens: 4096,
-				contextWindow: 128000,
-				supportsPromptCache: false,
-				supportsNativeTools: true,
-			}
-			const result = resolveToolProtocol(settings, modelInfo)
-			expect(result).toBe(TOOL_PROTOCOL.NATIVE) // Native fallback
+			const result = resolveToolProtocol(settings, undefined)
+			expect(result).toBe(TOOL_PROTOCOL.XML) // XML fallback
 		})
 	})
 
 	describe("Complete Precedence Chain", () => {
-		it("should respect full precedence: Profile > Model Default > Native Fallback", () => {
+		it("should respect full precedence: Profile > Model Default > XML Fallback", () => {
 			// Set up a scenario with all levels defined
 			const settings: ProviderSettings = {
 				toolProtocol: "native", // Level 1: User profile setting
@@ -192,7 +186,7 @@ describe("resolveToolProtocol", () => {
 			expect(result).toBe(TOOL_PROTOCOL.XML) // Model default wins
 		})
 
-		it("should skip to Native fallback when profile and model default are undefined", () => {
+		it("should skip to XML fallback when profile and model default are undefined", () => {
 			const settings: ProviderSettings = {
 				apiProvider: "openai-native",
 			}
@@ -205,7 +199,7 @@ describe("resolveToolProtocol", () => {
 			}
 
 			const result = resolveToolProtocol(settings, modelInfo)
-			expect(result).toBe(TOOL_PROTOCOL.NATIVE) // Native fallback
+			expect(result).toBe(TOOL_PROTOCOL.XML) // XML fallback
 		})
 
 		it("should skip to XML fallback when model info is unavailable", () => {
@@ -214,7 +208,7 @@ describe("resolveToolProtocol", () => {
 			}
 
 			const result = resolveToolProtocol(settings, undefined)
-			expect(result).toBe(TOOL_PROTOCOL.XML) // XML fallback (no model info means no native support)
+			expect(result).toBe(TOOL_PROTOCOL.XML) // XML fallback
 		})
 	})
 
@@ -222,7 +216,7 @@ describe("resolveToolProtocol", () => {
 		it("should handle missing provider name gracefully", () => {
 			const settings: ProviderSettings = {}
 			const result = resolveToolProtocol(settings)
-			expect(result).toBe(TOOL_PROTOCOL.XML) // Falls back to XML (no model info)
+			expect(result).toBe(TOOL_PROTOCOL.XML) // Falls back to global
 		})
 
 		it("should handle undefined model info gracefully", () => {
@@ -230,7 +224,7 @@ describe("resolveToolProtocol", () => {
 				apiProvider: "openai-native",
 			}
 			const result = resolveToolProtocol(settings, undefined)
-			expect(result).toBe(TOOL_PROTOCOL.XML) // XML fallback (no model info)
+			expect(result).toBe(TOOL_PROTOCOL.XML) // XML fallback
 		})
 
 		it("should fall back to XML when model doesn't support native", () => {
@@ -249,7 +243,7 @@ describe("resolveToolProtocol", () => {
 	})
 
 	describe("Real-world Scenarios", () => {
-		it("should use Native fallback for models without defaultToolProtocol", () => {
+		it("should use XML fallback for models without defaultToolProtocol", () => {
 			const settings: ProviderSettings = {
 				apiProvider: "openai-native",
 			}
@@ -260,7 +254,7 @@ describe("resolveToolProtocol", () => {
 				supportsNativeTools: true,
 			}
 			const result = resolveToolProtocol(settings, modelInfo)
-			expect(result).toBe(TOOL_PROTOCOL.NATIVE) // Native fallback
+			expect(result).toBe(TOOL_PROTOCOL.XML) // XML fallback
 		})
 
 		it("should use XML for Claude models with Anthropic provider", () => {

--- a/src/utils/resolveToolProtocol.ts
+++ b/src/utils/resolveToolProtocol.ts
@@ -6,7 +6,7 @@ import type { ProviderSettings, ModelInfo } from "@roo-code/types"
  *
  * 1. User Preference - Per-Profile (explicit profile setting)
  * 2. Model Default (defaultToolProtocol in ModelInfo)
- * 3. Native Fallback (final fallback)
+ * 3. XML Fallback (final fallback)
  *
  * Then check support: if protocol is "native" but model doesn't support it, use XML.
  *
@@ -31,6 +31,6 @@ export function resolveToolProtocol(providerSettings: ProviderSettings, modelInf
 		return modelInfo.defaultToolProtocol
 	}
 
-	// 3. Native Fallback
-	return TOOL_PROTOCOL.NATIVE
+	// 3. XML Fallback
+	return TOOL_PROTOCOL.XML
 }

--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -420,8 +420,8 @@ const ApiOptions = ({
 	// Mirrors the simplified logic in resolveToolProtocol.ts:
 	// 1. User preference (toolProtocol) - handled by the select value binding
 	// 2. Model default - use if available
-	// 3. Native fallback
-	const defaultProtocol = selectedModelInfo?.defaultToolProtocol || TOOL_PROTOCOL.NATIVE
+	// 3. XML fallback
+	const defaultProtocol = selectedModelInfo?.defaultToolProtocol || TOOL_PROTOCOL.XML
 
 	// Show the tool protocol selector when model supports native tools
 	const showToolProtocolSelector = selectedModelInfo?.supportsNativeTools === true


### PR DESCRIPTION
Reverts RooCodeInc/Roo-Code#9892
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts default tool protocol from native back to XML, updating related logic, tests, and UI components.
> 
>   - **Behavior**:
>     - Reverts default tool protocol from native back to XML in `resolveToolProtocol` function.
>     - Updates `ApiOptions.tsx` to reflect XML as the default protocol.
>   - **Tests**:
>     - Updates test cases in `resolveToolProtocol.spec.ts` to expect XML as the fallback instead of native.
>     - Removes `getMcpHub` mock in `Task.spec.ts`.
>   - **Misc**:
>     - Updates comments in `resolveToolProtocol.ts` to reflect XML fallback.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ee85065938773875e0b9016e108c4dc35be1babc. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->