### PR TITLE
fix(evals): add missing packages/core to Dockerfile.runner

### DIFF
--- a/packages/evals/Dockerfile.runner
+++ b/packages/evals/Dockerfile.runner
@@ -86,6 +86,7 @@ RUN mkdir -p \
   packages/build \
   packages/config-eslint \
   packages/config-typescript \
+  packages/core \
   packages/evals \
   packages/ipc \
   packages/telemetry \
@@ -101,6 +102,7 @@ COPY ./scripts/bootstrap.mjs                   ./scripts/
 COPY ./packages/build/package.json             ./packages/build/
 COPY ./packages/config-eslint/package.json     ./packages/config-eslint/
 COPY ./packages/config-typescript/package.json ./packages/config-typescript/
+COPY ./packages/core/package.json              ./packages/core/
 COPY ./packages/evals/package.json             ./packages/evals/
 COPY ./packages/ipc/package.json               ./packages/ipc/
 COPY ./packages/telemetry/package.json         ./packages/telemetry/


### PR DESCRIPTION
## Problem

Docker builds fail with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` for `@roo-code/core`:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND  In src: "@roo-code/core@workspace:^" is in the dependencies but no package named "@roo-code/core" is present in the workspace
```

## Cause

PR #10083 ("Custom tool calling") added `@roo-code/core` as a dependency to `src/package.json` but didn't update the Dockerfile to include `packages/core` in the workspace setup.

## Effect

All Docker-based builds (evals runner) are broken on main.

## Fix

Add `packages/core` to both the `mkdir` and `COPY` sections of `Dockerfile.runner`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix Docker build error by adding `packages/core` to `Dockerfile.runner`.
> 
>   - **Fix**:
>     - Add `packages/core` to `mkdir` and `COPY` sections in `Dockerfile.runner` to resolve `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND` error for `@roo-code/core`.
>   - **Cause**:
>     - `@roo-code/core` was added as a dependency in `src/package.json` in PR #10083 but not included in Dockerfile workspace setup.
>   - **Effect**:
>     - Fixes broken Docker-based builds for evals runner on main.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 207d9751bc49205d18614f2b7e7722e06fa0b593. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->