### PR TITLE
fix: enable native tools by default for OpenAI compatible provider

### DIFF
--- a/packages/types/src/providers/openai.ts
+++ b/packages/types/src/providers/openai.ts
@@ -551,6 +551,7 @@ export const openAiModelInfoSaneDefaults: ModelInfo = {
 	inputPrice: 0,
 	outputPrice: 0,
 	supportsNativeTools: true,
+	defaultToolProtocol: "native",
 }
 
 // https://learn.microsoft.com/en-us/azure/ai-services/openai/api-version-deprecation

--- a/src/utils/__tests__/resolveToolProtocol.spec.ts
+++ b/src/utils/__tests__/resolveToolProtocol.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { resolveToolProtocol } from "../resolveToolProtocol"
-import { TOOL_PROTOCOL } from "@roo-code/types"
+import { TOOL_PROTOCOL, openAiModelInfoSaneDefaults } from "@roo-code/types"
 import type { ProviderSettings, ModelInfo } from "@roo-code/types"
 
 describe("resolveToolProtocol", () => {
@@ -315,6 +315,15 @@ describe("resolveToolProtocol", () => {
 			}
 			const result = resolveToolProtocol(settings, modelInfo)
 			expect(result).toBe(TOOL_PROTOCOL.XML) // Model default wins
+		})
+
+		it("should use native tools for OpenAI compatible provider with default model info", () => {
+			const settings: ProviderSettings = {
+				apiProvider: "openai",
+			}
+			// Using the actual openAiModelInfoSaneDefaults to verify the fix
+			const result = resolveToolProtocol(settings, openAiModelInfoSaneDefaults)
+			expect(result).toBe(TOOL_PROTOCOL.NATIVE) // Should use native tools by default
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Add `defaultToolProtocol: 'native'` to `openAiModelInfoSaneDefaults` so that the OpenAI compatible provider uses native tool calling by default.

## Problem

Previously, even though `supportsNativeTools` was set to `true` in `openAiModelInfoSaneDefaults`, the absence of `defaultToolProtocol` caused `resolveToolProtocol()` to fall through to the XML fallback.

The resolution flow was:
1. Passed `supportsNativeTools === true` check
2. No user `toolProtocol` preference set
3. No `defaultToolProtocol` in model info
4. Fell through to XML fallback

## Solution

Added `defaultToolProtocol: "native"` to `openAiModelInfoSaneDefaults`, matching the behavior of all the specific OpenAI native models which already have this set.

## Changes

- `packages/types/src/providers/openai.ts`: Added `defaultToolProtocol: "native"` to `openAiModelInfoSaneDefaults`
- `src/utils/__tests__/resolveToolProtocol.spec.ts`: Added test case to verify the fix works with the actual `openAiModelInfoSaneDefaults`

## Testing

- All existing tests pass (4764 passed)
- New test case verifies native tools are used by default for OpenAI compatible provider