### PR TITLE
feat(anthropic): enable native tools by default and add telemetry tracking

### DIFF
--- a/packages/types/src/providers/anthropic.ts
+++ b/packages/types/src/providers/anthropic.ts
@@ -12,6 +12,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 3.0, // $3 per million input tokens (≤200K context)
 		outputPrice: 15.0, // $15 per million output tokens (≤200K context)
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
@@ -34,6 +35,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 3.0, // $3 per million input tokens (≤200K context)
 		outputPrice: 15.0, // $15 per million output tokens (≤200K context)
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
@@ -56,6 +58,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 5.0, // $5 per million input tokens
 		outputPrice: 25.0, // $25 per million output tokens
 		cacheWritesPrice: 6.25, // $6.25 per million tokens
@@ -68,6 +71,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 15.0, // $15 per million input tokens
 		outputPrice: 75.0, // $75 per million output tokens
 		cacheWritesPrice: 18.75, // $18.75 per million tokens
@@ -80,6 +84,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 15.0, // $15 per million input tokens
 		outputPrice: 75.0, // $75 per million output tokens
 		cacheWritesPrice: 18.75, // $18.75 per million tokens
@@ -92,6 +97,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 3.0, // $3 per million input tokens
 		outputPrice: 15.0, // $15 per million output tokens
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
@@ -105,6 +111,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 3.0, // $3 per million input tokens
 		outputPrice: 15.0, // $15 per million output tokens
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
@@ -116,6 +123,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 3.0, // $3 per million input tokens
 		outputPrice: 15.0, // $15 per million output tokens
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
@@ -127,6 +135,7 @@ export const anthropicModels = {
 		supportsImages: false,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 1.0,
 		outputPrice: 5.0,
 		cacheWritesPrice: 1.25,
@@ -138,6 +147,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 15.0,
 		outputPrice: 75.0,
 		cacheWritesPrice: 18.75,
@@ -149,6 +159,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 0.25,
 		outputPrice: 1.25,
 		cacheWritesPrice: 0.3,
@@ -160,6 +171,7 @@ export const anthropicModels = {
 		supportsImages: true,
 		supportsPromptCache: true,
 		supportsNativeTools: true,
+		defaultToolProtocol: "native",
 		inputPrice: 1.0,
 		outputPrice: 5.0,
 		cacheWritesPrice: 1.25,

--- a/src/api/providers/__tests__/anthropic.spec.ts
+++ b/src/api/providers/__tests__/anthropic.spec.ts
@@ -3,6 +3,15 @@
 import { AnthropicHandler } from "../anthropic"
 import { ApiHandlerOptions } from "../../../shared/api"
 
+// Mock TelemetryService
+vitest.mock("@roo-code/telemetry", () => ({
+	TelemetryService: {
+		instance: {
+			captureException: vitest.fn(),
+		},
+	},
+}))
+
 const mockCreate = vitest.fn()
 
 vitest.mock("@anthropic-ai/sdk", () => {
@@ -411,11 +420,11 @@ describe("AnthropicHandler", () => {
 			},
 		]
 
-		it("should include tools in request when toolProtocol is native", async () => {
+		it("should include tools in request by default (native is default)", async () => {
+			// Handler uses native protocol by default via model's defaultToolProtocol
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 			})
 
 			// Consume the stream to trigger the API call
@@ -443,10 +452,15 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should not include tools when toolProtocol is xml", async () => {
-			const stream = handler.createMessage(systemPrompt, messages, {
+			// Create handler with xml tool protocol in options
+			const xmlHandler = new AnthropicHandler({
+				...mockOptions,
+				toolProtocol: "xml",
+			})
+
+			const stream = xmlHandler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "xml",
 			})
 
 			// Consume the stream to trigger the API call
@@ -463,9 +477,9 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should not include tools when no tools are provided", async () => {
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
-				toolProtocol: "native",
 			})
 
 			// Consume the stream to trigger the API call
@@ -482,10 +496,10 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should convert tool_choice 'auto' to Anthropic format", async () => {
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 				tool_choice: "auto",
 			})
 
@@ -503,10 +517,10 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should convert tool_choice 'required' to Anthropic 'any' format", async () => {
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 				tool_choice: "required",
 			})
 
