### PR TITLE
Remove the mergeToolResultText in the Roo provider for now

### DIFF
--- a/src/api/providers/roo.ts
+++ b/src/api/providers/roo.ts
@@ -100,13 +100,7 @@ export class RooHandler extends BaseOpenAiCompatibleProvider<string> {
 			model,
 			max_tokens,
 			temperature,
-			// Enable mergeToolResultText to merge environment_details and other text content
-			// after tool_results into the last tool message. This prevents reasoning/thinking
-			// models from dropping reasoning_content when they see a user message after tool results.
-			messages: [
-				{ role: "system", content: systemPrompt },
-				...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
-			],
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 			stream: true,
 			stream_options: { include_usage: true },
 			...(reasoning && { reasoning }),


### PR DESCRIPTION
This was causing 400s in Sonnet 4.5 after condensing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `mergeToolResultText` option in `RooHandler` to fix 400 errors in Sonnet 4.5.
> 
>   - **Behavior**:
>     - Remove `mergeToolResultText` option from `convertToOpenAiMessages()` in `RooHandler`.
>     - Fixes 400 errors in Sonnet 4.5 caused by this option.
>   - **Misc**:
>     - No other changes or impacts on other files or functions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d056e0f9d7f408c2d0c11e24d7d66a8cd380e053. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->