### PR TITLE
Add temperature=0.9 and top_p=0.95 to zai-glm-4.7 model

### DIFF
--- a/.changeset/glm-47-temperature.md
+++ b/.changeset/glm-47-temperature.md
@@ -1,5 +1,0 @@
----
-"roo-cline": patch
----
-
-Set default temperature to 1.0 for Cerebras zai-glm-4.7 model


### PR DESCRIPTION
Added supportsTemperature: true, defaultTemperature: 0.9 to zai-glm-4.7 model + changeset

Similar to packages/types/src/providers/moonshot.ts:

```typescript
supportsTemperature: true, // Default temperature: 1.0
preserveReasoning: true,
defaultTemperature: 1.0,
```
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add temperature support with default 1.0 to `zai-glm-4.7` model in `cerebras.ts`.
> 
>   - **Behavior**:
>     - Adds `supportsTemperature: true` and `defaultTemperature: 1.0` to `zai-glm-4.7` model in `cerebras.ts`.
>   - **Documentation**:
>     - Adds `.changeset/glm-47-temperature.md` to document the default temperature setting for `zai-glm-4.7`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for b2dba307b3f70e492ce328c7a5199e7ceba4de3c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->