@@ -524,10 +538,10 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should omit both tools and tool_choice when tool_choice is 'none'", async () => {
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 				tool_choice: "none",
 			})
 
@@ -552,10 +566,10 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should convert specific tool_choice to Anthropic 'tool' format", async () => {
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 				tool_choice: { type: "function" as const, function: { name: "get_weather" } },
 			})
 
@@ -573,10 +587,10 @@ describe("AnthropicHandler", () => {
 		})
 
 		it("should enable parallel tool calls when parallelToolCalls is true", async () => {
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 				tool_choice: "auto",
 				parallelToolCalls: true,
 			})
@@ -618,10 +632,10 @@ describe("AnthropicHandler", () => {
 				},
 			}))
 
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 			})
 
 			const chunks: any[] = []
@@ -685,10 +699,10 @@ describe("AnthropicHandler", () => {
 				},
 			}))
 
+			// Handler uses native protocol by default
 			const stream = handler.createMessage(systemPrompt, messages, {
 				taskId: "test-task",
 				tools: mockTools,
-				toolProtocol: "native",
 			})
 
 			const chunks: any[] = []

--- a/src/core/task/__tests__/Task.spec.ts
+++ b/src/core/task/__tests__/Task.spec.ts
@@ -985,6 +985,7 @@ describe("Cline", () => {
 					postStateToWebview: vi.fn().mockResolvedValue(undefined),
 					postMessageToWebview: vi.fn().mockResolvedValue(undefined),
 					updateTaskHistory: vi.fn().mockResolvedValue(undefined),
+					getMcpHub: vi.fn().mockReturnValue(undefined),
 				}
 
 				// Get the mocked delay function


### PR DESCRIPTION
## Summary

Enable native tools by default for Anthropic provider and add telemetry tracking to errors, matching OpenRouter's approach.

## Changes

### 1. `packages/types/src/providers/anthropic.ts`
Added `defaultToolProtocol: "native"` to all 13 Anthropic model definitions to enable native tools by default through the `resolveToolProtocol()` utility.

### 2. `src/api/providers/anthropic.ts`
- Added imports for `TOOL_PROTOCOL` and `resolveToolProtocol`
- Updated `shouldIncludeNativeTools` logic to use `resolveToolProtocol(this.options, model.info)` which respects the model's `defaultToolProtocol`
- Added telemetry tracking using `TelemetryService.instance.captureException()` with `ApiProviderError` for all API calls (`createMessage` and `completePrompt`)

### 3. `src/api/providers/__tests__/anthropic.spec.ts`
- Updated tests to remove explicit `toolProtocol: "native"` from handler options since native is now the default
- All 29 tests pass

### 4. `src/core/task/__tests__/Task.spec.ts`
- Added `getMcpHub` mock to provider in Subtask Rate Limiting tests to support native tools code path

## How It Works

- Native tools are now enabled by default for all Anthropic models via `defaultToolProtocol: "native"` in model definitions
- Users can still override to XML by setting `toolProtocol: "xml"` in their profile settings
- Error telemetry captures provider name ("Anthropic"), model ID, and method name for debugging

## Testing

- All 4625 tests pass
- Manually verified native tool functionality
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable native tools by default for Anthropic models and add error telemetry tracking.
> 
>   - **Behavior**:
>     - Enable native tools by default for all Anthropic models by setting `defaultToolProtocol: "native"` in `anthropic.ts`.
>     - Add telemetry tracking for errors using `TelemetryService.instance.captureException()` in `anthropic.ts`.
>   - **Tests**:
>     - Update tests in `anthropic.spec.ts` to reflect native tools as default, removing explicit `toolProtocol: "native"`.
>     - Add mock for `getMcpHub` in `Task.spec.ts` to support native tools code path.
>   - **Misc**:
>     - Import `TOOL_PROTOCOL` and `resolveToolProtocol` in `anthropic.ts` to manage tool protocol logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f5520f15689b599048a1282128c1457a0b916663. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->