### PR TITLE
fix(task): drain queued messages while waiting for ask

### DIFF
--- a/src/core/task/__tests__/ask-queued-message-drain.spec.ts
+++ b/src/core/task/__tests__/ask-queued-message-drain.spec.ts
@@ -1,0 +1,38 @@
+import { Task } from "../Task"
+
+// Keep this test focused: if a queued message arrives while Task.ask() is blocked,
+// it should be consumed and used to fulfill the ask.
+
+describe("Task.ask queued message drain", () => {
+	it("consumes queued message while blocked on followup ask", async () => {
+		const task = Object.create(Task.prototype) as Task
+		;(task as any).abort = false
+		;(task as any).clineMessages = []
+		;(task as any).askResponse = undefined
+		;(task as any).askResponseText = undefined
+		;(task as any).askResponseImages = undefined
+		;(task as any).lastMessageTs = undefined
+
+		// Message queue service exists in constructor; for unit test we can attach a real one.
+		const { MessageQueueService } = await import("../../message-queue/MessageQueueService")
+		;(task as any).messageQueueService = new MessageQueueService()
+
+		// Minimal stubs used by ask()
+		;(task as any).addToClineMessages = vi.fn(async () => {})
+		;(task as any).saveClineMessages = vi.fn(async () => {})
+		;(task as any).updateClineMessage = vi.fn(async () => {})
+		;(task as any).cancelAutoApprovalTimeout = vi.fn(() => {})
+		;(task as any).checkpointSave = vi.fn(async () => {})
+		;(task as any).emit = vi.fn()
+		;(task as any).providerRef = { deref: () => undefined }
+
+		const askPromise = task.ask("followup", "Q?", false)
+
+		// Simulate webview queuing the user's selection text while the ask is pending.
+		;(task as any).messageQueueService.addMessage("picked answer")
+
+		const result = await askPromise
+		expect(result.response).toBe("messageResponse")
+		expect(result.text).toBe("picked answer")
+	})
+})


### PR DESCRIPTION
## Summary

Prevent follow-up (and other ask) flows from hanging when a user response is queued instead of being delivered as an askResponse.

## Changes

- Drain `messageQueueService` while `Task.ask()` is blocked, consuming a queued response to fulfill the ask
- Add regression test covering the queued-message drain behavior

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes hanging follow-up tasks by processing queued messages in `Task.ask()` while waiting for responses, with a new test to verify behavior.
> 
>   - **Behavior**:
>     - Modify `Task.ask()` in `Task.ts` to process queued messages while waiting for `askResponse`.
>     - Handles tool approval asks by sending `yesButtonClicked` with queued text/images.
>   - **Tests**:
>     - Add `ask-queued-message-drain.spec.ts` to test queued message consumption during `Task.ask()` blocking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b321db75e48015a2cbdb1696828c53c65e051111. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->