### PR TITLE
fix: disable Gemini thought signature persistence to prevent corrupted signature errors

### DIFF
--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -456,7 +456,10 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 	}
 
 	public getThoughtSignature(): string | undefined {
-		return this.lastThoughtSignature
+		// Disabled to prevent "Corrupted thought signature" errors on task resumption.
+		// Gemini thought signatures are session-specific and cannot be reliably reused
+		// across API calls or after task resumption from history.
+		return undefined
 	}
 
 	public getResponseId(): string | undefined {


### PR DESCRIPTION
## Summary

Fixes Gemini "Corrupted thought signature" (HTTP 400 INVALID_ARGUMENT) errors that occur when resuming tasks with Gemini models using extended thinking/reasoning (like `gemini-3-pro-preview`).

## Problem

Gemini thought signatures are session-specific cryptographic tokens that cannot be reliably reused across:
- Separate API calls within the same session
- Task resumption from history
- Different model versions

When stale signatures were passed back to the Gemini API during task resumption, it rejected them.

## Solution

Modified `GeminiHandler.getThoughtSignature()` to return `undefined`, preventing stale signatures from being stored in conversation history and sent to the Gemini API.

## Testing

All Gemini-related tests pass (42 total):
- `gemini.spec.ts` - 17 tests ✓
- `gemini-format.spec.ts` - 16 tests ✓
- `gemini caching` - 9 tests ✓

## Related

- Linear issue: ROO-422
- PostHog error: https://us.posthog.com/error_tracking/019b9de5-279d-7792-b512-f5d77510eaee
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `GeminiHandler.getThoughtSignature()` now returns `undefined` to prevent stale thought signature errors during task resumption.
> 
>   - **Behavior**:
>     - `GeminiHandler.getThoughtSignature()` now returns `undefined` to prevent stale thought signatures from causing errors during task resumption.
>   - **Testing**:
>     - All Gemini-related tests pass: 17 in `gemini.spec.ts`, 16 in `gemini-format.spec.ts`, and 9 in `gemini caching`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 99d7308636fe1a7be1ec54e77877e41a9b436dc5. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->