### PR TITLE
feat(telemetry): add diagnostic properties to Gemini API error telemetry

### DIFF
--- a/src/api/providers/__tests__/gemini.spec.ts
+++ b/src/api/providers/__tests__/gemini.spec.ts
@@ -274,6 +274,19 @@ describe("GeminiHandler", () => {
 					modelId: GEMINI_MODEL_NAME,
 					operation: "createMessage",
 				}),
+				// Verify diagnostic properties are included
+				expect.objectContaining({
+					messageCount: expect.any(Number),
+					geminiContentsCount: expect.any(Number),
+					hasToolUseBlocks: expect.any(Boolean),
+					hasToolResultBlocks: expect.any(Boolean),
+					hasImageBlocks: expect.any(Boolean),
+					emptyPartsCount: expect.any(Number),
+					toolIdToNameSize: expect.any(Number),
+					hasThinkingConfig: expect.any(Boolean),
+					usingNativeTools: expect.any(Boolean),
+					includeThoughtSignatures: expect.any(Boolean),
+				}),
 			)
 
 			// Verify it's an ApiProviderError


### PR DESCRIPTION
## Summary

When Gemini API errors occur (like `INVALID_ARGUMENT` with code 400), the error messages are too vague to diagnose the root cause. This PR adds diagnostic properties to the `captureException()` call in the Gemini handler's `createMessage()` method.

## Problem

A PostHog error showed only:

```
ApiProviderError: {
  "error": {
    "code": 400,
    "message": "Request contains an invalid argument.",
    "status": "INVALID_ARGUMENT"
  }
}
```

This provides no information about **which** argument is invalid or what caused the issue.

See original PostHog issue: https://us.posthog.com/error_tracking/019bb205-1968-7581-b2c9-9b7f27537d3d

## Solution

Add diagnostic properties to the telemetry capture:

| Property | Purpose |
|----------|---------|
| `messageCount` | Number of input messages |
| `geminiContentsCount` | Number of converted Gemini contents |
| `hasToolUseBlocks` | Whether messages contain tool_use blocks |
| `hasToolResultBlocks` | Whether messages contain tool_result blocks |
| `hasImageBlocks` | Whether messages contain image blocks |
| `emptyPartsCount` | Count of contents with empty parts (likely cause of INVALID_ARGUMENT) |
| `toolIdToNameSize` | Size of tool ID→name mapping |
| `hasThinkingConfig` | Whether thinking configuration is enabled |
| `usingNativeTools` | Whether native tools are in use |
| `includeThoughtSignatures` | Whether thought signatures are included |

## Testing

- All 17 Gemini tests pass
- Full test suite passes (371 passed, 4 skipped)

## Linear Issue

Resolves ROO-515
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds diagnostic properties to `GeminiHandler.createMessage()` telemetry for better error context in API errors.
> 
>   - **Behavior**:
>     - Adds diagnostic properties to `captureException()` in `GeminiHandler.createMessage()` for better error context.
>     - Properties include `messageCount`, `geminiContentsCount`, `hasToolUseBlocks`, `hasToolResultBlocks`, `hasImageBlocks`, `emptyPartsCount`, `toolIdToNameSize`, `hasThinkingConfig`, `usingNativeTools`, `includeThoughtSignatures`.
>   - **Testing**:
>     - Updates `gemini.spec.ts` to verify diagnostic properties in telemetry capture for `createMessage` errors.
>     - All 17 Gemini tests pass; full suite: 371 passed, 4 skipped.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 16529b7b932bc13db2962e0f8a3f81a9736788d1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->