### PR TITLE
fix: remove dots and colons from MCP tool names for Bedrock compatibility

### DIFF
--- a/src/utils/__tests__/mcp-name.spec.ts
+++ b/src/utils/__tests__/mcp-name.spec.ts
@@ -23,18 +23,24 @@ describe("mcp-name utilities", () => {
 			expect(sanitizeMcpName("test#$%^&*()")).toBe("test")
 		})
 
-		it("should keep valid characters (alphanumeric, underscore, dot, colon, dash)", () => {
+		it("should keep valid characters (alphanumeric, underscore, dash)", () => {
 			expect(sanitizeMcpName("server_name")).toBe("server_name")
-			expect(sanitizeMcpName("server.name")).toBe("server.name")
-			expect(sanitizeMcpName("server:name")).toBe("server:name")
 			expect(sanitizeMcpName("server-name")).toBe("server-name")
 			expect(sanitizeMcpName("Server123")).toBe("Server123")
+		})
+
+		it("should remove dots and colons for AWS Bedrock compatibility", () => {
+			// Dots and colons are NOT allowed due to AWS Bedrock restrictions
+			expect(sanitizeMcpName("server.name")).toBe("servername")
+			expect(sanitizeMcpName("server:name")).toBe("servername")
+			expect(sanitizeMcpName("awslabs.aws-documentation-mcp-server")).toBe("awslabsaws-documentation-mcp-server")
 		})
 
 		it("should prepend underscore if name starts with non-letter/underscore", () => {
 			expect(sanitizeMcpName("123server")).toBe("_123server")
 			expect(sanitizeMcpName("-server")).toBe("_-server")
-			expect(sanitizeMcpName(".server")).toBe("_.server")
+			// Dots are removed, so ".server" becomes "server" which starts with a letter
+			expect(sanitizeMcpName(".server")).toBe("server")
 		})
 
 		it("should not modify names that start with letter or underscore", () => {

--- a/src/utils/mcp-name.ts
+++ b/src/utils/mcp-name.ts
@@ -1,17 +1,12 @@
 /**
  * Utilities for sanitizing MCP server and tool names to conform to
- * API function name requirements (e.g., Gemini's restrictions).
- *
- * Gemini function name requirements:
- * - Must start with a letter or an underscore
- * - Must be alphanumeric (a-z, A-Z, 0-9), underscores (_), dots (.), colons (:), or dashes (-)
- * - Maximum length of 64 characters
+ * API function name requirements across all providers.
  */
 
 /**
  * Separator used between MCP prefix, server name, and tool name.
  * We use "--" (double hyphen) because:
- * 1. It's allowed by Gemini (dashes are permitted in function names)
+ * 1. It's allowed by all providers (dashes are permitted in function names)
  * 2. It won't conflict with underscores in sanitized server/tool names
  * 3. It's unique enough to be a reliable delimiter for parsing
  */
@@ -40,8 +35,8 @@ export function sanitizeMcpName(name: string): string {
 	// Replace spaces with underscores first
 	let sanitized = name.replace(/\s+/g, "_")
 
-	// Remove any characters that are not alphanumeric, underscores, dots, colons, or dashes
-	sanitized = sanitized.replace(/[^a-zA-Z0-9_.\-:]/g, "")
+	// Only allow alphanumeric, underscores, and dashes
+	sanitized = sanitized.replace(/[^a-zA-Z0-9_\-]/g, "")
 
 	// Replace any double-hyphen sequences with single hyphen to avoid separator conflicts
 	sanitized = sanitized.replace(/--+/g, "-")


### PR DESCRIPTION
## Summary

Fixes AWS Bedrock API validation errors when using MCP servers with dots or colons in their names.

## Problem

AWS Bedrock requires tool names to match the pattern `[a-zA-Z0-9_-]+`. MCP servers like `awslabs.aws-documentation-mcp-server` were causing validation errors:

```
Value 'mcp--awslabs.aws-documentation-mcp-server--read_documentation' 
failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z0-9_-]+
```

## Solution

Updated `sanitizeMcpName()` to remove dots and colons from allowed characters, using the most restrictive requirements (AWS Bedrock) to ensure compatibility with all API providers.

**Before:** `awslabs.aws-documentation-mcp-server` → `mcp--awslabs.aws-documentation-mcp-server--read_documentation`
**After:** `awslabs.aws-documentation-mcp-server` → `mcp--awslabsaws-documentation-mcp-server--read_documentation`

## Changes

- `src/utils/mcp-name.ts`: Changed regex to only allow alphanumeric, underscores, and dashes
- `src/utils/__tests__/mcp-name.spec.ts`: Updated tests to reflect new behavior

## Related

PostHog issue: https://us.posthog.com/error_tracking/019b2c44-b519-7301-9d43-a1f247a63cd3
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `sanitizeMcpName()` to remove dots and colons for AWS Bedrock compatibility, adjusting tests accordingly.
> 
>   - **Behavior**:
>     - `sanitizeMcpName()` in `mcp-name.ts` updated to remove dots and colons, allowing only alphanumeric, underscores, and dashes.
>     - Ensures compatibility with AWS Bedrock API by conforming to its naming pattern.
>   - **Tests**:
>     - Updated `mcp-name.spec.ts` to test removal of dots and colons, ensuring names like `server.name` become `servername`.
>     - Added test cases for AWS Bedrock compatibility and adjusted existing tests to reflect new sanitization rules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 8e4254788d329a4099fbeecf335d152954aa80fd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->