### PR TITLE
fix: merge approval feedback into tool result instead of pushing duplicate (ROO-410)

### DIFF
--- a/src/core/task/validateToolResultIds.ts
+++ b/src/core/task/validateToolResultIds.ts
@@ -83,8 +83,10 @@ export function validateAndFixToolResultIds(
 	)
 
 	// Deduplicate tool_result blocks to prevent API protocol violations (GitHub #10465)
-	// Terminal fallback race conditions can generate duplicate tool_results with the same tool_use_id.
-	// Filter out duplicates before validation since Set-based checks below would miss them.
+	// This serves as a safety net for any potential race conditions that could generate
+	// duplicate tool_results with the same tool_use_id. The root cause (approval feedback
+	// creating duplicate results) has been fixed in presentAssistantMessage.ts, but this
+	// deduplication remains as a defensive measure for unknown edge cases.
 	const seenToolResultIds = new Set<string>()
 	const deduplicatedContent = userMessage.content.filter((block) => {
 		if (block.type !== "tool_result") {


### PR DESCRIPTION
## Problem

When a user approves a tool execution AND provides feedback text, `askApproval` in `presentAssistantMessage.ts` was pushing the feedback as a separate `tool_result`. This created duplicate `tool_result` blocks with the same `tool_use_id` because the actual tool also pushes its result when it executes.

This is a protocol violation for the Anthropic API and was documented as GitHub #10465. A workaround existed in `validateAndFixToolResultIds.ts` that deduplicated results AFTER they were created, but the root cause was never addressed.

## Solution

Instead of pushing approval feedback as a separate tool_result, the feedback is now **stored** and **merged** into the actual tool's result when `pushToolResult` is called:

1. Added `approvalFeedback` storage variable to hold feedback until tool completes
2. Modified `pushToolResult` to merge stored feedback into the tool's actual result content
3. Updated `askApproval` to store feedback instead of pushing it as a separate tool_result
4. This applies to both MCP tools and regular tools, and both native and XML protocols

## Changes

- `src/core/assistant-message/presentAssistantMessage.ts` - root fix for both MCP and regular tools
- `src/core/task/validateToolResultIds.ts` - updated comments (deduplication kept as safety net)

## Testing

- All existing tests pass (5153 tests)
- The deduplication safety net in `validateAndFixToolResultIds.ts` remains as defense-in-depth

Closes ROO-410
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duplicate `tool_result` issue by merging approval feedback into tool results in `presentAssistantMessage.ts`.
> 
>   - **Behavior**:
>     - `presentAssistantMessage.ts`: Merges approval feedback into tool results instead of creating duplicate `tool_result` blocks.
>     - Applies to both MCP tools and regular tools, and both native and XML protocols.
>   - **Implementation**:
>     - Adds `approvalFeedback` variable to store feedback until tool completion.
>     - Modifies `pushToolResult` to merge stored feedback into tool results.
>     - Updates `askApproval` to store feedback instead of pushing it as a separate `tool_result`.
>   - **Validation**:
>     - `validateToolResultIds.ts`: Keeps deduplication as a safety net for unknown edge cases.
>   - **Testing**:
>     - All existing tests pass (5153 tests).
>     - Deduplication remains as defense-in-depth.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e4e67e27dc9c8b1e8f70a0bbd56d70ebcbf887f3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->