### PR TITLE
fix(zai): respect model defaultTemperature

### DIFF
--- a/src/api/providers/__tests__/zai.temperature.spec.ts
+++ b/src/api/providers/__tests__/zai.temperature.spec.ts
@@ -1,0 +1,114 @@
+// npx vitest run api/providers/__tests__/zai.temperature.spec.ts
+
+import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
+
+import type { ModelInfo } from "@roo-code/types"
+
+// Must be mocked before importing the handler.
+vi.mock("@roo-code/types", async () => {
+	const model: ModelInfo = {
+		maxTokens: 1000,
+		maxThinkingTokens: null,
+		contextWindow: 8000,
+		supportsImages: false,
+		supportsPromptCache: false,
+		defaultTemperature: 0.9,
+		supportsReasoningEffort: ["disable", "medium"],
+		reasoningEffort: "medium",
+		preserveReasoning: true,
+	}
+
+	const models = {
+		"glm-4.7": model,
+	} as const satisfies Record<string, ModelInfo>
+
+	return {
+		internationalZAiModels: models,
+		mainlandZAiModels: models,
+		internationalZAiDefaultModelId: "glm-4.7",
+		mainlandZAiDefaultModelId: "glm-4.7",
+		ZAI_DEFAULT_TEMPERATURE: 0.5,
+		zaiApiLineConfigs: {
+			international_coding: { isChina: false, baseUrl: "https://example.invalid/v1" },
+			china_coding: { isChina: true, baseUrl: "https://example.invalid/v1" },
+		} as const,
+	}
+})
+
+const mockCreate = vi.fn()
+
+vi.mock("openai", () => ({
+	default: vi.fn(() => ({
+		chat: {
+			completions: {
+				create: mockCreate,
+			},
+		},
+	})),
+}))
+
+import { ZAiHandler } from "../zai"
+
+describe("ZAiHandler temperature precedence", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	it("uses model defaultTemperature when modelTemperature is not set", async () => {
+		mockCreate.mockImplementationOnce(() => {
+			return {
+				[Symbol.asyncIterator]: () => ({
+					async next() {
+						return { done: true }
+					},
+				}),
+			}
+		})
+
+		const handler = new ZAiHandler({
+			apiModelId: "glm-4.7",
+			zaiApiKey: "test-key",
+			zaiApiLine: "international_coding",
+		})
+
+		const messages: Anthropic.Messages.MessageParam[] = [{ role: "user", content: "hi" }]
+		const stream = handler.createMessage("system", messages)
+		await stream.next()
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				temperature: 0.9,
+			}),
+		)
+	})
+
+	it("uses modelTemperature when set", async () => {
+		mockCreate.mockImplementationOnce(() => {
+			return {
+				[Symbol.asyncIterator]: () => ({
+					async next() {
+						return { done: true }
+					},
+				}),
+			}
+		})
+
+		const handler = new ZAiHandler({
+			apiModelId: "glm-4.7",
+			zaiApiKey: "test-key",
+			zaiApiLine: "international_coding",
+			modelTemperature: 0.1,
+		})
+
+		const messages: Anthropic.Messages.MessageParam[] = [{ role: "user", content: "hi" }]
+		const stream = handler.createMessage("system", messages)
+		await stream.next()
+
+		expect(mockCreate).toHaveBeenCalledWith(
+			expect.objectContaining({
+				temperature: 0.1,
+			}),
+		)
+	})
+})

--- a/src/api/providers/zai.ts
+++ b/src/api/providers/zai.ts
@@ -87,7 +87,7 @@ export class ZAiHandler extends BaseOpenAiCompatibleProvider<string> {
 				format: "openai",
 			}) ?? undefined
 
-		const temperature = this.options.modelTemperature ?? this.defaultTemperature
+		const temperature = this.options.modelTemperature ?? info.defaultTemperature ?? this.defaultTemperature
 
 		// Use Z.ai format to preserve reasoning_content and merge post-tool text into tool messages
 		const convertedMessages = convertToZAiFormat(messages, { mergeToolResultText: true })


### PR DESCRIPTION
## Summary

Ensure the Z.ai provider uses the model's  when the user has not set , matching the precedence used elsewhere.

## Changes

- Update temperature resolution in [](src/api/providers/zai.ts:74) to prefer  over provider defaults.
- Add regression tests covering temperature precedence in [](src/api/providers/__tests__/zai.temperature.spec.ts:1).
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes temperature precedence in `ZAiHandler` to use model's `defaultTemperature` when `modelTemperature` is not set, with tests added.
> 
>   - **Behavior**:
>     - Update temperature resolution in `zai.ts` to prefer `info.defaultTemperature` over provider defaults when `modelTemperature` is not set.
>     - Add regression tests in `zai.temperature.spec.ts` to verify temperature precedence.
>   - **Tests**:
>     - Test that `ZAiHandler` uses `defaultTemperature` when `modelTemperature` is not set.
>     - Test that `ZAiHandler` uses `modelTemperature` when it is set.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4e324f0bd35f94bce79481275d46108292b0e047. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->