### PR TITLE
feat: Refactor OpenRouter provider to use Vercel AI SDK

### DIFF
--- a/src/api/transform/__tests__/ai-sdk.spec.ts
+++ b/src/api/transform/__tests__/ai-sdk.spec.ts
@@ -501,6 +501,132 @@ describe("AI SDK conversion utilities", () => {
 			expect(toolCallPart).toBeDefined()
 			expect(toolCallPart.providerOptions).toBeUndefined()
 		})
+
+		it("attaches valid reasoning_details as providerOptions.openrouter, filtering invalid entries", () => {
+			const validEncrypted = {
+				type: "reasoning.encrypted",
+				data: "encrypted_blob_data",
+				id: "tool_call_123",
+				format: "google-gemini-v1",
+				index: 0,
+			}
+			const invalidEncrypted = {
+				// type is "reasoning.encrypted" but has text instead of data —
+				// this is a plaintext summary mislabeled as encrypted by Gemini/OpenRouter.
+				// The provider's ReasoningDetailEncryptedSchema requires `data: string`,
+				// so including this causes the entire Zod safeParse to fail.
+				type: "reasoning.encrypted",
+				text: "Plaintext reasoning summary",
+				id: "tool_call_123",
+				format: "google-gemini-v1",
+				index: 0,
+			}
+			const textWithSignature = {
+				type: "reasoning.text",
+				text: "Some reasoning content",
+				signature: "stale-signature-from-previous-model",
+			}
+
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Using a tool" },
+						{
+							type: "tool_use",
+							id: "tool_call_123",
+							name: "attempt_completion",
+							input: { result: "done" },
+						},
+					],
+					reasoning_details: [validEncrypted, invalidEncrypted, textWithSignature],
+				} as any,
+			]
+
+			const result = convertToAiSdkMessages(messages)
+
+			expect(result).toHaveLength(1)
+			const assistantMsg = result[0] as any
+			expect(assistantMsg.role).toBe("assistant")
+			expect(assistantMsg.providerOptions).toBeDefined()
+			expect(assistantMsg.providerOptions.openrouter).toBeDefined()
+			const details = assistantMsg.providerOptions.openrouter.reasoning_details
+			// Only the valid entries should survive filtering (invalidEncrypted dropped)
+			expect(details).toHaveLength(2)
+			expect(details[0]).toEqual(validEncrypted)
+			// Signatures should be preserved as-is for same-model Anthropic conversations via OpenRouter
+			expect(details[1]).toEqual(textWithSignature)
+		})
+
+		it("does not attach providerOptions when no reasoning_details are present", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "Just text" }],
+				},
+			]
+
+			const result = convertToAiSdkMessages(messages)
+
+			expect(result).toHaveLength(1)
+			const assistantMsg = result[0] as any
+			expect(assistantMsg.providerOptions).toBeUndefined()
+		})
+
+		it("does not attach providerOptions when reasoning_details is an empty array", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [{ type: "text", text: "Just text" }],
+					reasoning_details: [],
+				} as any,
+			]
+
+			const result = convertToAiSdkMessages(messages)
+
+			expect(result).toHaveLength(1)
+			const assistantMsg = result[0] as any
+			expect(assistantMsg.providerOptions).toBeUndefined()
+		})
+
+		it("preserves both reasoning_details and thoughtSignature providerOptions", () => {
+			const reasoningDetails = [
+				{
+					type: "reasoning.encrypted",
+					data: "encrypted_data",
+					id: "tool_call_abc",
+					format: "google-gemini-v1",
+					index: 0,
+				},
+			]
+
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "thoughtSignature", thoughtSignature: "sig-xyz" } as any,
+						{ type: "text", text: "Using tool" },
+						{
+							type: "tool_use",
+							id: "tool_call_abc",
+							name: "read_file",
+							input: { path: "test.ts" },
+						},
+					],
+					reasoning_details: reasoningDetails,
+				} as any,
+			]
+
+			const result = convertToAiSdkMessages(messages)
+
+			expect(result).toHaveLength(1)
+			const assistantMsg = result[0] as any
+			// Message-level providerOptions carries reasoning_details
+			expect(assistantMsg.providerOptions.openrouter.reasoning_details).toEqual(reasoningDetails)
+			// Part-level providerOptions carries thoughtSignature on the first tool-call
+			const toolCallPart = assistantMsg.content.find((p: any) => p.type === "tool-call")
+			expect(toolCallPart.providerOptions.google.thoughtSignature).toBe("sig-xyz")
+		})
 	})
 
 	describe("convertToolsForAiSdk", () => {
@@ -685,6 +811,27 @@ describe("AI SDK conversion utilities", () => {
 				const chunks = [...processAiSdkStreamPart(event as any)]
 				expect(chunks).toHaveLength(0)
 			}
+		})
+		it("should filter [REDACTED] from reasoning-delta parts", () => {
+			const redactedPart = { type: "reasoning-delta" as const, text: "[REDACTED]" }
+			const normalPart = { type: "reasoning-delta" as const, text: "actual reasoning" }
+
+			const redactedResult = [...processAiSdkStreamPart(redactedPart as any)]
+			const normalResult = [...processAiSdkStreamPart(normalPart as any)]
+
+			expect(redactedResult).toEqual([])
+			expect(normalResult).toEqual([{ type: "reasoning", text: "actual reasoning" }])
+		})
+
+		it("should filter [REDACTED] from reasoning (fullStream format) parts", () => {
+			const redactedPart = { type: "reasoning" as const, text: "[REDACTED]" }
+			const normalPart = { type: "reasoning" as const, text: "actual reasoning" }
+
+			const redactedResult = [...processAiSdkStreamPart(redactedPart as any)]
+			const normalResult = [...processAiSdkStreamPart(normalPart as any)]
+
+			expect(redactedResult).toEqual([])
+			expect(normalResult).toEqual([{ type: "reasoning", text: "actual reasoning" }])
 		})
 	})
 

