### PR TITLE
Release v3.47.1

### DIFF
--- a/.changeset/v3.47.1.md
+++ b/.changeset/v3.47.1.md
@@ -1,0 +1,7 @@
+---
+"roo-cline": patch
+---
+
+- Fix: Correct Bedrock model ID for Claude Opus 4.6, resolving model selection issues for Bedrock users (#11231 by @cogwirrel, PR #11232 by @roomote)
+- Fix: Guard against empty-string baseURL in provider constructors, preventing connection errors when baseURL is accidentally set to empty string (PR #11233 by @hannesrudolph)
+- Chore: Remove unused stripAppendedEnvironmentDetails and helpers to clean up codebase (#11228 by @hannesrudolph, PR #11226 by @hannesrudolph)


### PR DESCRIPTION
Release preparation for v3.47.1. This PR includes the changeset and any necessary documentation updates.

## Changes in this release:
- Fix: Correct Bedrock model ID for Claude Opus 4.6, resolving model selection issues for Bedrock users (#11231 by @cogwirrel, PR #11232 by @roomote)
- Fix: Guard against empty-string baseURL in provider constructors, preventing connection errors when baseURL is accidentally set to empty string (PR #11233 by @hannesrudolph)
- Chore: Remove unused stripAppendedEnvironmentDetails and helpers to clean up codebase (#11228 by @hannesrudolph, PR #11226 by @hannesrudolph)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Release v3.47.1 includes fixes for Bedrock model ID and baseURL handling, and removes unused code.
> 
>   - **Fixes**:
>     - Correct Bedrock model ID for Claude Opus 4.6 to resolve model selection issues.
>     - Guard against empty-string `baseURL` in provider constructors to prevent connection errors.
>   - **Chore**:
>     - Remove unused `stripAppendedEnvironmentDetails` and related helpers for code cleanup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a84fd96b0be6f38af33c875164b5815ff581ccbc. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->