### PR TITLE
fix(litellm): detect Gemini models with space-separated names for thought signature injection

### DIFF
--- a/src/api/providers/__tests__/lite-llm.spec.ts
+++ b/src/api/providers/__tests__/lite-llm.spec.ts
@@ -414,6 +414,18 @@ describe("LiteLLMHandler", () => {
 				expect(isGeminiModel("gemini-2.5-flash")).toBe(true)
 			})
 
+			it("should detect Gemini models with spaces (LiteLLM model groups)", () => {
+				const handler = new LiteLLMHandler(mockOptions)
+				const isGeminiModel = (handler as any).isGeminiModel.bind(handler)
+
+				// LiteLLM model groups often use space-separated names with title case
+				expect(isGeminiModel("Gemini 3 Pro")).toBe(true)
+				expect(isGeminiModel("Gemini 3 Flash")).toBe(true)
+				expect(isGeminiModel("gemini 3 pro")).toBe(true)
+				expect(isGeminiModel("Gemini 2.5 Pro")).toBe(true)
+				expect(isGeminiModel("gemini 2.5 flash")).toBe(true)
+			})
+
 			it("should detect provider-prefixed Gemini models", () => {
 				const handler = new LiteLLMHandler(mockOptions)
 				const isGeminiModel = (handler as any).isGeminiModel.bind(handler)
@@ -421,6 +433,9 @@ describe("LiteLLMHandler", () => {
 				expect(isGeminiModel("google/gemini-3-pro")).toBe(true)
 				expect(isGeminiModel("vertex_ai/gemini-3-pro")).toBe(true)
 				expect(isGeminiModel("vertex/gemini-2.5-pro")).toBe(true)
+				// Space-separated variants with provider prefix
+				expect(isGeminiModel("google/gemini 3 pro")).toBe(true)
+				expect(isGeminiModel("vertex_ai/gemini 2.5 pro")).toBe(true)
 			})
 
 			it("should not detect non-Gemini models", () => {

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -46,15 +46,21 @@ export class LiteLLMHandler extends RouterProvider implements SingleCompletionHa
 	private isGeminiModel(modelId: string): boolean {
 		// Match various Gemini model patterns:
 		// - gemini-3-pro, gemini-3-flash, gemini-3-*
+		// - gemini 3 pro, Gemini 3 Pro (space-separated, case-insensitive)
 		// - gemini/gemini-3-*, google/gemini-3-*
 		// - vertex_ai/gemini-3-*, vertex/gemini-3-*
 		// Also match Gemini 2.5+ models which use similar validation
 		const lowerModelId = modelId.toLowerCase()
 		return (
+			// Match hyphenated versions: gemini-3, gemini-2.5
 			lowerModelId.includes("gemini-3") ||
 			lowerModelId.includes("gemini-2.5") ||
+			// Match space-separated versions: "gemini 3", "gemini 2.5"
+			// This handles model names like "Gemini 3 Pro" from LiteLLM model groups
+			lowerModelId.includes("gemini 3") ||
+			lowerModelId.includes("gemini 2.5") ||
 			// Also match provider-prefixed versions
-			/\b(gemini|google|vertex_ai|vertex)\/gemini-(3|2\.5)/i.test(modelId)
+			/\b(gemini|google|vertex_ai|vertex)\/gemini[-\s](3|2\.5)/i.test(modelId)
 		)
 	}
 


### PR DESCRIPTION
## Summary

Fixes the "Corrupted thought signature" error when using LiteLLM with Gemini 3/2.5 models via model groups that use space-separated names (e.g., "Gemini 3 Pro").

## Problem

LiteLLM model groups can use space-separated model names like "Gemini 3 Pro" instead of hyphenated names like "gemini-3-pro". The `isGeminiModel()` function only matched hyphenated names, causing the thought signature injection to be skipped for space-separated names.

When Vertex AI receives a Gemini 3 request without the expected thought signature, it returns:
```
"Corrupted thought signature." 
"status": "INVALID_ARGUMENT"
```

## Solution

Updated `isGeminiModel()` to detect both naming conventions:
- Added checks for space-separated patterns: `gemini 3`, `gemini 2.5`
- Updated regex to match both hyphens and spaces in provider-prefixed patterns

## Changes

- **src/api/providers/lite-llm.ts**: Updated `isGeminiModel()` function
- **src/api/providers/__tests__/lite-llm.spec.ts**: Added tests for space-separated model names

## Testing

All 19 LiteLLM handler tests pass including new tests for:
- "Gemini 3 Pro" (title case with spaces)
- "Gemini 3 Flash" (title case with spaces) 
- "gemini 3 pro" (lowercase with spaces)
- "Gemini 2.5 Pro" (Gemini 2.5 variant)
- "google/gemini 3 pro" (provider-prefixed with spaces)
- "vertex_ai/gemini 2.5 pro" (provider-prefixed with spaces)

Closes COM-508
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes `isGeminiModel()` in `lite-llm.ts` to detect Gemini models with space-separated names, adding tests in `lite-llm.spec.ts`.
> 
>   - **Behavior**:
>     - Fixes detection of Gemini models with space-separated names in `isGeminiModel()` in `lite-llm.ts`.
>     - Handles both hyphenated and space-separated naming conventions for Gemini 3 and 2.5 models.
>   - **Testing**:
>     - Adds tests in `lite-llm.spec.ts` for space-separated Gemini model names, including provider-prefixed variants.
>     - Verifies detection of models like "Gemini 3 Pro", "gemini 3 pro", and "vertex_ai/gemini 2.5 pro".
>   - **Misc**:
>     - Updates regex in `isGeminiModel()` to match both hyphens and spaces.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 737fbb3fda155d7f9843cac4a36ee870b612eaaf. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->