### PR TITLE
fix: prevent nested condensing from including previously-condensed content

### DIFF
--- a/src/core/condense/__tests__/condense.spec.ts
+++ b/src/core/condense/__tests__/condense.spec.ts
@@ -250,7 +250,7 @@ Line 2
 		it("should not summarize messages that already contain a recent summary with no new messages", async () => {
 			const messages: ApiMessage[] = [
 				{ role: "user", content: "First message with /command" },
-				{ role: "assistant", content: "Previous summary", isSummary: true },
+				{ role: "user", content: "Previous summary", isSummary: true },
 			]
 
 			const result = await summarizeConversation(messages, mockApiHandler, "System prompt", taskId, false)
@@ -412,21 +412,6 @@ Line 2
 			expect(result[0]).toEqual(messages[3]) // Second summary
 			expect(result[1]).toEqual(messages[4])
 			expect(result[2]).toEqual(messages[5])
-		})
-
-		it("should prepend first user message when summary starts with assistant", () => {
-			const messages: ApiMessage[] = [
-				{ role: "user", content: "Original first message" },
-				{ role: "assistant", content: "Summary content", isSummary: true },
-				{ role: "user", content: "After summary" },
-			]
-
-			const result = getMessagesSinceLastSummary(messages)
-
-			// Should prepend original first message for Bedrock compatibility
-			expect(result[0]).toEqual(messages[0]) // Original first user message
-			expect(result[1]).toEqual(messages[1]) // The summary
-			expect(result[2]).toEqual(messages[2])
 		})
 	})
 })

--- a/src/core/condense/__tests__/index.spec.ts
+++ b/src/core/condense/__tests__/index.spec.ts
@@ -252,38 +252,36 @@ describe("getMessagesSinceLastSummary", () => {
 		expect(result).toEqual(messages)
 	})
 
