### PR TITLE
fix: round-trip Gemini thought signatures for tool calls

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -955,6 +955,13 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			const reasoningSummary = handler.getSummary?.()
 			const reasoningDetails = handler.getReasoningDetails?.()
 
+			// Only Anthropic's API expects/validates the special `thinking` content block signature.
+			// Other providers (notably Gemini 3) use different signature semantics (e.g. `thoughtSignature`)
+			// and require round-tripping the signature in their own format.
+			const modelId = getModelId(this.apiConfiguration)
+			const apiProtocol = getApiProtocol(this.apiConfiguration.apiProvider, modelId)
+			const isAnthropicProtocol = apiProtocol === "anthropic"
+
 			// Start from the original assistant message
 			const messageWithTs: any = {
 				...message,
@@ -969,7 +976,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 			// Store reasoning: Anthropic thinking (with signature), plain text (most providers), or encrypted (OpenAI Native)
 			// Skip if reasoning_details already contains the reasoning (to avoid duplication)
-			if (reasoning && thoughtSignature && !reasoningDetails) {
+			if (isAnthropicProtocol && reasoning && thoughtSignature && !reasoningDetails) {
 				// Anthropic provider with extended thinking: Store as proper `thinking` block
 				// This format passes through anthropic-filter.ts and is properly round-tripped
 				// for interleaved thinking with tool use (required by Anthropic API)
@@ -1028,10 +1035,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				}
 			}
 
-			// If we have a thought signature WITHOUT reasoning text (edge case),
-			// append it as a dedicated content block for non-Anthropic providers (e.g., Gemini).
-			// Note: For Anthropic, the signature is already included in the thinking block above.
-			if (thoughtSignature && !reasoning) {
+			// For non-Anthropic providers (e.g., Gemini 3), persist the thought signature as its own
+			// content block so converters can attach it back to the correct provider-specific fields.
+			// Note: For Anthropic extended thinking, the signature is already included in the thinking block above.
+			if (thoughtSignature && !isAnthropicProtocol) {
 				const thoughtSignatureBlock = {
 					type: "thoughtSignature",
 					thoughtSignature,


### PR DESCRIPTION
## Summary

Preserve and round-trip Gemini thought signatures required for Gemini 3 native tool calling.

## Changes

- Persist non-Anthropic thought signatures in API history for reliable round-tripping
- Ensure Gemini provider captures/sends thought signatures whenever native tools are in use
- Match Gemini 3 parallel function-call behavior by keeping the signature only on the first functionCall part
- Add Vitest coverage for the signature behavior

## Test

- npx vitest run api/transform/__tests__/gemini-format.spec.ts

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure Gemini thought signatures are correctly persisted and attached only to the first function call for Gemini 3 tool calls.
> 
>   - **Behavior**:
>     - Persist non-Anthropic thought signatures in API history for Gemini 3 tool calls in `Task.ts`.
>     - Ensure `GeminiHandler` in `gemini.ts` captures/sends thought signatures when native tools are used.
>     - Attach thought signature only to the first function call in `convertAnthropicContentToGemini()` in `gemini-format.ts`.
>   - **Tests**:
>     - Add test in `gemini-format.spec.ts` to verify thought signature is only attached to the first function call.
>   - **Misc**:
>     - Update `getThoughtSignature()` in `gemini.ts` to return `lastThoughtSignature` instead of `undefined`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4b5366dc5d0396f5bdc5fe0c8a7942a737043e38. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->