### PR TITLE
fix: sanitize tool_use IDs to match API validation pattern

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -90,6 +90,7 @@ import { TerminalRegistry } from "../../integrations/terminal/TerminalRegistry"
 // utils
 import { calculateApiCostAnthropic, calculateApiCostOpenAI } from "../../shared/cost"
 import { getWorkspacePath } from "../../utils/path"
+import { sanitizeToolUseId } from "../../utils/tool-id"
 
 // prompts
 import { formatResponse } from "../prompts/responses"
@@ -3435,7 +3436,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 							if (mcpBlock.id) {
 								assistantContent.push({
 									type: "tool_use" as const,
-									id: mcpBlock.id,
+									id: sanitizeToolUseId(mcpBlock.id),
 									name: mcpBlock.name, // Original dynamic name
 									input: mcpBlock.arguments, // Direct tool arguments
 								})
@@ -3456,7 +3457,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 								assistantContent.push({
 									type: "tool_use" as const,
-									id: toolCallId,
+									id: sanitizeToolUseId(toolCallId),
 									name: toolNameForHistory,
 									input,
 								})

--- a/src/utils/__tests__/tool-id.spec.ts
+++ b/src/utils/__tests__/tool-id.spec.ts
@@ -1,0 +1,71 @@
+import { sanitizeToolUseId } from "../tool-id"
+
+describe("sanitizeToolUseId", () => {
+	describe("valid IDs pass through unchanged", () => {
+		it("should preserve alphanumeric IDs", () => {
+			expect(sanitizeToolUseId("toolu_01AbC")).toBe("toolu_01AbC")
+		})
+
+		it("should preserve IDs with underscores", () => {
+			expect(sanitizeToolUseId("tool_use_123")).toBe("tool_use_123")
+		})
+
+		it("should preserve IDs with hyphens", () => {
+			expect(sanitizeToolUseId("tool-with-hyphens")).toBe("tool-with-hyphens")
+		})
+
+		it("should preserve mixed valid characters", () => {
+			expect(sanitizeToolUseId("toolu_01AbC-xyz_789")).toBe("toolu_01AbC-xyz_789")
+		})
+
+		it("should handle empty string", () => {
+			expect(sanitizeToolUseId("")).toBe("")
+		})
+	})
+
+	describe("invalid characters get replaced with underscore", () => {
+		it("should replace dots with underscores", () => {
+			expect(sanitizeToolUseId("tool.with.dots")).toBe("tool_with_dots")
+		})
+
+		it("should replace colons with underscores", () => {
+			expect(sanitizeToolUseId("tool:with:colons")).toBe("tool_with_colons")
+		})
+
+		it("should replace slashes with underscores", () => {
+			expect(sanitizeToolUseId("tool/with/slashes")).toBe("tool_with_slashes")
+		})
+
+		it("should replace backslashes with underscores", () => {
+			expect(sanitizeToolUseId("tool\\with\\backslashes")).toBe("tool_with_backslashes")
+		})
+
+		it("should replace spaces with underscores", () => {
+			expect(sanitizeToolUseId("tool with spaces")).toBe("tool_with_spaces")
+		})
+
+		it("should replace multiple invalid characters", () => {
+			expect(sanitizeToolUseId("mcp.server:tool/name")).toBe("mcp_server_tool_name")
+		})
+	})
+
+	describe("real-world MCP tool use ID patterns", () => {
+		it("should sanitize MCP server-prefixed IDs with dots", () => {
+			// MCP tool names often include server names with dots
+			expect(sanitizeToolUseId("toolu_mcp.linear.create_issue")).toBe("toolu_mcp_linear_create_issue")
+		})
+
+		it("should sanitize IDs with URL-like patterns", () => {
+			expect(sanitizeToolUseId("toolu_https://api.example.com/tool")).toBe("toolu_https___api_example_com_tool")
+		})
+
+		it("should sanitize IDs with special characters from server names", () => {
+			expect(sanitizeToolUseId("call_mcp--posthog--query-run")).toBe("call_mcp--posthog--query-run")
+		})
+
+		it("should preserve valid native tool call IDs", () => {
+			// Standard Anthropic tool_use IDs
+			expect(sanitizeToolUseId("toolu_01H2X3Y4Z5")).toBe("toolu_01H2X3Y4Z5")
+		})
+	})
+})

--- a/src/utils/tool-id.ts
+++ b/src/utils/tool-id.ts
@@ -1,0 +1,7 @@
+/**
+ * Sanitize a tool_use ID to match API validation pattern: ^[a-zA-Z0-9_-]+$
+ * Replaces any invalid character with underscore.
+ */
+export function sanitizeToolUseId(id: string): string {
+	return id.replace(/[^a-zA-Z0-9_-]/g, "_")
+}


### PR DESCRIPTION
## Problem

When storing conversation history with MCP tool calls, the `tool_use.id` may contain characters not allowed by the API validation pattern `^[a-zA-Z0-9_-]+$`. This causes errors like:
```
messages.1.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'
```

This can occur when MCP server names contain special characters (periods, colons, slashes) that leak into tool IDs.

## Solution

Created a `sanitizeToolUseId()` function that replaces any invalid character with underscore, applied at the storage boundary in Task.ts when building assistant content for API conversation history.

## Changes

1. **New: `src/utils/tool-id.ts`** - Utility function for ID sanitization
2. **Modified: `src/core/task/Task.ts`** - Applied sanitization at lines 3439 and 3460
3. **New: `src/utils/__tests__/tool-id.spec.ts`** - 15 comprehensive test cases

## Performance

- Single regex call per tool_use at storage time only
- No-op for valid IDs (most common case)
- All existing tests pass

Closes ROO-514
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `sanitizeToolUseId()` to ensure `tool_use.id` conforms to API validation, with updates in `Task.ts` and comprehensive tests.
> 
>   - **Behavior**:
>     - Adds `sanitizeToolUseId()` in `tool-id.ts` to replace invalid characters in `tool_use.id` with underscores.
>     - Applies `sanitizeToolUseId()` in `Task.ts` at lines 3439 and 3460 to sanitize `tool_use.id` before storing conversation history.
>   - **Utilities**:
>     - New utility function `sanitizeToolUseId()` in `tool-id.ts`.
>     - Updates `mcp-name.ts` with `normalizeMcpToolName()` to handle underscore to hyphen conversion.
>   - **Tests**:
>     - Adds `tool-id.spec.ts` with 15 test cases for `sanitizeToolUseId()`.
>     - Updates `mcp-name.spec.ts` to test `normalizeMcpToolName()` and other MCP name utilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b5fadc80084030a20f1adabf6fec1b313ca9343d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->