### PR TITLE
fix: record truncation event when condensation fails but truncation succeeds

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -4012,7 +4012,8 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				}
 				if (truncateResult.error) {
 					await this.say("condense_context_error", truncateResult.error)
-				} else if (truncateResult.summary) {
+				}
+				if (truncateResult.summary) {
 					const { summary, cost, prevContextTokens, newContextTokens = 0, condenseId } = truncateResult
 					const contextCondense: ContextCondense = {
 						summary,


### PR DESCRIPTION
## Summary

Fixes a bug where the `else if` chain in `attemptApiRequest()` prevented both error AND truncation events from being recorded when context condensation fails but sliding window truncation succeeds as a fallback.

## Problem

When `manageContext()` returns both:
- `error`: The error message explaining why condensation failed
- `truncationId`: The ID of the truncation that happened as fallback

Only the error was shown because of the `else if` chain. This meant the `sliding_window_truncation` clineMessage was never created.

## Impact

Since `MessageManager.collectRemovedContextEventIds()` looks for `sliding_window_truncation` clineMessages to find truncation IDs for cleanup:
- Rewind couldn't find the truncation ID
- Messages tagged with `truncationParent` stayed hidden forever
- Users couldn't recover their conversation context by rewinding

## Fix

Changed `else if` to separate `if` statements so both events can be recorded:
```typescript
// Before (bug):
if (truncateResult.error) {
    await this.say("condense_context_error", truncateResult.error)
} else if (truncateResult.summary) {  // <-- blocks truncation when error exists
    ...
} else if (truncateResult.truncationId) {
    ...
}

// After (fix):
if (truncateResult.error) {
    await this.say("condense_context_error", truncateResult.error)
}
if (truncateResult.summary) {  // <-- independent check
    ...
} else if (truncateResult.truncationId) {
    ...
}
```

## Testing

All 158 related tests pass:
- 55 context-management tests ✓
- 26 message-manager tests ✓
- 77 condense tests ✓