### PR TITLE
fix: prevent premature rawChunkTracker clearing for MCP tools

### DIFF
--- a/src/core/assistant-message/NativeToolCallParser.ts
+++ b/src/core/assistant-message/NativeToolCallParser.ts
@@ -156,7 +156,6 @@ export class NativeToolCallParser {
 					id: tracked.id,
 				})
 			}
-			this.rawChunkTracker.clear()
 		}
 
 		return events


### PR DESCRIPTION
## Problem

MCP tools were failing with the error: "Roo tried to use an unknown tool: mcp_context7_resolve-library-id"

## Root Cause

The `processFinishReason()` method in `NativeToolCallParser` was clearing `rawChunkTracker` immediately after emitting `tool_call_end` events. However, Task.ts doesn't process these events in the main streaming loop - they're only processed via the fallback mechanism in `finalizeRawChunks()`.

This caused MCP tools to never be converted from `tool_use` to `mcp_tool_use` type, resulting in 'unknown tool' errors.

## Solution

Removed the redundant `clear()` call from `processFinishReason()`. The tracker is still properly cleared by:
1. `finalizeRawChunks()` - after processing remaining tools (line 180)
2. `clearRawChunkState()` - when a new API request starts

## Testing

- All 7 NativeToolCallParser tests pass
- Verified the fix resolves the MCP tool streaming issue
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes premature clearing of `rawChunkTracker` in `NativeToolCallParser.ts` to resolve MCP tool processing errors.
> 
>   - **Behavior**:
>     - Removes `rawChunkTracker.clear()` from `processFinishReason()` in `NativeToolCallParser.ts` to prevent premature clearing.
>     - Ensures `rawChunkTracker` is cleared in `finalizeRawChunks()` and `clearRawChunkState()`.
>   - **Testing**:
>     - All 7 `NativeToolCallParser` tests pass.
>     - Verified fix resolves MCP tool streaming issue.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 57ea735a6a247baef72f9f9820860e3785a1d8cb. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->