### PR TITLE
feat(vscode-lm): add native tool support

### DIFF
--- a/src/api/providers/__tests__/vscode-lm.spec.ts
+++ b/src/api/providers/__tests__/vscode-lm.spec.ts
@@ -180,7 +180,7 @@ describe("VsCodeLmHandler", () => {
 			})
 		})
 
-		it("should handle tool calls", async () => {
+		it("should handle tool calls as text when not using native tool protocol", async () => {
 			const systemPrompt = "You are a helpful assistant"
 			const messages: Anthropic.Messages.MessageParam[] = [
 				{
@@ -223,6 +223,139 @@ describe("VsCodeLmHandler", () => {
 			})
 		})
 
+		it("should handle native tool calls when using native tool protocol", async () => {
+			const systemPrompt = "You are a helpful assistant"
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user" as const,
+					content: "Calculate 2+2",
+				},
+			]
+
+			const toolCallData = {
+				name: "calculator",
+				arguments: { operation: "add", numbers: [2, 2] },
+				callId: "call-1",
+			}
+
+			const tools = [
+				{
+					type: "function" as const,
+					function: {
+						name: "calculator",
+						description: "A simple calculator",
+						parameters: {
+							type: "object",
+							properties: {
+								operation: { type: "string" },
+								numbers: { type: "array", items: { type: "number" } },
+							},
+						},
+					},
+				},
+			]
+
+			mockLanguageModelChat.sendRequest.mockResolvedValueOnce({
+				stream: (async function* () {
+					yield new vscode.LanguageModelToolCallPart(
+						toolCallData.callId,
+						toolCallData.name,
+						toolCallData.arguments,
+					)
+					return
+				})(),
+				text: (async function* () {
+					yield JSON.stringify({ type: "tool_call", ...toolCallData })
+					return
+				})(),
+			})
+
+			const stream = handler.createMessage(systemPrompt, messages, {
+				taskId: "test-task",
+				toolProtocol: "native",
+				tools,
+			})
+			const chunks = []
+			for await (const chunk of stream) {
+				chunks.push(chunk)
+			}
+
+			expect(chunks).toHaveLength(2) // Tool call chunk + usage chunk
+			expect(chunks[0]).toEqual({
+				type: "tool_call",
+				id: toolCallData.callId,
+				name: toolCallData.name,
+				arguments: JSON.stringify(toolCallData.arguments),
+			})
+		})
+
+		it("should pass tools to request options when using native tool protocol", async () => {
+			const systemPrompt = "You are a helpful assistant"
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "user" as const,
+					content: "Calculate 2+2",
+				},
+			]
+
+			const tools = [
+				{
+					type: "function" as const,
+					function: {
+						name: "calculator",
+						description: "A simple calculator",
+						parameters: {
+							type: "object",
+							properties: {
+								operation: { type: "string" },
+							},
+						},
+					},
+				},
+			]
+
+			mockLanguageModelChat.sendRequest.mockResolvedValueOnce({
+				stream: (async function* () {
+					yield new vscode.LanguageModelTextPart("Result: 4")
+					return
+				})(),
+				text: (async function* () {
+					yield "Result: 4"
+					return
+				})(),
+			})
+
+			const stream = handler.createMessage(systemPrompt, messages, {
+				taskId: "test-task",
+				toolProtocol: "native",
+				tools,
+			})
+			const chunks = []
+			for await (const chunk of stream) {
+				chunks.push(chunk)
+			}
+
+			// Verify sendRequest was called with tools in options
+			expect(mockLanguageModelChat.sendRequest).toHaveBeenCalledWith(
+				expect.any(Array),
+				expect.objectContaining({
+					tools: [
+						{
+							name: "calculator",
+							description: "A simple calculator",
+							inputSchema: {
+								type: "object",
+								properties: {
+									operation: { type: "string" },
+								},
+							},
+						},
+					],
+				}),
+				expect.anything(),
+			)
+		})
+
 		it("should handle errors", async () => {
 			const systemPrompt = "You are a helpful assistant"
 			const messages: Anthropic.Messages.MessageParam[] = [
@@ -258,6 +391,26 @@ describe("VsCodeLmHandler", () => {
 			const model = handler.getModel()
 			expect(model.id).toBe("test-vendor/test-family")
 			expect(model.info).toBeDefined()
+		})
+
+		it("should return supportsNativeTools and defaultToolProtocol in model info", async () => {
+			const mockModel = { ...mockLanguageModelChat }
+			;(vscode.lm.selectChatModels as Mock).mockResolvedValueOnce([mockModel])
+
+			// Initialize client
+			await handler["getClient"]()
+
+			const model = handler.getModel()
+			expect(model.info.supportsNativeTools).toBe(true)
+			expect(model.info.defaultToolProtocol).toBe("native")
+		})
+
+		it("should return supportsNativeTools and defaultToolProtocol in fallback model info", () => {
+			// Clear the client first
+			handler["client"] = null
+			const model = handler.getModel()
+			expect(model.info.supportsNativeTools).toBe(true)
+			expect(model.info.defaultToolProtocol).toBe("native")
 		})
 	})
 

--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import * as vscode from "vscode"
+import OpenAI from "openai"
 
 import { type ModelInfo, openAiModelInfoSaneDefaults } from "@roo-code/types"
 
@@ -11,6 +12,21 @@ import { convertToVsCodeLmMessages, extractTextCountFromMessage } from "../trans
 
 import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+
+/**
+ * Converts OpenAI-format tools to VSCode Language Model tools.
+ * @param tools Array of OpenAI ChatCompletionTool definitions
+ * @returns Array of VSCode LanguageModelChatTool definitions
+ */
+function convertToVsCodeLmTools(tools: OpenAI.Chat.ChatCompletionTool[]): vscode.LanguageModelChatTool[] {
+	return tools
+		.filter((tool) => tool.type === "function")
+		.map((tool) => ({
+			name: tool.function.name,
+			description: tool.function.description || "",
+			inputSchema: tool.function.parameters as Record<string, unknown> | undefined,
+		}))
+}
 
 /**
  * Handles interaction with VS Code's Language Model API for chat-based operations.
@@ -360,14 +376,19 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 		// Accumulate the text and count at the end of the stream to reduce token counting overhead.
 		let accumulatedText: string = ""
 
+		// Determine if we're using native tool protocol
+		const useNativeTools = metadata?.toolProtocol === "native" && metadata?.tools && metadata.tools.length > 0
+
 		try {
-			// Create the response stream with minimal required options
+			// Create the response stream with required options
 			const requestOptions: vscode.LanguageModelChatRequestOptions = {
 				justification: `Roo Code would like to use '${client.name}' from '${client.vendor}', Click 'Allow' to proceed.`,
 			}
 
-			// Note: Tool support is currently provided by the VSCode Language Model API directly
-			// Extensions can register tools using vscode.lm.registerTool()
+			// Add tools to request options when using native tool protocol
+			if (useNativeTools && metadata?.tools) {
+				requestOptions.tools = convertToVsCodeLmTools(metadata.tools)
+			}
 
 			const response: vscode.LanguageModelChatResponse = await client.sendRequest(
 				vsCodeLmMessages,
@@ -408,17 +429,6 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 							continue
 						}
 
-						// Convert tool calls to text format with proper error handling
-						const toolCall = {
-							type: "tool_call",
-							name: chunk.name,
-							arguments: chunk.input,
-							callId: chunk.callId,
-						}
-
-						const toolCallText = JSON.stringify(toolCall)
-						accumulatedText += toolCallText
-
 						// Log tool call for debugging
 						console.debug("Roo Code <Language Model API>: Processing tool call:", {
 							name: chunk.name,
@@ -426,9 +436,32 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 							inputSize: JSON.stringify(chunk.input).length,
 						})
 
-						yield {
-							type: "text",
-							text: toolCallText,
+						// Yield native tool_call chunk when using native tool protocol
+						if (useNativeTools) {
+							const argumentsString = JSON.stringify(chunk.input)
+							accumulatedText += argumentsString
+							yield {
+								type: "tool_call",
+								id: chunk.callId,
+								name: chunk.name,
+								arguments: argumentsString,
+							}
+						} else {
+							// Fallback: Convert tool calls to text format for XML tool protocol
+							const toolCall = {
+								type: "tool_call",
+								name: chunk.name,
+								arguments: chunk.input,
+								callId: chunk.callId,
+							}
+
+							const toolCallText = JSON.stringify(toolCall)
+							accumulatedText += toolCallText
+
+							yield {
+								type: "text",
+								text: toolCallText,
+							}
 						}
 					} catch (error) {
 						console.error("Roo Code <Language Model API>: Failed to process tool call:", error)
@@ -512,6 +545,8 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 						: openAiModelInfoSaneDefaults.contextWindow,
 				supportsImages: false, // VSCode Language Model API currently doesn't support image inputs
 				supportsPromptCache: true,
+				supportsNativeTools: true, // VSCode Language Model API supports native tool calling
+				defaultToolProtocol: "native", // Use native tool protocol by default
 				inputPrice: 0,
 				outputPrice: 0,
 				description: `VSCode Language Model: ${modelId}`,
@@ -531,6 +566,8 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			id: fallbackId,
 			info: {
 				...openAiModelInfoSaneDefaults,
+				supportsNativeTools: true, // VSCode Language Model API supports native tool calling
+				defaultToolProtocol: "native", // Use native tool protocol by default
 				description: `VSCode Language Model (Fallback): ${fallbackId}`,
 			},
 		}


### PR DESCRIPTION
## Summary

This PR adds native tool support to the VSCode Language Model API provider.

## Changes

### `src/api/providers/vscode-lm.ts`

1. **Added `convertToVsCodeLmTools` function**: Converts OpenAI-format tools (`ChatCompletionTool[]`) to VSCode Language Model tools (`LanguageModelChatTool[]`).

2. **Modified `createMessage` method** to:
   - Detect when native tool protocol is being used (`metadata?.toolProtocol === "native"`)
   - Pass tools to the request options via `requestOptions.tools` when using native protocol
   - Yield proper `tool_call` chunks (type: "tool_call", id, name, arguments) instead of converting to text when using native tools
   - Maintain backward compatibility: still converts tool calls to text format for XML tool protocol

3. **Updated `getModel` method** to return:
   - `supportsNativeTools: true` - Indicates the provider supports native tool calling
   - `defaultToolProtocol: "native"` - Makes native tools the default protocol for this provider

### `src/api/providers/__tests__/vscode-lm.spec.ts`

Added 5 new tests:
- `should handle tool calls as text when not using native tool protocol` - verifies backward compatibility
- `should handle native tool calls when using native tool protocol` - verifies native `tool_call` chunks are yielded
- `should pass tools to request options when using native tool protocol` - verifies tools are converted and passed correctly
- `should return supportsNativeTools and defaultToolProtocol in model info` - verifies model info flags
- `should return supportsNativeTools and defaultToolProtocol in fallback model info` - verifies fallback model info flags

## Testing

All 15 tests pass.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds native tool support to VSCode Language Model API provider, enabling native tool calls and maintaining backward compatibility.
> 
>   - **Behavior**:
>     - Adds `convertToVsCodeLmTools` function in `vscode-lm.ts` to convert OpenAI tools to VSCode tools.
>     - Updates `createMessage` in `vscode-lm.ts` to handle native tool protocol, yielding `tool_call` chunks and passing tools in `requestOptions`.
>     - Updates `getModel` in `vscode-lm.ts` to indicate support for native tools and set default protocol to native.
>   - **Testing**:
>     - Adds tests in `vscode-lm.spec.ts` to verify handling of native tool calls, backward compatibility, and correct tool passing in request options.
>     - Verifies model info flags for native tool support and default protocol.
>   - **Misc**:
>     - All 15 tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2fa2333a16801fbb48f4978a983a26560d890e4b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->