### PR TITLE
fix: guard against empty-string baseURL in provider constructors

### DIFF
--- a/src/api/providers/__tests__/openai-native.spec.ts
+++ b/src/api/providers/__tests__/openai-native.spec.ts
@@ -11,6 +11,7 @@ vitest.mock("@roo-code/telemetry", () => ({
 }))
 
 import { Anthropic } from "@anthropic-ai/sdk"
+import OpenAI from "openai"
 
 import { ApiProviderError } from "@roo-code/types"
 
@@ -75,6 +76,28 @@ describe("OpenAiNativeHandler", () => {
 				openAiNativeApiKey: "",
 			})
 			expect(handlerWithoutKey).toBeInstanceOf(OpenAiNativeHandler)
+		})
+
+		it("should pass undefined baseURL when openAiNativeBaseUrl is empty string", () => {
+			;(OpenAI as unknown as ReturnType<typeof vitest.fn>).mockClear()
+			new OpenAiNativeHandler({
+				apiModelId: "gpt-4.1",
+				openAiNativeApiKey: "test-key",
+				openAiNativeBaseUrl: "",
+			})
+			expect(OpenAI).toHaveBeenCalledWith(expect.objectContaining({ baseURL: undefined }))
+		})
+
+		it("should pass custom baseURL when openAiNativeBaseUrl is a valid URL", () => {
+			;(OpenAI as unknown as ReturnType<typeof vitest.fn>).mockClear()
+			new OpenAiNativeHandler({
+				apiModelId: "gpt-4.1",
+				openAiNativeApiKey: "test-key",
+				openAiNativeBaseUrl: "https://custom-openai.example.com/v1",
+			})
+			expect(OpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({ baseURL: "https://custom-openai.example.com/v1" }),
+			)
 		})
 	})
 

--- a/src/api/providers/deepseek.ts
+++ b/src/api/providers/deepseek.ts
@@ -34,7 +34,7 @@ export class DeepSeekHandler extends BaseProvider implements SingleCompletionHan
 
 		// Create the DeepSeek provider using AI SDK
 		this.provider = createDeepSeek({
-			baseURL: options.deepSeekBaseUrl ?? "https://api.deepseek.com/v1",
+			baseURL: options.deepSeekBaseUrl || "https://api.deepseek.com/v1",
 			apiKey: options.deepSeekApiKey ?? "not-provided",
 			headers: DEFAULT_HEADERS,
 		})

--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -42,7 +42,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 		// (Vertex authentication happens separately)
 		this.provider = createGoogleGenerativeAI({
 			apiKey: this.options.geminiApiKey ?? "not-provided",
-			baseURL: this.options.googleGeminiBaseUrl,
+			baseURL: this.options.googleGeminiBaseUrl || undefined,
 			headers: DEFAULT_HEADERS,
 		})
 	}

--- a/src/api/providers/moonshot.ts
+++ b/src/api/providers/moonshot.ts
@@ -15,7 +15,7 @@ export class MoonshotHandler extends OpenAICompatibleHandler {
 
 		const config: OpenAICompatibleConfig = {
 			providerName: "moonshot",
-			baseURL: options.moonshotBaseUrl ?? "https://api.moonshot.ai/v1",
+			baseURL: options.moonshotBaseUrl || "https://api.moonshot.ai/v1",
 			apiKey: options.moonshotApiKey ?? "not-provided",
 			modelId,
 			modelInfo,

--- a/src/api/providers/openai-native.ts
+++ b/src/api/providers/openai-native.ts
@@ -87,7 +87,7 @@ export class OpenAiNativeHandler extends BaseProvider implements SingleCompletio
 		// Include originator, session_id, and User-Agent headers for API tracking and debugging
 		const userAgent = `roo-code/${Package.version} (${os.platform()} ${os.release()}; ${os.arch()}) node/${process.version.slice(1)}`
 		this.client = new OpenAI({
-			baseURL: this.options.openAiNativeBaseUrl,
+			baseURL: this.options.openAiNativeBaseUrl || undefined,
 			apiKey,
 			defaultHeaders: {
 				originator: "roo-code",

--- a/src/api/providers/openai.ts
+++ b/src/api/providers/openai.ts
@@ -37,7 +37,7 @@ export class OpenAiHandler extends BaseProvider implements SingleCompletionHandl
 		super()
 		this.options = options
 
-		const baseURL = this.options.openAiBaseUrl ?? "https://api.openai.com/v1"
+		const baseURL = this.options.openAiBaseUrl || "https://api.openai.com/v1"
 		const apiKey = this.options.openAiApiKey ?? "not-provided"
 		const isAzureAiInference = this._isAzureAiInference(this.options.openAiBaseUrl)
 		const urlHost = this._getUrlHost(this.options.openAiBaseUrl)


### PR DESCRIPTION
## Summary

When the "custom base URL" checkbox is unchecked in the settings UI, the base URL field is set to `""` (empty string). Providers that passed this directly to their SDK constructors caused `TypeError: Failed to parse URL` errors because the SDK treated `""` as a valid but broken base URL override, producing relative paths like `/models/gemini-3-pro-preview:streamGenerateContent?alt=sse` with no host.

## Changes

- **`gemini.ts`**: `baseURL: this.options.googleGeminiBaseUrl || undefined` — coerces `""` to `undefined` so the SDK uses the default Gemini API endpoint
- **`openai-native.ts`**: `baseURL: this.options.openAiNativeBaseUrl || undefined` — same fix for OpenAI Native provider
- **`openai.ts`**: Changed `??` to `||` for the fallback default — `??` only catches `null`/`undefined`, not `""`
- **`deepseek.ts`**: Changed `??` to `||` for defensive consistency
- **`moonshot.ts`**: Changed `??` to `||` for defensive consistency
- **`gemini.spec.ts`**: Added 3 constructor tests verifying empty, undefined, and valid baseURL handling
- **`openai-native.spec.ts`**: Added 2 constructor tests verifying empty and valid baseURL handling

## Providers already safe (no changes needed)

- **Anthropic** — already had `|| undefined` guard
- **OpenRouter** — already had `|| "https://openrouter.ai/api/v1"` guard
- **LiteLLM, DeepInfra, LM Studio** — already used `||` with fallback defaults
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `baseURL` handling in provider constructors to prevent errors by coercing empty strings to `undefined`.
> 
>   - **Behavior**:
>     - Coerce empty `baseURL` to `undefined` in `gemini.ts`, `openai-native.ts`, and `openai.ts` to prevent `TypeError`.
>     - Change `??` to `||` in `openai.ts`, `deepseek.ts`, and `moonshot.ts` for consistent handling of empty strings.
>   - **Tests**:
>     - Add tests in `gemini.spec.ts` for empty, undefined, and valid `baseURL` handling.
>     - Add tests in `openai-native.spec.ts` for empty and valid `baseURL` handling.
>   - **Providers already safe**:
>     - No changes needed for `Anthropic`, `OpenRouter`, `LiteLLM`, `DeepInfra`, and `LM Studio` as they already handle empty `baseURL`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bcfb7e4c52a0af7ae05aea89a1b870accf3b2848. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->