### PR TITLE
fix: normalize tool call IDs for cross-provider compatibility via OpenRouter

### DIFF
--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -16,7 +16,8 @@ import { NativeToolCallParser } from "../../core/assistant-message/NativeToolCal
 
 import type { ApiHandlerOptions, ModelRecord } from "../../shared/api"
 
-import { convertToOpenAiMessages, normalizeToolCallId } from "../transform/openai-format"
+import { convertToOpenAiMessages } from "../transform/openai-format"
+import { normalizeMistralToolCallId } from "../transform/mistral-format"
 import { resolveToolProtocol } from "../../utils/resolveToolProtocol"
 import { TOOL_PROTOCOL } from "@roo-code/types"
 import { ApiStreamChunk } from "../transform/stream"
@@ -230,7 +231,10 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 		const isMistral = modelId.toLowerCase().includes("mistral")
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages, isMistral ? { normalizeToolCallId } : undefined),
+			...convertToOpenAiMessages(
+				messages,
+				isMistral ? { normalizeToolCallId: normalizeMistralToolCallId } : undefined,
+			),
 		]
 
 		// DeepSeek highly recommends using user instead of system role.

--- a/src/api/transform/__tests__/mistral-format.spec.ts
+++ b/src/api/transform/__tests__/mistral-format.spec.ts
@@ -2,8 +2,44 @@
 
 import { Anthropic } from "@anthropic-ai/sdk"
 
