### PR TITLE
fix(requesty): set supportsNativeTools for all models

### DIFF
--- a/src/api/providers/fetchers/requesty.ts
+++ b/src/api/providers/fetchers/requesty.ts
@@ -43,6 +43,8 @@ export async function getRequestyModels(baseUrl?: string, apiKey?: string): Prom
 				description: rawModel.description,
 				cacheWritesPrice: parseApiPrice(rawModel.caching_price),
 				cacheReadsPrice: parseApiPrice(rawModel.cached_price),
+				supportsNativeTools: true,
+				defaultToolProtocol: "native",
 			}
 
 			models[rawModel.id] = modelInfo


### PR DESCRIPTION
## Summary

Requesty supports native tools for all models, but the `getRequestyModels` fetcher was not setting `supportsNativeTools` when building model info from the API response.

This caused tools to not be included in subsequent API requests when models were loaded from cache (`supportsNativeTools` was `undefined` instead of `true`).

## Changes

Added `supportsNativeTools: true` and `defaultToolProtocol: "native"` to the model info returned by `getRequestyModels`.

## Testing

- Manual testing confirmed that `supportsNativeTools` is now `true` for all requests (not just the first one)
- All existing tests pass

Fixes ROO-238
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sets `supportsNativeTools` and `defaultToolProtocol` in `getRequestyModels` to fix tool inclusion for cached models.
> 
>   - **Behavior**:
>     - Sets `supportsNativeTools: true` and `defaultToolProtocol: "native"` in `getRequestyModels` in `requesty.ts`.
>     - Fixes issue where `supportsNativeTools` was `undefined` for cached models, causing tools to be excluded in API requests.
>   - **Testing**:
>     - Manual testing confirms `supportsNativeTools` is `true` for all requests.
>     - All existing tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 676e4d3125743e774191b37a5f91db4395227caa. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->