### PR TITLE
fix: return undefined instead of 0 for disabled API timeout

### DIFF
--- a/src/api/providers/utils/__tests__/timeout-config.spec.ts
+++ b/src/api/providers/utils/__tests__/timeout-config.spec.ts
@@ -41,20 +41,23 @@ describe("getApiRequestTimeout", () => {
 		expect(timeout).toBe(1200000) // 1200 seconds in milliseconds
 	})
 
-	it("should handle zero timeout (no timeout)", () => {
+	it("should return undefined for zero timeout (disables timeout)", () => {
 		mockGetConfig.mockReturnValue(0)
 
 		const timeout = getApiRequestTimeout()
 
-		expect(timeout).toBe(0) // No timeout
+		// Zero means "no timeout" - return undefined so SDK uses its default
+		// (OpenAI SDK interprets 0 as "abort immediately", so we avoid that)
+		expect(timeout).toBeUndefined()
 	})
 
-	it("should handle negative values by clamping to 0", () => {
+	it("should return undefined for negative values (disables timeout)", () => {
 		mockGetConfig.mockReturnValue(-100)
 
 		const timeout = getApiRequestTimeout()
 
-		expect(timeout).toBe(0) // Negative values should be clamped to 0
+		// Negative values also mean "no timeout" - return undefined
+		expect(timeout).toBeUndefined()
 	})
 
 	it("should handle null by using default", () => {

--- a/src/api/providers/utils/timeout-config.ts
+++ b/src/api/providers/utils/timeout-config.ts
@@ -4,9 +4,10 @@ import { Package } from "../../../shared/package"
 /**
  * Gets the API request timeout from VSCode configuration with validation.
  *
- * @returns The timeout in milliseconds. Returns 0 for no timeout.
+ * @returns The timeout in milliseconds. Returns undefined to disable timeout
+ *          (letting the SDK use its default), or a positive number for explicit timeout.
  */
-export function getApiRequestTimeout(): number {
+export function getApiRequestTimeout(): number | undefined {
 	// Get timeout with validation to ensure it's a valid non-negative number
 	const configTimeout = vscode.workspace.getConfiguration(Package.name).get<number>("apiRequestTimeout", 600)
 
@@ -15,8 +16,11 @@ export function getApiRequestTimeout(): number {
 		return 600 * 1000 // Default to 600 seconds
 	}
 
-	// Allow 0 (no timeout) but clamp negative values to 0
-	const timeoutSeconds = configTimeout < 0 ? 0 : configTimeout
+	// 0 or negative means "no timeout" - return undefined to let SDK use its default
+	// (OpenAI SDK interprets 0 as "abort immediately", so we return undefined instead)
+	if (configTimeout <= 0) {
+		return undefined
+	}
 
-	return timeoutSeconds * 1000 // Convert to milliseconds
+	return configTimeout * 1000 // Convert to milliseconds
 }


### PR DESCRIPTION
## Summary

Followup to #9898. Fixes an issue where setting `apiRequestTimeout` to `0` (intended to disable timeout) caused requests to abort immediately.

The OpenAI SDK's `fetchWithTimeout` function uses `setTimeout(..., ms)`. When `ms = 0`, the timeout fires immediately on the next event loop tick, aborting the request before it can complete.

## Changes

- **`timeout-config.ts`**: Return `undefined` instead of `0` when timeout is disabled (value ≤ 0). This lets the SDK use its built-in default timeout rather than triggering immediate abort.
- **`timeout-config.spec.ts`**: Updated tests to expect `undefined` for zero and negative timeout values.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `getApiRequestTimeout()` now returns `undefined` for zero or negative timeouts, allowing SDK default timeout instead of immediate aborts.
> 
>   - **Behavior**:
>     - `getApiRequestTimeout()` in `timeout-config.ts` now returns `undefined` for zero or negative timeout values, allowing SDK to use default timeout.
>     - Previously, zero timeout caused immediate request aborts due to `setTimeout` behavior.
>   - **Tests**:
>     - Updated `timeout-config.spec.ts` to expect `undefined` for zero and negative timeout values.
>     - Added comments explaining the behavior change for zero and negative values.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e15f30e47b87e3fc3d29d5d2c08f565dbd99fd2f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->