### PR TITLE
fix: always show tool protocol selector for openai-compatible

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -423,8 +423,9 @@ const ApiOptions = ({
 	// 3. XML fallback
 	const defaultProtocol = selectedModelInfo?.defaultToolProtocol || TOOL_PROTOCOL.XML
 
-	// Show the tool protocol selector when model supports native tools
-	const showToolProtocolSelector = selectedModelInfo?.supportsNativeTools === true
+	// Show the tool protocol selector when model supports native tools.
+	// For OpenAI Compatible providers we always show it so users can force XML/native explicitly.
+	const showToolProtocolSelector = selectedProvider === "openai" || selectedModelInfo?.supportsNativeTools === true
 
 	// Convert providers to SearchableSelect options
 	const providerOptions = useMemo(() => {


### PR DESCRIPTION
## Summary

Always display the Tool Call Protocol selector when using the OpenAI Compatible provider so users can explicitly choose XML or Native regardless of model capability. Fixes #9965.

## Changes

- Always render the Tool Call Protocol dropdown for the OpenAI Compatible provider
- Leave capability-gated rendering in place for all other providers
- Verified provider filtering UI spec still passes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Always show Tool Call Protocol selector for OpenAI Compatible providers in `ApiOptions`.
> 
>   - **Behavior**:
>     - Always show Tool Call Protocol selector for OpenAI Compatible providers in `ApiOptions`.
>     - Retain capability-gated rendering for other providers.
>   - **Verification**:
>     - Confirmed provider filtering UI spec still passes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1a7c9fbfb76701b2916f2646fee656cc73e70f36. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->