### PR TITLE
Release v3.39.2

### DIFF
--- a/.changeset/v3.39.2.md
+++ b/.changeset/v3.39.2.md
@@ -1,0 +1,20 @@
+---
+"roo-cline": patch
+---
+
+- Fix: Ensure all tools have consistent strict mode values for Cerebras compatibility (#10334 by @brianboysen51, PR #10589 by @app/roomote)
+- Fix: Remove convertToSimpleMessages to restore tool calling for OpenAI-compatible providers (PR #10575 by @daniel-lxs)
+- Fix: Make edit_file matching more resilient to prevent false negatives (PR #10585 by @hannesrudolph)
+- Fix: Order text parts before tool calls in assistant messages for vscode-lm (PR #10573 by @daniel-lxs)
+- Fix: Ensure assistant message content is never undefined for Gemini compatibility (PR #10559 by @daniel-lxs)
+- Fix: Merge approval feedback into tool result instead of pushing duplicate messages (PR #10519 by @daniel-lxs)
+- Fix: Round-trip Gemini thought signatures for tool calls (PR #10590 by @hannesrudolph)
+- Feature: Improve error messaging for stream termination errors from provider (PR #10548 by @daniel-lxs)
+- Feature: Add debug setting to settings page for easier troubleshooting (PR #10580 by @hannesrudolph)
+- Chore: Disable edit_file tool for Gemini/Vertex providers (PR #10594 by @hannesrudolph)
+- Chore: Stop overriding tool allow/deny lists for Gemini (PR #10592 by @hannesrudolph)
+- Chore: Change default CLI model to anthropic/claude-opus-4.5 (PR #10544 by @mrubens)
+- Chore: Update Terms of Service effective January 9, 2026 (PR #10568 by @mrubens)
+- Chore: Move more types to @roo-code/types for CLI support (PR #10583 by @cte)
+- Chore: Add functionality to @roo-code/core for CLI support (PR #10584 by @cte)
+- Chore: Add slash commands useful for CLI development (PR #10586 by @cte)


### PR DESCRIPTION
Release preparation for v3.39.2. This PR includes the changeset and any necessary documentation updates.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Release v3.39.2 includes fixes for compatibility and functionality, new features for error messaging and debugging, and chore updates for CLI support and documentation.
> 
>   - **Fixes**:
>     - Ensure consistent strict mode values for Cerebras compatibility.
>     - Remove `convertToSimpleMessages` for OpenAI-compatible tool calling.
>     - Improve `edit_file` matching to prevent false negatives.
>     - Order text parts before tool calls in assistant messages for `vscode-lm`.
>     - Ensure assistant message content is defined for Gemini compatibility.
>     - Merge approval feedback into tool result to avoid duplicates.
>     - Round-trip Gemini thought signatures for tool calls.
>   - **Features**:
>     - Improve error messaging for stream termination errors.
>     - Add debug setting to settings page for troubleshooting.
>   - **Chores**:
>     - Disable `edit_file` tool for Gemini/Vertex providers.
>     - Stop overriding tool allow/deny lists for Gemini.
>     - Change default CLI model to `anthropic/claude-opus-4.5`.
>     - Update Terms of Service effective January 9, 2026.
>     - Move more types to `@roo-code/types` for CLI support.
>     - Add functionality to `@roo-code/core` for CLI support.
>     - Add slash commands for CLI development.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 097ea2d5c43549d039c7eec435048c4cf11b4197. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->