-import { convertToMistralMessages } from "../mistral-format"
-import { normalizeToolCallId } from "../openai-format"
+import { convertToMistralMessages, normalizeMistralToolCallId } from "../mistral-format"
+
+describe("normalizeMistralToolCallId", () => {
+	it("should strip non-alphanumeric characters and truncate to 9 characters", () => {
+		// OpenAI-style tool call ID: "call_5019f900..." -> "call5019f900..." -> first 9 chars = "call5019f"
+		expect(normalizeMistralToolCallId("call_5019f900a247472bacde0b82")).toBe("call5019f")
+	})
+
+	it("should handle Anthropic-style tool call IDs", () => {
+		// Anthropic-style tool call ID
+		expect(normalizeMistralToolCallId("toolu_01234567890abcdef")).toBe("toolu0123")
+	})
+
+	it("should pad short IDs to 9 characters", () => {
+		expect(normalizeMistralToolCallId("abc")).toBe("abc000000")
+		expect(normalizeMistralToolCallId("tool-1")).toBe("tool10000")
+	})
+
+	it("should handle IDs that are exactly 9 alphanumeric characters", () => {
+		expect(normalizeMistralToolCallId("abcd12345")).toBe("abcd12345")
+	})
+
+	it("should return consistent results for the same input", () => {
+		const id = "call_5019f900a247472bacde0b82"
+		expect(normalizeMistralToolCallId(id)).toBe(normalizeMistralToolCallId(id))
+	})
+
+	it("should handle edge cases", () => {
+		// Empty string
+		expect(normalizeMistralToolCallId("")).toBe("000000000")
+
+		// Only non-alphanumeric characters
+		expect(normalizeMistralToolCallId("---___---")).toBe("000000000")
+
+		// Mixed special characters
+		expect(normalizeMistralToolCallId("a-b_c.d@e")).toBe("abcde0000")
+	})
+})
 
 describe("convertToMistralMessages", () => {
 	it("should convert simple text messages for user and assistant roles", () => {
@@ -88,7 +124,9 @@ describe("convertToMistralMessages", () => {
 		const mistralMessages = convertToMistralMessages(anthropicMessages)
 		expect(mistralMessages).toHaveLength(1)
 		expect(mistralMessages[0].role).toBe("tool")
-		expect((mistralMessages[0] as { toolCallId?: string }).toolCallId).toBe(normalizeToolCallId("weather-123"))
+		expect((mistralMessages[0] as { toolCallId?: string }).toolCallId).toBe(
+			normalizeMistralToolCallId("weather-123"),
+		)
 		expect(mistralMessages[0].content).toBe("Current temperature in London: 20°C")
 	})
 
@@ -125,7 +163,9 @@ describe("convertToMistralMessages", () => {
 
 		// Only the tool result should be present
 		expect(mistralMessages[0].role).toBe("tool")
-		expect((mistralMessages[0] as { toolCallId?: string }).toolCallId).toBe(normalizeToolCallId("weather-123"))
+		expect((mistralMessages[0] as { toolCallId?: string }).toolCallId).toBe(
+			normalizeMistralToolCallId("weather-123"),
+		)
 		expect(mistralMessages[0].content).toBe("Current temperature in London: 20°C")
 	})
 
@@ -266,7 +306,9 @@ describe("convertToMistralMessages", () => {
 
 		// Tool result message
 		expect(mistralMessages[2].role).toBe("tool")
-		expect((mistralMessages[2] as { toolCallId?: string }).toolCallId).toBe(normalizeToolCallId("search-123"))
+		expect((mistralMessages[2] as { toolCallId?: string }).toolCallId).toBe(
+			normalizeMistralToolCallId("search-123"),
+		)
 		expect(mistralMessages[2].content).toBe("Found information about different mountain types.")
 
 		// Final assistant message

--- a/src/api/transform/mistral-format.ts
+++ b/src/api/transform/mistral-format.ts
@@ -4,7 +4,30 @@ import { SystemMessage } from "@mistralai/mistralai/models/components/systemmess
 import { ToolMessage } from "@mistralai/mistralai/models/components/toolmessage"
 import { UserMessage } from "@mistralai/mistralai/models/components/usermessage"
 
-import { normalizeToolCallId } from "./openai-format"
+/**
+ * Normalizes a tool call ID to be compatible with Mistral's strict ID requirements.
+ * Mistral requires tool call IDs to be:
+ * - Only alphanumeric characters (a-z, A-Z, 0-9)
+ * - Exactly 9 characters in length
+ *
+ * This function extracts alphanumeric characters from the original ID and
+ * pads/truncates to exactly 9 characters, ensuring deterministic output.
+ *
+ * @param id - The original tool call ID (e.g., "call_5019f900a247472bacde0b82" or "toolu_123")
+ * @returns A normalized 9-character alphanumeric ID compatible with Mistral
+ */
+export function normalizeMistralToolCallId(id: string): string {
+	// Extract only alphanumeric characters
+	const alphanumeric = id.replace(/[^a-zA-Z0-9]/g, "")
+
+	// Take first 9 characters, or pad with zeros if shorter
+	if (alphanumeric.length >= 9) {
+		return alphanumeric.slice(0, 9)
+	}
+
+	// Pad with zeros to reach 9 characters
+	return alphanumeric.padEnd(9, "0")
+}
 
 export type MistralMessage =
 	| (SystemMessage & { role: "system" })
@@ -69,7 +92,7 @@ export function convertToMistralMessages(anthropicMessages: Anthropic.Messages.M
 
 						mistralMessages.push({
 							role: "tool",
-							toolCallId: normalizeToolCallId(toolResult.tool_use_id),
+							toolCallId: normalizeMistralToolCallId(toolResult.tool_use_id),
 							content: resultContent,
 						} as ToolMessage & { role: "tool" })
 					}
@@ -124,7 +147,7 @@ export function convertToMistralMessages(anthropicMessages: Anthropic.Messages.M
 				let toolCalls: MistralToolCallMessage[] | undefined
 				if (toolMessages.length > 0) {
 					toolCalls = toolMessages.map((toolUse) => ({
-						id: normalizeToolCallId(toolUse.id),
+						id: normalizeMistralToolCallId(toolUse.id),
 						type: "function" as const,
 						function: {
 							name: toolUse.name,

--- a/src/api/transform/openai-format.ts
+++ b/src/api/transform/openai-format.ts
@@ -2,31 +2,6 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import OpenAI from "openai"
 
 /**
- * Normalizes a tool call ID to be compatible with providers that have strict ID requirements.
- * Some providers (like Mistral) require tool call IDs to be:
- * - Only alphanumeric characters (a-z, A-Z, 0-9)
- * - Exactly 9 characters in length
- *
- * This function extracts alphanumeric characters from the original ID and
- * pads/truncates to exactly 9 characters, ensuring deterministic output.
- *
- * @param id - The original tool call ID (e.g., "call_5019f900a247472bacde0b82" or "toolu_123")
- * @returns A normalized 9-character alphanumeric ID
- */
-export function normalizeToolCallId(id: string): string {
-	// Extract only alphanumeric characters
-	const alphanumeric = id.replace(/[^a-zA-Z0-9]/g, "")
-
-	// Take first 9 characters, or pad with zeros if shorter
-	if (alphanumeric.length >= 9) {
-		return alphanumeric.slice(0, 9)
-	}
-
-	// Pad with zeros to reach 9 characters
-	return alphanumeric.padEnd(9, "0")
-}
-
-/**
  * Options for converting Anthropic messages to OpenAI format.
  */
 export interface ConvertToOpenAiMessagesOptions {


### PR DESCRIPTION
## Summary
Some providers (like Mistral) require tool call IDs to be:
- Only alphanumeric characters (a-z, A-Z, 0-9)
- Exactly 9 characters in length

This caused errors when conversations with tool calls from one provider (e.g., OpenAI's `call_xxx` format) were routed to Mistral via OpenRouter.

## Error Example
```
ApiProviderError: {"object":"error","message":"Tool call id was call_5019f900a247472bacde0b82 but must be a-z, A-Z, 0-9, with a length of 9.","type":"invalid_function_call","param":null,"code":"3280"}
```

## Solution
- Added `normalizeToolCallId()` function that strips non-alphanumeric characters and pads/truncates to exactly 9 characters
- Added `modelId` option to `convertToOpenAiMessages()` that conditionally normalizes IDs only when the model contains 'mistral'
- OpenRouter now passes modelId to enable normalization for Mistral models
- Direct Mistral provider uses `convertToMistralMessages()` which always normalizes IDs

This scoped approach **only affects Mistral models**, avoiding any potential impact on the 15+ other providers using OpenAI-compatible format.

## Example Transformations
- `call_5019f900a247472bacde0b82` → `call5019f`
- `toolu_01234567890abcdef` → `toolu0123`
- `weather-123` → `weather12`

## Testing
- All 220 transform tests pass
- All 4681 tests pass in the full test suite
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds tool call ID normalization for Mistral models in OpenRouter to ensure compatibility with strict ID requirements.
> 
>   - **Behavior**:
>     - Adds `normalizeMistralToolCallId()` in `mistral-format.ts` to ensure tool call IDs are alphanumeric and 9 characters long.
>     - Updates `convertToOpenAiMessages()` in `openai-format.ts` to optionally use `normalizeToolCallId` for Mistral models.
>     - Modifies `OpenRouterHandler` in `openrouter.ts` to pass normalization function for Mistral models.
>   - **Testing**:
>     - Adds tests for `normalizeMistralToolCallId()` in `mistral-format.spec.ts`.
>     - Updates tests in `openai-format.spec.ts` to cover normalization scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 58410fe379bc7a5a5095feda99899b4c2ed2f099. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->