### PR TITLE
fix: VS Code LM token counting returns 0 outside requests, breaking context condensing (EXT-620)

### DIFF
--- a/src/api/providers/vscode-lm.ts
+++ b/src/api/providers/vscode-lm.ts
@@ -229,15 +229,21 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			return 0
 		}
 
-		if (!this.currentRequestCancellation) {
-			console.warn("Roo Code <Language Model API>: No cancellation token available for token counting")
-			return 0
-		}
-
 		// Validate input
 		if (!text) {
 			console.debug("Roo Code <Language Model API>: Empty text provided for token counting")
 			return 0
+		}
+
+		// Create a temporary cancellation token if we don't have one (e.g., when called outside a request)
+		let cancellationToken: vscode.CancellationToken
+		let tempCancellation: vscode.CancellationTokenSource | null = null
+
+		if (this.currentRequestCancellation) {
+			cancellationToken = this.currentRequestCancellation.token
+		} else {
+			tempCancellation = new vscode.CancellationTokenSource()
+			cancellationToken = tempCancellation.token
 		}
 
 		try {
@@ -245,7 +251,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			let tokenCount: number
 
 			if (typeof text === "string") {
-				tokenCount = await this.client.countTokens(text, this.currentRequestCancellation.token)
+				tokenCount = await this.client.countTokens(text, cancellationToken)
 			} else if (text instanceof vscode.LanguageModelChatMessage) {
 				// For chat messages, ensure we have content
 				if (!text.content || (Array.isArray(text.content) && text.content.length === 0)) {
@@ -253,7 +259,7 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 					return 0
 				}
 				const countMessage = extractTextCountFromMessage(text)
-				tokenCount = await this.client.countTokens(countMessage, this.currentRequestCancellation.token)
+				tokenCount = await this.client.countTokens(countMessage, cancellationToken)
 			} else {
 				console.warn("Roo Code <Language Model API>: Invalid input type for token counting")
 				return 0
@@ -287,6 +293,11 @@ export class VsCodeLmHandler extends BaseProvider implements SingleCompletionHan
 			}
 
 			return 0 // Fallback to prevent stream interruption
+		} finally {
+			// Clean up temporary cancellation token
+			if (tempCancellation) {
+				tempCancellation.dispose()
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem
VS Code LM API users (GitHub Copilot) experience context overflow errors because automatic condensing fails silently. The VsCodeLmHandler.internalCountTokens() method returns 0 when called outside of active requests, causing manageContext() to think context is empty and skip condensing.

## Root Cause
- internalCountTokens() requires this.currentRequestCancellation to exist
- This token is only created during createMessage() and cleared after each request completes
- Context condensing happens BETWEEN requests when checking if thresholds are exceeded
- When manageContext() tries to count tokens via apiHandler.countTokens(), there's no active request
- Token counting returns 0 → manageContext() skips condensing → context grows unchecked → 413 error

## Solution
Modified internalCountTokens() to create a temporary CancellationTokenSource when needed:
- If currentRequestCancellation exists → use it (during active requests)
- If not → create temporary token (between requests for condensing)
- Proper cleanup in finally block to dispose temporary tokens

## Changes
- src/api/providers/vscode-lm.ts: Modified internalCountTokens() to handle missing cancellation tokens
- src/api/providers/__tests__/vscode-lm.spec.ts: Added 4 new tests to verify the fix

## Test Results
✅ All 19 tests pass (15 original + 4 new)

## Resolves
- Fixes https://linear.app/roocode/issue/EXT-620
- Closes #10968