### PR TITLE
fix: force additionalProperties false for strict mode compatibility

### DIFF
--- a/src/core/prompts/tools/native-tools/__tests__/mcp_server.spec.ts
+++ b/src/core/prompts/tools/native-tools/__tests__/mcp_server.spec.ts
@@ -155,11 +155,12 @@ describe("getMcpServerTools", () => {
 		const result = getMcpServerTools(mockHub as McpHub)
 
 		expect(result).toHaveLength(1)
+		// additionalProperties: false should only be on the root object type, not on primitive types
 		expect(getFunction(result[0]).parameters).toEqual({
 			type: "object",
 			properties: {
-				requiredField: { type: "string", additionalProperties: false },
-				optionalField: { type: "number", additionalProperties: false },
+				requiredField: { type: "string" },
+				optionalField: { type: "number" },
 			},
 			additionalProperties: false,
 			required: ["requiredField"],
@@ -183,10 +184,11 @@ describe("getMcpServerTools", () => {
 		const result = getMcpServerTools(mockHub as McpHub)
 
 		expect(result).toHaveLength(1)
+		// additionalProperties: false should only be on the root object type, not on primitive types
 		expect(getFunction(result[0]).parameters).toEqual({
 			type: "object",
 			properties: {
-				optionalField: { type: "string", additionalProperties: false },
+				optionalField: { type: "string" },
 			},
 			additionalProperties: false,
 		})

--- a/src/utils/__tests__/json-schema.spec.ts
+++ b/src/utils/__tests__/json-schema.spec.ts
@@ -10,10 +10,10 @@ describe("normalizeToolSchema", () => {
 
 		const result = normalizeToolSchema(input)
 
+		// additionalProperties should NOT be added to non-object types (string, null)
 		expect(result).toEqual({
 			anyOf: [{ type: "string" }, { type: "null" }],
 			description: "Optional field",
-			additionalProperties: false,
 		})
 	})
 
@@ -26,11 +26,11 @@ describe("normalizeToolSchema", () => {
 
 		const result = normalizeToolSchema(input)
 
+		// additionalProperties should NOT be added to array or primitive types
 		expect(result).toEqual({
 			anyOf: [{ type: "array" }, { type: "null" }],
-			items: { type: "string", additionalProperties: false },
+			items: { type: "string" },
 			description: "Optional array",
-			additionalProperties: false,
 		})
 	})
 
@@ -42,10 +42,10 @@ describe("normalizeToolSchema", () => {
 
 		const result = normalizeToolSchema(input)
 
+		// additionalProperties should NOT be added to string type
 		expect(result).toEqual({
 			type: "string",
 			description: "Required field",
-			additionalProperties: false,
 		})
 	})
 
@@ -64,14 +64,14 @@ describe("normalizeToolSchema", () => {
 
 		const result = normalizeToolSchema(input)
 
+		// additionalProperties: false should ONLY be on the object type, not on primitives
 		expect(result).toEqual({
 			type: "object",
 			properties: {
-				name: { type: "string", additionalProperties: false },
+				name: { type: "string" },
 				optional: {
 					anyOf: [{ type: "string" }, { type: "null" }],
 					description: "Optional nested field",
-					additionalProperties: false,
 				},
 			},
 			required: ["name"],
@@ -96,21 +96,20 @@ describe("normalizeToolSchema", () => {
 
 		const result = normalizeToolSchema(input)
 
+		// additionalProperties: false should ONLY be on object types
 		expect(result).toEqual({
 			type: "array",
 			items: {
 				type: "object",
 				properties: {
-					path: { type: "string", additionalProperties: false },
+					path: { type: "string" },
 					line_ranges: {
 						anyOf: [{ type: "array" }, { type: "null" }],
-						items: { type: "integer", additionalProperties: false },
-						additionalProperties: false,
+						items: { type: "integer" },
 					},
 				},
 				additionalProperties: false,
 			},
-			additionalProperties: false,
 		})
 	})
 
@@ -162,18 +161,18 @@ describe("normalizeToolSchema", () => {
 
 		const result = normalizeToolSchema(input)
 
+		// additionalProperties: false should ONLY be on object types, not on null or primitive types
 		expect(result).toEqual({
 			anyOf: [
 				{
 					type: "object",
 					properties: {
-						optional: { anyOf: [{ type: "string" }, { type: "null" }], additionalProperties: false },
+						optional: { anyOf: [{ type: "string" }, { type: "null" }] },
 					},
 					additionalProperties: false,
 				},
-				{ type: "null", additionalProperties: false },
+				{ type: "null" },
 			],
-			additionalProperties: false,
 		})
 	})
 
@@ -183,7 +182,9 @@ describe("normalizeToolSchema", () => {
 		expect(normalizeToolSchema(123 as any)).toBe(123)
 	})
 
-	it("should transform additionalProperties when it is a schema object", () => {
+	it("should force additionalProperties to false for object types even when set to a schema", () => {
+		// For strict mode compatibility, we MUST force additionalProperties: false
+		// even when the original schema allowed arbitrary properties
 		const input = {
 			type: "object",
 			additionalProperties: {
@@ -193,13 +194,11 @@ describe("normalizeToolSchema", () => {
 
 		const result = normalizeToolSchema(input)
 
+		// The original additionalProperties schema is replaced with false for strict mode
 		expect(result).toEqual({
 			type: "object",
 			properties: {},
-			additionalProperties: {
-				anyOf: [{ type: "string" }, { type: "null" }],
-				additionalProperties: false,
-			},
+			additionalProperties: false,
 		})
 	})
 
@@ -276,11 +275,11 @@ describe("normalizeToolSchema", () => {
 
 			const result = normalizeToolSchema(input)
 
+			// additionalProperties should NOT be added to string types
 			expect(result).toEqual({
 				type: "string",
 				format: "date-time",
 				description: "Timestamp",
-				additionalProperties: false,
 			})
 		})
 
@@ -335,10 +334,10 @@ describe("normalizeToolSchema", () => {
 
 			const result = normalizeToolSchema(input)
 
+			// additionalProperties should NOT be added to string types
 			expect(result).toEqual({
 				type: "string",
 				description: "URL field",
-				additionalProperties: false,
 			})
 			expect(result.format).toBeUndefined()
 		})


### PR DESCRIPTION
## Problem

OpenRouter's strict mode validator requires `additionalProperties: false` on all object-type schemas. The Apify MCP server's `call-actor` tool had `additionalProperties: {}` (empty schema = allow any) which was rejected with:

```
Invalid schema for function 'mcp--apify--call-actor': In context=('properties', 'input'), 'additionalProperties' is required to be supplied and to be false.
```

## Solution

Modified `normalizeToolSchema()` to:
1. Force `additionalProperties: false` on **all** object-type schemas, even when the original schema explicitly set a different value (like `{}` or `true`)
2. Only add `additionalProperties` to actual object types (schemas with `type: "object"` or `properties`), not to primitive types like strings/numbers/arrays

This ensures MCP tools that expect arbitrary input objects have their schemas normalized for strict mode compatibility.

## Testing

- Updated tests in `json-schema.spec.ts` and `mcp_server.spec.ts` to expect the correct behavior
- All 31 related tests pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `normalizeToolSchema()` now enforces `additionalProperties: false` for object-type schemas to ensure strict mode compatibility, with updated tests verifying this behavior.
> 
>   - **Behavior**:
>     - `normalizeToolSchema()` in `json-schema.ts` now forces `additionalProperties: false` for all object-type schemas, overriding any existing values.
>     - Ensures `additionalProperties` is only added to schemas with `type: "object"` or `properties`, not to primitive types.
>   - **Testing**:
>     - Updated tests in `json-schema.spec.ts` and `mcp_server.spec.ts` to verify correct handling of `additionalProperties`.
>     - All 31 related tests pass, confirming strict mode compatibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b6deeb7b48f0703e2c93b9681dc8a8e21d0563f2. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->