### PR TITLE
fix(tools): prevent EACCES errors from absolute paths in tool calls (#11208)

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "roo-code",
 	"packageManager": "pnpm@10.8.1",
 	"engines": {
-		"node": "20.19.2"
+		"node": "20.20.0"
 	},
 	"scripts": {
 		"preinstall": "node scripts/bootstrap.mjs",
@@ -46,7 +46,7 @@
 		"prettier": "^3.4.2",
 		"rimraf": "^6.0.1",
 		"tsx": "^4.19.3",
-		"turbo": "^2.5.6",
+		"turbo": "^2.8.3",
 		"typescript": "5.8.3"
 	},
 	"lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^4.19.3
         version: 4.19.4
       turbo:
-        specifier: ^2.5.6
-        version: 2.5.6
+        specifier: ^2.8.3
+        version: 2.8.3
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -540,7 +540,7 @@ importers:
         version: 5.2.0(eslint@9.27.0(jiti@2.4.2))
       eslint-plugin-turbo:
         specifier: ^2.4.4
-        version: 2.5.6(eslint@9.27.0(jiti@2.4.2))(turbo@2.5.6)
+        version: 2.5.6(eslint@9.27.0(jiti@2.4.2))(turbo@2.8.3)
       globals:
         specifier: ^16.0.0
         version: 16.1.0
@@ -10332,38 +10332,38 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  turbo-darwin-64@2.5.6:
-    resolution: {integrity: sha512-3C1xEdo4aFwMJAPvtlPqz1Sw/+cddWIOmsalHFMrsqqydcptwBfu26WW2cDm3u93bUzMbBJ8k3zNKFqxJ9ei2A==}
+  turbo-darwin-64@2.8.3:
+    resolution: {integrity: sha512-4kXRLfcygLOeNcP6JquqRLmGB/ATjjfehiojL2dJkL7GFm3SPSXbq7oNj8UbD8XriYQ5hPaSuz59iF1ijPHkTw==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@2.5.6:
-    resolution: {integrity: sha512-LyiG+rD7JhMfYwLqB6k3LZQtYn8CQQUePbpA8mF/hMLPAekXdJo1g0bUPw8RZLwQXUIU/3BU7tXENvhSGz5DPA==}
+  turbo-darwin-arm64@2.8.3:
+    resolution: {integrity: sha512-xF7uCeC0UY0Hrv/tqax0BMbFlVP1J/aRyeGQPZT4NjvIPj8gSPDgFhfkfz06DhUwDg5NgMo04uiSkAWE8WB/QQ==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@2.5.6:
-    resolution: {integrity: sha512-GOcUTT0xiT/pSnHL4YD6Yr3HreUhU8pUcGqcI2ksIF9b2/r/kRHwGFcsHgpG3+vtZF/kwsP0MV8FTlTObxsYIA==}
+  turbo-linux-64@2.8.3:
+    resolution: {integrity: sha512-vxMDXwaOjweW/4etY7BxrXCSkvtwh0PbwVafyfT1Ww659SedUxd5rM3V2ZCmbwG8NiCfY7d6VtxyHx3Wh1GoZA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@2.5.6:
-    resolution: {integrity: sha512-10Tm15bruJEA3m0V7iZcnQBpObGBcOgUcO+sY7/2vk1bweW34LMhkWi8svjV9iDF68+KJDThnYDlYE/bc7/zzQ==}
+  turbo-linux-arm64@2.8.3:
+    resolution: {integrity: sha512-mQX7uYBZFkuPLLlKaNe9IjR1JIef4YvY8f21xFocvttXvdPebnq3PK1Zjzl9A1zun2BEuWNUwQIL8lgvN9Pm3Q==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@2.5.6:
-    resolution: {integrity: sha512-FyRsVpgaj76It0ludwZsNN40ytHN+17E4PFJyeliBEbxrGTc5BexlXVpufB7XlAaoaZVxbS6KT8RofLfDRyEPg==}
+  turbo-windows-64@2.8.3:
+    resolution: {integrity: sha512-YLGEfppGxZj3VWcNOVa08h6ISsVKiG85aCAWosOKNUjb6yErWEuydv6/qImRJUI+tDLvDvW7BxopAkujRnWCrw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@2.5.6:
-    resolution: {integrity: sha512-j/tWu8cMeQ7HPpKri6jvKtyXg9K1gRyhdK4tKrrchH8GNHscPX/F71zax58yYtLRWTiK04zNzPcUJuoS0+v/+Q==}
+  turbo-windows-arm64@2.8.3:
+    resolution: {integrity: sha512-afTUGKBRmOJU1smQSBnFGcbq0iabAPwh1uXu2BVk7BREg30/1gMnJh9DFEQTah+UD3n3ru8V55J83RQNFfqoyw==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@2.5.6:
-    resolution: {integrity: sha512-gxToHmi9oTBNB05UjUsrWf0OyN5ZXtD0apOarC1KIx232Vp3WimRNy3810QzeNSgyD5rsaIDXlxlbnOzlouo+w==}
+  turbo@2.8.3:
+    resolution: {integrity: sha512-8Osxz5Tu/Dw2kb31EAY+nhq/YZ3wzmQSmYa1nIArqxgCAldxv9TPlrAiaBUDVnKA4aiPn0OFBD1ACcpc5VFOAQ==}
     hasBin: true
 
   turndown@7.2.0:
@@ -16947,11 +16947,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.5.6(eslint@9.27.0(jiti@2.4.2))(turbo@2.5.6):
+  eslint-plugin-turbo@2.5.6(eslint@9.27.0(jiti@2.4.2))(turbo@2.8.3):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.27.0(jiti@2.4.2)
-      turbo: 2.5.6
+      turbo: 2.8.3
 
   eslint-scope@8.3.0:
     dependencies:
@@ -21605,32 +21605,32 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  turbo-darwin-64@2.5.6:
+  turbo-darwin-64@2.8.3:
     optional: true
 
-  turbo-darwin-arm64@2.5.6:
+  turbo-darwin-arm64@2.8.3:
     optional: true
 
-  turbo-linux-64@2.5.6:
+  turbo-linux-64@2.8.3:
     optional: true
 
-  turbo-linux-arm64@2.5.6:
+  turbo-linux-arm64@2.8.3:
     optional: true
 
-  turbo-windows-64@2.5.6:
+  turbo-windows-64@2.8.3:
     optional: true
 
-  turbo-windows-arm64@2.5.6:
+  turbo-windows-arm64@2.8.3:
     optional: true
 
-  turbo@2.5.6:
+  turbo@2.8.3:
     optionalDependencies:
-      turbo-darwin-64: 2.5.6
-      turbo-darwin-arm64: 2.5.6
-      turbo-linux-64: 2.5.6
-      turbo-linux-arm64: 2.5.6
-      turbo-windows-64: 2.5.6
-      turbo-windows-arm64: 2.5.6
+      turbo-darwin-64: 2.8.3
+      turbo-darwin-arm64: 2.8.3
+      turbo-linux-64: 2.8.3
+      turbo-linux-arm64: 2.8.3
+      turbo-windows-64: 2.8.3
+      turbo-windows-arm64: 2.8.3
 
   turndown@7.2.0:
     dependencies:

--- a/src/core/tools/ApplyDiffTool.ts
+++ b/src/core/tools/ApplyDiffTool.ts
@@ -252,7 +252,7 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 			}
 
 			await task.diffViewProvider.reset()
-			this.resetPartialState()
+			this.resetPartialState(task)
 
 			// Process any queued messages after file edit completes
 			task.processQueuedMessages()
@@ -261,7 +261,7 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 		} catch (error) {
 			await handleError("applying diff", error as Error)
 			await task.diffViewProvider.reset()
-			this.resetPartialState()
+			this.resetPartialState(task)
 			task.processQueuedMessages()
 			return
 		}
@@ -272,7 +272,7 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 		const diffContent: string | undefined = block.params.diff
 
 		// Wait for path to stabilize before showing UI (prevents truncated paths)
-		if (!this.hasPathStabilized(relPath)) {
+		if (!this.hasPathStabilized(task, relPath)) {
 			return
 		}
 

--- a/src/core/tools/EditFileTool.ts
+++ b/src/core/tools/EditFileTool.ts
@@ -466,7 +466,7 @@ export class EditFileTool extends BaseTool<"edit_file"> {
 			// Record successful tool usage and cleanup
 			task.recordToolUsage("edit_file")
 			await task.diffViewProvider.reset()
-			this.resetPartialState()
+			this.resetPartialState(task)
 
 			// Process any queued messages after file edit completes
 			task.processQueuedMessages()
@@ -480,7 +480,7 @@ export class EditFileTool extends BaseTool<"edit_file"> {
 		} finally {
 			this.didSendPartialToolAsk = false
 			this.partialToolAskRelPath = undefined
-			this.resetPartialState()
+			this.resetPartialState(task)
 		}
 	}
 
@@ -489,7 +489,7 @@ export class EditFileTool extends BaseTool<"edit_file"> {
 		const oldString: string | undefined = block.params.old_string
 
 		// Wait for path to stabilize before showing UI (prevents truncated paths)
-		if (!this.hasPathStabilized(filePath)) {
+		if (!this.hasPathStabilized(task, filePath)) {
 			return
 		}
 

--- a/src/core/tools/SearchAndReplaceTool.ts
+++ b/src/core/tools/SearchAndReplaceTool.ts
@@ -243,14 +243,14 @@ export class SearchAndReplaceTool extends BaseTool<"search_and_replace"> {
 			// Record successful tool usage and cleanup
 			task.recordToolUsage("search_and_replace")
 			await task.diffViewProvider.reset()
-			this.resetPartialState()
+			this.resetPartialState(task)
 
 			// Process any queued messages after file edit completes
 			task.processQueuedMessages()
 		} catch (error) {
 			await handleError("search and replace", error as Error)
 			await task.diffViewProvider.reset()
-			this.resetPartialState()
+			this.resetPartialState(task)
 		}
 	}
 
@@ -258,7 +258,7 @@ export class SearchAndReplaceTool extends BaseTool<"search_and_replace"> {
 		const relPath: string | undefined = block.params.path
 
 		// Wait for path to stabilize before showing UI (prevents truncated paths)
-		if (!this.hasPathStabilized(relPath)) {
+		if (!this.hasPathStabilized(task, relPath)) {
 			return
 		}
 

--- a/src/core/tools/SearchReplaceTool.ts
+++ b/src/core/tools/SearchReplaceTool.ts
@@ -228,14 +228,14 @@ export class SearchReplaceTool extends BaseTool<"search_replace"> {
 			// Record successful tool usage and cleanup
 			task.recordToolUsage("search_replace")
 			await task.diffViewProvider.reset()
-			this.resetPartialState()
+			this.resetPartialState(task)
 
 			// Process any queued messages after file edit completes
 			task.processQueuedMessages()
 		} catch (error) {
 			await handleError("search and replace", error as Error)
 			await task.diffViewProvider.reset()
-			this.resetPartialState()
+			this.resetPartialState(task)
 		}
 	}
 
@@ -244,7 +244,7 @@ export class SearchReplaceTool extends BaseTool<"search_replace"> {
 		const oldString: string | undefined = block.params.old_string
 
 		// Wait for path to stabilize before showing UI (prevents truncated paths)
-		if (!this.hasPathStabilized(filePath)) {
+		if (!this.hasPathStabilized(task, filePath)) {
 			return
 		}
 

--- a/src/core/tools/__tests__/BaseTool.spec.ts
+++ b/src/core/tools/__tests__/BaseTool.spec.ts
@@ -1,0 +1,308 @@
+// npx vitest core/tools/__tests__/BaseTool.spec.ts
+
+import type { ToolName } from "@roo-code/types"
+
+import { BaseTool, ToolCallbacks } from "../BaseTool"
+import type { ToolUse } from "../../../shared/tools"
+import { Task } from "../../task/Task"
+
+// Create a concrete implementation for testing
+class TestTool extends BaseTool<"read_file"> {
+	readonly name = "read_file" as const
+	public executeCallCount = 0
+	public handlePartialCallCount = 0
+	public shouldThrowInHandlePartial = false
+	public partialErrorMessage = "Test error"
+
+	async execute(params: any, task: Task, callbacks: ToolCallbacks): Promise<void> {
+		this.executeCallCount++
+	}
+
+	override async handlePartial(task: Task, block: ToolUse<"read_file">): Promise<void> {
+		this.handlePartialCallCount++
+		if (this.shouldThrowInHandlePartial) {
+			throw new Error(this.partialErrorMessage)
+		}
+	}
+
+	// Expose protected methods for testing
+	public testGetPartialState(task: Task) {
+		return this.getPartialState(task)
+	}
+
+	public testSetPartialState(task: Task, state: any) {
+		this.setPartialState(task, state)
+	}
+
+	public testHasPathStabilized(task: Task, path: string | undefined) {
+		return this.hasPathStabilized(task, path)
+	}
+
+	public testNotifyPartialError(task: Task, errorMessage: string, isPathValidationError = false) {
+		return this.notifyPartialError(task, errorMessage, isPathValidationError)
+	}
+
+	public testShouldSkipDueToPathError(task: Task) {
+		return this.shouldSkipDueToPathError(task)
+	}
+}
+
+// Mock Task
+const createMockTask = (): Task => {
+	return {
+		id: "test-task-" + Math.random(),
+	} as unknown as Task
+}
+
+// Mock ToolUse block
+const createMockToolUse = (partial: boolean): ToolUse<"read_file"> => ({
+	type: "tool_use",
+	name: "read_file",
+	params: { path: "/test/file.ts" },
+	nativeArgs: { path: "/test/file.ts" },
+	partial,
+})
+
+// Mock callbacks
+const createMockCallbacks = (): ToolCallbacks => ({
+	askApproval: vi.fn().mockResolvedValue(true),
+	handleError: vi.fn().mockResolvedValue(undefined),
+	pushToolResult: vi.fn(),
+})
+
+describe("BaseTool", () => {
+	let testTool: TestTool
+	let mockTask: Task
+	let mockCallbacks: ToolCallbacks
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		testTool = new TestTool()
+		mockTask = createMockTask()
+		mockCallbacks = createMockCallbacks()
+	})
+
+	describe("partial state management", () => {
+		it("should initialize with idle state", () => {
+			const state = testTool.testGetPartialState(mockTask)
+			expect(state.status).toBe("idle")
+		})
+
+		it("should isolate state per task", () => {
+			const task1 = createMockTask()
+			const task2 = createMockTask()
+
+			testTool.testSetPartialState(task1, { status: "streaming", lastSeenPath: "/path1" })
+			testTool.testSetPartialState(task2, { status: "streaming", lastSeenPath: "/path2" })
+
+			const state1 = testTool.testGetPartialState(task1)
+			const state2 = testTool.testGetPartialState(task2)
+
+			expect(state1.status).toBe("streaming")
+			expect((state1 as any).lastSeenPath).toBe("/path1")
+			expect(state2.status).toBe("streaming")
+			expect((state2 as any).lastSeenPath).toBe("/path2")
+		})
+
+		it("should reset state to idle", () => {
+			testTool.testSetPartialState(mockTask, {
+				status: "erroring",
+				errorCount: 5,
+				lastErrorMessage: "test",
+				firstErrorTime: Date.now(),
+			})
+
+			testTool.resetPartialState(mockTask)
+
+			const state = testTool.testGetPartialState(mockTask)
+			expect(state.status).toBe("idle")
+		})
+	})
+
+	describe("hasPathStabilized", () => {
+		it("should return false on first call", () => {
+			const result = testTool.testHasPathStabilized(mockTask, "/test/path.ts")
+			expect(result).toBe(false)
+		})
+
+		it("should return true when path matches previous call", () => {
+			testTool.testHasPathStabilized(mockTask, "/test/path.ts")
+			const result = testTool.testHasPathStabilized(mockTask, "/test/path.ts")
+			expect(result).toBe(true)
+		})
+
+		it("should return false when path changes", () => {
+			testTool.testHasPathStabilized(mockTask, "/test/path1.ts")
+			testTool.testHasPathStabilized(mockTask, "/test/path1.ts") // stabilized
+			const result = testTool.testHasPathStabilized(mockTask, "/test/path2.ts") // changed
+			expect(result).toBe(false)
+		})
+
+		it("should return false for undefined path", () => {
+			const result = testTool.testHasPathStabilized(mockTask, undefined)
+			expect(result).toBe(false)
+		})
+
+		it("should return false for empty path", () => {
+			testTool.testHasPathStabilized(mockTask, "")
+			const result = testTool.testHasPathStabilized(mockTask, "")
+			expect(result).toBe(false) // empty string is falsy
+		})
+
+		it("should transition from idle to streaming", () => {
+			testTool.testHasPathStabilized(mockTask, "/test/path.ts")
+			const state = testTool.testGetPartialState(mockTask)
+			expect(state.status).toBe("streaming")
+		})
+	})
+
+	describe("notifyPartialError", () => {
+		let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+		beforeEach(() => {
+			consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		})
+
+		afterEach(() => {
+			consoleErrorSpy.mockRestore()
+		})
+
+		it("should return true and log on first error", () => {
+			const result = testTool.testNotifyPartialError(mockTask, "First error")
+			expect(result).toBe(true)
+			expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("First error"))
+		})
+
+		it("should return false and not log on repeated identical error", () => {
+			testTool.testNotifyPartialError(mockTask, "Same error")
+			consoleErrorSpy.mockClear()
+
+			const result = testTool.testNotifyPartialError(mockTask, "Same error")
+			expect(result).toBe(false)
+			expect(consoleErrorSpy).not.toHaveBeenCalled()
+		})
+
+		it("should return true and log when error message changes", () => {
+			testTool.testNotifyPartialError(mockTask, "Error 1")
+			consoleErrorSpy.mockClear()
+
+			const result = testTool.testNotifyPartialError(mockTask, "Error 2")
+			expect(result).toBe(true)
+			expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining("Error 2"))
+		})
+
+		it("should track error count for repeated errors", () => {
+			testTool.testNotifyPartialError(mockTask, "Repeated error")
+			testTool.testNotifyPartialError(mockTask, "Repeated error")
+			testTool.testNotifyPartialError(mockTask, "Repeated error")
+
+			const state = testTool.testGetPartialState(mockTask)
+			expect(state.status).toBe("erroring")
+			expect((state as any).errorCount).toBe(3)
+		})
+
+		it("should set isPathValidationError flag when specified", () => {
+			testTool.testNotifyPartialError(mockTask, "Invalid path: /outside", true)
+
+			const state = testTool.testGetPartialState(mockTask)
+			expect(state.status).toBe("erroring")
+			expect((state as any).isPathValidationError).toBe(true)
+		})
+	})
+
+	describe("shouldSkipDueToPathError", () => {
+		it("should return false when in idle state", () => {
+			const result = testTool.testShouldSkipDueToPathError(mockTask)
+			expect(result).toBe(false)
+		})
+
+		it("should return false when in streaming state", () => {
+			testTool.testSetPartialState(mockTask, { status: "streaming" })
+			const result = testTool.testShouldSkipDueToPathError(mockTask)
+			expect(result).toBe(false)
+		})
+
+		it("should return false for non-path errors", () => {
+			testTool.testNotifyPartialError(mockTask, "Some other error", false)
+			const result = testTool.testShouldSkipDueToPathError(mockTask)
+			expect(result).toBe(false)
+		})
+
+		it("should return true for path validation errors", () => {
+			testTool.testNotifyPartialError(mockTask, "Invalid path: /outside", true)
+			const result = testTool.testShouldSkipDueToPathError(mockTask)
+			expect(result).toBe(true)
+		})
+	})
+
+	describe("handle() - error suppression integration", () => {
+		let consoleErrorSpy: ReturnType<typeof vi.spyOn>
+
+		beforeEach(() => {
+			consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		})
+
+		afterEach(() => {
+			consoleErrorSpy.mockRestore()
+		})
+
+		it("should call handlePartial for partial blocks", async () => {
+			const block = createMockToolUse(true)
+
+			await testTool.handle(mockTask, block, mockCallbacks)
+
+			expect(testTool.handlePartialCallCount).toBe(1)
+			expect(testTool.executeCallCount).toBe(0)
+		})
+
+		it("should call execute for complete blocks", async () => {
+			const block = createMockToolUse(false)
+
+			await testTool.handle(mockTask, block, mockCallbacks)
+
+			expect(testTool.handlePartialCallCount).toBe(0)
+			expect(testTool.executeCallCount).toBe(1)
+		})
+
+		it("should suppress repeated partial errors", async () => {
+			testTool.shouldThrowInHandlePartial = true
+			testTool.partialErrorMessage = "Repeated error"
+			const block = createMockToolUse(true)
+
+			// First error - logged
+			await testTool.handle(mockTask, block, mockCallbacks)
+			expect(consoleErrorSpy).toHaveBeenCalledTimes(1)
+
+			// Second identical error - suppressed
+			consoleErrorSpy.mockClear()
+			await testTool.handle(mockTask, block, mockCallbacks)
+			expect(consoleErrorSpy).not.toHaveBeenCalled()
+
+			// handleError should NOT be called (error suppression)
+			expect(mockCallbacks.handleError).not.toHaveBeenCalled()
+		})
+
+		it("should skip handlePartial when path error is active (fast-path guard)", async () => {
+			// Simulate a path validation error
+			testTool.testNotifyPartialError(mockTask, "Invalid path: /outside", true)
+			const block = createMockToolUse(true)
+
+			await testTool.handle(mockTask, block, mockCallbacks)
+
+			// handlePartial should be skipped due to fast-path guard
+			expect(testTool.handlePartialCallCount).toBe(0)
+		})
+
+		it("should recover from error state on reset", async () => {
+			// Set up error state
+			testTool.testNotifyPartialError(mockTask, "Invalid path: /outside", true)
+			expect(testTool.testShouldSkipDueToPathError(mockTask)).toBe(true)
+
+			// Reset state (simulating end of execute)
+			testTool.resetPartialState(mockTask)
+
+			// Should no longer skip
+			expect(testTool.testShouldSkipDueToPathError(mockTask)).toBe(false)
+		})
+	})
+})

--- a/src/package.json
+++ b/src/package.json
@@ -11,7 +11,7 @@
 	},
 	"engines": {
 		"vscode": "^1.84.0",
-		"node": "20.19.2"
+		"node": "20.20.0"
 	},
 	"author": {
 		"name": "Roo Code"

--- a/src/utils/__tests__/pathUtils.spec.ts
+++ b/src/utils/__tests__/pathUtils.spec.ts
@@ -1,0 +1,184 @@
+// npx vitest utils/__tests__/pathUtils.spec.ts
+
+import * as path from "path"
+
+import { normalizeToolPath, isPathOutsideWorkspace } from "../pathUtils"
+
+// Mock vscode module
+vi.mock("vscode", () => ({
+	workspace: {
+		workspaceFolders: [
+			{
+				uri: { fsPath: "/workspace/project" },
+				name: "project",
+				index: 0,
+			},
+		],
+		asRelativePath: vi.fn().mockImplementation((pathOrUri: string, includeWorkspaceFolder?: boolean) => {
+			// Simulate VS Code's asRelativePath behavior
+			const wsPath = "/workspace/project"
+			if (pathOrUri.startsWith(wsPath + "/") || pathOrUri.startsWith(wsPath + path.sep)) {
+				return pathOrUri.slice(wsPath.length + 1)
+			}
+			// Return unchanged if outside workspace
+			return pathOrUri
+		}),
+	},
+}))
+
+describe("pathUtils", () => {
+	describe("normalizeToolPath", () => {
+		const cwd = "/workspace/project"
+
+		describe("valid paths", () => {
+			it("should accept simple relative paths", () => {
+				const result = normalizeToolPath("src/file.ts", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("src/file.ts")
+				expect(result.error).toBeUndefined()
+			})
+
+			it("should accept nested relative paths", () => {
+				const result = normalizeToolPath("src/components/Button.tsx", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("src/components/Button.tsx")
+			})
+
+			it("should accept paths with ./", () => {
+				const result = normalizeToolPath("./src/file.ts", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("src/file.ts")
+			})
+
+			it("should normalize redundant path segments", () => {
+				const result = normalizeToolPath("src/../src/file.ts", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("src/file.ts")
+			})
+
+			it("should accept absolute paths within workspace", () => {
+				const result = normalizeToolPath("/workspace/project/src/file.ts", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("src/file.ts")
+			})
+
+			it("should accept file in root of workspace", () => {
+				const result = normalizeToolPath("README.md", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("README.md")
+			})
+		})
+
+		describe("invalid paths - directory traversal attacks", () => {
+			it("should reject paths starting with ../", () => {
+				const result = normalizeToolPath("../outside/file.ts", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+
+			it("should reject paths with multiple ../", () => {
+				const result = normalizeToolPath("../../etc/passwd", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+
+			it("should reject paths that traverse then back in", () => {
+				// src/../../outside resolves to ../outside
+				const result = normalizeToolPath("src/../../outside/file.ts", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+		})
+
+		describe("invalid paths - absolute paths outside workspace", () => {
+			it("should reject absolute paths to root", () => {
+				const result = normalizeToolPath("/plans", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+
+			it("should reject absolute paths to /etc", () => {
+				const result = normalizeToolPath("/etc/passwd", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+
+			it("should reject absolute paths to sibling directories", () => {
+				const result = normalizeToolPath("/workspace/other-project/file.ts", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+
+			it("should reject paths to home directory", () => {
+				const result = normalizeToolPath("/home/user/.ssh/id_rsa", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+		})
+
+		describe("edge cases", () => {
+			it("should handle empty path segments", () => {
+				const result = normalizeToolPath("src//file.ts", cwd)
+				expect(result.isValid).toBe(true)
+				// path.normalize handles this
+				expect(result.relPath).toBe("src/file.ts")
+			})
+
+			it("should handle paths with only dots", () => {
+				const result = normalizeToolPath(".", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe(".")
+			})
+
+			it("should handle paths with spaces", () => {
+				const result = normalizeToolPath("src/my file.ts", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("src/my file.ts")
+			})
+
+			it("should handle paths with special characters", () => {
+				const result = normalizeToolPath("src/file-name_v2.test.ts", cwd)
+				expect(result.isValid).toBe(true)
+				expect(result.relPath).toBe("src/file-name_v2.test.ts")
+			})
+		})
+
+		describe("the original issue #11208", () => {
+			it("should reject /plans path that caused the EACCES error", () => {
+				// This is the exact path from issue #11208 that caused:
+				// EACCES: permission denied, mkdir '/plans'
+				const result = normalizeToolPath("/plans", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+
+			it("should reject /plans/implementation.md", () => {
+				const result = normalizeToolPath("/plans/implementation.md", cwd)
+				expect(result.isValid).toBe(false)
+				expect(result.error).toContain("resolves outside the workspace")
+			})
+		})
+	})
+
+	describe("isPathOutsideWorkspace", () => {
+		it("should return false for paths inside workspace", () => {
+			expect(isPathOutsideWorkspace("/workspace/project/src/file.ts")).toBe(false)
+		})
+
+		it("should return false for workspace root", () => {
+			expect(isPathOutsideWorkspace("/workspace/project")).toBe(false)
+		})
+
+		it("should return true for paths outside workspace", () => {
+			expect(isPathOutsideWorkspace("/other/path/file.ts")).toBe(true)
+		})
+
+		it("should return true for absolute paths to root", () => {
+			expect(isPathOutsideWorkspace("/plans")).toBe(true)
+		})
+
+		it("should return true for sibling directories", () => {
+			expect(isPathOutsideWorkspace("/workspace/other-project")).toBe(true)
+		})
+	})
+})

--- a/src/utils/pathUtils.ts
+++ b/src/utils/pathUtils.ts
@@ -2,6 +2,80 @@ import * as vscode from "vscode"
 import * as path from "path"
 
 /**
+ * Result of path normalization for tool operations.
+ */
+export interface PathNormalizationResult {
+	/** The normalized relative path (if valid) */
+	relPath: string
+	/** Whether the path is valid for tool operations */
+	isValid: boolean
+	/** Error message if invalid */
+	error?: string
+}
+
+/**
+ * Normalize a tool path to workspace-relative, with security validation.
+ *
+ * This function:
+ * 1. Converts absolute paths to workspace-relative using VS Code's API
+ * 2. Validates the result is safe (no traversal, stays within workspace)
+ * 3. Returns a consistent result for both execute() and handlePartial()
+ *
+ * @param rawPath - The path from the LLM (may be absolute or relative)
+ * @param cwd - The task's current working directory (workspace folder)
+ * @returns Normalization result with validity status
+ */
+export function normalizeToolPath(rawPath: string, cwd: string): PathNormalizationResult {
+	let relPath = rawPath
+
+	// Step 1: Convert absolute paths to workspace-relative
+	if (path.isAbsolute(rawPath)) {
+		// Use VS Code's API for multi-root workspace support and separator handling
+		relPath = vscode.workspace.asRelativePath(rawPath, false)
+
+		// asRelativePath may return the absolute path unchanged if it's outside
+		// all workspace folders. Fall back to path.relative in that case.
+		if (path.isAbsolute(relPath)) {
+			relPath = path.relative(cwd, rawPath)
+		}
+	}
+
+	// Step 2: Normalize to remove redundant segments (./foo/../bar -> bar)
+	relPath = path.normalize(relPath)
+
+	// Step 3: Security validation - reject paths that escape workspace via ../
+	if (relPath.startsWith("..") || relPath.startsWith(path.sep + "..")) {
+		return {
+			relPath,
+			isValid: false,
+			error: `Path "${rawPath}" resolves outside the workspace`,
+		}
+	}
+
+	// Step 4: Reject paths that are still absolute after normalization
+	if (path.isAbsolute(relPath)) {
+		return {
+			relPath,
+			isValid: false,
+			error: `Path "${rawPath}" could not be resolved relative to workspace`,
+		}
+	}
+
+	// Step 5: Final check - resolve and verify it's within cwd
+	const absoluteResolved = path.resolve(cwd, relPath)
+	const cwdNormalized = path.normalize(cwd)
+	if (!absoluteResolved.startsWith(cwdNormalized + path.sep) && absoluteResolved !== cwdNormalized) {
+		return {
+			relPath,
+			isValid: false,
+			error: `Path "${rawPath}" resolves outside the workspace`,
+		}
+	}
+
+	return { relPath, isValid: true }
+}
+
+/**
  * Checks if a file path is outside all workspace folders
  * @param filePath The file path to check
  * @returns true if the path is outside all workspace folders, false otherwise


### PR DESCRIPTION
### Related GitHub Issue

Closes: #11208

### Roo Code Task Context (Optional)

N/A

### Description

This PR fixes the EACCES permission denied errors that occur when LLMs provide absolute paths (like `/plans`) in tool calls during streaming.

**Root Cause**: When `path.resolve(task.cwd, "/plans")` is called with an absolute path, it returns `/plans` directly, bypassing the workspace directory entirely. This causes filesystem operations to attempt creating directories at the root level.

**Key Implementation Details**:

1. **Shared path normalization** (`src/utils/pathUtils.ts`):
   - Added `normalizeToolPath()` with 5-step validation
   - Converts absolute paths to workspace-relative using VS Code API
   - Rejects paths that escape workspace via `../` or resolve outside cwd

2. **Error suppression in BaseTool** (`src/core/tools/BaseTool.ts`):
   - `PartialExecutionState` discriminated union (idle/streaming/erroring)
   - Per-task state isolation via `WeakMap<Task, State>`
   - `notifyPartialError()`: logs first error, suppresses identical repeats
   - `shouldSkipDueToPathError()`: fast-path guard skips expensive work on known-bad paths

3. **Updated all file-writing tools** to use new per-task signatures:
   - `hasPathStabilized(task, path)`
   - `resetPartialState(task)`

**Also includes** (required for test infrastructure):
- Upgrade turbo ^2.5.6 → ^2.8.3
- Upgrade node engine 20.19.2 → 20.20.0
- Pull flake.nix/flake.lock from nix branch ( still waiting for the nix PR merge )

### Test Procedure

**New tests added** (47 tests in 2 files):

1. `src/utils/__tests__/pathUtils.spec.ts` - Path normalization tests:
   - Valid paths (simple, nested, normalized, absolute within workspace)
   - Invalid paths (../ traversal, absolute outside workspace like `/plans`)
   - Edge cases (empty segments, dots, spaces, special characters)

2. `src/core/tools/__tests__/BaseTool.spec.ts` - Error suppression tests:
   - Per-task state isolation
   - Error suppression (first logged, repeats suppressed)
   - Fast-path guard behavior
   - State recovery after reset

**To run new tests only**:
```bash
cd src && pnpm vitest run utils/__tests__/pathUtils.spec.ts core/tools/__tests__/BaseTool.spec.ts
```

**Full test suite passes**: 370 files, 5461 tests

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A - No UI changes

### Documentation Updates

I'm not sure if this need extra documentation.  Happy for feedback.

### Additional Notes

The fix addresses PR #11209's approach but extends it to also handle the `handlePartial()` streaming path, which is where the repeated errors actually occur during LLM streaming.

### Get in Touch

N/A

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes EACCES errors by normalizing paths to workspace-relative and adds error suppression for repeated path errors in tool calls.
> 
>   - **Behavior**:
>     - Fixes EACCES errors by normalizing absolute paths to workspace-relative in `normalizeToolPath()` in `pathUtils.ts`.
>     - Implements error suppression for repeated path errors in `BaseTool.ts`.
>   - **Tools**:
>     - Updates `WriteToFileTool`, `EditFileTool`, `SearchReplaceTool`, `SearchAndReplaceTool`, and `ApplyDiffTool` to use `normalizeToolPath()`.
>     - Adds path stabilization checks and error handling improvements in `BaseTool.ts`.
>   - **Tests**:
>     - Adds tests for path normalization in `pathUtils.spec.ts`.
>     - Adds tests for error suppression and path handling in `BaseTool.spec.ts` and `writeToFileTool.spec.ts`.
>   - **Misc**:
>     - Updates Node.js version to 20.20.0 in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for bdae65b27bcd23e40fe782248107dcd864b4a49d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->