### PR TITLE
fix: restore Gemini thought signature round-tripping after AI SDK migration

### DIFF
--- a/src/api/providers/gemini.ts
+++ b/src/api/providers/gemini.ts
@@ -31,6 +31,7 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 	protected options: ApiHandlerOptions
 	protected provider: GoogleGenerativeAIProvider
 	private readonly providerName = "Gemini"
+	private lastThoughtSignature: string | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		super()
@@ -124,11 +125,23 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 		}
 
 		try {
+			// Reset thought signature for this request
+			this.lastThoughtSignature = undefined
+
 			// Use streamText for streaming responses
 			const result = streamText(requestOptions)
 
 			// Process the full stream to get all events including reasoning
 			for await (const part of result.fullStream) {
+				// Capture thoughtSignature from tool-call events (Gemini 3 thought signatures)
+				// The AI SDK's tool-call event includes providerMetadata with the signature
+				if (part.type === "tool-call") {
+					const googleMeta = (part as any).providerMetadata?.google
+					if (googleMeta?.thoughtSignature) {
+						this.lastThoughtSignature = googleMeta.thoughtSignature
+					}
+				}
+
 				for (const chunk of processAiSdkStreamPart(part)) {
 					yield chunk
 				}
@@ -400,5 +413,14 @@ export class GeminiHandler extends BaseProvider implements SingleCompletionHandl
 
 	override isAiSdkProvider(): boolean {
 		return true
+	}
+
+	/**
+	 * Returns the thought signature captured from the last Gemini response.
+	 * Gemini 3 models return thoughtSignature on function call parts,
+	 * which must be round-tripped back for tool use continuations.
+	 */
+	getThoughtSignature(): string | undefined {
+		return this.lastThoughtSignature
 	}
 }

--- a/src/api/providers/vertex.ts
+++ b/src/api/providers/vertex.ts
@@ -35,6 +35,7 @@ export class VertexHandler extends BaseProvider implements SingleCompletionHandl
 	protected options: ApiHandlerOptions
 	protected provider: GoogleVertexProvider
 	private readonly providerName = "Vertex"
+	private lastThoughtSignature: string | undefined
 
 	constructor(options: ApiHandlerOptions) {
 		super()
@@ -138,11 +139,26 @@ export class VertexHandler extends BaseProvider implements SingleCompletionHandl
 		}
 
 		try {
+			// Reset thought signature for this request
+			this.lastThoughtSignature = undefined
+
 			// Use streamText for streaming responses
 			const result = streamText(requestOptions)
 
 			// Process the full stream to get all events including reasoning
 			for await (const part of result.fullStream) {
+				// Capture thoughtSignature from tool-call events (Gemini 3 thought signatures)
+				// The AI SDK's tool-call event includes providerMetadata with the signature
+				// Vertex AI stores it under the "vertex" key in providerMetadata
+				if (part.type === "tool-call") {
+					const vertexMeta = (part as any).providerMetadata?.vertex
+					const googleMeta = (part as any).providerMetadata?.google
+					const sig = vertexMeta?.thoughtSignature ?? googleMeta?.thoughtSignature
+					if (sig) {
+						this.lastThoughtSignature = sig
+					}
+				}
+
 				for (const chunk of processAiSdkStreamPart(part)) {
 					yield chunk
 				}
@@ -405,5 +421,14 @@ export class VertexHandler extends BaseProvider implements SingleCompletionHandl
 
 	override isAiSdkProvider(): boolean {
 		return true
+	}
+
+	/**
+	 * Returns the thought signature captured from the last Vertex AI response.
+	 * Gemini 3 models return thoughtSignature on function call parts,
+	 * which must be round-tripped back for tool use continuations.
+	 */
+	getThoughtSignature(): string | undefined {
+		return this.lastThoughtSignature
 	}
 }

--- a/src/api/transform/__tests__/ai-sdk.spec.ts
+++ b/src/api/transform/__tests__/ai-sdk.spec.ts
@@ -399,6 +399,101 @@ describe("AI SDK conversion utilities", () => {
 				],
 			})
 		})
