### PR TITLE
fix(openai): prevent double emission of text/reasoning in native and codex handlers

### DIFF
--- a/src/api/providers/openai-codex.ts
+++ b/src/api/providers/openai-codex.ts
@@ -908,17 +908,25 @@ export class OpenAiCodexHandler extends BaseProvider implements SingleCompletion
 					}
 				}
 
-				if (item.type === "text" && item.text) {
-					yield { type: "text", text: item.text }
-				} else if (item.type === "reasoning" && item.text) {
-					yield { type: "reasoning", text: item.text }
-				} else if (item.type === "message" && Array.isArray(item.content)) {
-					for (const content of item.content) {
-						if ((content?.type === "text" || content?.type === "output_text") && content?.text) {
-							yield { type: "text", text: content.text }
+				// For "added" events, yield text/reasoning content (streaming path)
+				// For "done" events, do NOT yield text/reasoning - it's already been streamed via deltas
+				// and would cause double-emission (A, B, C, ABC).
+				if (event.type === "response.output_item.added") {
+					if (item.type === "text" && item.text) {
+						yield { type: "text", text: item.text }
+					} else if (item.type === "reasoning" && item.text) {
+						yield { type: "reasoning", text: item.text }
+					} else if (item.type === "message" && Array.isArray(item.content)) {
+						for (const content of item.content) {
+							if ((content?.type === "text" || content?.type === "output_text") && content?.text) {
+								yield { type: "text", text: content.text }
+							}
 						}
 					}
-				} else if (
+				}
+
+				// Only handle tool/function calls from done events (to ensure arguments are complete)
+				if (
 					(item.type === "function_call" || item.type === "tool_call") &&
 					event.type === "response.output_item.done"
 				) {

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -1223,20 +1223,28 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 					}
 				}
 
-				if (item.type === "text" && item.text) {
-					yield { type: "text", text: item.text }
-				} else if (item.type === "reasoning" && item.text) {
-					yield { type: "reasoning", text: item.text }
-				} else if (item.type === "message" && Array.isArray(item.content)) {
-					for (const content of item.content) {
-						// Some implementations send 'text'; others send 'output_text'
-						if ((content?.type === "text" || content?.type === "output_text") && content?.text) {
-							yield { type: "text", text: content.text }
+				// For "added" events, yield text/reasoning content (streaming path)
+				// For "done" events, do NOT yield text/reasoning - it's already been streamed via deltas
+				// and would cause double-emission (A, B, C, ABC).
+				if (event.type === "response.output_item.added") {
+					if (item.type === "text" && item.text) {
+						yield { type: "text", text: item.text }
+					} else if (item.type === "reasoning" && item.text) {
+						yield { type: "reasoning", text: item.text }
+					} else if (item.type === "message" && Array.isArray(item.content)) {
+						for (const content of item.content) {
+							// Some implementations send 'text'; others send 'output_text'
+							if ((content?.type === "text" || content?.type === "output_text") && content?.text) {
+								yield { type: "text", text: content.text }
+							}
 						}
 					}
-				} else if (
+				}
+
+				// Only handle tool/function calls from done events (to ensure arguments are complete)
+				if (
 					(item.type === "function_call" || item.type === "tool_call") &&
-					event.type === "response.output_item.done" // Only handle done events for tool calls to ensure arguments are complete
+					event.type === "response.output_item.done"
 				) {
 					// Handle complete tool/function call item
 					// Emit as tool_call for backward compatibility with non-streaming tool handling


### PR DESCRIPTION
This PR fixes a bug in `OpenAiNativeHandler` and `OpenAiCodexHandler` where text and reasoning content were being emitted twice: once via streaming delta events and again via the final `response.output_item.done` event.

This double emission caused duplicated text content (e.g., "Hello worldHello world") and likely contributed to duplicate tool call issues seen in other contexts.

### Related PRs / Context
This fix addresses the root cause likely necessitating several recent workarounds for duplicate tool calls and results, specifically:

- **#10760 (fix: prevent duplicate tool_use IDs causing API 400 errors)**: This PR added guards against duplicate `tool_call_start` events. The double emission from the handler was the probable "API quirk" causing these duplicates.
- **#10497 (fix: prevent duplicate tool_result blocks...)**: While dealing with tool results, this highlights the broader instability caused by duplication in the message stream.
- **#10494 & #10466**: Other deduplication efforts that may have been fighting symptoms of this upstream stream handling issue.

By fixing the handler to only emit content from deltas (streaming) and relying on `done` events only for non-content finalization, we ensure a clean, single stream of data.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes double emission of text and reasoning in OpenAI handlers by ensuring content is only emitted during streaming events.
> 
>   - **Behavior**:
>     - Fixes double emission of text and reasoning in `OpenAiNativeHandler` and `OpenAiCodexHandler` by ensuring content is only emitted during `response.output_item.added` events.
>     - Prevents emission of text/reasoning during `response.output_item.done` events to avoid duplication.
>   - **Context**:
>     - Addresses root cause of duplicate tool call issues seen in previous PRs (#10760, #10497, #10494, #10466).
>     - Ensures a clean, single stream of data by relying on streaming events for content emission.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ac2bdb70e59507bfd471fc554a29588fc922a52e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->