### PR TITLE
feat: hide worktree feature from menus

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -244,13 +244,8 @@
 					"when": "view == roo-cline.SidebarProvider"
 				},
 				{
-					"command": "roo-cline.worktreesButtonClicked",
-					"group": "overflow@2",
-					"when": "view == roo-cline.SidebarProvider"
-				},
-				{
 					"command": "roo-cline.popoutButtonClicked",
-					"group": "overflow@3",
+					"group": "overflow@2",
 					"when": "view == roo-cline.SidebarProvider"
 				}
 			],
@@ -281,13 +276,8 @@
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				},
 				{
-					"command": "roo-cline.worktreesButtonClicked",
-					"group": "overflow@2",
-					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
-				},
-				{
 					"command": "roo-cline.popoutButtonClicked",
-					"group": "overflow@3",
+					"group": "overflow@2",
 					"when": "activeWebviewPanelId == roo-cline.TabPanelProvider"
 				}
 			]


### PR DESCRIPTION
Removes the worktree button from both the sidebar overflow menu and the editor/tab panel overflow menu in package.json.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `worktreesButtonClicked` command from sidebar and editor/tab panel overflow menus in `package.json`.
> 
>   - **Behavior**:
>     - Removes `worktreesButtonClicked` command from sidebar overflow menu in `package.json`.
>     - Removes `worktreesButtonClicked` command from editor/tab panel overflow menu in `package.json`.
>     - Adjusts group order for remaining commands in both menus.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ade5303c1ed7bfe1f301f39195e05ee06c5349e6. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->