### PR TITLE
feat: add systemPrompt property to ModeConfig for custom system prompt override

### DIFF
--- a/packages/types/src/mode.ts
+++ b/packages/types/src/mode.ts
@@ -70,6 +70,12 @@ export const modeConfigSchema = z.object({
 	customInstructions: z.string().optional(),
 	groups: groupEntryArraySchema,
 	source: z.enum(["global", "project"]).optional(),
+	/**
+	 * When provided, replaces the middle sections of the generated system prompt
+	 * (CAPABILITIES, TOOL USE, OBJECTIVE, etc.) with this custom content.
+	 * The final prompt will be: roleDefinition + systemPrompt + customInstructions
+	 */
+	systemPrompt: z.string().optional(),
 })
 
 export type ModeConfig = z.infer<typeof modeConfigSchema>

--- a/src/core/prompts/__tests__/system-prompt.spec.ts
+++ b/src/core/prompts/__tests__/system-prompt.spec.ts
@@ -626,6 +626,169 @@ describe("SYSTEM_PROMPT", () => {
 		expect(prompt).toContain("OBJECTIVE")
 	})
 
+	describe("systemPrompt override", () => {
+		it("should use systemPrompt from mode config when provided", async () => {
+			const customSystemPrompt = "This is a custom system prompt that replaces the default sections."
+
+			const customModes: ModeConfig[] = [
+				{
+					slug: "minimal-mode",
+					name: "Minimal Mode",
+					roleDefinition: "You are a minimal assistant.",
+					customInstructions: "Be concise.",
+					groups: ["mcp"] as const,
+					systemPrompt: customSystemPrompt,
+				},
+			]
+
+			const prompt = await SYSTEM_PROMPT(
+				mockContext,
+				"/test/path",
+				false,
+				undefined, // mcpHub
+				undefined, // diffStrategy
+				undefined, // browserViewportSize
+				"minimal-mode", // mode
+				undefined, // customModePrompts
+				customModes, // customModes
+				"Global instructions", // globalCustomInstructions
+				experiments, // experiments
+				undefined, // language
+				undefined, // rooIgnoreInstructions
+				undefined, // settings
+			)
+
+			// Should contain the custom systemPrompt
+			expect(prompt).toContain(customSystemPrompt)
+
+			// Should contain role definition at the top
+			expect(prompt).toContain("You are a minimal assistant.")
+			expect(prompt.indexOf("You are a minimal assistant.")).toBeLessThan(prompt.indexOf(customSystemPrompt))
+
+			// Should NOT contain the default sections (TOOL USE, CAPABILITIES, OBJECTIVE, etc.)
+			expect(prompt).not.toContain("TOOL USE")
+			expect(prompt).not.toContain("CAPABILITIES")
+			expect(prompt).not.toContain("OBJECTIVE")
+			expect(prompt).not.toContain("MARKDOWN RULES")
+		})
+
+		it("should include customInstructions when using systemPrompt override", async () => {
+			const customSystemPrompt = "Custom system prompt content."
+			const modeCustomInstructions = "Be concise."
+
+			const customModes: ModeConfig[] = [
+				{
+					slug: "minimal-mode",
+					name: "Minimal Mode",
+					roleDefinition: "You are a minimal assistant.",
+					customInstructions: modeCustomInstructions,
+					groups: ["mcp"] as const,
+					systemPrompt: customSystemPrompt,
+				},
+			]
+
+			const prompt = await SYSTEM_PROMPT(
+				mockContext,
+				"/test/path",
+				false,
+				undefined, // mcpHub
+				undefined, // diffStrategy
+				undefined, // browserViewportSize
+				"minimal-mode", // mode
+				undefined, // customModePrompts
+				customModes, // customModes
+				"Global instructions", // globalCustomInstructions
+				experiments, // experiments
+				undefined, // language
+				undefined, // rooIgnoreInstructions
+				undefined, // settings
+			)
+
+			// Should contain the customInstructions
+			expect(prompt).toContain(modeCustomInstructions)
+
+			// Custom instructions should come after the systemPrompt
+			expect(prompt.indexOf(customSystemPrompt)).toBeLessThan(prompt.indexOf(modeCustomInstructions))
+		})
+
+		it("should use default sections when systemPrompt is not provided", async () => {
+			const customModes: ModeConfig[] = [
+				{
+					slug: "regular-mode",
+					name: "Regular Mode",
+					roleDefinition: "You are a regular assistant.",
+					customInstructions: "Follow all guidelines.",
+					groups: ["read"] as const,
+					// No systemPrompt provided
+				},
+			]
+
+			const prompt = await SYSTEM_PROMPT(
+				mockContext,
+				"/test/path",
+				false,
+				undefined, // mcpHub
+				undefined, // diffStrategy
+				undefined, // browserViewportSize
+				"regular-mode", // mode
+				undefined, // customModePrompts
+				customModes, // customModes
+				undefined, // globalCustomInstructions
+				experiments, // experiments
+				undefined, // language
+				undefined, // rooIgnoreInstructions
+				undefined, // settings
+			)
+
+			// Should contain the default sections
+			expect(prompt).toContain("TOOL USE")
+			expect(prompt).toContain("CAPABILITIES")
+			expect(prompt).toContain("OBJECTIVE")
+		})
+
+		it("should prioritize file-based system prompt over config systemPrompt", async () => {
+			// Mock fs to return a file-based system prompt
+			const fsMock = vi.mocked(await import("fs/promises"))
+			fsMock.readFile.mockResolvedValueOnce("File-based system prompt content.")
+
+			const customSystemPrompt = "Config-based system prompt content."
+
+			const customModes: ModeConfig[] = [
+				{
+					slug: "priority-mode",
+					name: "Priority Mode",
+					roleDefinition: "You are a priority assistant.",
+					customInstructions: "Test instructions.",
+					groups: ["read"] as const,
+					systemPrompt: customSystemPrompt,
+				},
+			]
+
+			const prompt = await SYSTEM_PROMPT(
+				mockContext,
+				"/test/path",
+				false,
+				undefined, // mcpHub
+				undefined, // diffStrategy
+				undefined, // browserViewportSize
+				"priority-mode", // mode
+				undefined, // customModePrompts
+				customModes, // customModes
+				undefined, // globalCustomInstructions
+				experiments, // experiments
+				undefined, // language
+				undefined, // rooIgnoreInstructions
+				undefined, // settings
+			)
+
+			// Should contain the file-based system prompt
+			expect(prompt).toContain("File-based system prompt content.")
+
+			// Should NOT contain the config-based systemPrompt
+			expect(prompt).not.toContain(customSystemPrompt)
+		})
+	})
+
 	afterAll(() => {
 		vi.restoreAllMocks()
 	})

