### PR TITLE
feat: new_task tool creates checkpoint the same way write_to_file does

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -862,6 +862,7 @@ export async function presentAssistantMessage(cline: Task) {
 					})
 					break
 				case "new_task":
+					await checkpointSaveAndMark(cline)
 					await newTaskTool.handle(cline, block as ToolUse<"new_task">, {
 						askApproval,
 						handleError,

--- a/src/core/tools/NewTaskTool.ts
+++ b/src/core/tools/NewTaskTool.ts
@@ -109,12 +109,6 @@ export class NewTaskTool extends BaseTool<"new_task"> {
 				return
 			}
 
-			// Provider is guaranteed to be defined here due to earlier check.
-
-			if (task.enableCheckpoints) {
-				task.checkpointSave(true)
-			}
-
 			// Delegate parent and open child as sole active task
 			const child = await (provider as any).delegateParentAndOpenChild({
 				parentTaskId: task.taskId,


### PR DESCRIPTION
## Summary

The `new_task` tool now creates a checkpoint using the same pattern as `write_to_file` and other file-modifying tools.

## Changes

1. Added `checkpointSaveAndMark(cline)` call before `newTaskTool.handle()` in `presentAssistantMessage.ts`
2. Removed redundant checkpoint logic from inside `NewTaskTool.ts`

This ensures consistent checkpoint behavior across all tools that modify state.

## Linear Issue

https://linear.app/roocode/issue/EXT-631/new-task-tool-should-create-checkpoint-the-same-way-write-to-file-does