### PR TITLE
fix: handle MCP tool names with hyphens in native tool calling

### DIFF
--- a/src/core/assistant-message/NativeToolCallParser.ts
+++ b/src/core/assistant-message/NativeToolCallParser.ts
@@ -16,7 +16,7 @@ import type {
 	ApiStreamToolCallDeltaChunk,
 	ApiStreamToolCallEndChunk,
 } from "../../api/transform/stream"
-import { MCP_TOOL_PREFIX, MCP_TOOL_SEPARATOR, parseMcpToolName } from "../../utils/mcp-name"
+import { isMcpTool, parseMcpToolName } from "../../utils/mcp-name"
 
 /**
  * Helper type to extract properly typed native arguments for a given tool.
@@ -242,8 +242,7 @@ export class NativeToolCallParser {
 		toolCall.argumentsAccumulator += chunk
 
 		// For dynamic MCP tools, we don't return partial updates - wait for final
-		const mcpPrefix = MCP_TOOL_PREFIX + MCP_TOOL_SEPARATOR
-		if (toolCall.name.startsWith(mcpPrefix)) {
+		if (isMcpTool(toolCall.name)) {
 			return null
 		}
 
@@ -574,10 +573,8 @@ export class NativeToolCallParser {
 		name: TName
 		arguments: string
 	}): ToolUse<TName> | McpToolUse | null {
-		// Check if this is a dynamic MCP tool (mcp--serverName--toolName)
-		const mcpPrefix = MCP_TOOL_PREFIX + MCP_TOOL_SEPARATOR
-
-		if (typeof toolCall.name === "string" && toolCall.name.startsWith(mcpPrefix)) {
+		// Check if this is a dynamic MCP tool (mcp--serverName--toolName or mcp__serverName__toolName)
+		if (typeof toolCall.name === "string" && isMcpTool(toolCall.name)) {
 			return this.parseDynamicMcpTool(toolCall)
 		}
 


### PR DESCRIPTION
## Problem
When models like Claude Opus 4.5 use native tool calling, they convert hyphens to underscores in function names. This causes MCP tool names like `mcp--atlassian-jira--search` to be returned as `mcp__atlassian_jira__search`, which the parser rejected as invalid.

## Solution
Implemented separator normalization AND fuzzy matching for server/tool name recovery:

### 1. Separator Normalization
- `isMcpTool()` recognizes both `mcp--` and `mcp__` prefixes
- `parseMcpToolName()` handles both separator formats and returns `wasMangled` flag

### 2. Server/Tool Name Recovery (via fuzzy matching)
- `generatePossibleOriginalNames()` generates all underscore-to-hyphen combinations (2^n, limited to 8 underscores)
- `findMatchingServerName()` fuzzy matches `atlassian_jira` → `atlassian-jira`
- `findMatchingToolName()` same for tool names
- `UseMcpToolTool.validateToolExists()` integrates fuzzy matching

### Files Modified
- `src/utils/mcp-name.ts` - Separator constants, parsing, fuzzy matching functions
- `src/core/assistant-message/NativeToolCallParser.ts` - Use `isMcpTool()` for detection
- `src/core/tools/UseMcpToolTool.ts` - Integrate fuzzy matching for name resolution
- `src/utils/__tests__/mcp-name.spec.ts` - 56 tests including end-to-end issue scenarios

## Test Results
All tests pass: 5215 passed, 49 skipped

Fixes #10642

Linear: ROO-496
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes MCP tool name mangling by implementing separator normalization and fuzzy matching for name recovery.
> 
>   - **Behavior**:
>     - `isMcpTool()` in `mcp-name.ts` now recognizes both `mcp--` and `mcp__` prefixes.
>     - `parseMcpToolName()` handles both separator formats and returns `wasMangled` flag.
>     - `generatePossibleOriginalNames()` creates combinations of underscore-to-hyphen replacements.
>     - `findMatchingServerName()` and `findMatchingToolName()` perform fuzzy matching.
>     - `UseMcpToolTool.validateToolExists()` integrates fuzzy matching.
>   - **Files Modified**:
>     - `mcp-name.ts`: Added separator constants, parsing, and fuzzy matching functions.
>     - `NativeToolCallParser.ts`: Uses `isMcpTool()` for detection.
>     - `UseMcpToolTool.ts`: Integrates fuzzy matching for name resolution.
>     - `mcp-name.spec.ts`: 56 tests including end-to-end issue scenarios.
>   - **Test Results**:
>     - All tests pass: 5215 passed, 49 skipped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d1ad5a71c3a8951afdb4e9f2d5073d8b30ed928d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->