### PR TITLE
fix: disable strict mode for MCP tools to preserve optional parameters

### DIFF
--- a/src/api/providers/base-provider.ts
+++ b/src/api/providers/base-provider.ts
@@ -5,6 +5,7 @@ import type { ModelInfo } from "@roo-code/types"
 import type { ApiHandler, ApiHandlerCreateMessageMetadata } from "../index"
 import { ApiStream } from "../transform/stream"
 import { countTokens } from "../../utils/countTokens"
+import { isMcpTool } from "../../utils/mcp-name"
 
 /**
  * Base class for API providers that implements common functionality.
@@ -35,14 +36,14 @@ export abstract class BaseProvider implements ApiHandler {
 
 			// MCP tools use the 'mcp--' prefix - disable strict mode for them
 			// to preserve optional parameters from the MCP server schema
-			const isMcpTool = tool.function.name.startsWith("mcp--")
+			const isMcp = isMcpTool(tool.function.name)
 
 			return {
 				...tool,
 				function: {
 					...tool.function,
-					strict: !isMcpTool,
-					parameters: isMcpTool
+					strict: !isMcp,
+					parameters: isMcp
 						? tool.function.parameters
 						: this.convertToolSchemaForOpenAI(tool.function.parameters),
 				},

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -24,6 +24,7 @@ import { getModelParams } from "../transform/model-params"
 
 import { BaseProvider } from "./base-provider"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
+import { isMcpTool } from "../../utils/mcp-name"
 
 export type OpenAiNativeModel = ReturnType<OpenAiNativeHandler["getModel"]>
 
@@ -294,15 +295,13 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 					.map((tool) => {
 						// MCP tools use the 'mcp--' prefix - disable strict mode for them
 						// to preserve optional parameters from the MCP server schema
-						const isMcpTool = tool.function.name.startsWith("mcp--")
+						const isMcp = isMcpTool(tool.function.name)
 						return {
 							type: "function",
 							name: tool.function.name,
 							description: tool.function.description,
-							parameters: isMcpTool
-								? tool.function.parameters
-								: ensureAllRequired(tool.function.parameters),
-							strict: !isMcpTool,
+							parameters: isMcp ? tool.function.parameters : ensureAllRequired(tool.function.parameters),
+							strict: !isMcp,
 						}
 					}),
 			}),

--- a/src/utils/__tests__/mcp-name.spec.ts
+++ b/src/utils/__tests__/mcp-name.spec.ts
@@ -1,10 +1,40 @@
-import { sanitizeMcpName, buildMcpToolName, parseMcpToolName, MCP_TOOL_SEPARATOR, MCP_TOOL_PREFIX } from "../mcp-name"
+import {
+	sanitizeMcpName,
+	buildMcpToolName,
+	parseMcpToolName,
+	isMcpTool,
+	MCP_TOOL_SEPARATOR,
+	MCP_TOOL_PREFIX,
+} from "../mcp-name"
 
 describe("mcp-name utilities", () => {
 	describe("constants", () => {
 		it("should have correct separator and prefix", () => {
 			expect(MCP_TOOL_SEPARATOR).toBe("--")
 			expect(MCP_TOOL_PREFIX).toBe("mcp")
+		})
+	})
+
+	describe("isMcpTool", () => {
+		it("should return true for valid MCP tool names", () => {
+			expect(isMcpTool("mcp--server--tool")).toBe(true)
+			expect(isMcpTool("mcp--my_server--get_forecast")).toBe(true)
+		})
+
+		it("should return false for non-MCP tool names", () => {
+			expect(isMcpTool("server--tool")).toBe(false)
+			expect(isMcpTool("tool")).toBe(false)
+			expect(isMcpTool("read_file")).toBe(false)
+			expect(isMcpTool("")).toBe(false)
+		})
+
+		it("should return false for old underscore format", () => {
+			expect(isMcpTool("mcp_server_tool")).toBe(false)
+		})
+
+		it("should return false for partial prefix", () => {
+			expect(isMcpTool("mcp-server")).toBe(false)
+			expect(isMcpTool("mcp")).toBe(false)
 		})
 	})
 

--- a/src/utils/mcp-name.ts
+++ b/src/utils/mcp-name.ts
@@ -18,6 +18,16 @@ export const MCP_TOOL_SEPARATOR = "--"
 export const MCP_TOOL_PREFIX = "mcp"
 
 /**
+ * Check if a tool name is an MCP tool (starts with the MCP prefix and separator).
+ *
+ * @param toolName - The tool name to check
+ * @returns true if the tool name starts with "mcp--", false otherwise
+ */
+export function isMcpTool(toolName: string): boolean {
+	return toolName.startsWith(`${MCP_TOOL_PREFIX}${MCP_TOOL_SEPARATOR}`)
+}
+
+/**
  * Sanitize a name to be safe for use in API function names.
  * This removes special characters and ensures the name starts correctly.
  *


### PR DESCRIPTION
## Summary

MCP tools (like Linear's MCP server) have optional parameters that were broken by OpenAI's strict mode which requires ALL properties to be in the `required` array.

## Changes

- Check if tool name starts with `mcp--` prefix (indicating MCP tool)
- Set `strict: false` for MCP tools
- Preserve original schema without forcing all properties to required
- Keep strict mode for Roo's native tools which are designed for it

## Files Changed
- `src/api/providers/base-provider.ts` - `convertToolsForOpenAI()`
- `src/api/providers/openai-native.ts` - `buildRequestBody()`

## Testing
- All existing tests pass (38/38 openai-native, 10/10 mcp_server)
- TypeScript compilation passes

Fixes ROO-241
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable strict mode for MCP tools by checking for `mcp--` prefix, preserving optional parameters while maintaining strict mode for native tools.
> 
>   - **Behavior**:
>     - Disable strict mode for MCP tools by checking for `mcp--` prefix in `convertToolsForOpenAI()` in `base-provider.ts` and `buildRequestBody()` in `openai-native.ts`.
>     - Preserve optional parameters for MCP tools, while keeping strict mode for native tools.
>   - **Utilities**:
>     - Add `isMcpTool()` function in `mcp-name.ts` to identify MCP tools by prefix.
>   - **Testing**:
>     - Add tests for `isMcpTool()` in `mcp-name.spec.ts`.
>     - All existing tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7b0985af5e22f47a4a1cca4cbf6426e27dcba4b0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->