### PR TITLE
feat(telemetry): add PostHog exception tracking for consecutive mistake errors

### DIFF
--- a/packages/telemetry/src/PostHogTelemetryClient.ts
+++ b/packages/telemetry/src/PostHogTelemetryClient.ts
@@ -65,10 +65,12 @@ export class PostHogTelemetryClient extends BaseTelemetryClient {
 			console.info(`[PostHogTelemetryClient#capture] ${event.event}`)
 		}
 
+		const properties = await this.getEventProperties(event)
+
 		this.client.capture({
 			distinctId: this.distinctId,
 			event: event.event,
-			properties: await this.getEventProperties(event),
+			properties,
 		})
 	}
 
@@ -128,10 +130,12 @@ export class PostHogTelemetryClient extends BaseTelemetryClient {
 			}
 		}
 
-		this.client.captureException(error, this.distinctId, {
+		const exceptionProperties = {
 			...mergedProperties,
 			$app_version: telemetryProperties?.appVersion,
-		})
+		}
+
+		this.client.captureException(error, this.distinctId, exceptionProperties)
 	}
 
 	/**

--- a/packages/types/src/__tests__/telemetry.test.ts
+++ b/packages/types/src/__tests__/telemetry.test.ts
@@ -405,6 +405,27 @@ describe("telemetry error utilities", () => {
 			expect(error.reason).toBe("no_tools_used")
 		})
 
+		it("should create an error with provider and modelId", () => {
+			const error = new ConsecutiveMistakeError(
+				"Test error",
+				"task-123",
+				5,
+				3,
+				"no_tools_used",
+				"anthropic",
+				"claude-3-sonnet-20240229",
+			)
+
+			expect(error.message).toBe("Test error")
+			expect(error.name).toBe("ConsecutiveMistakeError")
+			expect(error.taskId).toBe("task-123")
+			expect(error.consecutiveMistakeCount).toBe(5)
+			expect(error.consecutiveMistakeLimit).toBe(3)
+			expect(error.reason).toBe("no_tools_used")
+			expect(error.provider).toBe("anthropic")
+			expect(error.modelId).toBe("claude-3-sonnet-20240229")
+		})
+
 		it("should be an instance of Error", () => {
 			const error = new ConsecutiveMistakeError("Test error", "task-123", 3, 3)
 			expect(error).toBeInstanceOf(Error)
@@ -431,6 +452,12 @@ describe("telemetry error utilities", () => {
 		it("should accept no_tools_used reason", () => {
 			const error = new ConsecutiveMistakeError("Test error", "task-123", 3, 3, "no_tools_used")
 			expect(error.reason).toBe("no_tools_used")
+		})
+
+		it("should have undefined provider and modelId when not provided", () => {
+			const error = new ConsecutiveMistakeError("Test error", "task-123", 3, 3, "no_tools_used")
+			expect(error.provider).toBeUndefined()
+			expect(error.modelId).toBeUndefined()
 		})
 	})
 
@@ -490,6 +517,36 @@ describe("telemetry error utilities", () => {
 				consecutiveMistakeLimit: 3,
 				reason: "no_tools_used",
 			})
+		})
+
+		it("should extract all properties including provider and modelId", () => {
+			const error = new ConsecutiveMistakeError(
+				"Test error",
+				"task-123",
+				5,
+				3,
+				"no_tools_used",
+				"anthropic",
+				"claude-3-sonnet-20240229",
+			)
+			const properties = extractConsecutiveMistakeErrorProperties(error)
+
+			expect(properties).toEqual({
+				taskId: "task-123",
+				consecutiveMistakeCount: 5,
+				consecutiveMistakeLimit: 3,
+				reason: "no_tools_used",
+				provider: "anthropic",
+				modelId: "claude-3-sonnet-20240229",
+			})
+		})
+
+		it("should not include provider and modelId when undefined", () => {
+			const error = new ConsecutiveMistakeError("Test error", "task-123", 5, 3, "no_tools_used")
+			const properties = extractConsecutiveMistakeErrorProperties(error)
+
+			expect(properties).not.toHaveProperty("provider")
+			expect(properties).not.toHaveProperty("modelId")
 		})
 
 		it("should handle zero values correctly", () => {

--- a/packages/types/src/telemetry.ts
+++ b/packages/types/src/telemetry.ts
@@ -495,6 +495,8 @@ export class ConsecutiveMistakeError extends Error {
 		public readonly consecutiveMistakeCount: number,
 		public readonly consecutiveMistakeLimit: number,
 		public readonly reason: ConsecutiveMistakeReason = "unknown",
+		public readonly provider?: string,
+		public readonly modelId?: string,
 	) {
 		super(message)
 		this.name = "ConsecutiveMistakeError"
@@ -525,5 +527,7 @@ export function extractConsecutiveMistakeErrorProperties(error: ConsecutiveMista
 		consecutiveMistakeCount: error.consecutiveMistakeCount,
 		consecutiveMistakeLimit: error.consecutiveMistakeLimit,
 		reason: error.reason,
+		...(error.provider !== undefined && { provider: error.provider }),
+		...(error.modelId !== undefined && { modelId: error.modelId }),
 	}
 }

--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -776,18 +776,21 @@ export async function presentAssistantMessage(cline: Task) {
 
 						// Add user feedback to chat.
 						await cline.say("user_feedback", text, images)
-
-						// Track tool repetition in telemetry via PostHog exception tracking.
-						TelemetryService.instance.captureException(
-							new ConsecutiveMistakeError(
-								`Tool repetition limit reached for ${block.name}`,
-								cline.taskId,
-								cline.consecutiveMistakeCount,
-								cline.consecutiveMistakeLimit,
-								"tool_repetition",
-							),
-						)
 					}
+
+					// Track tool repetition in telemetry via PostHog exception tracking and event.
+					TelemetryService.instance.captureConsecutiveMistakeError(cline.taskId)
+					TelemetryService.instance.captureException(
+						new ConsecutiveMistakeError(
+							`Tool repetition limit reached for ${block.name}`,
+							cline.taskId,
+							cline.consecutiveMistakeCount,
+							cline.consecutiveMistakeLimit,
+							"tool_repetition",
+							cline.apiConfiguration.apiProvider,
+							cline.api.getModel().id,
+						),
+					)
 
 					// Return tool result message about the repetition
 					pushToolResult(


### PR DESCRIPTION
## Summary
Add structured exception tracking via PostHog for 'Roo is having trouble' events (consecutive mistake limit reached).

## Changes

### New Types (`packages/types/src/telemetry.ts`)
- `ConsecutiveMistakeReason` type: `"no_tools_used" | "tool_repetition" | "unknown"`
- `ConsecutiveMistakeError` class with properties: `taskId`, `consecutiveMistakeCount`, `consecutiveMistakeLimit`, `reason`
- `isConsecutiveMistakeError()` type guard
- `extractConsecutiveMistakeErrorProperties()` property extractor

### PostHog Integration (`packages/telemetry/src/PostHogTelemetryClient.ts`)
- Updated `captureException()` to detect `ConsecutiveMistakeError` and auto-extract properties

### Tracking Points
- **Task.ts** - When model fails to use any tools (reason: `no_tools_used`)
- **presentAssistantMessage.ts** - When model repeats the same tool call (reason: `tool_repetition`)

## PostHog Event Data
When a consecutive mistake event fires, PostHog receives:
| Property | Description |
|----------|-------------|
| `taskId` | Unique task identifier |
| `consecutiveMistakeCount` | How many mistakes occurred |
| `consecutiveMistakeLimit` | The configured limit threshold |
| `reason` | Why the limit was reached |
| `message` | Descriptive error message |
| Context properties | `appVersion`, `apiProvider`, `modelId`, etc. |

## Testing
- Added comprehensive tests for the new error class and utilities (69 tests in telemetry.test.ts)
- All 4784 tests pass
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `ConsecutiveMistakeError` for tracking consecutive mistake errors via PostHog, with updates to telemetry handling and comprehensive tests.
> 
>   - **Behavior**:
>     - Adds `ConsecutiveMistakeError` class in `telemetry.ts` for tracking consecutive mistake errors.
>     - Updates `captureException()` in `PostHogTelemetryClient.ts` to handle `ConsecutiveMistakeError`.
>     - Tracks errors in `Task.ts` when no tools are used and in `presentAssistantMessage.ts` for tool repetition.
>   - **Types and Utilities**:
>     - Adds `ConsecutiveMistakeReason` type and `isConsecutiveMistakeError()` type guard in `telemetry.ts`.
>     - Implements `extractConsecutiveMistakeErrorProperties()` in `telemetry.ts`.
>   - **Testing**:
>     - Adds tests for `ConsecutiveMistakeError` and related utilities in `telemetry.test.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2ab2df54a4cc70b9dcfa01c30d6c13d8137f8aca. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->