### PR TITLE
fix: merge settings and versionedSettings for Roo provider models

### DIFF
--- a/src/api/providers/fetchers/__tests__/roo.spec.ts
+++ b/src/api/providers/fetchers/__tests__/roo.spec.ts
@@ -803,7 +803,7 @@ describe("getRooModels", () => {
 		expect(model.nestedConfig).toEqual({ key: "value" })
 	})
 
-	it("should apply versioned settings when version matches", async () => {
+	it("should apply versioned settings when version matches, overriding plain settings", async () => {
 		const mockResponse = {
 			object: "list",
 			data: [
@@ -845,9 +845,63 @@ describe("getRooModels", () => {
 
 		const models = await getRooModels(baseUrl, apiKey)
 
-		// Versioned settings should be used instead of plain settings
+		// Versioned settings should override the same properties from plain settings
 		expect(models["test/versioned-model"].includedTools).toEqual(["apply_patch", "search_replace"])
 		expect(models["test/versioned-model"].excludedTools).toEqual(["apply_diff", "write_to_file"])
+	})
+
+	it("should merge settings and versionedSettings, with versioned settings taking precedence", async () => {
+		const mockResponse = {
+			object: "list",
+			data: [
+				{
+					id: "test/merged-settings-model",
+					object: "model",
+					created: 1234567890,
+					owned_by: "test",
+					name: "Model with Merged Settings",
+					description: "Model with both settings and versionedSettings that should be merged",
+					context_window: 128000,
+					max_tokens: 8192,
+					type: "language",
+					tags: ["tool-use"],
+					pricing: {
+						input: "0.0001",
+						output: "0.0002",
+					},
+					// Plain settings - provides base configuration
+					settings: {
+						includedTools: ["apply_patch"],
+						excludedTools: ["apply_diff", "write_to_file"],
+						reasoningEffort: "medium",
+					},
+					// Versioned settings - adds version-specific overrides
+					versionedSettings: {
+						"1.0.0": {
+							supportsTemperature: false,
+							supportsReasoningEffort: ["none", "low", "medium", "high"],
+						},
+					},
+				},
+			],
+		}
+
+		mockFetch.mockResolvedValueOnce({
+			ok: true,
+			json: async () => mockResponse,
+		})
+
+		const models = await getRooModels(baseUrl, apiKey)
+		const model = models["test/merged-settings-model"] as Record<string, unknown>
+
+		// Properties from plain settings should be present
+		expect(model.includedTools).toEqual(["apply_patch"])
+		expect(model.excludedTools).toEqual(["apply_diff", "write_to_file"])
+		expect(model.reasoningEffort).toBe("medium")
+
+		// Properties from versioned settings should also be present
+		expect(model.supportsTemperature).toBe(false)
+		expect(model.supportsReasoningEffort).toEqual(["none", "low", "medium", "high"])
 	})
 
 	it("should use plain settings when no versioned settings version matches", async () => {

--- a/src/api/providers/fetchers/roo.ts
+++ b/src/api/providers/fetchers/roo.ts
@@ -130,33 +130,30 @@ export async function getRooModels(baseUrl: string, apiKey?: string): Promise<Mo
 				// Settings allow the proxy to dynamically configure model-specific options
 				// like includedTools, excludedTools, reasoningEffort, etc.
 				//
-				// Two fields are used for backward compatibility:
-				// - `settings`: Plain values that work with all client versions (e.g., { includedTools: ['search_replace'] })
-				// - `versionedSettings`: Version-keyed settings (e.g., { '3.36.4': { includedTools: ['search_replace'] } })
+				// Two fields are used together:
+				// - `settings`: Base values that work with all client versions (e.g., { includedTools: ['search_replace'] })
+				// - `versionedSettings`: Version-keyed overrides (e.g., { '3.36.4': { supportsTemperature: false } })
 				//
-				// New clients check versionedSettings first - if a matching version is found, those settings are used.
-				// Otherwise, falls back to plain `settings`. Old clients only see `settings`.
+				// Settings are merged: `settings` provides the base, `versionedSettings` layers on top.
+				// This allows the proxy to set common configuration in `settings` and version-specific
+				// overrides in `versionedSettings`. Old clients only see `settings`.
 				const apiSettings = model.settings as Record<string, unknown> | undefined
 				const apiVersionedSettings = model.versionedSettings as VersionedSettings | undefined
 
 				// Start with base model info
 				let modelInfo: ModelInfo = { ...baseModelInfo }
 
-				// Try to resolve versioned settings first (finds highest version <= current plugin version)
-				// If versioned settings match, use them exclusively (they contain all necessary settings)
-				// Otherwise fall back to plain settings for backward compatibility
+				// Apply plain settings first as the base configuration
+				if (apiSettings) {
+					modelInfo = { ...modelInfo, ...(apiSettings as Partial<ModelInfo>) }
+				}
+
+				// Then layer versioned settings on top (can override plain settings)
 				if (apiVersionedSettings) {
 					const resolvedVersionedSettings = resolveVersionedSettings<Partial<ModelInfo>>(apiVersionedSettings)
 					if (Object.keys(resolvedVersionedSettings).length > 0) {
-						// Versioned settings found - use them exclusively
 						modelInfo = { ...modelInfo, ...resolvedVersionedSettings }
-					} else if (apiSettings) {
-						// No matching versioned settings - fall back to plain settings
-						modelInfo = { ...modelInfo, ...(apiSettings as Partial<ModelInfo>) }
 					}
-				} else if (apiSettings) {
-					// No versioned settings at all - use plain settings
-					modelInfo = { ...modelInfo, ...(apiSettings as Partial<ModelInfo>) }
 				}
 
 				models[modelId] = modelInfo


### PR DESCRIPTION
## Summary

This PR fixes a bug where `settings` and `versionedSettings` from the Roo provider API were mutually exclusive instead of being merged together.

## Bug Description

When the Roo proxy returns model configurations with both `settings` and `versionedSettings` fields, the intention is:
- **`settings`**: Base configuration that works with all client versions (backward compatibility)
- **`versionedSettings`**: Version-specific overrides that layer on top for newer clients

However, the previous implementation treated these as mutually exclusive—if `versionedSettings` matched, `settings` was completely ignored.

## User-Facing Impact

### Before (Broken Behavior)

Given a model configuration from the proxy like:
```javascript
{
  settings: {
    includedTools: ['apply_patch'],
    excludedTools: ['apply_diff', 'write_to_file'],
    reasoningEffort: 'medium',
  },
  versionedSettings: {
    '3.36.3': {
      supportsTemperature: false,
      supportsReasoningEffort: ['none', 'low', 'medium', 'high', 'xhigh'],
    },
  },
}
```

**On nightly or version ≥3.36.3:**
- ❌ `includedTools` → **missing** (should be `['apply_patch']`)
- ❌ `excludedTools` → **missing** (should be `['apply_diff', 'write_to_file']`)
- ❌ `reasoningEffort` → **missing** (should be `'medium'`)
- ✅ `supportsTemperature` → `false`
- ✅ `supportsReasoningEffort` → `['none', 'low', 'medium', 'high', 'xhigh']`

This meant model-specific tool restrictions and configurations from `settings` were being silently dropped.

### After (Fixed Behavior)

**On nightly or version ≥3.36.3:**
- ✅ `includedTools` → `['apply_patch']` (from settings)
- ✅ `excludedTools` → `['apply_diff', 'write_to_file']` (from settings)
- ✅ `reasoningEffort` → `'medium'` (from settings)
- ✅ `supportsTemperature` → `false` (from versionedSettings)
- ✅ `supportsReasoningEffort` → `['none', 'low', 'medium', 'high', 'xhigh']` (from versionedSettings)

Now both configurations are properly merged, with `versionedSettings` able to override specific properties from `settings` when needed.

## Changes

- **`src/api/providers/fetchers/roo.ts`**: Changed settings application logic from exclusive (either/or) to merge (both)
  - Apply `settings` first as base configuration
  - Then layer `versionedSettings` on top (can override properties)
- **`src/api/providers/fetchers/__tests__/roo.spec.ts`**: Added new test case to verify merge behavior with different properties in each settings object

## Test Results

All 53 related tests pass:
- 30 tests in `roo.spec.ts`
- 23 tests in `versionedSettings.spec.ts`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes merging logic in `getRooModels` to correctly combine `settings` and `versionedSettings`, with tests verifying the behavior.
> 
>   - **Behavior**:
>     - Fixes merging logic in `getRooModels` in `roo.ts` to combine `settings` and `versionedSettings`.
>     - `settings` applied as base, `versionedSettings` override specific properties.
>   - **Tests**:
>     - Added test case in `roo.spec.ts` to verify merged settings behavior.
>     - Updated existing test to check versioned settings override plain settings.
>   - **Misc**:
>     - Enhanced error logging in `getRooModels` for better debugging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ae7d7587ed5210b40b62ae2b1127b5e7c11623d1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->