### PR TITLE
fix: respect explicit supportsReasoningEffort array values

### DIFF
--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -87,11 +87,16 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 
 	// "disable" turns off reasoning entirely; "none" is a valid reasoning level.
 	// Both display as "None" in the UI but behave differently.
-	// Add "disable" option if reasoning effort is not required.
+	// Add "disable" option only when:
+	// 1. requiredReasoningEffort is not true, AND
+	// 2. supportsReasoningEffort is boolean true (not an explicit array)
+	// When the model provides an explicit array, respect those exact values.
 	type ReasoningEffortOption = ReasoningEffortWithMinimal | "none" | "disable"
-	const availableOptions: ReadonlyArray<ReasoningEffortOption> = modelInfo?.requiredReasoningEffort
-		? (baseAvailableOptions as ReadonlyArray<ReasoningEffortOption>)
-		: (["disable", ...baseAvailableOptions] as ReasoningEffortOption[])
+	const shouldAutoAddDisable =
+		!modelInfo?.requiredReasoningEffort && supports === true && !baseAvailableOptions.includes("disable" as any)
+	const availableOptions: ReadonlyArray<ReasoningEffortOption> = shouldAutoAddDisable
+		? (["disable", ...baseAvailableOptions] as ReasoningEffortOption[])
+		: (baseAvailableOptions as ReadonlyArray<ReasoningEffortOption>)
 
 	// Default reasoning effort - use model's default if available
 	// GPT-5 models have "medium" as their default in the model configuration


### PR DESCRIPTION
## Summary

Fix the reasoning effort dropdown to respect explicit array values in `supportsReasoningEffort`. Previously, "None" (the "disable" option) was unconditionally added to all reasoning effort dropdowns, even when a model explicitly specified only certain values like `["low", "high"]`.

## Changes

- Modified `ThinkingBudget.tsx` to only auto-add the "disable" option when:
  1. `requiredReasoningEffort` is not true, AND
  2. `supportsReasoningEffort` is boolean `true` (not an explicit array)
  
- When a model provides an explicit array of supported efforts, those exact values are now respected
- If a model wants to allow disabling reasoning, it should explicitly include `"disable"` in its `supportsReasoningEffort` array

## Behavior

| supportsReasoningEffort | Options Shown |
|------------------------|---------------|
| `true` | None, Low, Medium, High |
| `["low", "high"]` | Low, High |
| `["disable", "low", "high"]` | None, Low, High |

## Tests

Added 4 new test cases for the reasoning effort dropdown behavior:
- Boolean `true` shows disable option
- Explicit array without disable does NOT show disable option  
- Explicit array with disable shows disable option
- Explicit array with "none" shows correct options
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `ThinkingBudget.tsx` now respects explicit `supportsReasoningEffort` arrays, adding 'disable' only when appropriate, with updated tests.
> 
>   - **Behavior**:
>     - `ThinkingBudget.tsx` now respects explicit `supportsReasoningEffort` array values, only adding 'disable' when `requiredReasoningEffort` is false and `supportsReasoningEffort` is `true`.
>     - Models must include 'disable' in `supportsReasoningEffort` array to allow disabling reasoning.
>   - **Tests**:
>     - Added tests in `ThinkingBudget.spec.tsx` for dropdown behavior with boolean `true`, explicit arrays with and without 'disable', and arrays including 'none'.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1d867704cfb4af576e5f9812e5cf07a3cb3ec0f5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->