--- a/src/core/prompts/system.ts
+++ b/src/core/prompts/system.ts
@@ -180,6 +180,34 @@ ${fileCustomSystemPrompt}
 ${customInstructions}`
 	}
 
+	// If the mode config has a systemPrompt defined, use it as custom middle content
+	if (currentMode.systemPrompt) {
+		const { roleDefinition, baseInstructions: baseInstructionsForConfig } = getModeSelection(
+			mode,
+			promptComponent,
+			customModes,
+		)
+
+		const customInstructions = await addCustomInstructions(
+			baseInstructionsForConfig,
+			globalCustomInstructions || "",
+			cwd,
+			mode,
+			{
+				language: language ?? formatLanguage(vscode.env.language),
+				rooIgnoreInstructions,
+				settings,
+			},
+		)
+
+		// For config-based systemPrompt, use the simplified structure
+		return `${roleDefinition}
+
+${currentMode.systemPrompt}
+
+${customInstructions}`
+	}
+
 	return generatePrompt(
 		context,
 		cwd,


### PR DESCRIPTION
## Summary
Add a new `systemPrompt` property to `ModeConfig` that allows custom modes to override the default system prompt sections (CAPABILITIES, OBJECTIVE, TOOL USE, etc.) with custom content.

## Problem
Currently, custom modes can only customize:
- `roleDefinition` - The mode's identity/persona
- `customInstructions` - Mode-specific behavioral instructions

The middle sections of the system prompt are hardcoded and cannot be disabled or replaced except by creating a file at `.roo/system-prompt-{mode-slug}`. Users want the ability to define a minimal/custom system prompt directly in their mode configuration without creating external files. This is useful for creating specialized modes (e.g., MCP-only modes) where the default "code assistant" framing is unnecessary.

## Solution
Added a new optional `systemPrompt` property to the `ModeConfig` schema. When provided, it replaces the middle sections of the generated prompt with the custom content.

**Final prompt structure when `systemPrompt` is provided:**
```
roleDefinition + systemPrompt + customInstructions
```

**Instead of:**
```
roleDefinition + MARKDOWN + TOOL USE + MCP SERVERS + CAPABILITIES + MODES + RULES + SYSTEM INFO + OBJECTIVE + customInstructions
```

## Changes
- `packages/types/src/mode.ts` - Added `systemPrompt` to schema with JSDoc
- `src/core/prompts/system.ts` - Implemented the override logic
- `src/core/prompts/__tests__/system-prompt.spec.ts` - Added 4 new tests

## Priority Order
1. File-based (`.roo/system-prompt-{mode}`) - highest priority
2. Config `systemPrompt` property - second priority
3. Default generated prompt - fallback

## Usage Example
```json
{
  "slug": "mcp-only",
  "name": "MCP Only Mode",
  "roleDefinition": "You are an MCP assistant.",
  "groups": ["mcp"],
  "systemPrompt": "Use MCP tools to accomplish tasks. You have access to connected MCP servers.",
  "customInstructions": "Focus on efficiency."
}
```

## Testing
- All 5104 tests pass
- 4 new tests added for systemPrompt functionality

Closes EXT-557
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `systemPrompt` to `ModeConfig` for custom prompt overrides, with priority over default sections, tested in `system-prompt.spec.ts`.
> 
>   - **Behavior**:
>     - Adds `systemPrompt` property to `ModeConfig` schema in `mode.ts` for custom prompt content.
>     - Overrides default prompt sections (e.g., TOOL USE, CAPABILITIES) when `systemPrompt` is provided.
>     - Priority order: file-based prompt, config `systemPrompt`, default prompt.
>   - **Implementation**:
>     - `system.ts`: Implements logic to use `systemPrompt` if defined, otherwise defaults to file-based or generated prompt.
>     - `system-prompt.spec.ts`: Adds tests for `systemPrompt` functionality, including priority handling and content inclusion.
>   - **Testing**:
>     - 4 new tests in `system-prompt.spec.ts` to verify `systemPrompt` behavior and priority order.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for d4914ef91b86d4c4cc0fba20d939be1c23481974. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->