### PR TITLE
fix: apply versioned settings on nightly builds

### DIFF
--- a/src/api/providers/fetchers/__tests__/roo.spec.ts
+++ b/src/api/providers/fetchers/__tests__/roo.spec.ts
@@ -978,7 +978,7 @@ describe("getRooModels", () => {
 		expect(model.feature).toBe("current")
 	})
 
-	it("should apply highest versionedSettings for nightly versions (0.0.x)", async () => {
+	it("should apply highest versionedSettings for nightly builds (package name)", async () => {
 		const mockResponse = {
 			object: "list",
 			data: [
@@ -1012,9 +1012,9 @@ describe("getRooModels", () => {
 			json: async () => mockResponse,
 		})
 
-		// Simulate nightly version (0.0.x)
-		const originalVersion = Package.version
-		;(Package as { version: string }).version = "0.0.7465"
+		// Simulate nightly build via package name
+		const originalName = Package.name
+		;(Package as { name: string }).name = "roo-code-nightly"
 
 		try {
 			const models = await getRooModels(baseUrl, apiKey)
@@ -1023,7 +1023,7 @@ describe("getRooModels", () => {
 			// Should pick the highest available versionedSettings even though 3.36.3 > 0.0.7465
 			expect(model.feature).toBe("v3")
 		} finally {
-			;(Package as { version: string }).version = originalVersion
+			;(Package as { name: string }).name = originalName
 		}
 	})
 })

--- a/src/api/providers/fetchers/__tests__/versionedSettings.spec.ts
+++ b/src/api/providers/fetchers/__tests__/versionedSettings.spec.ts
@@ -5,6 +5,7 @@ import {
 	resolveVersionedSettings,
 	type VersionedSettings,
 } from "../versionedSettings"
+import { Package } from "../../../../shared/package"
 
 describe("versionedSettings", () => {
 	describe("compareSemver", () => {
@@ -112,6 +113,23 @@ describe("versionedSettings", () => {
 
 			const result = findHighestMatchingVersion(versionedSettings, "3.36.4")
 			expect(result).toBeUndefined()
+		})
+
+		it("should treat nightly builds (by package name) as always eligible and pick highest version", () => {
+			const versionedSettings: VersionedSettings = {
+				"3.36.3": { feature: "v3" },
+				"2.0.0": { feature: "v2" },
+			}
+
+			const originalName = Package.name
+			;(Package as { name: string }).name = "roo-code-nightly"
+
+			try {
+				const result = findHighestMatchingVersion(versionedSettings, "1.0.0")
+				expect(result).toBe("3.36.3")
+			} finally {
+				;(Package as { name: string }).name = originalName
+			}
 		})
 	})
 

--- a/src/api/providers/fetchers/versionedSettings.ts
+++ b/src/api/providers/fetchers/versionedSettings.ts
@@ -2,8 +2,8 @@ import cmp from "semver-compare"
 
 import { Package } from "../../../shared/package"
 
-function isNightlyVersion(version: string): boolean {
-	return version.startsWith("0.0.")
+function isNightlyBuild(): boolean {
+	return Package.name.toLowerCase().includes("nightly")
 }
 
 /**
@@ -76,8 +76,8 @@ export function findHighestMatchingVersion(
 		return undefined
 	}
 
-	// Nightly builds (0.0.x) should always pick the highest available versioned settings
-	if (isNightlyVersion(currentVersion)) {
+	// Nightly builds should always pick the highest available versioned settings
+	if (isNightlyBuild()) {
 		versions.sort((a, b) => compareSemver(b, a))
 		return versions[0]
 	}


### PR DESCRIPTION
## Summary
- ensure nightly builds (0.0.x) select the highest available versioned settings without minimum-version gating
- keep non-nightly behavior unchanged and retain plain-settings fallback when no versioned settings match
- add a nightly coverage test mocking Package.version to 0.0.x to verify highest versionedSettings is applied

## Changes
- adjust versionedSettings resolver to treat nightly builds as always eligible and pick highest version key
- add nightly test in roo provider fetcher specs to assert highest versionedSettings applies

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Nightly builds now select the highest available versioned settings without constraints, with tests added to verify this behavior.
> 
>   - **Behavior**:
>     - Nightly builds (0.0.x) now select the highest available `versionedSettings` without minimum-version gating in `versionedSettings.ts`.
>     - Non-nightly builds retain existing behavior, using plain settings if no versioned settings match.
>   - **Tests**:
>     - Added test in `roo.spec.ts` to verify highest `versionedSettings` is applied for nightly builds by mocking `Package.name`.
>     - Added test in `versionedSettings.spec.ts` to ensure nightly builds pick the highest versioned settings.
>   - **Functions**:
>     - Modified `findHighestMatchingVersion()` in `versionedSettings.ts` to treat nightly builds as always eligible for highest version.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5d181037e691d9e49536568dba8accc308de961a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->