### PR TITLE
feat: display edit_file errors in UI after consecutive failures

### DIFF
--- a/src/core/tools/__tests__/editFileTool.spec.ts
+++ b/src/core/tools/__tests__/editFileTool.spec.ts
@@ -425,6 +425,97 @@ describe("editFileTool", () => {
 		})
 	})
 
+	describe("consecutive error display behavior", () => {
+		it("does NOT show diff_error to user on first no_match failure", async () => {
+			await executeEditFileTool({ old_string: "NonExistent" }, { fileContent: "Line 1\nLine 2\nLine 3" })
+
+			expect(mockTask.consecutiveMistakeCountForEditFile.get(testFilePath)).toBe(1)
+			expect(mockTask.say).not.toHaveBeenCalledWith("diff_error", expect.any(String))
+			expect(mockTask.recordToolError).toHaveBeenCalledWith(
+				"edit_file",
+				expect.stringContaining("No match found"),
+			)
+		})
+
+		it("shows diff_error to user on second consecutive no_match failure", async () => {
+			// First failure
+			await executeEditFileTool({ old_string: "NonExistent" }, { fileContent: "Line 1\nLine 2\nLine 3" })
+
+			// Second failure on same file
+			await executeEditFileTool({ old_string: "AlsoNonExistent" }, { fileContent: "Line 1\nLine 2\nLine 3" })
+
+			expect(mockTask.consecutiveMistakeCountForEditFile.get(testFilePath)).toBe(2)
+			expect(mockTask.say).toHaveBeenCalledWith("diff_error", expect.stringContaining("No match found"))
+		})
+
+		it("does NOT show diff_error to user on first occurrence_mismatch failure", async () => {
+			await executeEditFileTool(
+				{ old_string: "Line", expected_replacements: "1" },
+				{ fileContent: "Line 1\nLine 2\nLine 3" },
+			)
+
+			expect(mockTask.consecutiveMistakeCountForEditFile.get(testFilePath)).toBe(1)
+			expect(mockTask.say).not.toHaveBeenCalledWith("diff_error", expect.any(String))
+			expect(mockTask.recordToolError).toHaveBeenCalledWith(
+				"edit_file",
+				expect.stringContaining("Occurrence count mismatch"),
+			)
+		})
+
+		it("shows diff_error to user on second consecutive occurrence_mismatch failure", async () => {
+			// First failure
+			await executeEditFileTool(
+				{ old_string: "Line", expected_replacements: "1" },
+				{ fileContent: "Line 1\nLine 2\nLine 3" },
+			)
+
+			// Second failure on same file
+			await executeEditFileTool(
+				{ old_string: "Line", expected_replacements: "5" },
+				{ fileContent: "Line 1\nLine 2\nLine 3" },
+			)
+
+			expect(mockTask.consecutiveMistakeCountForEditFile.get(testFilePath)).toBe(2)
+			expect(mockTask.say).toHaveBeenCalledWith("diff_error", expect.stringContaining("Occurrence count mismatch"))
+		})
+
+		it("resets consecutive error counter on successful edit", async () => {
+			// First failure
+			await executeEditFileTool({ old_string: "NonExistent" }, { fileContent: "Line 1\nLine 2\nLine 3" })
+
+			expect(mockTask.consecutiveMistakeCountForEditFile.get(testFilePath)).toBe(1)
+
+			// Successful edit
+			await executeEditFileTool(
+				{ old_string: "Line 2", new_string: "Modified Line 2" },
+				{ fileContent: "Line 1\nLine 2\nLine 3" },
+			)
+
+			// Counter should be deleted (reset) for the file
+			expect(mockTask.consecutiveMistakeCountForEditFile.has(testFilePath)).toBe(false)
+		})
+
+		it("tracks errors independently per file", async () => {
+			const otherFilePath = "other/file.txt"
+
+			// First failure on original file
+			await executeEditFileTool({ old_string: "NonExistent" }, { fileContent: "Line 1\nLine 2\nLine 3" })
+
+			// First failure on other file
+			await executeEditFileTool(
+				{ file_path: otherFilePath, old_string: "NonExistent" },
+				{ fileContent: "Line 1\nLine 2\nLine 3" },
+			)
+
+			// Both files should have count of 1, not 2
+			expect(mockTask.consecutiveMistakeCountForEditFile.get(testFilePath)).toBe(1)
+			expect(mockTask.consecutiveMistakeCountForEditFile.get(otherFilePath)).toBe(1)
+
+			// Neither should have triggered diff_error display
+			expect(mockTask.say).not.toHaveBeenCalledWith("diff_error", expect.any(String))
+		})
+	})
+
 	describe("file creation", () => {
 		it("creates new file when old_string is empty and file does not exist", async () => {
 			await executeEditFileTool({ old_string: "", new_string: "New file content" }, { fileExists: false })


### PR DESCRIPTION
## Summary

When `edit_file` fails due to "no match found" or "occurrence mismatch", the error was only sent to the model via `pushToolResult()` but never shown to the user. Users would see "Roo wants to edit this file" repeatedly followed by "Roo is having trouble..." without understanding why.

This PR adds error display to users for `edit_file` failures, following the same pattern as `apply_diff`.

## Changes

### `src/core/tools/EditFileTool.ts`
- Added per-file consecutive failure tracking (reusing `task.consecutiveMistakeCountForApplyDiff`)
- After 2+ consecutive failures on the same file, errors now display to users via `task.say("diff_error", ...)`
- User-friendly error messages separate from AI-instructional messages
- Counter resets on successful edit

### `src/core/tools/__tests__/editFileTool.spec.ts`
- Added 6 new tests covering error display behavior:
  - Error NOT shown on first failure
  - Error shown on second consecutive failure (for both no_match and occurrence_mismatch)
  - Counter reset on successful edit
  - Per-file tracking independence

## Testing

All 28 tests pass.

## Linear

Fixes ROO-436
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Display errors to users after 2+ consecutive `edit_file` failures, with per-file tracking and counter reset on success, tested in `editFileTool.spec.ts`.
> 
>   - **Behavior**:
>     - Display errors to users after 2+ consecutive `edit_file` failures in `EditFileTool.ts`.
>     - Track consecutive failures per file using `task.consecutiveMistakeCountForEditFile`.
>     - Reset error counter on successful edit.
>   - **Testing**:
>     - Add tests in `editFileTool.spec.ts` for error display after consecutive failures.
>     - Cover scenarios: no error on first failure, error on second, counter reset on success, independent tracking per file.
>   - **Misc**:
>     - Reuse `task.consecutiveMistakeCountForApplyDiff` for failure tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d9bd6eb4c6576490bb780e15bd8ef15c47439947. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->