### PR TITLE
fix: sanitize tool_use_id in tool_result blocks to match API history

### DIFF
--- a/src/core/assistant-message/presentAssistantMessage.ts
+++ b/src/core/assistant-message/presentAssistantMessage.ts
@@ -40,6 +40,7 @@ import { isValidToolName, validateToolUse } from "../tools/validateToolUse"
 import { codebaseSearchTool } from "../tools/CodebaseSearchTool"
 
 import { formatResponse } from "../prompts/responses"
+import { sanitizeToolUseId } from "../../utils/tool-id"
 
 /**
  * Processes and presents assistant message content to the user interface.
@@ -118,7 +119,7 @@ export async function presentAssistantMessage(cline: Task) {
 				if (toolCallId) {
 					cline.pushToolResultToUserContent({
 						type: "tool_result",
-						tool_use_id: toolCallId,
+						tool_use_id: sanitizeToolUseId(toolCallId),
 						content: errorMessage,
 						is_error: true,
 					})
@@ -169,7 +170,7 @@ export async function presentAssistantMessage(cline: Task) {
 				if (toolCallId) {
 					cline.pushToolResultToUserContent({
 						type: "tool_result",
-						tool_use_id: toolCallId,
+						tool_use_id: sanitizeToolUseId(toolCallId),
 						content: resultContent,
 					})
 
@@ -410,7 +411,7 @@ export async function presentAssistantMessage(cline: Task) {
 
 				cline.pushToolResultToUserContent({
 					type: "tool_result",
-					tool_use_id: toolCallId,
+					tool_use_id: sanitizeToolUseId(toolCallId),
 					content: errorMessage,
 					is_error: true,
 				})
@@ -447,7 +448,7 @@ export async function presentAssistantMessage(cline: Task) {
 					// continue gracefully.
 					cline.pushToolResultToUserContent({
 						type: "tool_result",
-						tool_use_id: toolCallId,
+						tool_use_id: sanitizeToolUseId(toolCallId),
 						content: formatResponse.toolError(errorMessage),
 						is_error: true,
 					})
@@ -493,7 +494,7 @@ export async function presentAssistantMessage(cline: Task) {
 
 				cline.pushToolResultToUserContent({
 					type: "tool_result",
-					tool_use_id: toolCallId,
+					tool_use_id: sanitizeToolUseId(toolCallId),
 					content: resultContent,
 				})
 
@@ -644,7 +645,7 @@ export async function presentAssistantMessage(cline: Task) {
 					// Push tool_result directly without setting didAlreadyUseTool
 					cline.pushToolResultToUserContent({
 						type: "tool_result",
-						tool_use_id: toolCallId,
+						tool_use_id: sanitizeToolUseId(toolCallId),
 						content: typeof errorContent === "string" ? errorContent : "(validation error)",
 						is_error: true,
 					})
@@ -947,7 +948,7 @@ export async function presentAssistantMessage(cline: Task) {
 					// This prevents the stream from being interrupted with "Response interrupted by tool use result"
 					cline.pushToolResultToUserContent({
 						type: "tool_result",
-						tool_use_id: toolCallId,
+						tool_use_id: sanitizeToolUseId(toolCallId),
 						content: formatResponse.toolError(errorMessage),
 						is_error: true,
 					})

--- a/src/utils/__tests__/tool-id.spec.ts
+++ b/src/utils/__tests__/tool-id.spec.ts
@@ -47,6 +47,14 @@ describe("sanitizeToolUseId", () => {
 		it("should replace multiple invalid characters", () => {
 			expect(sanitizeToolUseId("mcp.server:tool/name")).toBe("mcp_server_tool_name")
 		})
+
+		it("should sanitize Gemini/OpenRouter function call IDs with dots and colons", () => {
+			// This is the exact pattern seen in PostHog errors where tool_result IDs
+			// didn't match tool_use IDs due to missing sanitization
+			expect(sanitizeToolUseId("functions.read_file:0")).toBe("functions_read_file_0")
+			expect(sanitizeToolUseId("functions.write_to_file:1")).toBe("functions_write_to_file_1")
+			expect(sanitizeToolUseId("read_file:0")).toBe("read_file_0")
+		})
 	})
 
 	describe("real-world MCP tool use ID patterns", () => {


### PR DESCRIPTION
## Summary
Fixes ToolResultIdMismatchError where tool_result IDs didn't match tool_use IDs in API conversation history.

## Problem
PostHog reported 926 ToolResultIdMismatchError occurrences in v3.46.0 where `tool_result` IDs (e.g., `functions.read_file:0`) didn't match `tool_use` IDs (e.g., `functions_read_file_0`).

## Root Cause
In `Task.ts`, when saving `tool_use` blocks to API conversation history, IDs were sanitized using `sanitizeToolUseId()`. However, in `presentAssistantMessage.ts`, when creating `tool_result` blocks, the original unsanitized `toolCallId` was used.

## Solution
Updated `presentAssistantMessage.ts` to sanitize `toolCallId` using `sanitizeToolUseId()` when creating `tool_result` blocks, ensuring consistency with how `tool_use` IDs are stored in history.

## Changes
- Added import for `sanitizeToolUseId` in `presentAssistantMessage.ts`
- Updated all 7 occurrences of `tool_use_id: toolCallId` to `tool_use_id: sanitizeToolUseId(toolCallId)`
- Added test case for the exact pattern seen in PostHog

## Testing
- All existing tests pass (5317 tests)
- Added test case verifying `functions.read_file:0` → `functions_read_file_0` sanitization

## Linear Issue
Fixes EXT-711
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `ToolResultIdMismatchError` by sanitizing `toolCallId` in `presentAssistantMessage.ts` to ensure consistent ID format.
> 
>   - **Behavior**:
>     - Fixes `ToolResultIdMismatchError` by sanitizing `toolCallId` in `presentAssistantMessage.ts` using `sanitizeToolUseId()`.
>     - Ensures `tool_result` IDs match `tool_use` IDs in API history.
>   - **Testing**:
>     - Adds test case in `tool-id.spec.ts` for sanitizing `functions.read_file:0` to `functions_read_file_0`.
>     - Confirms all existing tests pass (5317 tests).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for fe85422d9c3411218c9d89850743745ad1105b75. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->