--- a/src/api/transform/__tests__/model-params.spec.ts
+++ b/src/api/transform/__tests__/model-params.spec.ts
@@ -830,8 +830,28 @@ describe("getModelParams", () => {
 
 			expect(result.maxTokens).toBe(20000)
 			expect(result.reasoningBudget).toBe(10000)
-			expect(result.temperature).toBe(1.0) // Overridden for reasoning budget models
+			expect(result.temperature).toBe(0.8) // User-specified temperature is respected
 			expect(result.reasoningEffort).toBeUndefined() // Budget takes precedence
+		})
+
+		it("should default to temperature 1.0 for reasoning budget models when no custom temperature is set", () => {
+			const model: ModelInfo = {
+				...baseModel,
+				maxTokens: 16000,
+				supportsReasoningBudget: true,
+			}
+
+			const result = getModelParams({
+				...anthropicParams,
+				settings: {
+					enableReasoningEffort: true,
+					modelMaxTokens: 20000,
+				},
+				model,
+			})
+
+			expect(result.temperature).toBe(1.0) // Defaults to 1.0 when no custom temperature
+			expect(result.reasoningBudget).toBeDefined()
 		})
 	})
 

--- a/src/api/transform/model-params.ts
+++ b/src/api/transform/model-params.ts
@@ -125,9 +125,13 @@ export function getModelParams({
 			reasoningBudget = minThinkingTokens
 		}
 
-		// Let's assume that "Hybrid" reasoning models require a temperature of
-		// 1.0 since Anthropic does.
-		temperature = 1.0
+		// Hybrid reasoning models typically require temperature = 1.0
+		// (Anthropic enforces this server-side for extended thinking).
+		// However, respect the user's explicitly-set temperature if provided,
+		// especially for non-Anthropic providers routed through OpenRouter.
+		if (customTemperature === undefined) {
+			temperature = 1.0
+		}
 	} else if (shouldUseReasoningEffort({ model, settings })) {
 		// "Traditional" reasoning models use the `reasoningEffort` parameter.
 		// Only fallback to model default if user hasn't explicitly set a value.


### PR DESCRIPTION
## Summary
Migrate the OpenRouter provider from the OpenAI SDK to the Vercel AI SDK for a more standardized and maintainable implementation.

Closes COM-502 (part 2/2)

**⚠️ This PR depends on #11047 (AI SDK dependencies and utilities)**

## Problem
The current OpenRouter provider implementation uses the raw OpenAI SDK directly, which requires complex message transformation and reasoning token handling code that is difficult to maintain.

## Solution
Refactor the OpenRouter provider to use the `@openrouter/ai-sdk-provider` package which integrates with Vercel's AI SDK. This provides:
- Standardized streaming via `streamText` and `generateText`
- Cleaner message conversion through the AI SDK's `CoreMessage` format
- Simplified tool handling
- Consistent provider options interface

## Changes
- Rewrote `src/api/providers/openrouter.ts` to use AI SDK patterns
- Updated `src/api/providers/__tests__/openrouter.spec.ts` with new test patterns

## Testing
- `tsc --noEmit` passes in both `packages/types` and `src`
- All 5254 tests pass (368 test files)

## Related
- Part 1: #11047 (AI SDK dependencies and utilities) - must be merged first
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refactor OpenRouter provider to use Vercel AI SDK, simplifying streaming, message conversion, and tool handling, with extensive testing and error handling improvements.
> 
>   - **Behavior**:
>     - Refactor `OpenRouterHandler` in `openrouter.ts` to use Vercel AI SDK, replacing OpenAI SDK.
>     - Implements standardized streaming with `streamText` and `generateText`.
>     - Simplifies message conversion using `CoreMessage` format.
>     - Handles tools consistently with AI SDK.
>     - Updates `openrouter.spec.ts` tests to reflect new patterns.
>   - **Error Handling**:
>     - Captures and logs API errors using `TelemetryService`.
>     - Handles stream errors and API errors gracefully.
>   - **Testing**:
>     - Extensive tests in `openrouter.spec.ts` for new streaming and message handling.
>     - Tests for reasoning details, tool handling, and error scenarios.
>   - **Misc**:
>     - Removes old OpenAI-specific logic and error handling.
>     - Adjusts model parameter handling in `model-params.ts` for reasoning and temperature settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3f935af5f313ce405046f346978335da793e589a. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->