### PR TITLE
fix: truncate AWS Bedrock toolUseId to 64 characters

### DIFF
--- a/src/api/transform/bedrock-converse-format.ts
+++ b/src/api/transform/bedrock-converse-format.ts
@@ -1,5 +1,6 @@
 import { Anthropic } from "@anthropic-ai/sdk"
 import { ConversationRole, Message, ContentBlock } from "@aws-sdk/client-bedrock-runtime"
+import { sanitizeOpenAiCallId } from "../../utils/tool-id"
 
 interface BedrockMessageContent {
 	type: "text" | "image" | "video" | "tool_use" | "tool_result"
@@ -90,7 +91,7 @@ export function convertToBedrockConverseMessages(anthropicMessages: Anthropic.Me
 				// Native-only: keep input as JSON object for Bedrock's toolUse format
 				return {
 					toolUse: {
-						toolUseId: messageBlock.id || "",
+						toolUseId: sanitizeOpenAiCallId(messageBlock.id || ""),
 						name: messageBlock.name || "",
 						input: messageBlock.input || {},
 					},
@@ -104,7 +105,7 @@ export function convertToBedrockConverseMessages(anthropicMessages: Anthropic.Me
 					if (typeof messageBlock.content === "string") {
 						return {
 							toolResult: {
-								toolUseId: messageBlock.tool_use_id || "",
+								toolUseId: sanitizeOpenAiCallId(messageBlock.tool_use_id || ""),
 								content: [
 									{
 										text: messageBlock.content,
@@ -118,7 +119,7 @@ export function convertToBedrockConverseMessages(anthropicMessages: Anthropic.Me
 					if (Array.isArray(messageBlock.content)) {
 						return {
 							toolResult: {
-								toolUseId: messageBlock.tool_use_id || "",
+								toolUseId: sanitizeOpenAiCallId(messageBlock.tool_use_id || ""),
 								content: messageBlock.content.map((item) => ({
 									text: typeof item === "string" ? item : item.text || String(item),
 								})),
@@ -132,7 +133,7 @@ export function convertToBedrockConverseMessages(anthropicMessages: Anthropic.Me
 				if (messageBlock.output && typeof messageBlock.output === "string") {
 					return {
 						toolResult: {
-							toolUseId: messageBlock.tool_use_id || "",
+							toolUseId: sanitizeOpenAiCallId(messageBlock.tool_use_id || ""),
 							content: [
 								{
 									text: messageBlock.output,
@@ -146,7 +147,7 @@ export function convertToBedrockConverseMessages(anthropicMessages: Anthropic.Me
 				if (Array.isArray(messageBlock.output)) {
 					return {
 						toolResult: {
-							toolUseId: messageBlock.tool_use_id || "",
+							toolUseId: sanitizeOpenAiCallId(messageBlock.tool_use_id || ""),
 							content: messageBlock.output.map((part) => {
 								if (typeof part === "object" && "text" in part) {
 									return { text: part.text }
@@ -165,7 +166,7 @@ export function convertToBedrockConverseMessages(anthropicMessages: Anthropic.Me
 				// Default case
 				return {
 					toolResult: {
-						toolUseId: messageBlock.tool_use_id || "",
+						toolUseId: sanitizeOpenAiCallId(messageBlock.tool_use_id || ""),
 						content: [
 							{
 								text: String(messageBlock.output || ""),


### PR DESCRIPTION
## Problem

AWS Bedrock has a 64-character limit on `toolUseId` fields, but the Bedrock Converse format converter doesn't truncate these IDs. This causes validation errors when using LiteLLM as a proxy to Bedrock, especially when switching modes with long conversation histories.

Error example:
```
Value at 'messages.2.member.content.1.member.toolUse.toolUseId' failed to satisfy constraint: 
Member must have length less than or equal to 64
```

The issue manifests when:
- Using LiteLLM to route to AWS Bedrock
- Switching between modes (e.g., Ask → Orchestrator) with existing tool calls in history
- Tool call IDs exceed 64 characters

## Solution

Applied the same ID sanitization approach used in OpenAI providers to the Bedrock Converse format converter:

1. Import `sanitizeOpenAiCallId` from `src/utils/tool-id.ts`
2. Apply sanitization to all `toolUseId` fields in:
   - `tool_use` blocks
   - `tool_result` blocks

This ensures IDs are truncated to 64 characters with hash suffixes to maintain uniqueness.

## Changes

- Updated `src/api/transform/bedrock-converse-format.ts`
- Added 7 comprehensive tests in `src/api/transform/__tests__/bedrock-converse-format.spec.ts`
- All tests pass (17/17)

## Related

Fixes EXT-556
Related to issue #10766 which addresses MCP tool name length, but this is a separate issue about tool call ID length.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Truncates `toolUseId` to 64 characters in `convertToBedrockConverseMessages()` to comply with AWS Bedrock limits, adding tests for verification.
> 
>   - **Behavior**:
>     - Truncates `toolUseId` to 64 characters in `convertToBedrockConverseMessages()` in `bedrock-converse-format.ts` using `sanitizeOpenAiCallId`.
>     - Handles `tool_use` and `tool_result` blocks, ensuring IDs are unique with hash suffixes.
>   - **Tests**:
>     - Adds 7 tests in `bedrock-converse-format.spec.ts` to verify ID truncation and uniqueness.
>     - Tests cover cases for long IDs, short IDs, consistent truncation, and matching `tool_use` and `tool_result` IDs.
>   - **Misc**:
>     - Imports `sanitizeOpenAiCallId` from `tool-id.ts` for ID sanitization.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 544cb9075ffa49355a5e823a30296c3e63df2325. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->