### PR TITLE
fix(auto-approval): handle heredocs safely

### DIFF
--- a/src/core/auto-approval/__tests__/commands.spec.ts
+++ b/src/core/auto-approval/__tests__/commands.spec.ts
@@ -1,0 +1,32 @@
+import { containsDangerousSubstitution, getCommandDecision } from "../commands"
+
+describe("containsDangerousSubstitution()", () => {
+	it("does not flag Python assignment grouping '=(' inside heredoc content", () => {
+		const cmd = [
+			"python - <<'PY'",
+			"import json, pathlib",
+			"data = {'notes': ''}",
+			"data['notes']=(data.get('notes','')+'; policy set to linked-only by user').lstrip('; ')",
+			"print(data['notes'])",
+			"PY",
+		].join("\n")
+
+		expect(containsDangerousSubstitution(cmd)).toBe(false)
+	})
+
+	it("does not flag simple assignment grouping pattern x=(...)", () => {
+		expect(containsDangerousSubstitution("x=(1+2)")).toBe(false)
+	})
+
+	it("does flag zsh process substitution when used as an argument", () => {
+		expect(containsDangerousSubstitution("cat =(echo hi)")).toBe(true)
+	})
+})
+
+describe("getCommandDecision()", () => {
+	it("auto-approves allowed heredoc command when no dangerous substitution is present", () => {
+		const cmd = ["python - <<'PY'", "x=(1+2)", "print(x)", "PY"].join("\n")
+
+		expect(getCommandDecision(cmd, ["python"], [])).toBe("auto_approve")
+	})
+})

--- a/src/core/auto-approval/commands.ts
+++ b/src/core/auto-approval/commands.ts
@@ -46,7 +46,9 @@ export function containsDangerousSubstitution(source: string): boolean {
 
 	// Check for zsh process substitution =(...) which executes commands
 	// =(...) creates a temporary file containing the output of the command, but executes it
-	const zshProcessSubstitution = /=\([^)]+\)/.test(source)
+	// Only match when preceded by whitespace or command separators (argument position),
+	// not when preceded by identifiers/brackets (assignment position like x=(...) or data['key']=(...))
+	const zshProcessSubstitution = /(^|[\s&|;])=\([^)]+\)/.test(source)
 
 	// Check for zsh glob qualifiers with code execution (e:...:)
 	// Patterns like *(e:whoami:) or ?(e:rm -rf /:) execute commands during glob expansion


### PR DESCRIPTION
## Summary

Fixes command auto-approval false positives / hangs caused by parsing heredoc bodies as shell commands and by overly broad zsh process-substitution detection.

## Changes

- Treat heredoc blocks as a single command when parsing for allow/deny decisions.
- Tighten zsh process-substitution detection so Python-style `x=(...)` does not trigger it.
- Add regression tests.

## Repro / test case

```python - <<'PY'
import json, pathlib
p=pathlib.Path('.roo/tmp/release-notes/temp_pr_inclusion_v3.40.0.json')
data=json.loads(p.read_text(encoding='utf-8'))
data['policy']='linked-only'
data['notes']=(data.get('notes','')+'; policy set to linked-only by user').lstrip('; ')
p.write_text(json.dumps(data, indent=2)+"\n", encoding='utf-8')
print('policy written')
PY
```

## Test

- `cd src && npx vitest run core/auto-approval/__tests__/commands.spec.ts`

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes command parsing issues by treating heredocs as single commands and refining zsh process substitution detection, with tests added.
> 
>   - **Behavior**:
>     - Treat heredoc blocks as single commands in `parseCommand()` in `parse-command.ts`.
>     - Refine zsh process substitution detection in `containsDangerousSubstitution()` in `commands.ts` to avoid false positives with Python-style assignments.
>   - **Tests**:
>     - Add tests in `commands.spec.ts` to verify heredoc handling and zsh process substitution detection.
>   - **Functions**:
>     - Add `parseHeredocStart()` in `parse-command.ts` to identify heredoc starts and delimiters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 9ad34926ed044e29a66fda030694c5d697b53791. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->