### PR TITLE
chore: disable edit_file tool for Gemini/Vertex

### DIFF
--- a/packages/types/src/providers/gemini.ts
+++ b/packages/types/src/providers/gemini.ts
@@ -15,8 +15,7 @@ export const geminiModels = {
 		supportsPromptCache: true,
 		supportsReasoningEffort: ["low", "high"],
 		reasoningEffort: "low",
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		supportsTemperature: true,
 		defaultTemperature: 1,
 		inputPrice: 4.0,
@@ -43,8 +42,7 @@ export const geminiModels = {
 		supportsPromptCache: true,
 		supportsReasoningEffort: ["minimal", "low", "medium", "high"],
 		reasoningEffort: "medium",
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		supportsTemperature: true,
 		defaultTemperature: 1,
 		inputPrice: 0.3,
@@ -60,8 +58,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5, // This is the pricing for prompts above 200k tokens.
 		outputPrice: 15,
 		cacheReadsPrice: 0.625,
@@ -91,8 +88,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5, // This is the pricing for prompts above 200k tokens.
 		outputPrice: 15,
 		cacheReadsPrice: 0.625,
@@ -121,8 +117,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5, // This is the pricing for prompts above 200k tokens.
 		outputPrice: 15,
 		cacheReadsPrice: 0.625,
@@ -149,8 +144,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5, // This is the pricing for prompts above 200k tokens.
 		outputPrice: 15,
 		cacheReadsPrice: 0.625,
@@ -181,8 +175,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 0.3,
 		outputPrice: 2.5,
 		cacheReadsPrice: 0.075,
@@ -197,8 +190,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 0.3,
 		outputPrice: 2.5,
 		cacheReadsPrice: 0.075,
@@ -213,8 +205,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 0.3,
 		outputPrice: 2.5,
 		cacheReadsPrice: 0.075,
@@ -231,8 +222,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 0.1,
 		outputPrice: 0.4,
 		cacheReadsPrice: 0.025,
@@ -247,8 +237,7 @@ export const geminiModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		// includedTools: ["write_file", "edit_file"],
-		// excludedTools: ["apply_diff"],
+
 		inputPrice: 0.1,
 		outputPrice: 0.4,
 		cacheReadsPrice: 0.025,

--- a/packages/types/src/providers/vertex.ts
+++ b/packages/types/src/providers/vertex.ts
@@ -15,8 +15,7 @@ export const vertexModels = {
 		supportsPromptCache: true,
 		supportsReasoningEffort: ["low", "high"],
 		reasoningEffort: "low",
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		supportsTemperature: true,
 		defaultTemperature: 1,
 		inputPrice: 4.0,
@@ -43,8 +42,7 @@ export const vertexModels = {
 		supportsPromptCache: true,
 		supportsReasoningEffort: ["minimal", "low", "medium", "high"],
 		reasoningEffort: "medium",
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		supportsTemperature: true,
 		defaultTemperature: 1,
 		inputPrice: 0.3,
@@ -59,8 +57,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.15,
 		outputPrice: 3.5,
 		maxThinkingTokens: 24_576,
@@ -74,8 +71,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.15,
 		outputPrice: 0.6,
 	},
@@ -86,8 +82,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.3,
 		outputPrice: 2.5,
 		cacheReadsPrice: 0.075,
@@ -102,8 +97,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: false,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.15,
 		outputPrice: 3.5,
 		maxThinkingTokens: 24_576,
@@ -117,8 +111,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: false,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.15,
 		outputPrice: 0.6,
 	},
@@ -129,8 +122,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5,
 		outputPrice: 15,
 	},
@@ -141,8 +133,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5,
 		outputPrice: 15,
 	},
@@ -153,8 +144,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5,
 		outputPrice: 15,
 		maxThinkingTokens: 32_768,
@@ -167,8 +157,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 2.5,
 		outputPrice: 15,
 		maxThinkingTokens: 32_768,
@@ -196,8 +185,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: false,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0,
 		outputPrice: 0,
 	},
@@ -208,8 +196,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: false,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0,
 		outputPrice: 0,
 	},
@@ -220,8 +207,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.15,
 		outputPrice: 0.6,
 	},
@@ -232,8 +218,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: false,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.075,
 		outputPrice: 0.3,
 	},
@@ -244,8 +229,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: false,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0,
 		outputPrice: 0,
 	},
@@ -256,8 +240,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.075,
 		outputPrice: 0.3,
 	},
@@ -268,8 +251,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: false,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 1.25,
 		outputPrice: 5,
 	},
@@ -463,8 +445,7 @@ export const vertexModels = {
 		supportsNativeTools: true,
 		defaultToolProtocol: "native",
 		supportsPromptCache: true,
-		includedTools: ["write_file", "edit_file"],
-		excludedTools: ["apply_diff"],
+
 		inputPrice: 0.1,
 		outputPrice: 0.4,
 		cacheReadsPrice: 0.025,

--- a/src/api/providers/utils/router-tool-preferences.ts
+++ b/src/api/providers/utils/router-tool-preferences.ts
@@ -5,7 +5,6 @@ import type { ModelInfo } from "@roo-code/types"
  *
  * Different model families perform better with specific tools:
  * - OpenAI models: Better results with apply_patch instead of apply_diff/write_to_file
- * - Gemini models: Higher quality results with write_file and edit_file
  *
  * This function modifies the model info to apply these preferences consistently
  * across all dynamic router providers.
@@ -24,16 +23,6 @@ export function applyRouterToolPreferences(modelId: string, info: ModelInfo): Mo
 			...result,
 			excludedTools: [...new Set([...(result.excludedTools || []), "apply_diff", "write_to_file"])],
 			includedTools: [...new Set([...(result.includedTools || []), "apply_patch"])],
-		}
-	}
-
-	// For Gemini models via routers, include write_file and edit_file
-	// This matches the behavior of the native Gemini provider
-	if (modelId.includes("gemini")) {
-		result = {
-			...result,
-			excludedTools: [...new Set([...(result.excludedTools || []), "apply_diff"])],
-			includedTools: [...new Set([...(result.includedTools || []), "write_file", "edit_file"])],
 		}
 	}
 


### PR DESCRIPTION
## Summary

Stop preferring/forcing the edit_file tool for Gemini-based models (Gemini provider and Vertex provider) and remove router-level Gemini tool preferences.

## Changes

- Remove Gemini router tool preferences that added write_file/edit_file and excluded apply_diff.
- Remove Vertex model tool allow/deny lists that included edit_file and excluded apply_diff.
- Clean up commented-out Gemini model tool allow/deny list hints.
