### PR TITLE
fix: capture and round-trip thinking signature for Bedrock Claude

### DIFF
--- a/src/api/transform/bedrock-converse-format.ts
+++ b/src/api/transform/bedrock-converse-format.ts
@@ -209,9 +209,21 @@ export function convertToBedrockConverseMessages(anthropicMessages: Anthropic.Me
 				} as ContentBlock
 			}
 
-			// Handle redacted thinking blocks (Anthropic sends these when content is filtered)
+			// Handle redacted thinking blocks (Anthropic sends these when content is filtered).
+			// Convert base64-encoded data back to Uint8Array for Bedrock Converse API's
+			// reasoningContent.redactedContent format.
+			if (blockAny.type === "redacted_thinking" && (blockAny as unknown as { data?: string }).data) {
+				const base64Data = (blockAny as unknown as { data: string }).data
+				const binaryData = Buffer.from(base64Data, "base64")
+				return {
+					reasoningContent: {
+						redactedContent: new Uint8Array(binaryData),
+					},
+				} as ContentBlock
+			}
+
+			// Skip redacted_thinking blocks without data (shouldn't happen, but be safe)
 			if (blockAny.type === "redacted_thinking") {
-				// Skip redacted thinking — Bedrock doesn't support redactedContent in input
 				return undefined as unknown as ContentBlock
 			}
 

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -1022,6 +1022,7 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			getThoughtSignature?: () => string | undefined
 			getSummary?: () => any[] | undefined
 			getReasoningDetails?: () => any[] | undefined
+			getRedactedThinkingBlocks?: () => Array<{ type: "redacted_thinking"; data: string }> | undefined
 		}
 
 		if (message.role === "assistant") {
@@ -1071,6 +1072,15 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 					messageWithTs.content = [thinkingBlock, ...messageWithTs.content]
 				} else if (!messageWithTs.content) {
 					messageWithTs.content = [thinkingBlock]
+				}
+
+				// Also insert any redacted_thinking blocks after the thinking block.
+				// Anthropic returns these when safety filters trigger on reasoning content.
+				// They must be passed back verbatim for proper reasoning continuity.
+				const redactedBlocks = handler.getRedactedThinkingBlocks?.()
+				if (redactedBlocks && Array.isArray(messageWithTs.content)) {
+					// Insert after the thinking block (index 1, right after thinking at index 0)
+					messageWithTs.content.splice(1, 0, ...redactedBlocks)
 				}
 			} else if (reasoning && !reasoningDetails) {
 				// Other providers (non-Anthropic): Store as generic reasoning block


### PR DESCRIPTION
## Summary

Fixes thinking signature and redacted thinking round-tripping for Bedrock Claude models with extended thinking. Without this fix, multi-turn conversations with tool use fail with a **400 error**:

```
messages.1.content.0.type: Expected 'thinking' or 'redacted_thinking',
but found 'tool_use'. When 'thinking' is enabled, a final 'assistant'
message must start with a thinking block.
```

Reported by user on Twitter/X using Claude Opus 4.5 via Bedrock with Roo Code v3.47.0.

## Root Cause

The Bedrock Converse API returns reasoning content with a cryptographic `signature` (and sometimes `redactedContent` for safety-filtered reasoning), but the handler never captured either. Without the signature, `Task.ts` stored thinking as generic `reasoning` blocks which get stripped by `filterNonAnthropicBlocks()`. The Bedrock converse format converter also had no handling for `thinking` or `redacted_thinking` content blocks.

## Changes

### `src/api/providers/bedrock.ts`
- Updated `ContentBlockDeltaEvent` interface to include `signature` and `redactedContent` fields in `reasoningContent`
- Capture `reasoningContent.signature` from stream deltas → `getThoughtSignature()`
- Capture `reasoningContent.redactedContent` (Uint8Array → base64) from stream deltas → `getRedactedThinkingBlocks()`

### `src/core/task/Task.ts`
- Added `getRedactedThinkingBlocks` to handler type cast
- Insert `redacted_thinking` blocks after the `thinking` block in assistant messages

### `src/api/transform/bedrock-converse-format.ts`
- Convert `thinking` blocks → `reasoningContent.reasoningText` with `text` and `signature`
- Convert `redacted_thinking` blocks → `reasoningContent.redactedContent` (base64 → Uint8Array)
- Skip `reasoning` and `thoughtSignature` blocks (internal formats)

### `src/api/transform/__tests__/bedrock-converse-format.spec.ts`
- 6 new tests: thinking blocks, redacted_thinking with/without data, reasoning blocks, thoughtSignature blocks, full combined message

## Testing

166 tests pass across 9 Bedrock test files. Full CI: 5,475 tests pass.