### PR TITLE
fix: use relative paths in isPathInIgnoredDirectory to fix worktree indexing

### DIFF
--- a/src/services/code-index/processors/file-watcher.ts
+++ b/src/services/code-index/processors/file-watcher.ts
@@ -508,8 +508,12 @@ export class FileWatcher implements IFileWatcher {
 	 */
 	async processFile(filePath: string): Promise<FileProcessingResult> {
 		try {
+			// Get relative path for ignore checks
+			const relativeFilePath = generateRelativeFilePath(filePath, this.workspacePath)
+
 			// Check if file is in an ignored directory
-			if (isPathInIgnoredDirectory(filePath)) {
+			// Use relative path to avoid matching parent directories outside the workspace
+			if (isPathInIgnoredDirectory(relativeFilePath)) {
 				return {
 					path: filePath,
 					status: "skipped" as const,
@@ -518,7 +522,6 @@ export class FileWatcher implements IFileWatcher {
 			}
 
 			// Check if file should be ignored
-			const relativeFilePath = generateRelativeFilePath(filePath, this.workspacePath)
 			if (
 				!this.ignoreController.validateAccess(filePath) ||
 				(this.ignoreInstance && this.ignoreInstance.ignores(relativeFilePath))

--- a/src/services/code-index/processors/scanner.ts
+++ b/src/services/code-index/processors/scanner.ts
@@ -96,7 +96,8 @@ export class DirectoryScanner implements IDirectoryScanner {
 			const relativeFilePath = generateRelativeFilePath(filePath, scanWorkspace)
 
 			// Check if file is in an ignored directory using the shared helper
-			if (isPathInIgnoredDirectory(filePath)) {
+			// Use relative path to avoid matching parent directories outside the workspace
+			if (isPathInIgnoredDirectory(relativeFilePath)) {
 				return false
 			}
 


### PR DESCRIPTION
## Summary

Fixes codebase indexing for worktrees located in hidden directories (e.g., `~/.roo/worktrees/`).

## Problem

Files in worktrees at `~/.roo/worktrees/` were not being indexed because `isPathInIgnoredDirectory()` was checking absolute paths. This caused parent directories like `.roo` to trigger the `".*"` ignore pattern in `DIRS_TO_IGNORE`.

## Solution

Changed `scanner.ts` and `file-watcher.ts` to pass **relative paths** (relative to workspace root) to `isPathInIgnoredDirectory()` instead of absolute paths. This ensures only directories **within** the workspace are checked for ignore patterns.

## Changes

- `src/services/code-index/processors/scanner.ts` - Use `relativeFilePath` instead of `filePath`
- `src/services/code-index/processors/file-watcher.ts` - Calculate relative path before ignore check

## Testing

- All 5158 existing tests pass
- No side effects on normal project behavior - hidden directories within the workspace are still correctly ignored

## Linear Issue

EXT-637