### PR TITLE
fix: filter Ollama models without native tool support

### DIFF
--- a/src/api/providers/fetchers/__tests__/ollama.test.ts
+++ b/src/api/providers/fetchers/__tests__/ollama.test.ts
@@ -55,10 +55,71 @@ describe("Ollama Fetcher", () => {
 				description: "Family: qwen3, Context: 40960, Size: 32.8B",
 			})
 		})
+
+		it("should return null when capabilities does not include 'tools'", () => {
+			const modelDataWithoutTools = {
+				...ollamaModelsData["qwen3-2to16:latest"],
+				capabilities: ["completion"], // No "tools" capability
+			}
+
+			const parsedModel = parseOllamaModel(modelDataWithoutTools as any)
+
+			// Models without tools capability are filtered out (return null)
+			expect(parsedModel).toBeNull()
+		})
+
+		it("should return model info when capabilities includes 'tools'", () => {
+			const modelDataWithTools = {
+				...ollamaModelsData["qwen3-2to16:latest"],
+				capabilities: ["completion", "tools"], // Has "tools" capability
+			}
+
+			const parsedModel = parseOllamaModel(modelDataWithTools as any)
+
+			expect(parsedModel).not.toBeNull()
+			expect(parsedModel!.supportsNativeTools).toBe(true)
+		})
+
+		it("should return null when capabilities is undefined (no tool support)", () => {
+			const modelDataWithoutCapabilities = {
+				...ollamaModelsData["qwen3-2to16:latest"],
+				capabilities: undefined, // No capabilities array
+			}
+
+			const parsedModel = parseOllamaModel(modelDataWithoutCapabilities as any)
+
+			// Models without explicit tools capability are filtered out
+			expect(parsedModel).toBeNull()
+		})
+
+		it("should return null when model has vision but no tools capability", () => {
+			const modelDataWithVision = {
+				...ollamaModelsData["qwen3-2to16:latest"],
+				capabilities: ["completion", "vision"],
+			}
+
+			const parsedModel = parseOllamaModel(modelDataWithVision as any)
+
+			// No "tools" capability means filtered out
+			expect(parsedModel).toBeNull()
+		})
+
+		it("should return model with both vision and tools when both capabilities present", () => {
+			const modelDataWithBoth = {
+				...ollamaModelsData["qwen3-2to16:latest"],
+				capabilities: ["completion", "vision", "tools"],
+			}
+
+			const parsedModel = parseOllamaModel(modelDataWithBoth as any)
+
+			expect(parsedModel).not.toBeNull()
+			expect(parsedModel!.supportsImages).toBe(true)
+			expect(parsedModel!.supportsNativeTools).toBe(true)
+		})
 	})
 
 	describe("getOllamaModels", () => {
-		it("should fetch model list from /api/tags and details for each model from /api/show", async () => {
+		it("should fetch model list from /api/tags and include models with tools capability", async () => {
 			const baseUrl = "http://localhost:11434"
 			const modelName = "devstral2to16:latest"
 
@@ -99,7 +160,7 @@ describe("Ollama Fetcher", () => {
 					"ollama.context_length": 4096,
 					"some.other.info": "value",
 				},
-				capabilities: ["completion"],
+				capabilities: ["completion", "tools"], // Has tools capability
 			}
 
 			mockedAxios.get.mockResolvedValueOnce({ data: mockApiTagsResponse })
@@ -120,6 +181,60 @@ describe("Ollama Fetcher", () => {
 
 			const expectedParsedDetails = parseOllamaModel(mockApiShowResponse as any)
 			expect(result[modelName]).toEqual(expectedParsedDetails)
+		})
+
+		it("should filter out models without tools capability", async () => {
+			const baseUrl = "http://localhost:11434"
+			const modelName = "no-tools-model:latest"
+
+			const mockApiTagsResponse = {
+				models: [
+					{
+						name: modelName,
+						model: modelName,
+						modified_at: "2025-06-03T09:23:22.610222878-04:00",
+						size: 14333928010,
+						digest: "6a5f0c01d2c96c687d79e32fdd25b87087feb376bf9838f854d10be8cf3c10a5",
+						details: {
+							family: "llama",
+							families: ["llama"],
+							format: "gguf",
+							parameter_size: "23.6B",
+							parent_model: "",
+							quantization_level: "Q4_K_M",
+						},
+					},
+				],
+			}
+			const mockApiShowResponse = {
+				license: "Mock License",
+				modelfile: "FROM /path/to/blob\nTEMPLATE {{ .Prompt }}",
+				parameters: "num_ctx 4096\nstop_token <eos>",
+				template: "{{ .System }}USER: {{ .Prompt }}ASSISTANT:",
+				modified_at: "2025-06-03T09:23:22.610222878-04:00",
+				details: {
+					parent_model: "",
+					format: "gguf",
+					family: "llama",
+					families: ["llama"],
+					parameter_size: "23.6B",
+					quantization_level: "Q4_K_M",
+				},
+				model_info: {
+					"ollama.context_length": 4096,
+					"some.other.info": "value",
+				},
+				capabilities: ["completion"], // No tools capability
+			}
+
+			mockedAxios.get.mockResolvedValueOnce({ data: mockApiTagsResponse })
+			mockedAxios.post.mockResolvedValueOnce({ data: mockApiShowResponse })
+
+			const result = await getOllamaModels(baseUrl)
+
+			// Model without tools capability should be filtered out
+			expect(Object.keys(result).length).toBe(0)
+			expect(result[modelName]).toBeUndefined()
 		})
 
 		it("should return an empty list if the initial /api/tags call fails", async () => {
@@ -195,7 +310,7 @@ describe("Ollama Fetcher", () => {
 					"ollama.context_length": 4096,
 					"some.other.info": "value",
 				},
-				capabilities: ["completion"],
+				capabilities: ["completion", "tools"], // Has tools capability
 			}
 
 			mockedAxios.get.mockResolvedValueOnce({ data: mockApiTagsResponse })
@@ -260,7 +375,7 @@ describe("Ollama Fetcher", () => {
 					"ollama.context_length": 4096,
 					"some.other.info": "value",
 				},
-				capabilities: ["completion"],
+				capabilities: ["completion", "tools"], // Has tools capability
 			}
 
 			mockedAxios.get.mockResolvedValueOnce({ data: mockApiTagsResponse })

--- a/src/api/providers/native-ollama.ts
+++ b/src/api/providers/native-ollama.ts
@@ -253,6 +253,8 @@ export class NativeOllamaHandler extends BaseProvider implements SingleCompletio
 			let totalOutputTokens = 0
 			// Track tool calls across chunks (Ollama may send complete tool_calls in final chunk)
 			let toolCallIndex = 0
+			// Track tool call IDs for emitting end events
+			const toolCallIds: string[] = []
 
 			try {
 				for await (const chunk of stream) {
@@ -268,6 +270,7 @@ export class NativeOllamaHandler extends BaseProvider implements SingleCompletio
 						for (const toolCall of chunk.message.tool_calls) {
 							// Generate a unique ID for this tool call
 							const toolCallId = `ollama-tool-${toolCallIndex}`
+							toolCallIds.push(toolCallId)
 							yield {
 								type: "tool_call_partial",
 								index: toolCallIndex,
@@ -293,6 +296,13 @@ export class NativeOllamaHandler extends BaseProvider implements SingleCompletio
 				// Yield any remaining content from the matcher
 				for (const chunk of matcher.final()) {
 					yield chunk
+				}
+
+				for (const toolCallId of toolCallIds) {
+					yield {
+						type: "tool_call_end",
+						id: toolCallId,
+					}
 				}
 
 				// Yield usage information if available


### PR DESCRIPTION
## Summary
Fixes an issue where Ollama models without native tool support (like `qwen2.5-coder:7b`) would output tool-call JSON as text instead of triggering native tool calls, causing an infinite loop with the error: *"The model provided text/reasoning but did not call any of the required tools."*

## Root Causes
1. **Missing Capability Detection**: `parseOllamaModel()` wasn't checking if models report `"tools"` in their capabilities array
2. **Missing `tool_call_end` Events**: `NativeOllamaHandler` emitted `tool_call_partial` chunks but never emitted `tool_call_end` events

## Solution
1. Filter out models without `"tools"` capability in `parseOllamaModel()` - returns `null` for incompatible models
2. Emit `tool_call_end` events after streaming completes in `NativeOllamaHandler`

## Files Changed
- `src/api/providers/fetchers/ollama.ts` - Added capability checking in parseOllamaModel
- `src/api/providers/native-ollama.ts` - Added tool_call_end emission
- `src/api/providers/fetchers/__tests__/ollama.test.ts` - Updated tests with tools capability
- `src/api/providers/__tests__/native-ollama.spec.ts` - New test for tool_call_end events

## Testing
- ✅ 13/13 tests pass in `ollama.test.ts`
- ✅ 15/15 tests pass in `native-ollama.spec.ts`
- ✅ Full test suite: 5242 tests pass

## Linear Issue
COM-487
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Ollama model handling by filtering models without tool support and ensuring proper event emissions.
> 
>   - **Behavior**:
>     - `parseOllamaModel()` now filters out models without "tools" capability, returning `null` for such models.
>     - `NativeOllamaHandler` emits `tool_call_end` events after streaming completes.
>   - **Files Changed**:
>     - `ollama.ts`: Added capability checking in `parseOllamaModel()`.
>     - `native-ollama.ts`: Added `tool_call_end` emission.
>     - `ollama.test.ts` and `native-ollama.spec.ts`: Updated tests to cover new behavior.
>   - **Testing**:
>     - All tests pass, including new tests for tool capability and event emissions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 55caabd5ec23d37144dff3c9d79426257631400f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->