### PR TITLE
Revert "feat: enable mergeToolResultText for all OpenAI-compatible providers (#10299)"

### DIFF
--- a/src/api/providers/base-openai-compatible-provider.ts
+++ b/src/api/providers/base-openai-compatible-provider.ts
@@ -90,13 +90,7 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 			model,
 			max_tokens,
 			temperature,
-			// Enable mergeToolResultText to merge environment_details and other text content
-			// after tool_results into the last tool message. This prevents reasoning/thinking
-			// models from dropping reasoning_content when they see a user message after tool results.
-			messages: [
-				{ role: "system", content: systemPrompt },
-				...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
-			],
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 			stream: true,
 			stream_options: { include_usage: true },
 			...(metadata?.tools && { tools: this.convertToolsForOpenAI(metadata.tools) }),

--- a/src/api/providers/cerebras.ts
+++ b/src/api/providers/cerebras.ts
@@ -106,7 +106,7 @@ export class CerebrasHandler extends BaseProvider implements SingleCompletionHan
 			supportsNativeTools && metadata?.tools && metadata.tools.length > 0 && metadata?.toolProtocol !== "xml"
 
 		// Convert Anthropic messages to OpenAI format (Cerebras is OpenAI-compatible)
-		const openaiMessages = convertToOpenAiMessages(messages, { mergeToolResultText: true })
+		const openaiMessages = convertToOpenAiMessages(messages)
 
 		// Prepare request body following Cerebras API specification exactly
 		const requestBody: Record<string, any> = {

--- a/src/api/providers/chutes.ts
+++ b/src/api/providers/chutes.ts
@@ -44,10 +44,7 @@ export class ChutesHandler extends RouterProvider implements SingleCompletionHan
 		const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 			model,
 			max_tokens,
-			messages: [
-				{ role: "system", content: systemPrompt },
-				...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
-			],
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 			stream: true,
 			stream_options: { include_usage: true },
 			...(metadata?.tools && { tools: metadata.tools }),

--- a/src/api/providers/deepinfra.ts
+++ b/src/api/providers/deepinfra.ts
@@ -72,10 +72,7 @@ export class DeepInfraHandler extends RouterProvider implements SingleCompletion
 
 		const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 			model: modelId,
-			messages: [
-				{ role: "system", content: systemPrompt },
-				...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
-			],
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 			stream: true,
 			stream_options: { include_usage: true },
 			reasoning_effort,

--- a/src/api/providers/featherless.ts
+++ b/src/api/providers/featherless.ts
@@ -44,10 +44,7 @@ export class FeatherlessHandler extends BaseOpenAiCompatibleProvider<Featherless
 			model,
 			max_tokens,
 			temperature,
-			messages: [
-				{ role: "system", content: systemPrompt },
-				...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
-			],
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 			stream: true,
 			stream_options: { include_usage: true },
 		}

--- a/src/api/providers/huggingface.ts
+++ b/src/api/providers/huggingface.ts
@@ -56,10 +56,7 @@ export class HuggingFaceHandler extends BaseProvider implements SingleCompletion
 		const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 			model: modelId,
 			temperature,
-			messages: [
-				{ role: "system", content: systemPrompt },
-				...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
-			],
+			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
 			stream: true,
 			stream_options: { include_usage: true },
 		}

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -45,7 +45,7 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 	): ApiStream {
 		const { id: modelId, info } = await this.fetchModel()
 
-		const openAiMessages = convertToOpenAiMessages(messages, { mergeToolResultText: true })
+		const openAiMessages = convertToOpenAiMessages(messages)
 
 		// Prepare messages with cache control if enabled and supported
 		let systemMessage: OpenAI.Chat.ChatCompletionMessageParam

--- a/src/api/providers/lm-studio.ts
+++ b/src/api/providers/lm-studio.ts
@@ -44,7 +44,7 @@ export class LmStudioHandler extends BaseProvider implements SingleCompletionHan
 	): ApiStream {
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
+			...convertToOpenAiMessages(messages),
 		]
 
 		// LM Studio always supports native tools (https://lmstudio.ai/docs/developer/core/tools)

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -127,7 +127,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 					}
 				}
 
-				convertedMessages = [systemMessage, ...convertToOpenAiMessages(messages, { mergeToolResultText: true })]
+				convertedMessages = [systemMessage, ...convertToOpenAiMessages(messages)]
 
 				if (modelInfo.supportsPromptCache) {
 					// Note: the following logic is copied from openrouter:
@@ -235,7 +235,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 					? convertToR1Format([{ role: "user", content: systemPrompt }, ...messages])
 					: enabledLegacyFormat
 						? [systemMessage, ...convertToSimpleMessages(messages)]
-						: [systemMessage, ...convertToOpenAiMessages(messages, { mergeToolResultText: true })],
+						: [systemMessage, ...convertToOpenAiMessages(messages)],
 				...(metadata?.tools && { tools: this.convertToolsForOpenAI(metadata.tools) }),
 				...(metadata?.tool_choice && { tool_choice: metadata.tool_choice }),
 				...(metadata?.toolProtocol === "native" && {
@@ -356,7 +356,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 						role: "developer",
 						content: `Formatting re-enabled\n${systemPrompt}`,
 					},
-					...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
+					...convertToOpenAiMessages(messages),
 				],
 				stream: true,
 				...(isGrokXAI ? {} : { stream_options: { include_usage: true } }),
@@ -393,7 +393,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 						role: "developer",
 						content: `Formatting re-enabled\n${systemPrompt}`,
 					},
