### PR TITLE
fix(ROO-202): refresh Roo models cache with session token on auth state change

### DIFF
--- a/src/__tests__/extension.spec.ts
+++ b/src/__tests__/extension.spec.ts
@@ -48,17 +48,22 @@ vi.mock("@dotenvx/dotenvx", () => ({
 
 const mockBridgeOrchestratorDisconnect = vi.fn().mockResolvedValue(undefined)
 
+const mockCloudServiceInstance = {
+	off: vi.fn(),
+	on: vi.fn(),
+	getUserInfo: vi.fn().mockReturnValue(null),
+	isTaskSyncEnabled: vi.fn().mockReturnValue(false),
+	authService: {
+		getSessionToken: vi.fn().mockReturnValue("test-session-token"),
+	},
+}
+
 vi.mock("@roo-code/cloud", () => ({
 	CloudService: {
 		createInstance: vi.fn(),
 		hasInstance: vi.fn().mockReturnValue(true),
 		get instance() {
-			return {
-				off: vi.fn(),
-				on: vi.fn(),
-				getUserInfo: vi.fn().mockReturnValue(null),
-				isTaskSyncEnabled: vi.fn().mockReturnValue(false),
-			}
+			return mockCloudServiceInstance
 		},
 	},
 	BridgeOrchestrator: {
@@ -203,10 +208,12 @@ vi.mock("../core/webview/ClineProvider", async () => {
 })
 
 // Mock modelCache to prevent network requests during module loading
+const mockRefreshModels = vi.fn().mockResolvedValue({})
 vi.mock("../api/providers/fetchers/modelCache", () => ({
 	flushModels: vi.fn(),
 	getModels: vi.fn().mockResolvedValue([]),
 	initializeModelCacheRefresh: vi.fn(),
+	refreshModels: mockRefreshModels,
 }))
 
 describe("extension.ts", () => {
@@ -244,6 +251,8 @@ describe("extension.ts", () => {
 				off: vi.fn(),
 				on: vi.fn(),
 				telemetryClient: null,
+				hasActiveSession: vi.fn().mockReturnValue(false),
+				authService: null,
 			} as any
 		})
 
@@ -277,6 +286,8 @@ describe("extension.ts", () => {
 				off: vi.fn(),
 				on: vi.fn(),
 				telemetryClient: null,
+				hasActiveSession: vi.fn().mockReturnValue(false),
+				authService: null,
 			} as any
 		})
 
@@ -292,5 +303,88 @@ describe("extension.ts", () => {
 
 		// Verify BridgeOrchestrator.disconnect was NOT called.
 		expect(mockBridgeOrchestratorDisconnect).not.toHaveBeenCalled()
+	})
+
+	describe("Roo model cache refresh on auth state change (ROO-202)", () => {
+		beforeEach(() => {
+			vi.resetModules()
+			mockRefreshModels.mockClear()
+		})
+
+		test("refreshModels is called with session token when auth state changes to active-session", async () => {
+			const mockAuthService = {
+				getSessionToken: vi.fn().mockReturnValue("test-session-token"),
+			}
+
+			const { CloudService } = await import("@roo-code/cloud")
+
+			vi.mocked(CloudService.createInstance).mockImplementation(async (_context, _logger, handlers) => {
+				if (handlers?.["auth-state-changed"]) {
+					authStateChangedHandler = handlers["auth-state-changed"]
+				}
+				return {
+					off: vi.fn(),
+					on: vi.fn(),
+					telemetryClient: null,
+					authService: mockAuthService,
+					hasActiveSession: vi.fn().mockReturnValue(false),
+				} as any
+			})
+
+			vi.mocked(CloudService.hasInstance).mockReturnValue(true)
+
+			// Activate the extension
+			const { activate } = await import("../extension")
+			await activate(mockContext)
+
+			// Clear any calls during activation
+			mockRefreshModels.mockClear()
+
+			// Trigger active-session state
+			await authStateChangedHandler!({
+				state: "active-session" as AuthState,
+				previousState: "logged-out" as AuthState,
+			})
+
+			// Verify refreshModels was called with correct parameters including session token
+			expect(mockRefreshModels).toHaveBeenCalledWith({
+				provider: "roo",
+				baseUrl: expect.any(String),
+				apiKey: "test-session-token",
+			})
+		})
+
+		test("flushModels is called when auth state changes to logged-out", async () => {
+			const { flushModels } = await import("../api/providers/fetchers/modelCache")
+			const { CloudService } = await import("@roo-code/cloud")
+
+			vi.mocked(CloudService.createInstance).mockImplementation(async (_context, _logger, handlers) => {
+				if (handlers?.["auth-state-changed"]) {
+					authStateChangedHandler = handlers["auth-state-changed"]
+				}
+				return {
+					off: vi.fn(),
+					on: vi.fn(),
+					telemetryClient: null,
+					authService: null,
+					hasActiveSession: vi.fn().mockReturnValue(false),
+				} as any
+			})
+
+			vi.mocked(CloudService.hasInstance).mockReturnValue(true)
+
+			// Activate the extension
+			const { activate } = await import("../extension")
+			await activate(mockContext)
+
+			// Trigger logged-out state
+			await authStateChangedHandler!({
+				state: "logged-out" as AuthState,
+				previousState: "active-session" as AuthState,
+			})
+
+			// Verify flushModels was called to clear the cache on logout
+			expect(flushModels).toHaveBeenCalledWith("roo", false)
+		})
 	})
 })


### PR DESCRIPTION
## Summary

Fixes ROO-202: Model cache is not refreshing on extension init

### Problem

When a user is authenticated with Roo Code Cloud, the model cache was being refreshed **without** passing the session token. This meant models requiring authentication (like `google/gemini-3-flash`) were not being returned by the API.

The original code called `flushModels("roo", true)` which internally called `refreshModels({ provider: "roo" })` without the token.

### Solution

Modified the `authStateChangedHandler` in `src/extension.ts` to:

1. **On `active-session` state**: Call `refreshModels()` directly with the session token from `CloudService.instance.authService?.getSessionToken()`
2. **On `logged-out` state**: Call `flushModels("roo", false)` to clear the cache without refetching

### Changes

- `src/extension.ts`: Fixed `handleRooModelsCache` to pass session token when refreshing models
- `src/__tests__/extension.spec.ts`: Added tests for auth state change model cache behavior

### Testing

- 4 tests pass covering the auth state change scenarios
- Manual testing confirms new authenticated models (e.g., `google/gemini-3-flash`) now appear after login

---

Linear: ROO-202
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Roo models cache refresh to include session token on auth state changes in `extension.ts`, with tests added in `extension.spec.ts`.
> 
>   - **Behavior**:
>     - `authStateChangedHandler` in `extension.ts` now refreshes Roo models cache with session token on `active-session` state.
>     - Calls `flushModels("roo", false)` on `logged-out` state to clear cache without refetching.
>   - **Testing**:
>     - Added tests in `extension.spec.ts` for auth state change handling, ensuring `refreshModels` is called with session token and `flushModels` is called on logout.
>   - **Misc**:
>     - Mocked `refreshModels` in `extension.spec.ts` to prevent network requests during tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ebd7031d08c8a478254f409d52db01c2ae585992. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->