### PR TITLE
fix: remove duplicate tool_call emission from Responses API providers

### DIFF
--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -1241,24 +1241,12 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 					}
 				}
 
-				// Only handle tool/function calls from done events (to ensure arguments are complete)
-				if (
-					(item.type === "function_call" || item.type === "tool_call") &&
-					event.type === "response.output_item.done"
-				) {
-					// Handle complete tool/function call item
-					// Emit as tool_call for backward compatibility with non-streaming tool handling
-					const callId = item.call_id || item.tool_call_id || item.id
-					if (callId) {
-						const args = item.arguments || item.function?.arguments || item.function_arguments
-						yield {
-							type: "tool_call",
-							id: callId,
-							name: item.name || item.function?.name || item.function_name || "",
-							arguments: typeof args === "string" ? args : "{}",
-						}
-					}
-				}
+				// Note: We intentionally do NOT emit tool_call from response.output_item.done
+				// for function_call/tool_call items. The streaming path handles tool calls via:
+				// 1. tool_call_partial events during argument deltas
+				// 2. NativeToolCallParser.finalizeRawChunks() at stream end emitting tool_call_end
+				// 3. NativeToolCallParser.finalizeStreamingToolCall() creating the final ToolUse
+				// Emitting tool_call here would cause duplicate tool rendering.
 			}
 			return
 		}


### PR DESCRIPTION
## Summary

Fixed duplicate tool rendering in the OpenAI Responses API providers (`openai-native.ts` and `openai-codex.ts`).

## Problem

Tools were being rendered twice because both providers were emitting tool calls through two separate code paths:

1. **Streaming path**: `tool_call_partial` events during `response.tool_call_arguments.delta` → processed by `NativeToolCallParser` → `finalizeRawChunks()` at stream end emits `tool_call_end` → `finalizeStreamingToolCall()` creates the final ToolUse
2. **Done event path**: `response.output_item.done` with function_call/tool_call item → emitted a complete `tool_call` event → processed separately by Task.ts

Both paths resulted in the same tool being rendered, causing duplication.

## Solution

Removed the `tool_call` emission from the `response.output_item.done` handler in both providers. The streaming path already handles tool call completion correctly through `NativeToolCallParser`.

## Testing

- All 79 related tests pass (65 openai-native + 7 openai-codex + 7 NativeToolCallParser)

## Affected Providers

- `openai-native.ts` - ✅ Fixed
- `openai-codex.ts` - ✅ Fixed
- `openai.ts` (Chat Completions API) - Not affected (uses different event pattern)