### PR TITLE
feat: add pnpm serve command for code-server development

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"clean": "turbo clean --log-order grouped --output-logs new-only && rimraf dist out bin .vite-port .turbo",
 		"install:vsix": "pnpm install --frozen-lockfile && pnpm clean && pnpm vsix && node scripts/install-vsix.js",
 		"install:vsix:nightly": "pnpm install --frozen-lockfile && pnpm clean && pnpm vsix:nightly && node scripts/install-vsix.js --nightly",
-		"code-server:install": "node scripts/serve.js",
+		"code-server:install": "node scripts/code-server.js",
 		"changeset:version": "cp CHANGELOG.md src/CHANGELOG.md && changeset version && cp -vf src/CHANGELOG.md .",
 		"knip": "knip --include files",
 		"evals": "dotenvx run -f packages/evals/.env.development packages/evals/.env.local -- docker compose -f packages/evals/docker-compose.yml --profile server --profile runner up --build --scale runner=0",

--- a/scripts/code-server.js
+++ b/scripts/code-server.js
@@ -23,7 +23,7 @@ const RED = "\x1b[31m"
 const VSIX_PATH = path.join(os.tmpdir(), "roo-code-serve.vsix")
 
 function log(message) {
-	console.log(`${CYAN}[serve]${RESET} ${message}`)
+	console.log(`${CYAN}[code-server]${RESET} ${message}`)
 }
 
 function logSuccess(message) {


### PR DESCRIPTION
## Summary

This adds a new `pnpm serve` command that builds and serves the Roo Code extension via code-server for web-based VS Code testing.

## What it does

1. Checks if code-server is installed (provides install instructions if not)
2. Builds the extension as a vsix to a temp directory (`$TMPDIR/roo-code-serve.vsix`)
3. Installs the vsix into code-server
4. Configures user settings:
   - Disables welcome tab (`workbench.startupEditor: none`)
   - Hides secondary sidebar (`workbench.auxiliaryBar.visible: false`)
   - Disables extension recommendations (`extensions.ignoreRecommendations: true`)
5. Launches code-server with flags:
   - `--disable-workspace-trust`: Auto-trusts the workspace
   - `--disable-getting-started-override`: Disables getting started overlay
   - `-e`: Ignores last opened directory

## New Commands

- **`pnpm serve`** - Build, install, and start code-server
- **`pnpm serve:rebuild`** - Only rebuild and reinstall the extension (for when code-server is already running)

## Prerequisites

```bash
brew install code-server
```

## Usage

```bash
# Start code-server with the extension
pnpm serve

# In another terminal, rebuild after making changes
pnpm serve:rebuild
# Then reload the code-server window (Cmd+Shift+P → Developer: Reload Window)
```

Then open http://127.0.0.1:8080 in your browser.
Password is stored in `~/.config/code-server/config.yaml`

## Why

This enables testing the extension in a web-based VS Code environment, which is useful for:
- Testing web-specific behavior
- Cross-browser testing
- Remote development scenarios