### PR TITLE
feat: add pnpm install:vsix:nightly command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"vsix:nightly": "turbo vsix:nightly --log-order grouped --output-logs new-only",
 		"clean": "turbo clean --log-order grouped --output-logs new-only && rimraf dist out bin .vite-port .turbo",
 		"install:vsix": "pnpm install --frozen-lockfile && pnpm clean && pnpm vsix && node scripts/install-vsix.js",
+		"install:vsix:nightly": "pnpm install --frozen-lockfile && pnpm clean && pnpm vsix:nightly && node scripts/install-vsix.js --nightly",
 		"changeset:version": "cp CHANGELOG.md src/CHANGELOG.md && changeset version && cp -vf src/CHANGELOG.md .",
 		"knip": "knip --include files",
 		"evals": "dotenvx run -f packages/evals/.env.development packages/evals/.env.local -- docker compose -f packages/evals/docker-compose.yml --profile server --profile runner up --build --scale runner=0",

--- a/scripts/install-vsix.js
+++ b/scripts/install-vsix.js
@@ -5,6 +5,9 @@ const readline = require("readline")
 // detect "yes" flags
 const autoYes = process.argv.includes("-y")
 
+// detect nightly flag
+const isNightly = process.argv.includes("--nightly")
+
 // detect editor command from args or default to "code"
 const editorArg = process.argv.find((arg) => arg.startsWith("--editor="))
 const defaultEditor = editorArg ? editorArg.split("=")[1] : "code"
@@ -24,14 +27,29 @@ const askQuestion = (question) => {
 
 async function main() {
 	try {
-		const packageJson = JSON.parse(fs.readFileSync("./src/package.json", "utf-8"))
-		const name = packageJson.name
-		const version = packageJson.version
-		const vsixFileName = `./bin/${name}-${version}.vsix`
-		const publisher = packageJson.publisher
-		const extensionId = `${publisher}.${name}`
+		let name, version, publisher
 
-		console.log("\n🚀 Roo Code VSIX Installer")
+		if (isNightly) {
+			// For nightly, read the nightly-specific package.json and get publisher from src
+			const nightlyPackageJson = JSON.parse(
+				fs.readFileSync("./apps/vscode-nightly/package.nightly.json", "utf-8"),
+			)
+			const srcPackageJson = JSON.parse(fs.readFileSync("./src/package.json", "utf-8"))
+			name = nightlyPackageJson.name
+			version = nightlyPackageJson.version
+			publisher = srcPackageJson.publisher
+		} else {
+			const packageJson = JSON.parse(fs.readFileSync("./src/package.json", "utf-8"))
+			name = packageJson.name
+			version = packageJson.version
+			publisher = packageJson.publisher
+		}
+
+		const vsixFileName = `./bin/${name}-${version}.vsix`
+		const extensionId = `${publisher}.${name}`
+		const buildType = isNightly ? "Nightly" : "Regular"
+
+		console.log(`\n🚀 Roo Code VSIX Installer (${buildType})`)
 		console.log("========================")
 		console.log("\nThis script will:")
 		console.log("1. Uninstall any existing version of the Roo Code extension")


### PR DESCRIPTION
## Summary

Adds support for installing the nightly build via pnpm, mirroring the existing `install:vsix` command.

## Changes

- Add `--nightly` flag to `scripts/install-vsix.js` that reads from `apps/vscode-nightly/package.nightly.json`
- Add `install:vsix:nightly` script to `package.json`
- Display "(Nightly)" in the installer header to indicate build type

## Usage

```sh
pnpm install:vsix:nightly [-y] [--editor=<command>]
```

Options:
- `-y`: Skip all confirmation prompts and use defaults
- `--editor=<command>`: Specify the editor command (e.g., `--editor=cursor` or `--editor=code-insiders`)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `install:vsix:nightly` command to install nightly VSIX builds with pnpm, updating `scripts/install-vsix.js` to handle `--nightly` flag and display build type.
> 
>   - **Behavior**:
>     - Adds `install:vsix:nightly` command in `package.json` to install nightly VSIX builds.
>     - Updates `scripts/install-vsix.js` to handle `--nightly` flag, reading from `apps/vscode-nightly/package.nightly.json`.
>     - Displays "(Nightly)" in installer header to indicate build type.
>   - **Options**:
>     - `-y`: Skip confirmation prompts.
>     - `--editor=<command>`: Specify editor command (e.g., `cursor`, `code-insiders`).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4df0ae125088e465bba66caf9764054b2ad12e78. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->