### PR TITLE
fix: normalize tool schemas for VS Code LM API to fix error 400

### DIFF
--- a/src/api/providers/__tests__/vscode-lm.spec.ts
+++ b/src/api/providers/__tests__/vscode-lm.spec.ts
@@ -336,6 +336,7 @@ describe("VsCodeLmHandler", () => {
 			}
 
 			// Verify sendRequest was called with tools in options
+			// Note: normalizeToolSchema adds additionalProperties: false for JSON Schema 2020-12 compliance
 			expect(mockLanguageModelChat.sendRequest).toHaveBeenCalledWith(
 				expect.any(Array),
 				expect.objectContaining({
@@ -348,6 +349,7 @@ describe("VsCodeLmHandler", () => {
 								properties: {
 									operation: { type: "string" },
 								},
+								additionalProperties: false,
 							},
 						},
 					],

--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -6,6 +6,7 @@ import { type ModelInfo, openAiModelInfoSaneDefaults } from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
 import { SELECTOR_SEPARATOR, stringifyVsCodeLmModelSelector } from "../../shared/vsCodeSelectorUtils"
+import { normalizeToolSchema } from "../../utils/json-schema"
 
 import { ApiStream } from "../transform/stream"
 import { convertToVsCodeLmMessages, extractTextCountFromMessage } from "../transform/vscode-lm-format"
@@ -15,6 +16,8 @@ import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from ".
 
 /**
  * Converts OpenAI-format tools to VSCode Language Model tools.
+ * Normalizes the JSON Schema to draft 2020-12 compliant format required by
+ * GitHub Copilot's backend, converting type: ["T", "null"] to anyOf format.
  * @param tools Array of OpenAI ChatCompletionTool definitions
  * @returns Array of VSCode LanguageModelChatTool definitions
  */
@@ -24,7 +27,9 @@ function convertToVsCodeLmTools(tools: OpenAI.Chat.ChatCompletionTool[]): vscode
 		.map((tool) => ({
 			name: tool.function.name,
 			description: tool.function.description || "",
-			inputSchema: tool.function.parameters as Record<string, unknown> | undefined,
+			inputSchema: tool.function.parameters
+				? normalizeToolSchema(tool.function.parameters as Record<string, unknown>)
+				: undefined,
 		}))
 }
 


### PR DESCRIPTION
## Problem

The VS Code LM API provider (GitHub Copilot) was returning error 400 when using native tool calling. This occurred because tool schemas were being passed directly to the API without proper normalization.

## Root Cause

The `convertToVsCodeLmTools` function was passing tool `inputSchema` directly to VS Code's `LanguageModelChatTool` constructor. However, native tool definitions use JSON Schema draft-07 syntax (e.g., `type: ['string', 'null']`), but GitHub Copilot's backend expects JSON Schema 2020-12 compliant format (e.g., `anyOf: [{type: 'string'}, {type: 'null'}]`).

The Bedrock provider correctly uses `normalizeToolSchema()` for this conversion, but VS Code LM was missing it.

## Solution

Apply `normalizeToolSchema()` to the tool's `inputSchema` in `convertToVsCodeLmTools()`:

```typescript
inputSchema: normalizeToolSchema(tool.inputSchema)
```

This:
1. Converts `type: ['string', 'null']` array syntax to `anyOf` format
2. Sets `additionalProperties: false` for object types
3. Ensures schema compliance with what Copilot's backend expects

## Testing

- All 15 vscode-lm tests pass
- Updated test expectation to reflect normalized schema output

## Files Changed

- `src/api/providers/vscode-lm.ts` - Added normalizeToolSchema import and usage
- `src/api/providers/__tests__/vscode-lm.spec.ts` - Updated test expectation
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error 400 in VS Code LM API by normalizing tool schemas to JSON Schema 2020-12 format using `normalizeToolSchema()` in `convertToVsCodeLmTools()`.
> 
>   - **Behavior**:
>     - Fixes error 400 in VS Code LM API by normalizing tool schemas to JSON Schema 2020-12 format using `normalizeToolSchema()` in `convertToVsCodeLmTools()`.
>     - Converts `type: ['string', 'null']` to `anyOf` format and sets `additionalProperties: false` for object types.
>   - **Files Changed**:
>     - `vscode-lm.ts`: Applies `normalizeToolSchema()` to tool `inputSchema` in `convertToVsCodeLmTools()`.
>     - `vscode-lm.spec.ts`: Updates test expectations to reflect normalized schema output.
>   - **Testing**:
>     - All 15 vscode-lm tests pass after changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fd4fd92fbb269b578b4f65f148d34bf996c90400. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->