### PR TITLE
fix: preserve DeepSeek reasoning_content through condense and API transmission

### DIFF
--- a/src/core/task-persistence/apiMessages.ts
+++ b/src/core/task-persistence/apiMessages.ts
@@ -20,6 +20,9 @@ export type ApiMessage = Anthropic.MessageParam & {
 	text?: string
 	// For OpenRouter reasoning_details array format (used by Gemini 3, etc.)
 	reasoning_details?: any[]
+	// For DeepSeek interleaved thinking mode: reasoning content that must be passed back
+	// during tool call sequences. See: https://api-docs.deepseek.com/guides/thinking_mode
+	reasoning_content?: string
 	// For non-destructive condense: unique identifier for summary messages
 	condenseId?: string
 	// For non-destructive condense: points to the condenseId of the summary that replaces this message

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -4164,10 +4164,18 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 			// Default path for regular messages (no embedded reasoning)
 			if (msg.role) {
-				cleanConversationHistory.push({
+				const cleanMessage: Anthropic.Messages.MessageParam & { reasoning_content?: string } = {
 					role: msg.role,
 					content: msg.content as Anthropic.Messages.ContentBlockParam[] | string,
-				})
+				}
+				// Preserve reasoning_content for DeepSeek interleaved thinking mode
+				// This is required for tool call sequences where the model needs its previous
+				// reasoning content passed back to continue the thinking chain
+				// See: https://api-docs.deepseek.com/guides/thinking_mode
+				if (msg.role === "assistant" && msg.reasoning_content) {
+					cleanMessage.reasoning_content = msg.reasoning_content
+				}
+				cleanConversationHistory.push(cleanMessage)
 			}
 		}
 


### PR DESCRIPTION
## Problem

DeepSeek's interleaved thinking mode requires `reasoning_content` to be passed back during multi-turn tool call sequences. After context condensing, this field was being lost, causing 400 API errors with the message:

> Missing `reasoning_content` field in the assistant message at message index 1

## Root Cause

The `buildCleanConversationHistory()` function in Task.ts was stripping `reasoning_content` from assistant messages before sending them to the API. According to the [DeepSeek API documentation](https://api-docs.deepseek.com/guides/thinking_mode#tool-calls):

> Since the tool invocation process in thinking mode requires users to pass back `reasoning_content` to the API, if your code does not correctly pass back `reasoning_content`, the API will return a 400 error.

## Changes

1. **Added `reasoning_content` field to `ApiMessage` type** - This ensures the type system properly tracks this field through the codebase.

2. **Updated condense logic to preserve `reasoning_content`** - Added `getReasoningContent()` helper function and ensured messages retained after condensing preserve their reasoning content.

3. **Fixed turn alternation** - After condensing, the summary message (assistant) followed by kept messages could create consecutive assistant messages. Added logic to inject an empty user message when needed to maintain proper turn alternation.

4. **Updated `buildCleanConversationHistory()`** - Now preserves `reasoning_content` on assistant messages when sending to the API.

5. **Added comprehensive tests** - Tests verify reasoning content preservation and turn alternation fixes.

## Testing

- All 41 condense tests pass
- All 20 r1-format tests pass
- Full test suite passes (4923 tests)

## Documentation Reference

- [DeepSeek Thinking Mode - Tool Calls](https://api-docs.deepseek.com/guides/thinking_mode#tool-calls)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Preserve `reasoning_content` in DeepSeek API messages to prevent errors and ensure proper turn alternation in message condensing.
> 
>   - **Behavior**:
>     - Preserve `reasoning_content` in `getKeepMessagesWithToolBlocks()` and `buildCleanConversationHistory()` to prevent DeepSeek API errors.
>     - Ensure turn alternation by extending keep range backwards in `getKeepMessagesWithToolBlocks()`.
>   - **Types**:
>     - Add `reasoning_content` to `ApiMessage` type in `apiMessages.ts`.
>   - **Functions**:
>     - Update `getKeepMessagesWithToolBlocks()` in `index.ts` to handle `reasoning_content` and turn alternation.
>     - Modify `buildCleanConversationHistory()` in `Task.ts` to include `reasoning_content` in API messages.
>   - **Tests**:
>     - Add tests in `index.spec.ts` to verify `reasoning_content` preservation and turn alternation logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5028d0ca79ea612081b17b8e86b2d3b5acd62013. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->