### PR TITLE
Allow the cli release script to install locally for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ qdrant_storage/
 
 # Architect plans
 plans/
+
+roo-cli-*.tar.gz*


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `release.sh` to support local builds and installations with new options for testing without GitHub involvement.
> 
>   - **Behavior**:
>     - Adds `--local`, `--install`, and `--skip-verify` options to `release.sh` for local testing and installation.
>     - Skips GitHub checks and changelog prompts when `--local` is used.
>     - Appends `-local.<hash>` to version for local builds.
>     - Skips end-to-end verification tests if `--skip-verify` is used.
>   - **Validation**:
>     - Validates that `--install` is only used with `--local`.
>   - **Installation**:
>     - Adds `install_local()` function to handle local installation.
>     - Adds `print_local_summary()` and `print_local_install_summary()` for local build summaries.
>   - **Misc**:
>     - Updates `check_prerequisites()` to skip GitHub CLI checks for local builds.
>     - Modifies `main()` to handle new local build and install options.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d38918fc3623fa63944929751799b76411f1808d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->