+
+		it("attaches thoughtSignature to first tool-call part for Gemini 3 round-tripping", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Let me check that." },
+						{
+							type: "tool_use",
+							id: "tool-1",
+							name: "read_file",
+							input: { path: "test.txt" },
+						},
+						{ type: "thoughtSignature", thoughtSignature: "encrypted-sig-abc" } as any,
+					],
+				},
+			]
+
+			const result = convertToAiSdkMessages(messages)
+
+			expect(result).toHaveLength(1)
+			const assistantMsg = result[0]
+			expect(assistantMsg.role).toBe("assistant")
+
+			const content = assistantMsg.content as any[]
+			expect(content).toHaveLength(2) // text + tool-call (thoughtSignature block is consumed, not passed through)
+
+			const toolCallPart = content.find((p: any) => p.type === "tool-call")
+			expect(toolCallPart).toBeDefined()
+			expect(toolCallPart.providerOptions).toEqual({
+				google: { thoughtSignature: "encrypted-sig-abc" },
+				vertex: { thoughtSignature: "encrypted-sig-abc" },
+			})
+		})
+
+		it("attaches thoughtSignature only to the first tool-call in parallel calls", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [
+						{
+							type: "tool_use",
+							id: "tool-1",
+							name: "get_weather",
+							input: { city: "Paris" },
+						},
+						{
+							type: "tool_use",
+							id: "tool-2",
+							name: "get_weather",
+							input: { city: "London" },
+						},
+						{ type: "thoughtSignature", thoughtSignature: "sig-parallel" } as any,
+					],
+				},
+			]
+
+			const result = convertToAiSdkMessages(messages)
+			const content = (result[0] as any).content as any[]
+
+			const toolCalls = content.filter((p: any) => p.type === "tool-call")
+			expect(toolCalls).toHaveLength(2)
+
+			// Only the first tool call should have the signature
+			expect(toolCalls[0].providerOptions).toEqual({
+				google: { thoughtSignature: "sig-parallel" },
+				vertex: { thoughtSignature: "sig-parallel" },
+			})
+			// Second tool call should NOT have the signature
+			expect(toolCalls[1].providerOptions).toBeUndefined()
+		})
+
+		it("does not attach providerOptions when no thoughtSignature block is present", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "text", text: "Using tool" },
+						{
+							type: "tool_use",
+							id: "tool-1",
+							name: "read_file",
+							input: { path: "test.txt" },
+						},
+					],
+				},
+			]
+
+			const result = convertToAiSdkMessages(messages)
+			const content = (result[0] as any).content as any[]
+			const toolCallPart = content.find((p: any) => p.type === "tool-call")
+
+			expect(toolCallPart).toBeDefined()
+			expect(toolCallPart.providerOptions).toBeUndefined()
+		})
 	})
 
 	describe("convertToolsForAiSdk", () => {


### PR DESCRIPTION
## Summary

PR #11180 migrated Gemini/Vertex providers to the AI SDK and deleted `gemini-format.ts` which contained the working thought signature round-trip logic (originally added in PR #10590). This broke **all Gemini 3 tool use** with a 400 error:

```
Function call is missing a thought_signature in functionCall parts.
This is required for tools to work correctly, and missing thought_signature
may lead to degraded model performance.
```

## Root Cause

The AI SDK migration deleted the custom Gemini message format converter that:
1. Extracted `thoughtSignature` blocks from conversation history
2. Attached them to `functionCall` parts when sending messages back to Gemini
3. Followed Gemini 3's rules (signature on first functionCall only for parallel calls)

The replacement `convertToAiSdkMessages()` stripped `thoughtSignature` blocks without round-tripping them.

## Changes

- **`src/api/providers/gemini.ts`**: Capture `thoughtSignature` from `providerMetadata.google` on `tool-call` stream events. Implement `getThoughtSignature()` so Task.ts stores it as a `{ type: "thoughtSignature" }` content block.
- **`src/api/providers/vertex.ts`**: Same changes, checking both `providerMetadata.vertex` and `.google` keys.
- **`src/api/transform/ai-sdk.ts`**: In `convertToAiSdkMessages()`, extract `thoughtSignature` content blocks from history and attach as `providerOptions: { google: { thoughtSignature }, vertex: { thoughtSignature } }` on the first `tool-call` part. The AI SDK's `@ai-sdk/google` provider reads this and injects it into the Gemini API's `functionCall.thoughtSignature` field.
- **`src/api/transform/__tests__/ai-sdk.spec.ts`**: 3 new tests verifying signature attachment, parallel call behavior, and no-op without signatures.

## How the round-trip works

1. **Gemini responds** → AI SDK exposes `providerMetadata.google.thoughtSignature` on `tool-call` events
2. **Provider captures** → `getThoughtSignature()` returns the signature
3. **Task.ts stores** → Creates `{ type: "thoughtSignature", thoughtSignature }` content block (existing logic at Task.ts:1117-1133)
4. **Next API call** → `convertToAiSdkMessages()` finds the block, attaches as `providerOptions` on first tool-call
5. **AI SDK** → Reads `providerOptions.google.thoughtSignature` and injects into Gemini API request
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restores Gemini thought signature round-tripping by capturing and attaching signatures in message conversion, ensuring compliance with Gemini 3's requirements.
> 
>   - **Behavior**:
>     - Restores Gemini thought signature round-tripping in `gemini.ts` and `vertex.ts` by capturing `thoughtSignature` from `providerMetadata` on `tool-call` events.
>     - Implements `getThoughtSignature()` in both `gemini.ts` and `vertex.ts` to store the signature as a content block.
>     - Updates `convertToAiSdkMessages()` in `ai-sdk.ts` to attach `thoughtSignature` to the first `tool-call` part.
>   - **Tests**:
>     - Adds tests in `ai-sdk.spec.ts` to verify signature attachment, parallel call behavior, and no-op without signatures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 4089d3590fe1beb365fbe1808c649e0aa7ae9549. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->