### PR TITLE
fix(vscode-lm): order text parts before tool calls in assistant messages

### DIFF
--- a/src/api/transform/__tests__/vscode-lm-format.spec.ts
+++ b/src/api/transform/__tests__/vscode-lm-format.spec.ts
@@ -143,9 +143,11 @@ describe("convertToVsCodeLmMessages", () => {
 		expect(result).toHaveLength(1)
 		expect(result[0].role).toBe("assistant")
 		expect(result[0].content).toHaveLength(2)
-		const [toolCall, textContent] = result[0].content as [MockLanguageModelToolCallPart, MockLanguageModelTextPart]
-		expect(toolCall.type).toBe("tool_call")
+		// Text must come before tool calls so that tool calls are at the end,
+		// properly followed by user message with tool results
+		const [textContent, toolCall] = result[0].content as [MockLanguageModelTextPart, MockLanguageModelToolCallPart]
 		expect(textContent.type).toBe("text")
+		expect(toolCall.type).toBe("tool_call")
 	})
 
 	it("should handle image blocks with appropriate placeholders", () => {

--- a/src/api/transform/vscode-lm-format.ts
+++ b/src/api/transform/vscode-lm-format.ts
@@ -114,9 +114,18 @@ export function convertToVsCodeLmMessages(
 					{ nonToolMessages: [], toolMessages: [] },
 				)
 
-				// Process tool messages first then non-tool messages
+				// Process non-tool messages first, then tool messages
+				// Tool calls must come at the end so they are properly followed by user message with tool results
 				const contentParts = [
-					// Convert tool messages to ToolCallParts first
+					// Convert non-tool messages to TextParts first
+					...nonToolMessages.map((part) => {
+						if (part.type === "image") {
+							return new vscode.LanguageModelTextPart("[Image generation not supported by VSCode LM API]")
+						}
+						return new vscode.LanguageModelTextPart(part.text)
+					}),
+
+					// Convert tool messages to ToolCallParts after text
 					...toolMessages.map(
 						(toolMessage) =>
 							new vscode.LanguageModelToolCallPart(
@@ -125,14 +134,6 @@ export function convertToVsCodeLmMessages(
 								asObjectSafe(toolMessage.input),
 							),
 					),
-
-					// Convert non-tool messages to TextParts after tool messages
-					...nonToolMessages.map((part) => {
-						if (part.type === "image") {
-							return new vscode.LanguageModelTextPart("[Image generation not supported by VSCode LM API]")
-						}
-						return new vscode.LanguageModelTextPart(part.text)
-					}),
 				]
 
 				// Add the assistant message to the list of messages


### PR DESCRIPTION
## Summary
Fixes the VS Code LM API error: "Invalid request: Tool call part must be followed by a User message with a LanguageModelToolResultPart with a matching callId."

## Problem
In `convertToVsCodeLmMessages()`, assistant messages were putting `LanguageModelToolCallPart` objects **before** text parts. The VS Code LM API requires that within an assistant message, tool calls must come at the **end** so they are properly followed by the next user message containing matching `LanguageModelToolResultPart` objects.

## Solution
Changed the content ordering for assistant messages:
- **Before:** Tool calls first, then text parts
- **After:** Text parts first, then tool calls at the end

This ensures the message structure satisfies the VS Code LM API requirement that tool call parts are properly followed by a user message with tool results.

## Testing
- Updated existing tests to verify the correct ordering
- All 19 tests in `vscode-lm-format.spec.ts` pass
- All 5179 tests pass in the full test suite

Fixes ROO-427
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes order of tool call and text parts in assistant messages in `convertToVsCodeLmMessages()` to comply with VS Code LM API.
> 
>   - **Behavior**:
>     - Fixes order of `LanguageModelToolCallPart` and text parts in `convertToVsCodeLmMessages()` in `vscode-lm-format.ts`.
>     - Ensures tool calls in assistant messages come after text parts to comply with VS Code LM API.
>   - **Testing**:
>     - Updates tests in `vscode-lm-format.spec.ts` to verify correct ordering of message parts.
>     - Confirms all 19 tests in `vscode-lm-format.spec.ts` and 5179 tests in full suite pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3a355839dbe6a5f281416389b028ec327f129aeb. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->