### PR TITLE
chore(cli): prepare release v0.0.49

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.49] - 2026-01-18
+
+### Added
+
+- **Output Format Options**: New `--output-format` flag to control CLI output format for scripting and automation:
+    - `text` (default) - Human-readable interactive output
+    - `json` - Single JSON object with all events and final result at task completion
+    - `stream-json` - NDJSON (newline-delimited JSON) for real-time streaming of events
+    - See [`json-events.ts`](src/types/json-events.ts) for the complete event schema
+    - New [`JsonEventEmitter`](src/agent/json-event-emitter.ts) for structured output generation
+
 ## [0.0.48] - 2026-01-17
 
 ### Changed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.0.48",
+	"version": "0.0.49",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.0.49

This PR prepares the CLI release v0.0.49.

### Changes
- Version bump in package.json
- Changelog update

### What's New
- **Output Format Options**: New `--output-format` flag to control CLI output format for scripting and automation:
    - `text` (default) - Human-readable interactive output
    - `json` - Single JSON object with all events and final result at task completion
    - `stream-json` - NDJSON (newline-delimited JSON) for real-time streaming of events

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prepare CLI release v0.0.49 with version bump, changelog update, and new output format options.
> 
>   - **Version Update**:
>     - Bump version to `0.0.49` in `package.json`.
>   - **Changelog**:
>     - Update `CHANGELOG.md` with details of version `0.0.49`.
>   - **New Feature**:
>     - Add `--output-format` flag for CLI with options `text`, `json`, and `stream-json` for different output formats.
>     - Introduce `JsonEventEmitter` in `json-event-emitter.ts` for structured output.
>     - Reference `json-events.ts` for event schema.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7d429ce98e52c286a7edda62a18a8a6b27d28bcd. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->