### PR TITLE
fix: prevent task abortion when resuming via IPC/bridge

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1546,7 +1546,10 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 
 				this.emit(RooCodeEventName.TaskUserMessage, this.taskId)
 
-				provider.postMessageToWebview({ type: "invoke", invoke: "sendMessage", text, images })
+				// Handle the message directly instead of routing through the webview.
+				// This avoids a race condition where the webview's message state hasn't
+				// hydrated yet, causing it to interpret the message as a new task request.
+				this.handleWebviewAskResponse("messageResponse", text, images)
 			} else {
 				console.error("[Task#submitUserMessage] Provider reference lost")
 			}

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -862,7 +862,11 @@ export class ClineProvider
 		this.webviewDisposables.push(configDisposable)
 
 		// If the extension is starting a new session, clear previous task state.
-		await this.removeClineFromStack()
+		// But don't clear if there's already an active task (e.g., resumed via IPC/bridge).
+		const currentTask = this.getCurrentTask()
+		if (!currentTask || currentTask.abandoned || currentTask.abort) {
+			await this.removeClineFromStack()
+		}
 	}
 
 	public async createTaskWithHistoryItem(


### PR DESCRIPTION
When a task is resumed via IPC or the cloud bridge, resolveWebviewView could race and abort the task by unconditionally calling removeClineFromStack(). This caused resumed tasks to be cleared when the webview panel became visible.

Changes:
- Check for active task before clearing in resolveWebviewView
- Route submitUserMessage through handleWebviewAskResponse directly
  instead of the webview to avoid message hydration race conditions
- Update tests to reflect the new message handling behavior
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix task abortion issue by checking for active tasks before clearing and routing messages directly to avoid race conditions.
> 
>   - **Behavior**:
>     - In `ClineProvider.ts`, `resolveWebviewView()` now checks for active tasks before calling `removeClineFromStack()` to prevent clearing active tasks when resuming via IPC/bridge.
>     - In `Task.ts`, `submitUserMessage()` now routes messages directly through `handleWebviewAskResponse()` instead of the webview to avoid race conditions.
>   - **Tests**:
>     - Updated `Task.spec.ts` to verify `submitUserMessage()` calls `handleWebviewAskResponse()` directly and does not route through the webview.
>     - Added checks to ensure `handleWebviewAskResponse()` is not called for empty messages.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for acd1f13135e27457fb99ad2dd4ebf26c1bd6a965. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->