### PR TITLE
fix: show tool protocol dropdown for LiteLLM provider

### DIFF
--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -27,6 +27,7 @@ import {
 	ioIntelligenceModels,
 	basetenModels,
 	qwenCodeModels,
+	litellmDefaultModelInfo,
 	BEDROCK_1M_CONTEXT_MODEL_IDS,
 	isDynamicProvider,
 	getProviderDefaultModelId,
@@ -164,7 +165,7 @@ function getSelectedModel({
 		}
 		case "litellm": {
 			const id = getValidatedModelId(apiConfiguration.litellmModelId, routerModels.litellm, defaultModelId)
-			const info = routerModels.litellm?.[id]
+			const info = routerModels.litellm?.[id] ?? litellmDefaultModelInfo
 			return { id, info }
 		}
 		case "xai": {


### PR DESCRIPTION
## Summary

The tool protocol dropdown was not appearing in advanced settings for the LiteLLM provider.

## Problem

The dropdown visibility depends on `selectedModelInfo?.supportsNativeTools === true`. While the LiteLLM fetcher hardcodes `supportsNativeTools: true` for all models it retrieves, this info is only available **after** a successful fetch from the LiteLLM server.

Before/without a successful fetch (e.g., server not configured, unreachable, or fetch in progress), `routerModels.litellm?.[id]` returns `undefined`, causing the dropdown to not appear.

## Solution

Added `litellmDefaultModelInfo` (which has `supportsNativeTools: true`) as a fallback in `useSelectedModel.ts` when the model info isn't available from the router models. This ensures the dropdown shows immediately when LiteLLM is selected, regardless of whether models have been fetched from the server yet.

## Changes

- `webview-ui/src/components/ui/hooks/useSelectedModel.ts`: Added import for `litellmDefaultModelInfo` and updated the litellm case to use it as fallback
- `webview-ui/src/components/ui/hooks/__tests__/useSelectedModel.spec.ts`: Added 3 test cases for LiteLLM fallback behavior

## Testing

- All 17 tests pass in useSelectedModel.spec.ts (14 existing + 3 new)
- All pre-push hooks pass (lint, type-check, tests)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds fallback model info for LiteLLM provider in `useSelectedModel.ts` to ensure tool protocol dropdown visibility.
> 
>   - **Behavior**:
>     - Adds `litellmDefaultModelInfo` as a fallback in `getSelectedModel()` in `useSelectedModel.ts` for LiteLLM provider.
>     - Ensures tool protocol dropdown is visible even if LiteLLM model data isn't fetched.
>   - **Testing**:
>     - Adds 3 test cases in `useSelectedModel.spec.ts` to verify LiteLLM fallback behavior.
>     - All 17 tests pass in `useSelectedModel.spec.ts` (14 existing + 3 new).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a84ba5eb08f2c3be5c9fef0c5f3f7fcf0fed5886. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->