### PR TITLE
feat: merge native tool defaults for openai-compatible provider

### DIFF
--- a/webview-ui/src/components/ui/hooks/useSelectedModel.ts
+++ b/webview-ui/src/components/ui/hooks/useSelectedModel.ts
@@ -279,7 +279,13 @@ function getSelectedModel({
 		}
 		case "openai": {
 			const id = apiConfiguration.openAiModelId ?? ""
-			const info = apiConfiguration?.openAiCustomModelInfo ?? openAiModelInfoSaneDefaults
+			const customInfo = apiConfiguration?.openAiCustomModelInfo
+			// Only merge native tool call defaults, not prices or other model-specific info
+			const nativeToolDefaults = {
+				supportsNativeTools: openAiModelInfoSaneDefaults.supportsNativeTools,
+				defaultToolProtocol: openAiModelInfoSaneDefaults.defaultToolProtocol,
+			}
+			const info = customInfo ? { ...nativeToolDefaults, ...customInfo } : openAiModelInfoSaneDefaults
 			return { id, info }
 		}
 		case "ollama": {


### PR DESCRIPTION
## Summary

Applies the same fix from PR #10187 to the openai-compatible provider. This ensures that native tool calling (`supportsNativeTools: true`, `defaultToolProtocol: 'native'`) is enabled by default for OpenAI-compatible endpoints, while still allowing users to override these settings in their custom model info.

## Changes

- Modified `useSelectedModel.ts` to merge native tool defaults with custom model info for the `openai` provider case
- Added 3 new tests to verify the behavior:
  - Uses `openAiModelInfoSaneDefaults` when no custom model info is provided
  - Merges native tool defaults with custom model info
  - Allows custom model info to override native tool defaults

## Related

- Follows the same pattern as #10187 for litellm provider
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modifies `useSelectedModel.ts` to merge native tool defaults for OpenAI provider and adds tests to verify behavior.
> 
>   - **Behavior**:
>     - Modified `useSelectedModel.ts` to merge native tool defaults with custom model info for `openai` provider.
>     - Ensures `supportsNativeTools: true` and `defaultToolProtocol: 'native'` are defaults unless overridden.
>   - **Tests**:
>     - Added tests in `useSelectedModel.spec.ts` to verify default behavior when no custom model info is provided.
>     - Added tests to ensure merging of native tool defaults with custom model info.
>     - Added tests to verify custom model info can override native tool defaults.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fb5934d917dd13826b863ef6025bf7556acefd84. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->