### PR TITLE
fix: remove noisy console.warn logs from NativeToolCallParser

### DIFF
--- a/src/core/assistant-message/NativeToolCallParser.ts
+++ b/src/core/assistant-message/NativeToolCallParser.ts
@@ -250,7 +250,6 @@ export class NativeToolCallParser {
 	public static processStreamingChunk(id: string, chunk: string): ToolUse | null {
 		const toolCall = this.streamingToolCalls.get(id)
 		if (!toolCall) {
-			console.warn(`[NativeToolCallParser] Received chunk for unknown tool call: ${id}`)
 			return null
 		}
 
@@ -295,7 +294,6 @@ export class NativeToolCallParser {
 	public static finalizeStreamingToolCall(id: string): ToolUse | McpToolUse | null {
 		const toolCall = this.streamingToolCalls.get(id)
 		if (!toolCall) {
-			console.warn(`[NativeToolCallParser] Attempting to finalize unknown tool call: ${id}`)
 			return null
 		}
 


### PR DESCRIPTION
## Summary

Removes two `console.warn` messages from `NativeToolCallParser` that fire excessively when loading tasks from history:

- `"Attempting to finalize unknown tool call"` in `finalizeStreamingToolCall()`
- `"Received chunk for unknown tool call"` in `processStreamingChunk()`

## Changes

These warnings are triggered whenever a tool call ID isn't found in the `streamingToolCalls` map, which happens frequently during task history restoration (since the streaming state isn't persisted). The defensive `null`-return behavior is preserved — only the noisy log output is removed.

## Testing

- All existing tests pass (5453 passed)
- `NativeToolCallParser.spec.ts`: 12/12 passed
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove excessive `console.warn` logs from `NativeToolCallParser` methods for unknown tool call IDs.
> 
>   - **Behavior**:
>     - Remove `console.warn` in `processStreamingChunk()` for unknown tool call ID.
>     - Remove `console.warn` in `finalizeStreamingToolCall()` for unknown tool call ID.
>     - Both methods still return `null` if tool call ID is not found.
>   - **Testing**:
>     - All existing tests pass (5453 passed).
>     - `NativeToolCallParser.spec.ts`: 12/12 passed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5f716b4dd0e8584af727586f903d075e8ee88854. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->