### PR TITLE
Drop MacOS-13 cli support

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -23,9 +23,6 @@ jobs:
           - os: macos-latest
             platform: darwin-arm64
             runs-on: macos-latest
-          - os: macos-13
-            platform: darwin-x64
-            runs-on: macos-13
           - os: ubuntu-latest
             platform: linux-x64
             runs-on: ubuntu-latest
@@ -331,7 +328,7 @@ jobs:
           echo "## Requirements" >> "$NOTES_FILE"
           echo "" >> "$NOTES_FILE"
           echo "- Node.js 20 or higher" >> "$NOTES_FILE"
-          echo "- macOS (Intel or Apple Silicon) or Linux x64" >> "$NOTES_FILE"
+          echo "- macOS Apple Silicon (M1/M2/M3/M4) or Linux x64" >> "$NOTES_FILE"
           echo "" >> "$NOTES_FILE"
           echo "## Usage" >> "$NOTES_FILE"
           echo "" >> "$NOTES_FILE"
@@ -347,7 +344,6 @@ jobs:
           echo "" >> "$NOTES_FILE"
           echo "This release includes binaries for:" >> "$NOTES_FILE"
           echo '- `roo-cli-darwin-arm64.tar.gz` - macOS Apple Silicon (M1/M2/M3)' >> "$NOTES_FILE"
-          echo '- `roo-cli-darwin-x64.tar.gz` - macOS Intel' >> "$NOTES_FILE"
           echo '- `roo-cli-linux-x64.tar.gz` - Linux x64' >> "$NOTES_FILE"
           echo "" >> "$NOTES_FILE"
           echo "## Checksums" >> "$NOTES_FILE"

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -19,7 +19,7 @@ curl -fsSL https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/apps/cli/i
 **Requirements:**
 
 - Node.js 20 or higher
-- macOS (Intel or Apple Silicon) or Linux x64
+- macOS Apple Silicon (M1/M2/M3/M4) or Linux x64
 
 **Custom installation directory:**
 
@@ -259,7 +259,7 @@ To trigger a release:
 
 The workflow will:
 
-1. Build the CLI on all platforms (macOS Intel, macOS ARM, Linux x64)
+1. Build the CLI on all platforms (macOS Apple Silicon, Linux x64)
 2. Create platform-specific tarballs with bundled ripgrep
 3. Verify each tarball
 4. Create a GitHub release with all tarballs attached


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove macOS-13 support from CLI release workflow and update documentation to reflect this change.
> 
>   - **Workflow Changes**:
>     - Remove macOS-13 support from `cli-release.yml` by deleting the macOS-13 build matrix entry.
>     - Update platform support notes in `cli-release.yml` to reflect removal of macOS Intel.
>   - **Documentation**:
>     - Update `README.md` to remove references to macOS Intel and specify support for macOS Apple Silicon only.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for ea585174090eb3d520b5a620da5d61771ba69603. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->