-					...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
+					...convertToOpenAiMessages(messages),
 				],
 				reasoning_effort: modelInfo.reasoningEffort as "low" | "medium" | "high" | undefined,
 				temperature: undefined,

--- a/src/api/providers/openrouter.ts
+++ b/src/api/providers/openrouter.ts
@@ -229,15 +229,13 @@ export class OpenRouterHandler extends BaseProvider implements SingleCompletionH
 
 		// Convert Anthropic messages to OpenAI format.
 		// Pass normalization function for Mistral compatibility (requires 9-char alphanumeric IDs)
-		// Enable mergeToolResultText to merge environment_details after tool_results into the last
-		// tool message, preventing reasoning/thinking models from dropping reasoning_content.
 		const isMistral = modelId.toLowerCase().includes("mistral")
 		let openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages, {
-				mergeToolResultText: true,
-				...(isMistral && { normalizeToolCallId: normalizeMistralToolCallId }),
-			}),
+			...convertToOpenAiMessages(
+				messages,
+				isMistral ? { normalizeToolCallId: normalizeMistralToolCallId } : undefined,
+			),
 		]
 
 		// DeepSeek highly recommends using user instead of system role.

--- a/src/api/providers/qwen-code.ts
+++ b/src/api/providers/qwen-code.ts
@@ -222,7 +222,7 @@ export class QwenCodeHandler extends BaseProvider implements SingleCompletionHan
 			content: systemPrompt,
 		}
 
-		const convertedMessages = [systemMessage, ...convertToOpenAiMessages(messages, { mergeToolResultText: true })]
+		const convertedMessages = [systemMessage, ...convertToOpenAiMessages(messages)]
 
 		const requestOptions: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
 			model: model.id,

--- a/src/api/providers/requesty.ts
+++ b/src/api/providers/requesty.ts
@@ -140,7 +140,7 @@ export class RequestyHandler extends BaseProvider implements SingleCompletionHan
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
+			...convertToOpenAiMessages(messages),
 		]
 
 		// Map extended efforts to OpenAI Chat Completions-accepted values (omit unsupported)

--- a/src/api/providers/unbound.ts
+++ b/src/api/providers/unbound.ts
@@ -86,7 +86,7 @@ export class UnboundHandler extends RouterProvider implements SingleCompletionHa
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
+			...convertToOpenAiMessages(messages),
 		]
 
 		if (info.supportsPromptCache) {

--- a/src/api/providers/vercel-ai-gateway.ts
+++ b/src/api/providers/vercel-ai-gateway.ts
@@ -45,7 +45,7 @@ export class VercelAiGatewayHandler extends RouterProvider implements SingleComp
 
 		const openAiMessages: OpenAI.Chat.ChatCompletionMessageParam[] = [
 			{ role: "system", content: systemPrompt },
-			...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
+			...convertToOpenAiMessages(messages),
 		]
 
 		if (VERCEL_AI_GATEWAY_PROMPT_CACHING_MODELS.has(modelId) && info.supportsPromptCache) {

--- a/src/api/providers/xai.ts
+++ b/src/api/providers/xai.ts
@@ -66,7 +66,7 @@ export class XAIHandler extends BaseProvider implements SingleCompletionHandler 
 			temperature: this.options.modelTemperature ?? XAI_DEFAULT_TEMPERATURE,
 			messages: [
 				{ role: "system", content: systemPrompt },
-				...convertToOpenAiMessages(messages, { mergeToolResultText: true }),
+				...convertToOpenAiMessages(messages),
 			] as OpenAI.Chat.ChatCompletionMessageParam[],
 			stream: true as const,
 			stream_options: { include_usage: true },


### PR DESCRIPTION
## Summary

This reverts commit ded6486a46b112cdd08ad36aa99b843295b77d07 (PR #10299).

## What was reverted

The original PR added `mergeToolResultText` option to all OpenAI-compatible providers. This feature merged text content after tool_result blocks (like `environment_details`) into the last tool message instead of creating separate user messages.

## Files Changed

- src/api/providers/base-openai-compatible-provider.ts
- src/api/providers/cerebras.ts
- src/api/providers/chutes.ts
- src/api/providers/deepinfra.ts
- src/api/providers/featherless.ts
- src/api/providers/huggingface.ts
- src/api/providers/lite-llm.ts
- src/api/providers/lm-studio.ts
- src/api/providers/openai.ts
- src/api/providers/openrouter.ts
- src/api/providers/qwen-code.ts
- src/api/providers/requesty.ts
- src/api/providers/unbound.ts
- src/api/providers/vercel-ai-gateway.ts
- src/api/providers/xai.ts
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts `mergeToolResultText` option for OpenAI-compatible providers, affecting message processing across multiple files.
> 
>   - **Behavior**:
>     - Reverts `mergeToolResultText` option in `convertToOpenAiMessages()` calls across multiple provider files.
>     - Affects message processing by no longer merging text content after tool_result blocks into the last tool message.
>   - **Files**:
>     - Changes in `base-openai-compatible-provider.ts`, `cerebras.ts`, and `chutes.ts` to remove `mergeToolResultText`.
>     - Similar changes in `deepinfra.ts`, `featherless.ts`, and `huggingface.ts`.
>     - Additional changes in `lite-llm.ts`, `lm-studio.ts`, and `openai.ts`.
>     - Further changes in `openrouter.ts`, `qwen-code.ts`, and `requesty.ts`.
>     - Also affects `unbound.ts`, `vercel-ai-gateway.ts`, and `xai.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 097781c9999a00e2ecdd9dbd98746bfa71487c7c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->