### PR TITLE
fix: omit parallel_tool_calls when not explicitly enabled (COM-406)

### DIFF
--- a/src/api/providers/__tests__/openai-native-tools.spec.ts
+++ b/src/api/providers/__tests__/openai-native-tools.spec.ts
@@ -71,10 +71,13 @@ describe("OpenAiHandler native tools", () => {
 						function: expect.objectContaining({ name: "test_tool" }),
 					}),
 				]),
-				parallel_tool_calls: false,
 			}),
 			expect.anything(),
 		)
+		// Verify parallel_tool_calls is NOT included when parallelToolCalls is not explicitly true
+		// This is required for LiteLLM/Bedrock compatibility (see COM-406)
+		const callArgs = mockCreate.mock.calls[0][0]
+		expect(callArgs).not.toHaveProperty("parallel_tool_calls")
 	})
 })
 

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -162,9 +162,10 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				...(reasoning && reasoning),
 				...(metadata?.tools && { tools: this.convertToolsForOpenAI(metadata.tools) }),
 				...(metadata?.tool_choice && { tool_choice: metadata.tool_choice }),
-				...(metadata?.toolProtocol === "native" && {
-					parallel_tool_calls: metadata.parallelToolCalls ?? false,
-				}),
+				...(metadata?.toolProtocol === "native" &&
+					metadata.parallelToolCalls === true && {
+						parallel_tool_calls: true,
+					}),
 			}
 
 			// Add max_tokens if needed
@@ -231,9 +232,10 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 					: [systemMessage, ...convertToOpenAiMessages(messages)],
 				...(metadata?.tools && { tools: this.convertToolsForOpenAI(metadata.tools) }),
 				...(metadata?.tool_choice && { tool_choice: metadata.tool_choice }),
-				...(metadata?.toolProtocol === "native" && {
-					parallel_tool_calls: metadata.parallelToolCalls ?? false,
-				}),
+				...(metadata?.toolProtocol === "native" &&
+					metadata.parallelToolCalls === true && {
+						parallel_tool_calls: true,
+					}),
 			}
 
 			// Add max_tokens if needed
@@ -357,9 +359,10 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				temperature: undefined,
 				...(metadata?.tools && { tools: this.convertToolsForOpenAI(metadata.tools) }),
 				...(metadata?.tool_choice && { tool_choice: metadata.tool_choice }),
-				...(metadata?.toolProtocol === "native" && {
-					parallel_tool_calls: metadata.parallelToolCalls ?? false,
-				}),
+				...(metadata?.toolProtocol === "native" &&
+					metadata.parallelToolCalls === true && {
+						parallel_tool_calls: true,
+					}),
 			}
 
 			// O3 family models do not support the deprecated max_tokens parameter
@@ -392,9 +395,10 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 				temperature: undefined,
 				...(metadata?.tools && { tools: this.convertToolsForOpenAI(metadata.tools) }),
 				...(metadata?.tool_choice && { tool_choice: metadata.tool_choice }),
-				...(metadata?.toolProtocol === "native" && {
-					parallel_tool_calls: metadata.parallelToolCalls ?? false,
-				}),
+				...(metadata?.toolProtocol === "native" &&
+					metadata.parallelToolCalls === true && {
+						parallel_tool_calls: true,
+					}),
 			}
 
 			// O3 family models do not support the deprecated max_tokens parameter


### PR DESCRIPTION
## Summary

Fixes [COM-406](https://linear.app/roocode/issue/COM-406/bug-parallel-tool-callsfalse-breaks-litellmbedrock-routes-with-native): `parallel_tool_calls=false` breaks LiteLLM/Bedrock routes with native tools.

## Problem

The OpenAI provider was always sending `parallel_tool_calls=false` with native tools (via `metadata.parallelToolCalls ?? false`). This caused errors with non-OpenAI backends accessed through LiteLLM:

- **Bedrock/Claude**: Don't support the parameter at all - any value breaks
- **Gemini**: Supports parallel tool calls, but rejects `parallel_tool_calls=false` when multiple tools are provided

## Solution

Changed the logic to only include `parallel_tool_calls: true` when `metadata.parallelToolCalls` is explicitly set to `true`. The parameter is now omitted entirely when not explicitly enabled, which allows LiteLLM routes to work with any backend.

## Changes

- `src/api/providers/openai.ts` - Updated 4 locations where `parallel_tool_calls` was being set (streaming, non-streaming, and O3 family models)
- `src/api/providers/__tests__/openai-native-tools.spec.ts` - Updated test to verify parameter is NOT included when `parallelToolCalls` is not explicitly `true`

## Testing

All 121 OpenAI provider tests pass, including the updated test that verifies the fix.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `parallel_tool_calls` logic in `openai.ts` to only include it when explicitly enabled, resolving LiteLLM/Bedrock compatibility issues.
> 
>   - **Behavior**:
>     - `parallel_tool_calls` is now only included when `metadata.parallelToolCalls` is explicitly `true` in `openai.ts`.
>     - Fixes compatibility issues with LiteLLM/Bedrock routes by omitting `parallel_tool_calls` when not enabled.
>   - **Testing**:
>     - Updated test in `openai-native-tools.spec.ts` to verify `parallel_tool_calls` is omitted when not explicitly set to `true`.
>   - **Files Affected**:
>     - `openai.ts`: Updated logic in 4 locations for streaming, non-streaming, and O3 family models.
>     - `openai-native-tools.spec.ts`: Added test verification for the fix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for dbb85f8f3582cd80590ca0b645b2811a15ebd81b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- roo-code-linear-sync:start -->
Closes #10553
(from Linear COM-406)
<!-- roo-code-linear-sync:end -->