### PR TITLE
feat: add Kimi K2.5 model to Fireworks provider

### DIFF
--- a/packages/types/src/providers/fireworks.ts
+++ b/packages/types/src/providers/fireworks.ts
@@ -4,6 +4,7 @@ export type FireworksModelId =
 	| "accounts/fireworks/models/kimi-k2-instruct"
 	| "accounts/fireworks/models/kimi-k2-instruct-0905"
 	| "accounts/fireworks/models/kimi-k2-thinking"
+	| "accounts/fireworks/models/kimi-k2p5"
 	| "accounts/fireworks/models/minimax-m2"
 	| "accounts/fireworks/models/minimax-m2p1"
 	| "accounts/fireworks/models/qwen3-235b-a22b-instruct-2507"
@@ -59,6 +60,17 @@ export const fireworksModels = {
 		cacheReadsPrice: 0.15,
 		description:
 			"The kimi-k2-thinking model is a general-purpose agentic reasoning model developed by Moonshot AI. Thanks to its strength in deep reasoning and multi-turn tool use, it can solve even the hardest problems.",
+	},
+	"accounts/fireworks/models/kimi-k2p5": {
+		maxTokens: 16384,
+		contextWindow: 262144,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 0.6,
+		outputPrice: 3.0,
+		cacheReadsPrice: 0.1,
+		description:
+			"Kimi K2.5 is Moonshot AI's flagship agentic model and a new SOTA open model. It unifies vision and text, thinking and non-thinking modes, and single-agent and multi-agent execution into one model. Fireworks enables users to control the reasoning behavior and inspect its reasoning history for greater transparency.",
 	},
 	"accounts/fireworks/models/minimax-m2": {
 		maxTokens: 4096,


### PR DESCRIPTION
Adds the new Kimi K2.5 model from Moonshot AI to the Fireworks provider.

## Model Details
- **Model ID**: `accounts/fireworks/models/kimi-k2p5`
- **Context Window**: 262,144 tokens (262.1k)
- **Max Tokens**: 16,384
- **Supports Images**: Yes
- **Supports Prompt Cache**: Yes
- **Pricing**: $0.60 input / $0.10 cached / $3.00 output per 1M tokens

## Description
Kimi K2.5 is Moonshot AI's flagship agentic model and a new SOTA open model. It unifies vision and text, thinking and non-thinking modes, and single-agent and multi-agent execution into one model. Fireworks enables users to control the reasoning behavior and inspect its reasoning history for greater transparency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds Kimi K2.5 model to Fireworks provider with detailed properties and description in `fireworks.ts`.
> 
>   - **Model Addition**:
>     - Adds `accounts/fireworks/models/kimi-k2p5` to `FireworksModelId` in `fireworks.ts`.
>     - Updates `fireworksModels` in `fireworks.ts` with Kimi K2.5 details: 16,384 max tokens, 262,144 context window, supports images and prompt cache, pricing details.
>   - **Model Description**:
>     - Describes Kimi K2.5 as a flagship agentic model unifying vision and text, with reasoning control and history inspection.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 1a67554221d53175594718cb6f525a544041d1c3. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->