### PR TITLE
refactor(zai): merge environment_details into tool result instead of system message

### DIFF
--- a/src/api/providers/zai.ts
+++ b/src/api/providers/zai.ts
@@ -89,8 +89,8 @@ export class ZAiHandler extends BaseOpenAiCompatibleProvider<string> {
 
 		const temperature = this.options.modelTemperature ?? this.defaultTemperature
 
-		// Use Z.ai format to preserve reasoning_content and convert post-tool text to system messages
-		const convertedMessages = convertToZAiFormat(messages, { convertToolResultTextToSystem: true })
+		// Use Z.ai format to preserve reasoning_content and merge post-tool text into tool messages
+		const convertedMessages = convertToZAiFormat(messages, { mergeToolResultText: true })
 
 		const params: ZAiChatCompletionParams = {
 			model,


### PR DESCRIPTION
## Summary

Aligns the Z.ai/GLM provider with the MiniMax/DeepSeek approach for handling `environment_details` after tool results. Instead of converting post-tool text to system messages, the text is now merged into the last tool message content.

## Changes

- Updated `src/api/transform/zai-format.ts`:
  - Replaced `convertToolResultTextToSystem` option with `mergeToolResultText` option
  - Changed logic to merge text content into the last tool message instead of creating a system message
  - Updated JSDoc comments to reflect the new behavior

- Updated `src/api/providers/zai.ts`:
  - Changed to use `{ mergeToolResultText: true }` instead of `{ convertToolResultTextToSystem: true }`

## Rationale

This approach:
- Better preserves `reasoning_content` continuity for GLM-4.7's interleaved thinking mode
- Matches the proven pattern used by DeepSeek (`r1-format.ts`) and MiniMax providers
- Avoids creating separate system messages that could interfere with thinking mode
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor Z.ai to merge `environment_details` into tool messages, preserving reasoning continuity and aligning with other providers.
> 
>   - **Behavior**:
>     - `environment_details` are now merged into the last tool message instead of being converted to system messages in `convertToZAiFormat()` in `zai-format.ts`.
>     - Updated `ZAiHandler` in `zai.ts` to use `{ mergeToolResultText: true }`.
>   - **Rationale**:
>     - Preserves `reasoning_content` continuity for GLM-4.7's interleaved thinking mode.
>     - Aligns with MiniMax and DeepSeek providers' approach.
>     - Avoids creating separate system messages that could interfere with thinking mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 79043fcf5f43e03f46f19dde175bbed1bcbe43a6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->