### PR TITLE
fix: use placeholder for empty tool result content to fix Gemini API validation

### DIFF
--- a/src/api/transform/openai-format.ts
+++ b/src/api/transform/openai-format.ts
@@ -116,7 +116,8 @@ export function convertToOpenAiMessages(
 					openAiMessages.push({
 						role: "tool",
 						tool_call_id: normalizeId(toolMessage.tool_use_id),
-						content: content,
+						// Use "(empty)" placeholder for empty content to satisfy providers like Gemini (via OpenRouter)
+						content: content || "(empty)",
 					})
 				})
 


### PR DESCRIPTION
## Summary
Fixes Gemini API validation error where empty tool result content causes "Unable to submit request because it must include at least one parts field" error.

## Problem
Users were encountering an `ApiProviderError` when using Gemini models via OpenRouter because tool result messages with empty content fail Gemini's validation requirements.

## Root Cause
While most tool execution paths add fallback content, empty content can still reach the API from:
- Legacy/persisted conversations stored before fallbacks were added
- Resumed tasks from history with empty tool results
- Context condensation where tool results may lose content
- MCP tools with empty responses (`processToolContent` returns "" for empty results)

## Solution
Applied a defensive fix at the transformation layer in `src/api/transform/openai-format.ts`:
```typescript
content: content || "(empty)",
```

This is the correct location because:
- It's the last transformation before the API call
- It catches ALL edge cases regardless of origin
- It doesn't require changes across multiple tool execution paths

## Testing
- Added 3 test cases covering empty string, undefined, and empty array content
- All 27 tests in openai-format.spec.ts pass

## PostHog Reference
https://us.posthog.com/error_tracking/019bb191-73dd-7471-8079-4723c6b2efa0

Closes ROO-517
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Gemini API validation by using "(empty)" placeholder for empty tool result content in `convertToOpenAiMessages()` in `openai-format.ts`.
> 
>   - **Behavior**:
>     - Fixes Gemini API validation error by using "(empty)" placeholder for empty tool result content in `convertToOpenAiMessages()` in `openai-format.ts`.
>     - Handles cases with empty string, undefined, and empty array content.
>   - **Testing**:
>     - Adds test cases for empty content scenarios in `openai-format.spec.ts`.
>     - Ensures all 27 tests in `openai-format.spec.ts` pass.
>   - **Misc**:
>     - Closes issue ROO-517.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5ef90c7c914a67d0cdb11e69eae48f22212ecb5f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->