### PR TITLE
Revert "fix: merge settings and versionedSettings for Roo provider models"

### DIFF
--- a/src/api/providers/fetchers/__tests__/roo.spec.ts
+++ b/src/api/providers/fetchers/__tests__/roo.spec.ts
@@ -803,7 +803,7 @@ describe("getRooModels", () => {
 		expect(model.nestedConfig).toEqual({ key: "value" })
 	})
 
-	it("should apply versioned settings when version matches, overriding plain settings", async () => {
+	it("should apply versioned settings when version matches", async () => {
 		const mockResponse = {
 			object: "list",
 			data: [
@@ -845,63 +845,9 @@ describe("getRooModels", () => {
 
 		const models = await getRooModels(baseUrl, apiKey)
 
-		// Versioned settings should override the same properties from plain settings
+		// Versioned settings should be used instead of plain settings
 		expect(models["test/versioned-model"].includedTools).toEqual(["apply_patch", "search_replace"])
 		expect(models["test/versioned-model"].excludedTools).toEqual(["apply_diff", "write_to_file"])
-	})
-
-	it("should merge settings and versionedSettings, with versioned settings taking precedence", async () => {
-		const mockResponse = {
-			object: "list",
-			data: [
-				{
-					id: "test/merged-settings-model",
-					object: "model",
-					created: 1234567890,
-					owned_by: "test",
-					name: "Model with Merged Settings",
-					description: "Model with both settings and versionedSettings that should be merged",
-					context_window: 128000,
-					max_tokens: 8192,
-					type: "language",
-					tags: ["tool-use"],
-					pricing: {
-						input: "0.0001",
-						output: "0.0002",
-					},
-					// Plain settings - provides base configuration
-					settings: {
-						includedTools: ["apply_patch"],
-						excludedTools: ["apply_diff", "write_to_file"],
-						reasoningEffort: "medium",
-					},
-					// Versioned settings - adds version-specific overrides
-					versionedSettings: {
-						"1.0.0": {
-							supportsTemperature: false,
-							supportsReasoningEffort: ["none", "low", "medium", "high"],
-						},
-					},
-				},
-			],
-		}
-
-		mockFetch.mockResolvedValueOnce({
-			ok: true,
-			json: async () => mockResponse,
-		})
-
-		const models = await getRooModels(baseUrl, apiKey)
-		const model = models["test/merged-settings-model"] as Record<string, unknown>
-
-		// Properties from plain settings should be present
-		expect(model.includedTools).toEqual(["apply_patch"])
-		expect(model.excludedTools).toEqual(["apply_diff", "write_to_file"])
-		expect(model.reasoningEffort).toBe("medium")
-
-		// Properties from versioned settings should also be present
-		expect(model.supportsTemperature).toBe(false)
-		expect(model.supportsReasoningEffort).toEqual(["none", "low", "medium", "high"])
 	})
 
 	it("should use plain settings when no versioned settings version matches", async () => {


### PR DESCRIPTION
Reverts RooCodeInc/Roo-Code#10030
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts merging of `settings` and `versionedSettings` in `getRooModels`, affecting settings application logic and related tests.
> 
>   - **Behavior**:
>     - Reverts merging of `settings` and `versionedSettings` in `getRooModels` in `roo.ts`.
>     - `versionedSettings` are now used exclusively if a matching version is found, otherwise falls back to `settings`.
>   - **Tests**:
>     - Removes test case for merging `settings` and `versionedSettings` in `roo.spec.ts`.
>     - Updates test descriptions to reflect the reverted behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b5b4abee5758ecc6f5c44a1914538d0a4c287dee. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->