### PR TITLE
fix: ensure assistant message content is never undefined for Gemini compatibility

### DIFF
--- a/src/api/transform/openai-format.ts
+++ b/src/api/transform/openai-format.ts
@@ -223,7 +223,9 @@ export function convertToOpenAiMessages(
 					reasoning_details?: any[]
 				} = {
 					role: "assistant",
-					content,
+					// Use empty string instead of undefined for providers like Gemini (via OpenRouter)
+					// that require every message to have content in the "parts" field
+					content: content ?? "",
 				}
 
 				// Pass through reasoning_details to preserve the original shape from the API.


### PR DESCRIPTION
## Summary

Fixes ROO-425: OpenRouter + Gemini "parts field" validation error when assistant message has undefined content.

## Problem

When assistant messages contain only `tool_use` blocks (no text), the `content` field was left as `undefined`. While OpenAI accepts `content: null` with `tool_calls`, **Gemini (via OpenRouter) strictly requires every message to have content** in the "parts" field.

This caused users to encounter a **400 Bad Request** error:
```
ApiProviderError: Unable to submit request because it must include at least one parts field, which describes the prompt input.
```

## Solution

Use empty string fallback (`content ?? ""`) for assistant message content instead of allowing `undefined`.

## Changes

- `src/api/transform/openai-format.ts`: Use `content ?? ""` instead of `content`
- `src/api/transform/__tests__/openai-format.spec.ts`: Add test case for Gemini compatibility

## Testing

- ✅ All 24 tests pass in `openai-format.spec.ts`
- ✅ All 5179 tests pass across the project

## Related

- Linear: https://linear.app/roocode/issue/ROO-425
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes undefined content in assistant messages for Gemini compatibility by using empty string fallback in `convertToOpenAiMessages()`.
> 
>   - **Behavior**:
>     - Fixes issue where assistant messages with only `tool_use` blocks had `undefined` content, causing errors with Gemini via OpenRouter.
>     - Uses `content ?? ""` to ensure content is never `undefined` in `convertToOpenAiMessages()` in `openai-format.ts`.
>   - **Testing**:
>     - Adds test case in `openai-format.spec.ts` to verify empty string content for Gemini compatibility.
>     - All tests pass in `openai-format.spec.ts` and across the project.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f6304d4bd6cfaff88dad66b76db633f1cb44f9eb. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->