### PR TITLE
fix: validate tool_result IDs in delegation resume flow

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -98,6 +98,7 @@ import { readTaskMessages } from "../task-persistence/taskMessages"
 import { getNonce } from "./getNonce"
 import { getUri } from "./getUri"
 import { REQUESTY_BASE_URL } from "../../shared/utils/requesty"
+import { validateAndFixToolResultIds } from "../task/validateToolResultIds"
 
 /**
  * https://github.com/microsoft/vscode-webview-ui-toolkit-samples/blob/main/default/weather-webview/src/providers/WeatherViewProvider.ts
@@ -3165,6 +3166,15 @@ export class ClineProvider
 				],
 				ts,
 			})
+		}
+
+		// Validate the newly injected tool_result against the preceding assistant message.
+		// This ensures the tool_result's tool_use_id matches a tool_use in the immediately
+		// preceding assistant message (Anthropic API requirement).
+		const lastMessage = parentApiMessages[parentApiMessages.length - 1]
+		if (lastMessage?.role === "user") {
+			const validatedMessage = validateAndFixToolResultIds(lastMessage, parentApiMessages.slice(0, -1))
+			parentApiMessages[parentApiMessages.length - 1] = validatedMessage
 		}
 
 		await saveApiMessages({ messages: parentApiMessages as any, taskId: parentTaskId, globalStoragePath })


### PR DESCRIPTION
## Summary
Fixes an Anthropic API error where the API rejected tool_result blocks with mismatched tool_use_ids during task delegation resumption.

## Root Cause
In `reopenParentFromDelegation()`, when a parent task resumes after a child task delegation completes, a new user message with a `tool_result` is injected. The code searched backwards through the **entire** history to find the `new_task` tool_use_id, but Anthropic requires that each `tool_result` must have a matching `tool_use` in the **immediately preceding** assistant message. When the tool_use was not in the last assistant message (e.g., due to conversation rehydration or other intermediate messages), the API rejected the request with:
> unexpected `tool_use_id` found in `tool_result` blocks: toolu_xxx. Each `tool_result` block must have a corresponding `tool_use` block in the previous message.

## Fix
Added targeted validation at the injection site in `ClineProvider.ts`:
```typescript
// Validate the newly injected tool_result against the preceding assistant message.
const lastMessage = parentApiMessages[parentApiMessages.length - 1]
if (lastMessage?.role === "user") {
    const validatedMessage = validateAndFixToolResultIds(lastMessage, parentApiMessages.slice(0, -1))
    parentApiMessages[parentApiMessages.length - 1] = validatedMessage
}
```

The existing `validateAndFixToolResultIds()` function handles:
- Correcting mismatched tool_use_ids by position matching
- Filtering out orphaned tool_results without matching tool_uses
- Reporting issues to TelemetryService/PostHog for tracking

## PostHog Issue
https://us.posthog.com/error_tracking/019b27da-aa13-7670-906f-4bb5c3cd250e

## Testing
- All 31 existing tests in `validateToolResultIds.spec.ts` pass
- All 4722 tests pass across the codebase
- TypeScript compilation succeeds
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Anthropic API error by validating `tool_result` IDs in `ClineProvider.ts` to ensure they match the preceding `tool_use` IDs.
> 
>   - **Behavior**:
>     - Fixes Anthropic API error by validating `tool_result` IDs in `reopenParentFromDelegation()` in `ClineProvider.ts`.
>     - Ensures `tool_result` IDs match `tool_use` in the immediately preceding assistant message.
>   - **Validation**:
>     - Uses `validateAndFixToolResultIds()` to correct mismatched IDs, filter orphaned results, and report issues.
>   - **Testing**:
>     - All 31 tests in `validateToolResultIds.spec.ts` pass.
>     - All 4722 tests pass across the codebase.
>     - TypeScript compilation succeeds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9da5aec96b83bba745d24b6cd6f591e5468c1c66. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->