### PR TITLE
chore(cli): change default model to anthropic/claude-opus-4.5

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -21,7 +21,7 @@ import { getEnvVarName, getApiKeyFromEnv, getDefaultExtensionPath } from "./util
 const DEFAULTS = {
 	mode: "code",
 	reasoningEffort: "medium" as const,
-	model: "anthropic/claude-sonnet-4.5",
+	model: "anthropic/claude-opus-4.5",
 }
 
 const REASONING_EFFORTS = [...reasoningEffortsExtended, "unspecified", "disabled"]


### PR DESCRIPTION
Changes the default model in the CLI from `anthropic/claude-sonnet-4.5` to `anthropic/claude-opus-4.5`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change default model in CLI from `anthropic/claude-sonnet-4.5` to `anthropic/claude-opus-4.5`.
> 
>   - **Behavior**:
>     - Change default model in `index.ts` from `anthropic/claude-sonnet-4.5` to `anthropic/claude-opus-4.5`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c96febfac5c3ac06b303526010d7e94a0466365f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->