### PR TITLE
Remove the description from bedrock service tiers

### DIFF
--- a/webview-ui/src/components/settings/providers/Bedrock.tsx
+++ b/webview-ui/src/components/settings/providers/Bedrock.tsx
@@ -168,30 +168,9 @@ export const Bedrock = ({ apiConfiguration, setApiConfigurationField, selectedMo
 							<SelectValue placeholder={t("settings:common.select")} />
 						</SelectTrigger>
 						<SelectContent>
-							<SelectItem value="STANDARD">
-								<div>
-									<div>{t("settings:providers.awsServiceTierStandard")}</div>
-									<div className="text-xs text-vscode-descriptionForeground">
-										{t("settings:providers.awsServiceTierStandardDesc")}
-									</div>
-								</div>
-							</SelectItem>
-							<SelectItem value="FLEX">
-								<div>
-									<div>{t("settings:providers.awsServiceTierFlex")}</div>
-									<div className="text-xs text-vscode-descriptionForeground">
-										{t("settings:providers.awsServiceTierFlexDesc")}
-									</div>
-								</div>
-							</SelectItem>
-							<SelectItem value="PRIORITY">
-								<div>
-									<div>{t("settings:providers.awsServiceTierPriority")}</div>
-									<div className="text-xs text-vscode-descriptionForeground">
-										{t("settings:providers.awsServiceTierPriorityDesc")}
-									</div>
-								</div>
-							</SelectItem>
+							<SelectItem value="STANDARD">{t("settings:providers.awsServiceTierStandard")}</SelectItem>
+							<SelectItem value="FLEX">{t("settings:providers.awsServiceTierFlex")}</SelectItem>
+							<SelectItem value="PRIORITY">{t("settings:providers.awsServiceTierPriority")}</SelectItem>
 						</SelectContent>
 					</Select>
 					<div className="text-sm text-vscode-descriptionForeground mt-1">


### PR DESCRIPTION
Before:
<img width="388" height="112" alt="Screenshot 2025-12-15 at 10 54 06 PM" src="https://github.com/user-attachments/assets/b7e8dcc0-715e-4ec0-880d-96c2e13de2b6" />

After:
<img width="388" height="115" alt="Screenshot 2025-12-15 at 10 53 54 PM" src="https://github.com/user-attachments/assets/644d3bbe-d16f-4e8f-a34f-02c8671c0f4c" />

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove description text from service tier options in `Bedrock.tsx`.
> 
>   - **UI Changes**:
>     - Removed description text from service tier options in `Bedrock.tsx`.
>     - Affected options: `STANDARD`, `FLEX`, `PRIORITY`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3b3483282d33b17b7cc85b42fc757b76c7544af3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->