### PR TITLE
feat: add telemetry error capture to Mistral provider

### DIFF
--- a/src/api/providers/mistral.ts
+++ b/src/api/providers/mistral.ts
@@ -2,7 +2,14 @@ import { Anthropic } from "@anthropic-ai/sdk"
 import { Mistral } from "@mistralai/mistralai"
 import OpenAI from "openai"
 
-import { type MistralModelId, mistralDefaultModelId, mistralModels, MISTRAL_DEFAULT_TEMPERATURE } from "@roo-code/types"
+import {
+	type MistralModelId,
+	mistralDefaultModelId,
+	mistralModels,
+	MISTRAL_DEFAULT_TEMPERATURE,
+	ApiProviderError,
+} from "@roo-code/types"
+import { TelemetryService } from "@roo-code/telemetry"
 
 import { ApiHandlerOptions } from "../../shared/api"
 
@@ -43,6 +50,7 @@ type MistralTool = {
 export class MistralHandler extends BaseProvider implements SingleCompletionHandler {
 	protected options: ApiHandlerOptions
 	private client: Mistral
+	private readonly providerName = "Mistral"
 
 	constructor(options: ApiHandlerOptions) {
 		super()
@@ -93,10 +101,15 @@ export class MistralHandler extends BaseProvider implements SingleCompletionHand
 			requestOptions.toolChoice = "any"
 		}
 
-		// Temporary debug log for QA
-		// console.log("[MISTRAL DEBUG] Raw API request body:", requestOptions)
-
-		const response = await this.client.chat.stream(requestOptions)
+		let response
+		try {
+			response = await this.client.chat.stream(requestOptions)
+		} catch (error) {
+			const errorMessage = error instanceof Error ? error.message : String(error)
+			const apiError = new ApiProviderError(errorMessage, this.providerName, model, "createMessage")
+			TelemetryService.instance.captureException(apiError)
+			throw new Error(`Mistral completion error: ${errorMessage}`)
+		}
 
 		for await (const event of response) {
 			const delta = event.data.choices[0]?.delta
@@ -181,9 +194,9 @@ export class MistralHandler extends BaseProvider implements SingleCompletionHand
 	}
 
 	async completePrompt(prompt: string): Promise<string> {
-		try {
-			const { id: model, temperature } = this.getModel()
+		const { id: model, temperature } = this.getModel()
 
+		try {
 			const response = await this.client.chat.complete({
 				model,
 				messages: [{ role: "user", content: prompt }],
@@ -202,11 +215,10 @@ export class MistralHandler extends BaseProvider implements SingleCompletionHand
 
 			return content || ""
 		} catch (error) {
-			if (error instanceof Error) {
-				throw new Error(`Mistral completion error: ${error.message}`)
-			}
-
-			throw error
+			const errorMessage = error instanceof Error ? error.message : String(error)
+			const apiError = new ApiProviderError(errorMessage, this.providerName, model, "completePrompt")
+			TelemetryService.instance.captureException(apiError)
+			throw new Error(`Mistral completion error: ${errorMessage}`)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
Adds telemetry error capture to the Mistral provider, following the pattern established in PR #10073 for OpenRouter.

## Changes
- Import `TelemetryService` from `@roo-code/telemetry`
- Import `ApiProviderError` from `@roo-code/types`
- Add `providerName` property to `MistralHandler` class
- Wrap `createMessage()` `client.chat.stream()` call in try/catch with telemetry capture
- Add telemetry capture in `completePrompt()` catch block
- Add tests to verify telemetry is called on error for both methods

## Related
Follows the pattern established in PR #10073 for OpenRouter provider.

## Testing
- All 19 tests in `mistral.spec.ts` pass
- Added 2 new tests specifically for telemetry error capture:
  - `should capture telemetry exception on createMessage error`
  - `should capture telemetry exception on completePrompt error`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add telemetry error capture to Mistral provider's `createMessage` and `completePrompt` methods with tests for error handling.
> 
>   - **Behavior**:
>     - Add telemetry error capture in `createMessage()` and `completePrompt()` methods in `mistral.ts` using `TelemetryService`.
>     - Wrap `client.chat.stream()` and `client.chat.complete()` calls in try/catch blocks to capture exceptions.
>   - **Imports**:
>     - Import `TelemetryService` from `@roo-code/telemetry`.
>     - Import `ApiProviderError` from `@roo-code/types`.
>   - **Tests**:
>     - Add tests in `mistral.spec.ts` to verify telemetry is called on errors in `createMessage` and `completePrompt` methods.
>     - Add mock for `TelemetryService` to capture exceptions in tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for cf5c75db36a0a9cde986457e5323cecfb25eb09a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->