### PR TITLE
fix(cli): resolve race condition causing provider switch during mode changes

### DIFF
--- a/src/core/webview/webviewMessageHandler.ts
+++ b/src/core/webview/webviewMessageHandler.ts
@@ -498,12 +498,18 @@ export const webviewMessageHandler = async (
 						if (!checkExistKey(listApiConfig[0])) {
 							const { apiConfiguration } = await provider.getState()
 
-							await provider.providerSettingsManager.saveConfig(
-								listApiConfig[0].name ?? "default",
-								apiConfiguration,
-							)
+							// Only save if the current configuration has meaningful settings
+							// (e.g., API keys). This prevents saving a default "anthropic"
+							// fallback when no real config exists, which can happen during
+							// CLI initialization before provider settings are applied.
+							if (checkExistKey(apiConfiguration)) {
+								await provider.providerSettingsManager.saveConfig(
+									listApiConfig[0].name ?? "default",
+									apiConfiguration,
+								)
 
-							listApiConfig[0].apiProvider = apiConfiguration.apiProvider
+								listApiConfig[0].apiProvider = apiConfiguration.apiProvider
+							}
 						}
 					}
 


### PR DESCRIPTION
## Summary

Fixes a race condition where CLI-provided provider settings (e.g., `--provider roo --api-key <key>`) were overwritten during mode switches triggered by slash commands with `mode:` frontmatter.

**Symptom**: Running `roo --provider roo --api-key $ROO_API_KEY "/cli-release"` would immediately fail with `"Could not resolve authentication method"` from the Anthropic SDK, even though the roo provider uses the OpenAI SDK — the Anthropic SDK should never have been invoked.

**Root cause**: In `markWebviewReady()`, the `webviewDidLaunch` message was sent *before* `updateSettings`, creating a race condition:

1. `webviewDidLaunch` fires → its handler starts an unawaited `.then()` chain for "first-time init" sync
2. The init reads `provider.getState()` which defaults `apiProvider` to `"anthropic"` (since `updateSettings` hasn't written CLI values to the context proxy yet)
3. This default `"anthropic"` config (with no API key) gets saved to the default provider profile
4. When the slash command's `mode: code` triggers `handleModeSwitch()`, it finds the corrupted profile with `apiProvider: "anthropic"` and activates it
5. The CLI's working roo provider configuration is overwritten → Anthropic SDK throws auth error

**Fix** (two-pronged for robustness):

- **Reorder `markWebviewReady()`**: Send `updateSettings` before `webviewDidLaunch` so the context proxy has CLI-provided values when the initialization handler runs
- **Guard first-time init sync**: Wrap the profile save with `checkExistKey(apiConfiguration)` to prevent saving a profile that only has the default `"anthropic"` fallback and no actual API keys

## Test plan

- [ ] Run `roo --provider roo --api-key $ROO_API_KEY --ephemeral "/cli-release"` — should successfully make API calls instead of failing with auth error
- [ ] Run `roo --provider roo --api-key $ROO_API_KEY "1+1=?"` — should still work (no mode switch, unaffected path)
- [ ] VS Code extension behavior unchanged — first-time init sync still works when a user has actual Anthropic API key configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race condition in CLI by reordering function calls and adding a guard to prevent overwriting provider settings during mode changes.
> 
>   - **Behavior**:
>     - Fixes race condition in `markWebviewReady()` in `extension-host.ts` by reordering `updateSettings` before `webviewDidLaunch`.
>     - Adds a guard in `webviewMessageHandler.ts` to prevent saving default provider profiles without API keys.
>   - **Functions**:
>     - `markWebviewReady()` now ensures CLI settings are applied before triggering webview initialization.
>     - `webviewMessageHandler` checks for meaningful settings before saving provider profiles.
>   - **Misc**:
>     - Updates ensure CLI-provided settings are not overwritten during mode switches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3b5e6609ffd62903a66d3f0323bad872ac34e12c. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->