### PR TITLE
feat: make read_file optional params nullable for proper strict mode support

### DIFF
--- a/src/core/prompts/tools/native-tools/__tests__/read_file.spec.ts
+++ b/src/core/prompts/tools/native-tools/__tests__/read_file.spec.ts
@@ -33,21 +33,59 @@ describe("createReadFileTool", () => {
 			expect(schema.properties).toHaveProperty("indentation")
 		})
 
-		it("should include mode parameter in schema", () => {
+		it("should include mode parameter in schema with nullable type", () => {
 			const tool = createReadFileTool()
 			const schema = getFunctionDef(tool).parameters as any
 
 			expect(schema.properties).toHaveProperty("mode")
+			expect(schema.properties.mode.type).toEqual(["string", "null"])
 			expect(schema.properties.mode.enum).toContain("slice")
 			expect(schema.properties.mode.enum).toContain("indentation")
 		})
 
-		it("should include offset and limit parameters in schema", () => {
+		it("should include nullable offset and limit parameters in schema", () => {
 			const tool = createReadFileTool()
 			const schema = getFunctionDef(tool).parameters as any
 
 			expect(schema.properties).toHaveProperty("offset")
+			expect(schema.properties.offset.type).toEqual(["integer", "null"])
 			expect(schema.properties).toHaveProperty("limit")
+			expect(schema.properties.limit.type).toEqual(["integer", "null"])
+		})
+
+		it("should have nullable indentation object type", () => {
+			const tool = createReadFileTool()
+			const schema = getFunctionDef(tool).parameters as any
+
+			expect(schema.properties.indentation.type).toEqual(["object", "null"])
+		})
+
+		it("should have nullable indentation sub-properties", () => {
+			const tool = createReadFileTool()
+			const schema = getFunctionDef(tool).parameters as any
+			const indentProps = schema.properties.indentation.properties
+
+			expect(indentProps.anchor_line.type).toEqual(["integer", "null"])
+			expect(indentProps.max_levels.type).toEqual(["integer", "null"])
+			expect(indentProps.include_siblings.type).toEqual(["boolean", "null"])
+			expect(indentProps.include_header.type).toEqual(["boolean", "null"])
+			expect(indentProps.max_lines.type).toEqual(["integer", "null"])
+		})
+
+		it("should require all indentation sub-properties for strict mode", () => {
+			const tool = createReadFileTool()
+			const schema = getFunctionDef(tool).parameters as any
+			const indentation = schema.properties.indentation
+
+			expect(indentation.required).toEqual(
+				expect.arrayContaining([
+					"anchor_line",
+					"max_levels",
+					"include_siblings",
+					"include_header",
+					"max_lines",
+				]),
+			)
 		})
 	})
 
@@ -112,11 +150,11 @@ describe("createReadFileTool", () => {
 			expect(getFunctionDef(tool).strict).toBe(true)
 		})
 
-		it("should require path parameter", () => {
+		it("should require all parameters for strict mode compatibility", () => {
 			const tool = createReadFileTool()
 			const schema = getFunctionDef(tool).parameters as any
 
-			expect(schema.required).toContain("path")
+			expect(schema.required).toEqual(expect.arrayContaining(["path", "mode", "offset", "limit", "indentation"]))
 		})
 	})
 })


### PR DESCRIPTION
### Related GitHub Issue

Closes: #11191

### Description

Models (especially non-OpenAI) were setting inefficiently low `limit` values (100-200) on `read_file` calls instead of using the 2000-line default.

**Root cause:** `read_file` had `strict: true` but only `required: ["path"]`. The `ensureAllRequired` transform in `openai-native.ts` forces ALL properties into `required` at runtime, meaning models **must** provide explicit values for every parameter — they cannot omit optional params like `limit`, `offset`, or `mode`. The model is forced to pick a number, and often picks a low one.

**Fix:** Follow the pattern used by other `strict: true` tools (`codebase_search`, `execute_command`, `skill`, `generate_image`) — make optional parameters nullable using `type: ["integer", "null"]` so models can send `null` to get defaults.

**Changes:**
- `mode`: `type: ["string", "null"]` — null → default slice mode
- `offset`: `type: ["integer", "null"]` — null → start from line 1
- `limit`: `type: ["integer", "null"]` — null → use 2000 default
- `indentation`: `type: ["object", "null"]` — null → not used in slice mode
- All indentation sub-properties: nullable types (`anchor_line`, `max_levels`, `include_siblings`, `include_header`, `max_lines`)
- All properties explicitly listed in `required` arrays (matching strict mode contract)
- Updated descriptions to say "Pass null for default" instead of "Omit this parameter"
- Added clarification that indentation mode ignores offset/limit

**No handler changes needed** — `ReadFileTool.ts` already uses `||` and `??` operators which handle `null` identically to `undefined`.

**Previous attempt:** PR #11192 tried description-only changes but was closed because the model physically cannot follow "omit this parameter" instructions when strict mode forces all parameters to be required.

### Test Procedure

- Ran `cd src && npx vitest run core/prompts/tools/native-tools/__tests__/read_file.spec.ts` — 16 tests pass
- Ran json-schema, NativeToolCallParser, readFileTool, and openai-native-tools tests — all pass
- Full test suite: 5457 passed, 0 failures across 370 test files
- Lint passes

### Pre-Submission Checklist

- [x] I've read the [Contributor's Guide](../CONTRIBUTING.md)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [x] Tests added/updated
- [x] Linted and formatted
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make `read_file` optional parameters nullable to support strict mode, allowing `null` for defaults, with updated tests and descriptions.
> 
>   - **Behavior**:
>     - `read_file` parameters `mode`, `offset`, `limit`, and `indentation` made nullable in `read_file.ts` to allow `null` for defaults.
>     - Updated descriptions to instruct passing `null` for defaults instead of omitting parameters.
>     - No handler changes needed; existing logic handles `null` as `undefined`.
>   - **Tests**:
>     - Updated `read_file.spec.ts` to test nullable types for `mode`, `offset`, `limit`, and `indentation`.
>     - Added tests for nullable sub-properties of `indentation`.
>     - Ensured all parameters are required in strict mode tests.
>   - **Misc**:
>     - Clarified that indentation mode ignores `offset`/`limit` in `read_file.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6ad9a84ca91fb00c8dfbfee83174cd6792a43c6d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->