### PR TITLE
chore: remove POWER_STEERING experiment remnants

### DIFF
--- a/packages/types/src/experiment.ts
+++ b/packages/types/src/experiment.ts
@@ -7,7 +7,6 @@ import type { Keys, Equals, AssertEqual } from "./type-fu.js"
  */
 
 export const experimentIds = [
-	"powerSteering",
 	"preventFocusDisruption",
 	"imageGeneration",
 	"runSlashCommand",
@@ -24,7 +23,6 @@ export type ExperimentId = z.infer<typeof experimentIdsSchema>
  */
 
 export const experimentsSchema = z.object({
-	powerSteering: z.boolean().optional(),
 	preventFocusDisruption: z.boolean().optional(),
 	imageGeneration: z.boolean().optional(),
 	runSlashCommand: z.boolean().optional(),

--- a/src/shared/__tests__/experiments.spec.ts
+++ b/src/shared/__tests__/experiments.spec.ts
@@ -5,50 +5,47 @@ import type { ExperimentId } from "@roo-code/types"
 import { EXPERIMENT_IDS, experimentConfigsMap, experiments as Experiments } from "../experiments"
 
 describe("experiments", () => {
-	describe("POWER_STEERING", () => {
+	describe("PREVENT_FOCUS_DISRUPTION", () => {
 		it("is configured correctly", () => {
-			expect(EXPERIMENT_IDS.POWER_STEERING).toBe("powerSteering")
-			expect(experimentConfigsMap.POWER_STEERING).toMatchObject({
+			expect(EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION).toBe("preventFocusDisruption")
+			expect(experimentConfigsMap.PREVENT_FOCUS_DISRUPTION).toMatchObject({
 				enabled: false,
 			})
 		})
 	})
 
 	describe("isEnabled", () => {
-		it("returns false when POWER_STEERING experiment is not enabled", () => {
+		it("returns false when experiment is not enabled", () => {
 			const experiments: Record<ExperimentId, boolean> = {
-				powerSteering: false,
 				preventFocusDisruption: false,
 				imageGeneration: false,
 				runSlashCommand: false,
 				multipleNativeToolCalls: false,
 				customTools: false,
 			}
-			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.POWER_STEERING)).toBe(false)
+			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION)).toBe(false)
 		})
 
-		it("returns true when experiment POWER_STEERING is enabled", () => {
+		it("returns true when experiment is enabled", () => {
 			const experiments: Record<ExperimentId, boolean> = {
-				powerSteering: true,
-				preventFocusDisruption: false,
+				preventFocusDisruption: true,
 				imageGeneration: false,
 				runSlashCommand: false,
 				multipleNativeToolCalls: false,
 				customTools: false,
 			}
-			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.POWER_STEERING)).toBe(true)
+			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION)).toBe(true)
 		})
 
 		it("returns false when experiment is not present", () => {
 			const experiments: Record<ExperimentId, boolean> = {
-				powerSteering: false,
 				preventFocusDisruption: false,
 				imageGeneration: false,
 				runSlashCommand: false,
 				multipleNativeToolCalls: false,
 				customTools: false,
 			}
-			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.POWER_STEERING)).toBe(false)
+			expect(Experiments.isEnabled(experiments, EXPERIMENT_IDS.PREVENT_FOCUS_DISRUPTION)).toBe(false)
 		})
 	})
 })

--- a/src/shared/experiments.ts
+++ b/src/shared/experiments.ts
@@ -1,7 +1,6 @@
 import type { AssertEqual, Equals, Keys, Values, ExperimentId, Experiments } from "@roo-code/types"
 
 export const EXPERIMENT_IDS = {
-	POWER_STEERING: "powerSteering",
 	PREVENT_FOCUS_DISRUPTION: "preventFocusDisruption",
 	IMAGE_GENERATION: "imageGeneration",
 	RUN_SLASH_COMMAND: "runSlashCommand",
@@ -18,7 +17,6 @@ interface ExperimentConfig {
 }
 
 export const experimentConfigsMap: Record<ExperimentKey, ExperimentConfig> = {
-	POWER_STEERING: { enabled: false },
 	PREVENT_FOCUS_DISRUPTION: { enabled: false },
 	IMAGE_GENERATION: { enabled: false },
 	RUN_SLASH_COMMAND: { enabled: false },

--- a/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
+++ b/webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx
@@ -233,10 +233,6 @@ describe("mergeExtensionState", () => {
 			...baseState,
 			apiConfiguration: { modelMaxThinkingTokens: 456, modelTemperature: 0.3 },
 			experiments: {
-				powerSteering: true,
-				marketplace: false,
-				disableCompletionCommand: false,
-				concurrentFileReads: true,
 				preventFocusDisruption: false,
 				imageGeneration: false,
 				runSlashCommand: false,
@@ -254,10 +250,6 @@ describe("mergeExtensionState", () => {
 		})
 
 		expect(result.experiments).toEqual({
-			powerSteering: true,
-			marketplace: false,
-			disableCompletionCommand: false,
-			concurrentFileReads: true,
 			preventFocusDisruption: false,
 			imageGeneration: false,
 			runSlashCommand: false,


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/RooCodeInc/Roo-Code/pull/10926 - removes leftover `POWER_STEERING` references that were missed during the original feature removal.

The UI was displaying raw translation keys (`experimental.POWER_STEERING.name`) because the experiment config still existed but the translations had been removed.

## Changes

- Remove `powerSteering` from `packages/types/src/experiment.ts` (experimentIds array and experimentsSchema)
- Remove `POWER_STEERING` from `src/shared/experiments.ts` (EXPERIMENT_IDS and experimentConfigsMap)
- Update `src/shared/__tests__/experiments.spec.ts` to use `PREVENT_FOCUS_DISRUPTION` instead of `POWER_STEERING`
- Clean up stale experiment IDs from `webview-ui/src/context/__tests__/ExtensionStateContext.spec.tsx` test mocks

## Testing

- ✅ `experiments.spec.ts` tests pass (4/4)
- ✅ `ExtensionStateContext.spec.tsx` tests pass (9/9)
- ✅ Types package builds successfully