### PR TITLE
fix: flush pending tool results before condensing context

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1424,6 +1424,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	}
 
 	public async condenseContext(): Promise<void> {
+		// CRITICAL: Flush any pending tool results before condensing
+		// to ensure tool_use/tool_result pairs are complete in history
+		await this.flushPendingToolResultsToHistory()
+
 		const systemPrompt = await this.getSystemPrompt()
 
 		// Get condensing configuration


### PR DESCRIPTION
## Summary
Fixes ROO-329: Race condition in condenseContext causing tool_use/tool_result protocol violation

## Problem
When a user triggered manual context condensation (e.g., "Condense now please") while a tool was executing, the API returned a protocol violation error:

```
tool_use ids were found without tool_result blocks immediately after: toolu_01KFQ9DpyPKPE8vfzbiNozUn. Each tool_use block must have a corresponding tool_result block in the next message.
```

## Root Cause
The `condenseContext()` method did NOT call `flushPendingToolResultsToHistory()` before condensing.

**Race condition flow:**
1. Tool executes successfully (e.g., `update_todo_list`)
2. The assistant message with `tool_use` block is saved to `apiConversationHistory`
3. The `tool_result` is accumulated in `userMessageContent` but **NOT yet saved** to history (happens at end of turn)
4. User triggers manual condense
5. `condenseContext()` operates on `apiConversationHistory` which has `tool_use` but missing `tool_result`
6. Condensing/truncation happens on incomplete history
7. Next API request sends history with orphaned `tool_use` → API rejects

## Solution
Added `await this.flushPendingToolResultsToHistory()` at the start of `condenseContext()` to ensure `tool_use`/`tool_result` pairs are complete before any condensation operation.

## Testing
All existing tests pass, including the 5 tests in `flushPendingToolResultsToHistory.spec.ts`.

---
Linear: ROO-329