### PR TITLE
fix: emit tool_call_end events in BaseOpenAiCompatibleProvider

### DIFF
--- a/src/api/providers/base-openai-compatible-provider.ts
+++ b/src/api/providers/base-openai-compatible-provider.ts
@@ -129,6 +129,7 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 		)
 
 		let lastUsage: OpenAI.CompletionUsage | undefined
+		const activeToolCallIds = new Set<string>()
 
 		for await (const chunk of stream) {
 			// Check for provider-specific error responses (e.g., MiniMax base_resp)
@@ -140,6 +141,7 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 			}
 
 			const delta = chunk.choices?.[0]?.delta
+			const finishReason = chunk.choices?.[0]?.finish_reason
 
 			if (delta?.content) {
 				for (const processedChunk of matcher.update(delta.content)) {
@@ -162,6 +164,9 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 			// Emit raw tool call chunks - NativeToolCallParser handles state management
 			if (delta?.tool_calls) {
 				for (const toolCall of delta.tool_calls) {
+					if (toolCall.id) {
+						activeToolCallIds.add(toolCall.id)
+					}
 					yield {
 						type: "tool_call_partial",
 						index: toolCall.index,
@@ -170,6 +175,15 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 						arguments: toolCall.function?.arguments,
 					}
 				}
+			}
+
+			// Emit tool_call_end events when finish_reason is "tool_calls"
+			// This ensures tool calls are finalized even if the stream doesn't properly close
+			if (finishReason === "tool_calls" && activeToolCallIds.size > 0) {
+				for (const id of activeToolCallIds) {
+					yield { type: "tool_call_end", id }
+				}
+				activeToolCallIds.clear()
 			}
 
 			if (chunk.usage) {


### PR DESCRIPTION
## Summary

The `BaseOpenAiCompatibleProvider` was not emitting `tool_call_end` events when the API stream ended with `finish_reason === 'tool_calls'`. This could cause the extension to appear stuck waiting for more stream data.

This is the same fix applied in PR #10280 to the OpenAI handler, now applied to the base class that ZAi and other OpenAI-compatible providers extend.

## Changes

### `src/api/providers/base-openai-compatible-provider.ts`
- Added tracking of active tool call IDs in `createMessage()`
- When `finish_reason === 'tool_calls'`, emit `tool_call_end` events for all tracked tool calls
- Matches the pattern used by OpenAI handler (PR #10280)

### `src/api/providers/__tests__/base-openai-compatible-provider.spec.ts`
- Added test assertions to verify `tool_call_end` events are emitted when `finish_reason === 'tool_calls'`
- Added coverage for single and parallel tool call scenarios
- Added negative test for when `finish_reason` is not `tool_calls`

## Affected Providers

- ZAi (extends `BaseOpenAiCompatibleProvider`)
- Any other providers extending this base class

## Related

- Follow-up to #10280
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `BaseOpenAiCompatibleProvider` to emit `tool_call_end` events when `finish_reason === 'tool_calls'`, preventing the extension from appearing stuck.
> 
>   - **Behavior**:
>     - In `base-openai-compatible-provider.ts`, added tracking of active tool call IDs in `createMessage()`.
>     - Emit `tool_call_end` events when `finish_reason === 'tool_calls'` for all tracked tool calls.
>   - **Tests**:
>     - In `base-openai-compatible-provider.spec.ts`, added tests to verify `tool_call_end` events are emitted correctly.
>     - Covered single and parallel tool call scenarios, and negative test for non-`tool_calls` finish reasons.
>   - **Affected Providers**:
>     - ZAi and other providers extending `BaseOpenAiCompatibleProvider`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 17cfa2b2c77d0bee6321adc7ec0bebf85ae2bd81. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->