### PR TITLE
fix: enable Requesty refresh models with credentials

### DIFF
--- a/webview-ui/src/components/settings/providers/Requesty.tsx
+++ b/webview-ui/src/components/settings/providers/Requesty.tsx
@@ -30,7 +30,6 @@ export const Requesty = ({
 	apiConfiguration,
 	setApiConfigurationField,
 	routerModels,
-	refetchRouterModels,
 	organizationAllowList,
 	modelValidationError,
 	uriScheme,
@@ -127,8 +126,7 @@ export const Requesty = ({
 			<Button
 				variant="outline"
 				onClick={() => {
-					vscode.postMessage({ type: "flushRouterModels", text: "requesty" })
-					refetchRouterModels()
+					vscode.postMessage({ type: "requestRouterModels", values: { provider: "requesty", refresh: true } })
 				}}>
 				<div className="flex items-center gap-2">
 					<span className="codicon codicon-refresh" />


### PR DESCRIPTION
## Summary

The existing `flushRouterModels` pattern doesn't work for Requesty because it doesn't pass API credentials. This caused the 'Refresh Models' button to return stale cached data instead of fresh models.

## Changes

### Backend (`webviewMessageHandler.ts`)
- Added a `refresh: true` flag support to `requestRouterModels` handler
- When `refresh=true` with a provider filter, flushes cache WITH credentials before fetching

### Frontend (`Requesty.tsx`)  
- Updated to use `requestRouterModels` with `refresh: true` instead of `flushRouterModels`
- Removed unused `refetchRouterModels` prop since it's no longer needed

## Why this is necessary

The `flushRouterModels` message (used by DeepInfra) calls `flushModels({ provider }, true)` **without credentials**. For Requesty, this means `getRequestyModels(undefined, undefined)` - which fails or returns empty data. The cache isn't cleared on failure, so subsequent `refetchRouterModels()` returns stale cached data.

This approach reuses existing infrastructure while ensuring the credential-aware cache flush works for providers like Requesty that require `apiKey` and `baseUrl` for API calls.

## Testing

- Tested refresh models button with Requesty API key - successfully fetches fresh models
- All existing tests pass

Supersedes #10264
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable Requesty model refresh with credentials by adding a `refresh` flag to `requestRouterModels` and updating frontend usage.
> 
>   - **Backend (`webviewMessageHandler.ts`)**:
>     - Add `refresh: true` flag support to `requestRouterModels` handler.
>     - Flush cache with credentials when `refresh=true` and provider filter is set.
>   - **Frontend (`Requesty.tsx`)**:
>     - Use `requestRouterModels` with `refresh: true` instead of `flushRouterModels`.
>     - Remove unused `refetchRouterModels` prop.
>   - **Testing**:
>     - Verified refresh models button with Requesty API key fetches fresh models.
>     - All existing tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c19730ed20855ccdc5eb767c462bec6ed5dfcb57. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->