### PR TITLE
fix: change minItems from 2 to 1 for Anthropic API compatibility

### DIFF
--- a/src/core/prompts/tools/native-tools/ask_followup_question.ts
+++ b/src/core/prompts/tools/native-tools/ask_followup_question.ts
@@ -51,7 +51,7 @@ export default {
 						required: ["text", "mode"],
 						additionalProperties: false,
 					},
-					minItems: 2,
+					minItems: 1,
 					maxItems: 4,
 				},
 			},


### PR DESCRIPTION
## Summary

Fix for the Anthropic API 400 error when using the `ask_followup_question` tool with Anthropic models.

## Problem

The Anthropic API (and OpenRouter when proxying to Anthropic models) has stricter JSON Schema validation for tool definitions. It only supports `minItems` values of **0 or 1** for array types in tool schemas.

The `ask_followup_question` tool had `minItems: 2` for the `follow_up` array, causing a 400 error:

```
ApiProviderError: tools.1.custom: For 'array' type, 'minItems' values other than 0 or 1 are not supported (got: [2, 5])
```

## Solution

Changed `minItems: 2` to `minItems: 1` in the tool schema. The descriptions remain unchanged at "2-4 suggested answers" - the schema constraint is just relaxed to satisfy Anthropic's API validation.

## Links

- Linear: https://linear.app/roocode/issue/ROO-420
- PostHog: https://us.posthog.com/error_tracking/019b94a7-5dfa-7023-99c9-0ff38c09a290
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `minItems` from 2 to 1 in `ask_followup_question.ts` to fix Anthropic API 400 error.
> 
>   - **Behavior**:
>     - Change `minItems` from 2 to 1 in `ask_followup_question.ts` for `follow_up` array to fix Anthropic API 400 error.
>     - Ensures compatibility with Anthropic's stricter JSON Schema validation.
>   - **Misc**:
>     - No changes to descriptions or other schema properties.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 68e51639e1ce7382feb33f87a2c0e94153cd6417. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->