### PR TITLE
Fix spacing typo in Cloud banner text

### DIFF
--- a/webview-ui/src/i18n/locales/en/cloud.json
+++ b/webview-ui/src/i18n/locales/en/cloud.json
@@ -31,6 +31,6 @@
 	"upsell": {
 		"autoApprovePowerUser": "Giving Roo some independence? Control it from anywhere with Roo Code Cloud. <learnMoreLink>Learn more</learnMoreLink>.",
 		"longRunningTask": "This might take a while. Continue from anywhere with Cloud.",
-		"taskList": "Enjoying Roo? Check out Roo Code Cloud: follow and control your tasks from anywhere, run autonomous Cloud agents, get usage stats and more. <learnMoreLink>Learn more</learnMoreLink>."
+		"taskList": "Enjoying Roo? Check out Roo Code Cloud: follow and control your tasks from anywhere, run autonomous Cloud agents, get usage stats and more. <learnMoreLink>Learn more</learnMoreLink> ."
 	}
 }


### PR DESCRIPTION
Closes #10655

Adds space before period after 'Learn more' link in the Cloud banner taskList message to prevent the period from appearing directly adjacent to the link text.

**Changes:**
- Fixed spacing in `webview-ui/src/i18n/locales/en/cloud.json`
- Changed `</learnMoreLink>.` to `</learnMoreLink> .`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a space before the period in the `taskList` message in `cloud.json` to improve text readability.
> 
>   - **Text Fix**:
>     - Adds a space before the period in the `taskList` message in `cloud.json` to separate it from the `Learn more` link text.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3a73b643e526df013ae32aa3456db41762bf0379. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->