### PR TITLE
fix: prevent stale cache when editing prompts across multiple windows

### DIFF
--- a/src/core/config/ContextProxy.ts
+++ b/src/core/config/ContextProxy.ts
@@ -208,6 +208,19 @@ export class ContextProxy {
 		return this.originalContext.globalState.update(key, value)
 	}
 
+	/**
+	 * Refresh a specific key from globalState and update the cache.
+	 * This is useful for settings that may be edited across multiple VS Code windows,
+	 * ensuring we read the latest value before making modifications.
+	 * @param key The global state key to refresh
+	 * @returns The fresh value from globalState
+	 */
+	refreshGlobalStateKey<K extends GlobalStateKey>(key: K): GlobalState[K] {
+		const value = this.originalContext.globalState.get<GlobalState[K]>(key)
+		this.stateCache[key] = value
+		return value as GlobalState[K]
+	}
+
 	private getAllGlobalState(): GlobalState {
 		return Object.fromEntries(GLOBAL_STATE_KEYS.map((key) => [key, this.getGlobalState(key)]))
 	}

--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -1485,7 +1485,9 @@ export const webviewMessageHandler = async (
 			break
 		case "updatePrompt":
 			if (message.promptMode && message.customPrompt !== undefined) {
-				const existingPrompts = getGlobalState("customModePrompts") ?? {}
+				// Use refreshGlobalStateKey to get the latest value from globalState,
+				// avoiding stale cache issues when multiple VS Code windows are open.
+				const existingPrompts = provider.contextProxy.refreshGlobalStateKey("customModePrompts") ?? {}
 				const updatedPrompts = { ...existingPrompts, [message.promptMode]: message.customPrompt }
 				await updateGlobalState("customModePrompts", updatedPrompts)
 				const currentState = await provider.getStateToPostToWebview()
@@ -1571,7 +1573,9 @@ export const webviewMessageHandler = async (
 		case "updateCondensingPrompt":
 			// Store the condensing prompt in customSupportPrompts["CONDENSE"]
 			// instead of customCondensingPrompt.
-			const currentSupportPrompts = getGlobalState("customSupportPrompts") ?? {}
+			// Use refreshGlobalStateKey to get the latest value from globalState,
+			// avoiding stale cache issues when multiple VS Code windows are open.
+			const currentSupportPrompts = provider.contextProxy.refreshGlobalStateKey("customSupportPrompts") ?? {}
 			const updatedSupportPrompts = { ...currentSupportPrompts, CONDENSE: message.text }
 			await updateGlobalState("customSupportPrompts", updatedSupportPrompts)
 			// Also update the old field for backward compatibility during migration.


### PR DESCRIPTION
## Summary

Fixes a bug where the context condensing prompt (and mode prompts) would revert to a previous value when multiple VS Code windows are open. This occurred because each window had its own stale cache of the global state, and read-modify-write operations would overwrite newer values from other windows.

## Changes

- Add `refreshGlobalStateKey()` method to `ContextProxy` that reads fresh values directly from VS Code's `globalState` and updates the local cache
- Update `updateCondensingPrompt` handler to use `refreshGlobalStateKey()` before modifying `customSupportPrompts`
- Update `updatePrompt` handler to use `refreshGlobalStateKey()` before modifying `customModePrompts`  
- Add unit tests for the new `refreshGlobalStateKey()` method

## Root Cause

Each VS Code window runs its own extension host process with a separate `ContextProxy` singleton. The cache was populated at initialization but never refreshed when other windows updated `globalState`. This caused stale values to be used in read-modify-write operations.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes stale cache issue in VS Code extension by adding `refreshGlobalStateKey()` to update cache from `globalState`, ensuring consistency across multiple windows.
> 
>   - **Behavior**:
>     - Fixes stale cache issue in `ContextProxy` when editing prompts across multiple VS Code windows.
>     - Introduces `refreshGlobalStateKey()` in `ContextProxy` to update cache from `globalState`.
>     - Updates `updateCondensingPrompt` and `updatePrompt` handlers in `webviewMessageHandler.ts` to use `refreshGlobalStateKey()`.
>   - **Tests**:
>     - Adds unit tests for `refreshGlobalStateKey()` in `ContextProxy.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 33f8e5883308c59a44ce8b67476489aa6fe1a551. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->