### PR TITLE
docs: clarify read_command_output search param should be omitted when not filtering

### DIFF
--- a/src/core/prompts/tools/native-tools/read_command_output.ts
+++ b/src/core/prompts/tools/native-tools/read_command_output.ts
@@ -20,7 +20,7 @@ The tool supports two modes:
 
 Parameters:
 - artifact_id: (required) The artifact filename from the truncated output message (e.g., "cmd-1706119234567.txt")
-- search: (optional) Pattern to filter lines. Supports regex or literal strings. Case-insensitive.
+- search: (optional) Pattern to filter lines. Supports regex or literal strings. Case-insensitive. **Omit this parameter entirely if you don't need to filter - do not pass null or empty string.**
 - offset: (optional) Byte offset to start reading from. Default: 0. Use for pagination.
 - limit: (optional) Maximum bytes to return. Default: 40KB.
 
@@ -38,7 +38,7 @@ Example: Finding specific test failures
 
 const ARTIFACT_ID_DESCRIPTION = `The artifact filename from the truncated command output (e.g., "cmd-1706119234567.txt")`
 
-const SEARCH_DESCRIPTION = `Optional regex or literal pattern to filter lines (case-insensitive, like grep)`
+const SEARCH_DESCRIPTION = `Optional regex or literal pattern to filter lines (case-insensitive, like grep). Omit this parameter if not searching - do not pass null or empty string.`
 
 const OFFSET_DESCRIPTION = `Byte offset to start reading from (default: 0, for pagination)`
 


### PR DESCRIPTION
## Summary

Adds explicit guidance to the `read_command_output` tool description telling models to omit the `search` parameter entirely when not filtering, rather than passing `null` or empty string.

This prevents models from mistakenly passing the literal string `"null"` as a search pattern, which causes the tool to search for lines containing the text "null" instead of returning all content.

## Changes

- Updated the `search` parameter description in the tool's overall description to include: "**Omit this parameter entirely if you don't need to filter - do not pass null or empty string.**"
- Updated the `SEARCH_DESCRIPTION` constant with the same guidance

## Context

Investigation found that models sometimes pass `"search": "null"` when they intend "no search filter". The tool was designed with `strict: false` specifically so models could omit optional parameters. This documentation update teaches models the correct behavior.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Clarifies `search` parameter usage in `read_command_output.ts` to omit it when not filtering.
> 
>   - **Documentation**:
>     - Updated `search` parameter description in `read_command_output.ts` to instruct omitting it if not filtering.
>     - Updated `SEARCH_DESCRIPTION` constant with the same guidance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for c2f6d009118562c646540d36177b1092b29aee84. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->