### PR TITLE
fix: clear approval buttons when API request starts (ROO-526)

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -402,12 +402,14 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setSendingDisabled(true)
 							break
 						case "api_req_started":
-							if (secondLastMessage?.ask === "command_output") {
-								setSendingDisabled(true)
-								setSelectedImages([])
-								setClineAsk(undefined)
-								setEnableButtons(false)
-							}
+							// Clear button state when a new API request starts
+							// This fixes buttons persisting when the task continues
+							setSendingDisabled(true)
+							setSelectedImages([])
+							setClineAsk(undefined)
+							setEnableButtons(false)
+							setPrimaryButtonText(undefined)
+							setSecondaryButtonText(undefined)
 							break
 						case "api_req_finished":
 						case "error":


### PR DESCRIPTION
## Motivation

After PR #10696, the approval buttons (Save/Deny) would persist when they shouldn't. When a new API request started after a tool ask (like file edits), the buttons would remain visible instead of being cleared.

## Root Cause

In `ChatView.tsx`, the `api_req_started` handler was only clearing button state when `secondLastMessage?.ask === 'command_output'`. This meant that when an API request started after a tool ask, the buttons would persist.

## Solution

Changed the `api_req_started` case to always clear the button state when a new API request starts:
- `setSendingDisabled(true)`
- `setSelectedImages([])`
- `setClineAsk(undefined)`
- `setEnableButtons(false)`
- `setPrimaryButtonText(undefined)`
- `setSecondaryButtonText(undefined)`

## Testing

All 27 existing ChatView tests pass.

Fixes ROO-526
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes button persistence issue in `ChatView.tsx` by clearing button state on new API request start.
> 
>   - **Behavior**:
>     - In `ChatView.tsx`, modify `api_req_started` case to always clear button state when a new API request starts.
>     - Functions affected: `setSendingDisabled`, `setSelectedImages`, `setClineAsk`, `setEnableButtons`, `setPrimaryButtonText`, `setSecondaryButtonText`.
>   - **Testing**:
>     - All 27 existing `ChatView` tests pass.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for db939fa639ab7b80450c4d6d48e9ea43ea7a8de4. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->