### PR TITLE
fix: prevent time-travel bug in parallel tool calling

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -356,6 +356,20 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	userMessageContentReady = false
 
 	/**
+	 * Flag indicating whether the assistant message for the current streaming session
+	 * has been saved to API conversation history.
+	 *
+	 * This is critical for parallel tool calling: tools should NOT execute until
+	 * the assistant message is saved. Otherwise, if a tool like `new_task` triggers
+	 * `flushPendingToolResultsToHistory()`, the user message with tool_results would
+	 * appear BEFORE the assistant message with tool_uses, causing API errors.
+	 *
+	 * Reset to `false` at the start of each API request.
+	 * Set to `true` after the assistant message is saved in `recursivelyMakeClineRequests`.
+	 */
+	assistantMessageSavedToHistory = false
+
+	/**
 	 * Push a tool_result block to userMessageContent, preventing duplicates.
 	 * Duplicate tool_use_ids cause API errors.
 	 *
@@ -1060,6 +1074,36 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 	public async flushPendingToolResultsToHistory(): Promise<void> {
 		// Only flush if there's actually pending content to save
 		if (this.userMessageContent.length === 0) {
+			return
+		}
+
+		// CRITICAL: Wait for the assistant message to be saved to API history first.
+		// Without this, tool_result blocks would appear BEFORE tool_use blocks in the
+		// conversation history, causing API errors like:
+		// "unexpected `tool_use_id` found in `tool_result` blocks"
+		//
+		// This can happen when parallel tools are called (e.g., update_todo_list + new_task).
+		// Tools execute during streaming via presentAssistantMessage, BEFORE the assistant
+		// message is saved. When new_task triggers delegation, it calls this method to
+		// flush pending results - but the assistant message hasn't been saved yet.
+		//
+		// The assistantMessageSavedToHistory flag is:
+		// - Reset to false at the start of each API request
+		// - Set to true after the assistant message is saved in recursivelyMakeClineRequests
+		if (!this.assistantMessageSavedToHistory) {
+			await pWaitFor(() => this.assistantMessageSavedToHistory || this.abort, {
+				interval: 50,
+				timeout: 30_000, // 30 second timeout as safety net
+			}).catch(() => {
+				// If timeout or abort, log and proceed anyway to avoid hanging
+				console.warn(
+					`[Task#${this.taskId}] flushPendingToolResultsToHistory: timed out waiting for assistant message to be saved`,
+				)
+			})
+		}
+
+		// If task was aborted while waiting, don't flush
+		if (this.abort) {
 			return
 		}
 
@@ -2707,6 +2751,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 				this.userMessageContentReady = false
 				this.didRejectTool = false
 				this.didAlreadyUseTool = false
+				this.assistantMessageSavedToHistory = false
 				// Reset tool failure flag for each new assistant turn - this ensures that tool failures
 				// only prevent attempt_completion within the same assistant message, not across turns
 				// (e.g., if a tool fails, then user sends a message saying "just complete anyway")
@@ -3488,6 +3533,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 						{ role: "assistant", content: assistantContent },
 						reasoningMessage || undefined,
 					)
+					this.assistantMessageSavedToHistory = true
 
 					TelemetryService.instance.captureConversationMessage(this.taskId, "assistant")
 				}

--- a/src/core/task/__tests__/flushPendingToolResultsToHistory.spec.ts
+++ b/src/core/task/__tests__/flushPendingToolResultsToHistory.spec.ts
@@ -38,8 +38,12 @@ vi.mock("fs/promises", async (importOriginal) => {
 	}
 })
 
+const { mockPWaitFor } = vi.hoisted(() => {
+	return { mockPWaitFor: vi.fn().mockImplementation(async () => Promise.resolve()) }
+})
+
 vi.mock("p-wait-for", () => ({
-	default: vi.fn().mockImplementation(async () => Promise.resolve()),
+	default: mockPWaitFor,
 }))
 
 vi.mock("vscode", () => {
@@ -343,5 +347,100 @@ describe("flushPendingToolResultsToHistory", () => {
 		// Message should have timestamp
 		expect((task.apiConversationHistory[0] as any).ts).toBeGreaterThanOrEqual(beforeTs)
 		expect((task.apiConversationHistory[0] as any).ts).toBeLessThanOrEqual(afterTs)
+	})
+
+	it("should skip waiting for assistantMessageSavedToHistory when flag is already true", async () => {
+		const task = new Task({
+			provider: mockProvider,
+			apiConfiguration: mockApiConfig,
+			task: "test task",
+			startTask: false,
+		})
+
+		// Set flag to true (assistant message already saved)
+		task.assistantMessageSavedToHistory = true
+
+		// Set up pending tool result
+		task.userMessageContent = [
+			{
+				type: "tool_result",
+				tool_use_id: "tool-skip-wait",
+				content: "Result when flag is true",
+			},
+		]
+
+		// Clear mock call history
+		mockPWaitFor.mockClear()
+
+		await task.flushPendingToolResultsToHistory()
+
+		// Should not have called pWaitFor since flag was already true
+		expect(mockPWaitFor).not.toHaveBeenCalled()
+
+		// Should still save the message
+		expect(task.apiConversationHistory.length).toBe(1)
+		expect((task.apiConversationHistory[0].content as any[])[0].tool_use_id).toBe("tool-skip-wait")
+	})
+
+	it("should wait for assistantMessageSavedToHistory when flag is false", async () => {
+		const task = new Task({
+			provider: mockProvider,
+			apiConfiguration: mockApiConfig,
+			task: "test task",
+			startTask: false,
+		})
+
+		// Flag is false by default - assistant message not yet saved
+		expect(task.assistantMessageSavedToHistory).toBe(false)
+
+		// Set up pending tool result
+		task.userMessageContent = [
+			{
+				type: "tool_result",
+				tool_use_id: "tool-wait",
+				content: "Result when flag is false",
+			},
+		]
+
+		// Clear mock call history
+		mockPWaitFor.mockClear()
+
+		await task.flushPendingToolResultsToHistory()
+
+		// Should have called pWaitFor since flag was false
+		expect(mockPWaitFor).toHaveBeenCalled()
+
+		// Should still save the message (mock resolves immediately)
+		expect(task.apiConversationHistory.length).toBe(1)
+	})
+
+	it("should not flush when task is aborted during wait", async () => {
+		const task = new Task({
+			provider: mockProvider,
+			apiConfiguration: mockApiConfig,
+			task: "test task",
+			startTask: false,
+		})
+
+		// Flag is false - will need to wait
+		task.assistantMessageSavedToHistory = false
+
+		// Set up pending tool result
+		task.userMessageContent = [
+			{
+				type: "tool_result",
+				tool_use_id: "tool-aborted",
+				content: "Should not be saved",
+			},
+		]
+
+		// Set abort flag - this will cause the condition in pWaitFor to return true
+		// AND will cause early return after the wait
+		task.abort = true
+
+		await task.flushPendingToolResultsToHistory()
+
+		// Should not have saved anything since task was aborted
+		expect(task.apiConversationHistory.length).toBe(0)
 	})
 })


### PR DESCRIPTION
## Problem

When multiple tools are called in parallel (e.g., `update_todo_list` + `new_task`), tool_results could appear in API history BEFORE their corresponding tool_use blocks, causing Anthropic API 400 errors:
```
"unexpected `tool_use_id` found in `tool_result` blocks. Each `tool_result` block must have a corresponding `tool_use` block in the previous message."
```

Example of malformed history:
```
[user msg] → [user msg with tool_results] → [assistant msg with tool_uses] ❌
```

Should be:
```
[user msg] → [assistant msg with tool_uses] → [user msg with tool_results] ✓
```

## Root Cause

Tools executed during streaming via `presentAssistantMessage()` BEFORE the assistant message was saved to history. The sequence was:

1. Stream starts, tool_use chunks arrive
2. Each tool_use is finalized (marked non-partial)
3. `presentAssistantMessage` immediately executes completed tools
4. `update_todo_list` executes → pushes tool_result to `userMessageContent`
5. `new_task` executes → calls `flushPendingToolResultsToHistory()`
6. **User message with tool_results is saved BEFORE assistant message exists in history**
7. Stream completes, assistant message finally saved at Task.ts:3475

## Solution

Added `assistantMessageSavedToHistory` coordination flag to ensure correct message ordering:

1. **Flag is reset** at the start of each API request (Task.ts:2724)
2. **Flag is set to true** after assistant message is saved to history (Task.ts:3506)
3. **`flushPendingToolResultsToHistory()` waits** for the flag before flushing (Task.ts:1074-1110)
4. This ensures: `[assistant with tool_uses] → [user with tool_results]`

Also removed the "CRITICAL: This tool MUST be called alone" restriction from `new_task` tool description to enable parallel tool calling.

## Changes

- **src/core/task/Task.ts**: Added `assistantMessageSavedToHistory` flag and waiting logic in `flushPendingToolResultsToHistory()`
- **src/core/prompts/tools/native-tools/new_task.ts**: Removed restriction preventing parallel tool calling
- **src/core/task/__tests__/flushPendingToolResultsToHistory.spec.ts**: Added tests for waiting behavior

## Testing

All 8 tests pass in the new test file, including tests verifying:
- ✓ Skips waiting when flag is already true
- ✓ Waits via pWaitFor when flag is false  
- ✓ Aborts without flushing when task is aborted during wait

All 5228 tests pass across the entire codebase.

## Related

This fix enables parallel tool calling (when the `multipleNativeToolCalls` experiment is enabled) by ensuring the assistant message is always saved to history before tool_results are flushed, preventing the time-travel bug.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes a bug in `Task.ts` by adding a coordination flag to ensure tool results are saved after assistant messages, preventing API errors.
> 
>   - **Behavior**:
>     - Added `assistantMessageSavedToHistory` flag in `Task.ts` to ensure tool results are saved after assistant messages.
>     - `flushPendingToolResultsToHistory()` now waits for the flag before proceeding.
>     - Removed restriction on `new_task` tool for parallel execution.
>   - **Testing**:
>     - Added tests in `flushPendingToolResultsToHistory.spec.ts` to verify waiting behavior and flag handling.
>     - Tests cover scenarios where the flag is true, false, and task is aborted.
>   - **Misc**:
>     - Updated logic in `Task.ts` to reset and set the flag at appropriate points in the task lifecycle.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bf7a662e032ad8da6933bca586932cbfaa21276e. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->