### PR TITLE
fix: preserve tool_use/tool_result pairs during conversation condensation

### DIFF
--- a/src/core/condense/__tests__/condense.spec.ts
+++ b/src/core/condense/__tests__/condense.spec.ts
@@ -92,7 +92,9 @@ describe("Condense", () => {
 			// Use getEffectiveApiHistory to verify the effective view matches the old behavior
 			expect(result.messages.length).toBe(messages.length + 1) // All original messages + summary
 			const effectiveHistory = getEffectiveApiHistory(result.messages)
-			expect(effectiveHistory.length).toBe(1 + 1 + N_MESSAGES_TO_KEEP) // first + summary + last N
+			// first + summary + extended kept messages (when first kept is user, we extend to include preceding assistant)
+			// The new behavior keeps 1 extra message to preserve tool_use/tool_result pairs
+			expect(effectiveHistory.length).toBe(1 + 1 + N_MESSAGES_TO_KEEP + 1) // first + summary + last N + 1 extended
 
 			// Verify the last N messages are preserved (same messages by reference)
 			const lastMessages = result.messages.slice(-N_MESSAGES_TO_KEEP)

--- a/src/core/context-management/__tests__/context-management.spec.ts
+++ b/src/core/context-management/__tests__/context-management.spec.ts
@@ -621,7 +621,6 @@ describe("Context Management", () => {
 				true,
 				undefined, // customCondensingPrompt
 				undefined, // condensingApiHandler
-				undefined, // useNativeTools
 			)
 
 			// Verify the result contains the summary information
@@ -797,7 +796,6 @@ describe("Context Management", () => {
 				true,
 				undefined, // customCondensingPrompt
 				undefined, // condensingApiHandler
-				undefined, // useNativeTools
 			)
 
 			// Verify the result contains the summary information

--- a/src/core/context-management/index.ts
+++ b/src/core/context-management/index.ts
@@ -219,7 +219,6 @@ export type ContextManagementOptions = {
 	condensingApiHandler?: ApiHandler
 	profileThresholds: Record<string, number>
 	currentProfileId: string
-	useNativeTools?: boolean
 }
 
 export type ContextManagementResult = SummarizeResponse & {
@@ -249,7 +248,6 @@ export async function manageContext({
 	condensingApiHandler,
 	profileThresholds,
 	currentProfileId,
-	useNativeTools,
 }: ContextManagementOptions): Promise<ContextManagementResult> {
 	let error: string | undefined
 	let cost = 0
@@ -303,7 +301,6 @@ export async function manageContext({
 				true, // automatic trigger
 				customCondensingPrompt,
 				condensingApiHandler,
-				useNativeTools,
 			)
 			if (result.error) {
 				error = result.error


### PR DESCRIPTION
## Problem

The "tool result's tool id not found" error (ApiError 2013) was occurring when:
1. Conversation condensation tagged messages with `condenseParent` to hide them from API
2. This could split tool_use/tool_result pairs - the tool_use would be hidden but the tool_result would remain
3. When the API received a tool_result without its matching tool_use, OpenRouter returned the error

## Solution

Replace the complex `getKeepMessagesWithToolBlocks` with a simpler `getKeepMessagePairs` function that:
- Extends the keep range when the first kept message is a user message (to include the preceding assistant)
- This naturally keeps tool_use/tool_result pairs together since tool_use blocks are in assistant messages and tool_result blocks are in the subsequent user messages

## Changes

- **`src/core/condense/index.ts`**: 
  - Renamed `getKeepMessagesWithToolBlocks` → `getKeepMessagePairs`
  - Simplified logic: when first kept message is user, extend to include preceding assistant
  - Removed `useNativeTools` parameter (no longer needed)

- **`src/core/context-management/index.ts`**:
  - Removed `useNativeTools` from `ContextManagementOptions` type and `manageContext` call

- **`src/core/task/Task.ts`**:
  - Removed `useNativeTools` from calls to `manageContext`

- **Test files**:
  - Updated assertions for new message pair preservation behavior

## Testing

All 4,684 tests pass.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies conversation condensation logic to preserve tool_use/tool_result pairs, removing `useNativeTools` parameter and updating related tests.
> 
>   - **Behavior**:
>     - Replaces `getKeepMessagesWithToolBlocks` with `getKeepMessagePairs` in `index.ts` to ensure tool_use/tool_result pairs are kept together.
>     - Extends keep range when first kept message is a user message to include preceding assistant message.
>     - Removes `useNativeTools` parameter from `summarizeConversation()` and related calls.
>   - **Files and Functions**:
>     - `index.ts`: Simplifies message keeping logic, removes `useNativeTools`.
>     - `context-management/index.ts`: Removes `useNativeTools` from `ContextManagementOptions` and `manageContext()`.
>     - `Task.ts`: Updates `validateAndFixToolResultIds()` to use `getEffectiveApiHistory()` for validation.
>   - **Testing**:
>     - Updates tests in `condense.spec.ts` and `index.spec.ts` to reflect new message pair preservation behavior.
>     - All tests pass, ensuring no regressions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b47659962b9406c856c7f6a1cbe13cd0c2a1db55. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->