### PR TITLE
Skip thoughtSignature blocks during markdown export #10199

### DIFF
--- a/src/integrations/misc/__tests__/export-markdown.spec.ts
+++ b/src/integrations/misc/__tests__/export-markdown.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest"
+import { formatContentBlockToMarkdown, ExtendedContentBlock } from "../export-markdown"
+
+describe("export-markdown", () => {
+	describe("formatContentBlockToMarkdown", () => {
+		it("should format text blocks", () => {
+			const block = { type: "text", text: "Hello, world!" } as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("Hello, world!")
+		})
+
+		it("should format image blocks", () => {
+			const block = {
+				type: "image",
+				source: { type: "base64", media_type: "image/png", data: "data" },
+			} as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("[Image]")
+		})
+
+		it("should format tool_use blocks with string input", () => {
+			const block = { type: "tool_use", name: "read_file", id: "123", input: "file.txt" } as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("[Tool Use: read_file]\nfile.txt")
+		})
+
+		it("should format tool_use blocks with object input", () => {
+			const block = {
+				type: "tool_use",
+				name: "read_file",
+				id: "123",
+				input: { path: "file.txt", line_count: 10 },
+			} as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("[Tool Use: read_file]\nPath: file.txt\nLine_count: 10")
+		})
+
+		it("should format tool_result blocks with string content", () => {
+			const block = { type: "tool_result", tool_use_id: "123", content: "File content" } as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("[Tool]\nFile content")
+		})
+
+		it("should format tool_result blocks with error", () => {
+			const block = {
+				type: "tool_result",
+				tool_use_id: "123",
+				content: "Error message",
+				is_error: true,
+			} as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("[Tool (Error)]\nError message")
+		})
+
+		it("should format tool_result blocks with array content", () => {
+			const block = {
+				type: "tool_result",
+				tool_use_id: "123",
+				content: [
+					{ type: "text", text: "Line 1" },
+					{ type: "text", text: "Line 2" },
+				],
+			} as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("[Tool]\nLine 1\nLine 2")
+		})
+
+		it("should format reasoning blocks", () => {
+			const block = { type: "reasoning", text: "Let me think about this..." } as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("[Reasoning]\nLet me think about this...")
+		})
+
+		it("should skip thoughtSignature blocks", () => {
+			const block = { type: "thoughtSignature" } as ExtendedContentBlock
+			expect(formatContentBlockToMarkdown(block)).toBe("")
+		})
+
+		it("should handle unexpected content types", () => {
+			const block = { type: "unknown_type" as const } as any
+			expect(formatContentBlockToMarkdown(block)).toBe("[Unexpected content type: unknown_type]")
+		})
+	})
+})

--- a/src/integrations/misc/export-markdown.ts
+++ b/src/integrations/misc/export-markdown.ts
@@ -9,7 +9,11 @@ interface ReasoningBlock {
 	text: string
 }
 
-type ExtendedContentBlock = Anthropic.Messages.ContentBlockParam | ReasoningBlock
+interface ThoughtSignatureBlock {
+	type: "thoughtSignature"
+}
+
+export type ExtendedContentBlock = Anthropic.Messages.ContentBlockParam | ReasoningBlock | ThoughtSignatureBlock
 
 export function getTaskFileName(dateTs: number): string {
 	const date = new Date(dateTs)
@@ -98,6 +102,9 @@ export function formatContentBlockToMarkdown(block: ExtendedContentBlock): strin
 		}
 		case "reasoning":
 			return `[Reasoning]\n${block.text}`
+		case "thoughtSignature":
+			// Not relevant for human-readable exports
+			return ""
 		default:
 			return `[Unexpected content type: ${block.type}]`
 	}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #10199

### Description

This PR fixes the issue where exporting tasks from models that use thought signatures (like Gemini 3) would display `[Unexpected content type: thoughtSignature]` in the exported markdown file.

**Changes:**

1. Added a case for `thoughtSignature` in the `formatContentBlockToMarkdown` switch statement that returns an empty string
2. Created comprehensive tests in `src/integrations/misc/__tests__/export-markdown.spec.ts` to verify the fix

### Test Procedure

1. Use a model like Gemini 3 that generates thought signatures (e.g., `gemini-3-flash-preview`)
2. Complete a task that includes multiple tool uses
3. Export the task to markdown
4. Verify that the exported markdown does NOT contain `[Unexpected content type: thoughtSignature]`
5. Verify that the exported markdown contains all expected content (user messages, assistant responses, tool uses, tool results)

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

No UI changes - this is a bug fix for the markdown export functionality.

### Documentation Updates

- [x] No documentation updates are required.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Skip `thoughtSignature` blocks during markdown export to prevent unexpected content type errors.
> 
>   - **Behavior**:
>     - `formatContentBlockToMarkdown` in `export-markdown.ts` now skips `thoughtSignature` blocks, returning an empty string.
>     - Previously, these blocks caused `[Unexpected content type: thoughtSignature]` in markdown exports.
>   - **Tests**:
>     - Added test for `thoughtSignature` block handling in `export-markdown.spec.ts`.
>     - Comprehensive tests for other block types in `export-markdown.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 44ae315ab3b2628258164a70234cf91f49520b84. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->