### PR TITLE
chore(prompts): clarify linked SKILL.md file handling

### DIFF
--- a/src/core/prompts/sections/skills.ts
+++ b/src/core/prompts/sections/skills.ts
@@ -80,6 +80,16 @@ CONSTRAINTS:
 - FAILURE to perform this check is an error.
 </mandatory_skill_check>
 
+<linked_file_handling>
+- When a SKILL.md is loaded, ONLY the contents of SKILL.md are present.
+- Files linked from SKILL.md are NOT loaded automatically.
+- The model MUST explicitly decide to read a linked file based on task relevance.
+- Do NOT assume the contents of linked files unless they have been explicitly read.
+- Prefer reading the minimum necessary linked file.
+- Avoid reading multiple linked files unless required.
+- Treat linked files as progressive disclosure, not mandatory context.
+</linked_file_handling>
+
 <context_notes>
 - The skill list is already filtered for the current mode: "${currentMode}".
 - Mode-specific skills may come from skills-${currentMode}/ with project-level overrides taking precedence over global skills.


### PR DESCRIPTION
## Summary

Clarifies that when a `SKILL.md` is loaded, linked files are *not* automatically loaded, and must be explicitly read only when relevant.

## Changes

- Add a `<linked_file_handling>` section to the skills prompt text to document linked-file loading expectations.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `<linked_file_handling>` section in `skills.ts` to clarify explicit reading of linked files in `SKILL.md`.
> 
>   - **Documentation**:
>     - Adds `<linked_file_handling>` section in `skills.ts` to clarify that linked files in `SKILL.md` are not automatically loaded.
>     - Specifies that linked files must be explicitly read based on task relevance and should be treated as progressive disclosure.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 25f8300edad4f052bc95d72095d764ddf26de867. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->