-	it("should return messages since the last summary (preserves original first user message when needed)", () => {
+	it("should return messages since the last summary", () => {
 		const messages: ApiMessage[] = [
 			{ role: "user", content: "Hello", ts: 1 },
 			{ role: "assistant", content: "Hi there", ts: 2 },
-			{ role: "assistant", content: "Summary of conversation", ts: 3, isSummary: true },
-			{ role: "user", content: "How are you?", ts: 4 },
-			{ role: "assistant", content: "I'm good", ts: 5 },
+			{ role: "user", content: "Summary of conversation", ts: 3, isSummary: true },
+			{ role: "assistant", content: "How are you?", ts: 4 },
+			{ role: "user", content: "I'm good", ts: 5 },
 		]
 
 		const result = getMessagesSinceLastSummary(messages)
 		expect(result).toEqual([
-			{ role: "user", content: "Hello", ts: 1 },
-			{ role: "assistant", content: "Summary of conversation", ts: 3, isSummary: true },
-			{ role: "user", content: "How are you?", ts: 4 },
-			{ role: "assistant", content: "I'm good", ts: 5 },
+			{ role: "user", content: "Summary of conversation", ts: 3, isSummary: true },
+			{ role: "assistant", content: "How are you?", ts: 4 },
+			{ role: "user", content: "I'm good", ts: 5 },
 		])
 	})
 
 	it("should handle multiple summary messages and return since the last one", () => {
 		const messages: ApiMessage[] = [
 			{ role: "user", content: "Hello", ts: 1 },
-			{ role: "assistant", content: "First summary", ts: 2, isSummary: true },
-			{ role: "user", content: "How are you?", ts: 3 },
-			{ role: "assistant", content: "Second summary", ts: 4, isSummary: true },
-			{ role: "user", content: "What's new?", ts: 5 },
+			{ role: "user", content: "First summary", ts: 2, isSummary: true },
+			{ role: "assistant", content: "How are you?", ts: 3 },
+			{ role: "user", content: "Second summary", ts: 4, isSummary: true },
+			{ role: "assistant", content: "What's new?", ts: 5 },
 		]
 
 		const result = getMessagesSinceLastSummary(messages)
 		expect(result).toEqual([
-			{ role: "user", content: "Hello", ts: 1 },
-			{ role: "assistant", content: "Second summary", ts: 4, isSummary: true },
-			{ role: "user", content: "What's new?", ts: 5 },
+			{ role: "user", content: "Second summary", ts: 4, isSummary: true },
+			{ role: "assistant", content: "What's new?", ts: 5 },
 		])
 	})
 

--- a/src/core/context-management/__tests__/context-management.spec.ts
+++ b/src/core/context-management/__tests__/context-management.spec.ts
@@ -578,8 +578,8 @@ describe("Context Management", () => {
 			const mockSummarizeResponse: condenseModule.SummarizeResponse = {
 				messages: [
 					{ role: "user", content: "First message" },
-					{ role: "assistant", content: mockSummary, isSummary: true },
-					{ role: "user", content: "Last message" },
+					{ role: "user", content: mockSummary, isSummary: true },
+					{ role: "assistant", content: "Last message" },
 				],
 				summary: mockSummary,
 				cost: mockCost,
@@ -751,8 +751,8 @@ describe("Context Management", () => {
 			const mockSummarizeResponse: condenseModule.SummarizeResponse = {
 				messages: [
 					{ role: "user", content: "First message" },
-					{ role: "assistant", content: mockSummary, isSummary: true },
-					{ role: "user", content: "Last message" },
+					{ role: "user", content: mockSummary, isSummary: true },
+					{ role: "assistant", content: "Last message" },
 				],
 				summary: mockSummary,
 				cost: mockCost,
@@ -899,8 +899,8 @@ describe("Context Management", () => {
 			const mockSummarizeResponse: condenseModule.SummarizeResponse = {
 				messages: [
 					{ role: "user", content: "First message" },
-					{ role: "assistant", content: mockSummary, isSummary: true },
-					{ role: "user", content: "Last message" },
+					{ role: "user", content: mockSummary, isSummary: true },
+					{ role: "assistant", content: "Last message" },
 				],
 				summary: mockSummary,
 				cost: mockCost,
@@ -965,8 +965,8 @@ describe("Context Management", () => {
 			const mockSummarizeResponse: condenseModule.SummarizeResponse = {
 				messages: [
 					{ role: "user", content: "First message" },
-					{ role: "assistant", content: mockSummary, isSummary: true },
-					{ role: "user", content: "Last message" },
+					{ role: "user", content: mockSummary, isSummary: true },
+					{ role: "assistant", content: "Last message" },
 				],
 				summary: mockSummary,
 				cost: mockCost,

--- a/src/core/webview/__tests__/webviewMessageHandler.delete.spec.ts
+++ b/src/core/webview/__tests__/webviewMessageHandler.delete.spec.ts
@@ -267,7 +267,7 @@ describe("webviewMessageHandler delete functionality", () => {
 					{ ts: 100, role: "user", content: "First message", condenseParent: condenseId },
 					{ ts: 200, role: "assistant", content: "Response 1", condenseParent: condenseId },
 					{ ts: 300, role: "user", content: "Second message", condenseParent: condenseId },
-					{ ts: 799, role: "assistant", content: "Summary", isSummary: true, condenseId },
+					{ ts: 799, role: "user", content: "Summary", isSummary: true, condenseId },
 					{ ts: 800, role: "assistant", content: "Kept message 1" },
 					{ ts: 900, role: "user", content: "Kept message 2" },
 					{ ts: 1000, role: "assistant", content: "Kept message 3" },
@@ -314,8 +314,8 @@ describe("webviewMessageHandler delete functionality", () => {
 					{ ts: 100, role: "user", content: "Task start", condenseParent: condenseId },
 					{ ts: 200, role: "assistant", content: "Response 1", condenseParent: condenseId },
 					{ ts: 300, role: "user", content: "Message 2", condenseParent: condenseId },
-					{ ts: 999, role: "assistant", content: "Summary", isSummary: true, condenseId },
-					{ ts: 1000, role: "user", content: "First kept" },
+					{ ts: 999, role: "user", content: "Summary", isSummary: true, condenseId },
+					{ ts: 1000, role: "assistant", content: "First kept" },
 				]
 
 				// Delete "Message 2" (ts=300) - this removes summary too, so orphaned tags should be cleared
@@ -357,7 +357,7 @@ describe("webviewMessageHandler delete functionality", () => {
 					// First summary - ALSO tagged with condenseId2 from second condense
 					{
 						ts: 799,
-						role: "assistant",
+						role: "user",
 						content: "Summary1",
 						isSummary: true,
 						condenseId: condenseId1,
@@ -367,7 +367,7 @@ describe("webviewMessageHandler delete functionality", () => {
 					{ ts: 1000, role: "assistant", content: "Msg after summary1", condenseParent: condenseId2 },
 					{ ts: 1100, role: "user", content: "More msgs", condenseParent: condenseId2 },
 					// Second summary
-					{ ts: 1799, role: "assistant", content: "Summary2", isSummary: true, condenseId: condenseId2 },
+					{ ts: 1799, role: "user", content: "Summary2", isSummary: true, condenseId: condenseId2 },
 					// Kept messages
 					{ ts: 1800, role: "user", content: "Kept1" },
 					{ ts: 1900, role: "assistant", content: "Kept2" },
@@ -407,9 +407,9 @@ describe("webviewMessageHandler delete functionality", () => {
 				// Summary and regular message share timestamp (edge case)
 				getCurrentTaskMock.apiConversationHistory = [
 					{ ts: 900, role: "user", content: "Previous message" },
-					{ ts: sharedTs, role: "assistant", content: "Summary", isSummary: true, condenseId: "abc" },
-					{ ts: sharedTs, role: "user", content: "First kept message" },
-					{ ts: 1100, role: "assistant", content: "Response" },
+					{ ts: sharedTs, role: "user", content: "Summary", isSummary: true, condenseId: "abc" },
+					{ ts: sharedTs, role: "assistant", content: "First kept message" },
+					{ ts: 1100, role: "user", content: "Response" },
 				]
 
 				// Delete at shared timestamp - MessageManager uses ts < cutoffTs, so ALL
@@ -450,10 +450,10 @@ describe("webviewMessageHandler delete functionality", () => {
 					{ ts: 100, role: "user", content: "Task start", condenseParent: condenseId },
 					{ ts: 200, role: "assistant", content: "Response 1", condenseParent: condenseId },
 					// Summary timestamp is BEFORE the kept messages (this is the bug scenario)
-					{ ts: 299, role: "assistant", content: "Summary text", isSummary: true, condenseId },
-					{ ts: 300, role: "user", content: "Message to delete this and after" },
-					{ ts: 400, role: "assistant", content: "Response 2" },
-					{ ts: 600, role: "user", content: "Post-condense message" },
+					{ ts: 299, role: "user", content: "Summary text", isSummary: true, condenseId },
+					{ ts: 300, role: "assistant", content: "Message to delete this and after" },
+					{ ts: 400, role: "user", content: "Response 2" },
+					{ ts: 600, role: "assistant", content: "Post-condense message" },
 				]
 
 				// Delete at ts=300 - this removes condense_context (ts=500), so Summary should be removed too
@@ -510,30 +510,30 @@ describe("webviewMessageHandler delete functionality", () => {
 					// First summary (also tagged with condenseId2 from second condense)
 					{
 						ts: 799,
-						role: "assistant",
+						role: "user",
 						content: "First summary",
 						isSummary: true,
 						condenseId: condenseId1,
 						condenseParent: condenseId2,
 					},
-					{ ts: 900, role: "user", content: "After first condense", condenseParent: condenseId2 },
+					{ ts: 900, role: "assistant", content: "After first condense", condenseParent: condenseId2 },
 					{
 						ts: 1000,
-						role: "assistant",
+						role: "user",
 						content: "Response after 1st condense",
 						condenseParent: condenseId2,
 					},
-					{ ts: 1100, role: "user", content: "Message to delete this and after" },
+					{ ts: 1100, role: "assistant", content: "Message to delete this and after" },
 					// Second summary (timestamp is BEFORE the messages it summarized for sort purposes)
 					{
 						ts: 1799,
-						role: "assistant",
+						role: "user",
 						content: "Second summary",
 						isSummary: true,
 						condenseId: condenseId2,
 					},
-					{ ts: 1900, role: "user", content: "Post second condense" },
-					{ ts: 2000, role: "assistant", content: "Final response" },
+					{ ts: 1900, role: "assistant", content: "Post second condense" },
+					{ ts: 2000, role: "user", content: "Final response" },
 				]
 
 				// Delete at ts=1100 - this removes second condense_context (ts=1800) but keeps first (ts=800)


### PR DESCRIPTION
## Summary

This PR prevents nested condensing from including previously-condensed content, and removes legacy Bedrock-specific code that is no longer needed since summaries are always created with `role: "user"` (fresh-start model).

## Changes

### Bug Fix: Nested Condense
- Fixed issue where `getMessagesSinceLastSummary` could return already-condensed content during nested condense operations

### Code Cleanup: Remove Legacy Bedrock Code Path
- **Simplified `getMessagesSinceLastSummary`**: Removed ~47 lines of legacy Bedrock-specific code that handled assistant-role summaries
- Summary messages are always created with `role: "user"` (see line 322 of `summarizeConversation`), so the Bedrock workaround (prepending first user message) was dead code
- Sliding window truncation also creates user-role markers, confirming no workflow depends on assistant-role summaries

### Test Updates
Updated all test files to use user-role summaries consistently:
- `nested-condense.spec.ts` - Removed entire "legacy assistant-role summaries" describe block (~150 lines)
- `condense.spec.ts` - Removed legacy Bedrock test case
- `index.spec.ts` - Updated 3 tests to use user-role summaries
- `rewind-after-condense.spec.ts` - Updated 6+ tests to use user-role summaries
- `webviewMessageHandler.delete.spec.ts` - Updated 6 API history mocks
- `context-management.spec.ts` - Updated 4 mockSummarizeResponse objects

## Test Coverage

All 137 tests pass across the affected test files:
- 89 condense-related tests
- 48 webview/context-management tests

---

*Extracted from #10942 to ship this bug fix faster while the feature PR continues review.*