### PR TITLE
refactor: migrate chutes provider to AI SDK

### DIFF
--- a/src/api/providers/chutes.ts
+++ b/src/api/providers/chutes.ts
@@ -1,62 +1,110 @@
-import { DEEP_SEEK_DEFAULT_TEMPERATURE, chutesDefaultModelId, chutesDefaultModelInfo } from "@roo-code/types"
 import { Anthropic } from "@anthropic-ai/sdk"
-import OpenAI from "openai"
+import { streamText, generateText, LanguageModel, ToolSet } from "ai"
+
+import {
+	DEEP_SEEK_DEFAULT_TEMPERATURE,
+	chutesDefaultModelId,
+	chutesDefaultModelInfo,
+	type ModelInfo,
+	type ModelRecord,
+} from "@roo-code/types"
 
 import type { ApiHandlerOptions } from "../../shared/api"
 import { getModelMaxOutputTokens } from "../../shared/api"
 import { TagMatcher } from "../../utils/tag-matcher"
-import { convertToR1Format } from "../transform/r1-format"
-import { convertToOpenAiMessages } from "../transform/openai-format"
+import {
+	convertToAiSdkMessages,
+	convertToolsForAiSdk,
+	processAiSdkStreamPart,
+	mapToolChoice,
+	handleAiSdkError,
+} from "../transform/ai-sdk"
 import { ApiStream } from "../transform/stream"
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 
-import { RouterProvider } from "./router-provider"
+import { OpenAICompatibleHandler, OpenAICompatibleConfig } from "./openai-compatible"
+import { getModels, getModelsFromCache } from "./fetchers/modelCache"
 
-export class ChutesHandler extends RouterProvider implements SingleCompletionHandler {
+export class ChutesHandler extends OpenAICompatibleHandler implements SingleCompletionHandler {
+	private models: ModelRecord = {}
+
 	constructor(options: ApiHandlerOptions) {
-		super({
-			options,
-			name: "chutes",
+		const modelId = options.apiModelId ?? chutesDefaultModelId
+
+		const config: OpenAICompatibleConfig = {
+			providerName: "chutes",
 			baseURL: "https://llm.chutes.ai/v1",
-			apiKey: options.chutesApiKey,
-			modelId: options.apiModelId,
-			defaultModelId: chutesDefaultModelId,
-			defaultModelInfo: chutesDefaultModelInfo,
-		})
+			apiKey: options.chutesApiKey ?? "not-provided",
+			modelId,
+			modelInfo: chutesDefaultModelInfo,
+		}
+
+		super(options, config)
 	}
 
-	private getCompletionParams(
-		systemPrompt: string,
-		messages: Anthropic.Messages.MessageParam[],
-		metadata?: ApiHandlerCreateMessageMetadata,
-	): OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming {
-		const { id: model, info } = this.getModel()
+	async fetchModel() {
+		this.models = await getModels({ provider: "chutes", apiKey: this.config.apiKey, baseUrl: this.config.baseURL })
+		return this.getModel()
+	}
 
-		// Centralized cap: clamp to 20% of the context window (unless provider-specific exceptions apply)
-		const max_tokens =
+	override getModel(): { id: string; info: ModelInfo; temperature?: number } {
+		const id = this.options.apiModelId ?? chutesDefaultModelId
+
+		let info: ModelInfo | undefined = this.models[id]
+
+		if (!info) {
+			const cachedModels = getModelsFromCache("chutes")
+			if (cachedModels?.[id]) {
+				this.models = cachedModels
+				info = cachedModels[id]
+			}
+		}
+
+		if (!info) {
+			const isDeepSeekR1 = chutesDefaultModelId.includes("DeepSeek-R1")
+			const defaultTemp = isDeepSeekR1 ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0.5
+			return {
+				id: chutesDefaultModelId,
+				info: {
+					...chutesDefaultModelInfo,
+					defaultTemperature: defaultTemp,
+				},
+				temperature: this.options.modelTemperature ?? defaultTemp,
+			}
+		}
+
+		const isDeepSeekR1 = id.includes("DeepSeek-R1")
+		const defaultTemp = isDeepSeekR1 ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0.5
+
+		return {
+			id,
+			info: {
+				...info,
+				defaultTemperature: defaultTemp,
+			},
+			temperature: this.supportsTemperature(id) ? (this.options.modelTemperature ?? defaultTemp) : undefined,
+		}
+	}
+
+	protected override getLanguageModel(): LanguageModel {
+		const { id } = this.getModel()
+		return this.provider(id)
+	}
+
+	protected override getMaxOutputTokens(): number | undefined {
+		const { id, info } = this.getModel()
+		return (
 			getModelMaxOutputTokens({
-				modelId: model,
+				modelId: id,
 				model: info,
 				settings: this.options,
 				format: "openai",
 			}) ?? undefined
+		)
+	}
 
-		const params: OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming = {
-			model,
-			max_tokens,
-			messages: [{ role: "system", content: systemPrompt }, ...convertToOpenAiMessages(messages)],
-			stream: true,
-			stream_options: { include_usage: true },
-			tools: metadata?.tools,
-			tool_choice: metadata?.tool_choice,
-		}
-
-		// Only add temperature if model supports it
-		if (this.supportsTemperature(model)) {
-			params.temperature = this.options.modelTemperature ?? info.temperature
-		}
-
-		return params
+	private supportsTemperature(modelId: string): boolean {
+		return !modelId.startsWith("openai/o3-mini")
 	}
 
 	override async *createMessage(
@@ -67,143 +115,128 @@ export class ChutesHandler extends RouterProvider implements SingleCompletionHan
 		const model = await this.fetchModel()
 
 		if (model.id.includes("DeepSeek-R1")) {
-			const stream = await this.client.chat.completions.create({
-				...this.getCompletionParams(systemPrompt, messages, metadata),
-				messages: convertToR1Format([{ role: "user", content: systemPrompt }, ...messages]),
-			})
-
-			const matcher = new TagMatcher(
-				"think",
-				(chunk) =>
-					({
-						type: chunk.matched ? "reasoning" : "text",
-						text: chunk.data,
-					}) as const,
-			)
-
-			for await (const chunk of stream) {
-				const delta = chunk.choices[0]?.delta
-
-				if (delta?.content) {
-					for (const processedChunk of matcher.update(delta.content)) {
-						yield processedChunk
-					}
-				}
-
-				// Emit raw tool call chunks - NativeToolCallParser handles state management
-				if (delta && "tool_calls" in delta && Array.isArray(delta.tool_calls)) {
-					for (const toolCall of delta.tool_calls) {
-						yield {
-							type: "tool_call_partial",
-							index: toolCall.index,
-							id: toolCall.id,
-							name: toolCall.function?.name,
-							arguments: toolCall.function?.arguments,
-						}
-					}
-				}
-
-				if (chunk.usage) {
-					yield {
-						type: "usage",
-						inputTokens: chunk.usage.prompt_tokens || 0,
-						outputTokens: chunk.usage.completion_tokens || 0,
-					}
-				}
-			}
-
-			// Process any remaining content
-			for (const processedChunk of matcher.final()) {
-				yield processedChunk
-			}
+			yield* this.createR1Message(systemPrompt, messages, model, metadata)
 		} else {
-			// For non-DeepSeek-R1 models, use standard OpenAI streaming
-			const stream = await this.client.chat.completions.create(
-				this.getCompletionParams(systemPrompt, messages, metadata),
-			)
-
-			for await (const chunk of stream) {
-				const delta = chunk.choices[0]?.delta
-
-				if (delta?.content) {
-					yield { type: "text", text: delta.content }
-				}
-
-				if (delta && "reasoning_content" in delta && delta.reasoning_content) {
-					yield { type: "reasoning", text: (delta.reasoning_content as string | undefined) || "" }
-				}
-
-				// Emit raw tool call chunks - NativeToolCallParser handles state management
-				if (delta && "tool_calls" in delta && Array.isArray(delta.tool_calls)) {
-					for (const toolCall of delta.tool_calls) {
-						yield {
-							type: "tool_call_partial",
-							index: toolCall.index,
-							id: toolCall.id,
-							name: toolCall.function?.name,
-							arguments: toolCall.function?.arguments,
-						}
-					}
-				}
-
-				if (chunk.usage) {
-					yield {
-						type: "usage",
-						inputTokens: chunk.usage.prompt_tokens || 0,
-						outputTokens: chunk.usage.completion_tokens || 0,
-					}
-				}
-			}
+			yield* super.createMessage(systemPrompt, messages, metadata)
 		}
 	}
 
-	async completePrompt(prompt: string): Promise<string> {
-		const model = await this.fetchModel()
-		const { id: modelId, info } = model
+	private async *createR1Message(
+		systemPrompt: string,
+		messages: Anthropic.Messages.MessageParam[],
+		model: { id: string; info: ModelInfo },
+		metadata?: ApiHandlerCreateMessageMetadata,
+	): ApiStream {
+		const languageModel = this.getLanguageModel()
+
+		const modifiedMessages = [...messages] as Anthropic.Messages.MessageParam[]
+
+		if (modifiedMessages.length > 0 && modifiedMessages[0].role === "user") {
+			const first = modifiedMessages[0]
+			if (typeof first.content === "string") {
+				modifiedMessages[0] = { role: "user", content: `${systemPrompt}\n\n${first.content}` }
+			} else {
+				modifiedMessages[0] = {
+					role: "user",
+					content: [{ type: "text", text: systemPrompt }, ...first.content],
+				}
+			}
+		} else {
+			modifiedMessages.unshift({ role: "user", content: systemPrompt })
+		}
+
+		const aiSdkMessages = convertToAiSdkMessages(modifiedMessages)
+
+		const openAiTools = this.convertToolsForOpenAI(metadata?.tools)
+		const aiSdkTools = convertToolsForAiSdk(openAiTools) as ToolSet | undefined
+
+		const maxOutputTokens =
+			getModelMaxOutputTokens({
+				modelId: model.id,
+				model: model.info,
+				settings: this.options,
+				format: "openai",
+			}) ?? undefined
+
+		const temperature = this.supportsTemperature(model.id)
+			? (this.options.modelTemperature ?? model.info.defaultTemperature)
+			: undefined
+
+		const result = streamText({
+			model: languageModel,
+			messages: aiSdkMessages,
+			temperature,
+			maxOutputTokens,
+			tools: aiSdkTools,
+			toolChoice: mapToolChoice(metadata?.tool_choice),
+		})
+
+		const matcher = new TagMatcher(
+			"think",
+			(chunk) =>
+				({
+					type: chunk.matched ? "reasoning" : "text",
+					text: chunk.data,
+				}) as const,
+		)
 
 		try {
-			// Centralized cap: clamp to 20% of the context window (unless provider-specific exceptions apply)
-			const max_tokens =
-				getModelMaxOutputTokens({
-					modelId,
-					model: info,
-					settings: this.options,
-					format: "openai",
-				}) ?? undefined
-
-			const requestParams: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
-				model: modelId,
-				messages: [{ role: "user", content: prompt }],
-				max_tokens,
+			for await (const part of result.fullStream) {
+				if (part.type === "text-delta") {
+					for (const processedChunk of matcher.update(part.text)) {
+						yield processedChunk
+					}
+				} else {
+					for (const chunk of processAiSdkStreamPart(part)) {
+						yield chunk
+					}
+				}
 			}
 
-			// Only add temperature if model supports it
-			if (this.supportsTemperature(modelId)) {
-				const isDeepSeekR1 = modelId.includes("DeepSeek-R1")
-				const defaultTemperature = isDeepSeekR1 ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0.5
-				requestParams.temperature = this.options.modelTemperature ?? defaultTemperature
+			for (const processedChunk of matcher.final()) {
+				yield processedChunk
 			}
 
-			const response = await this.client.chat.completions.create(requestParams)
-			return response.choices[0]?.message.content || ""
+			const usage = await result.usage
+			if (usage) {
+				yield this.processUsageMetrics(usage)
+			}
+		} catch (error) {
+			throw handleAiSdkError(error, "chutes")
+		}
+	}
+
+	override async completePrompt(prompt: string): Promise<string> {
+		const model = await this.fetchModel()
+		const languageModel = this.getLanguageModel()
+
+		const maxOutputTokens =
+			getModelMaxOutputTokens({
+				modelId: model.id,
+				model: model.info,
+				settings: this.options,
+				format: "openai",
+			}) ?? undefined
+
+		const isDeepSeekR1 = model.id.includes("DeepSeek-R1")
+		const defaultTemperature = isDeepSeekR1 ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0.5
+		const temperature = this.supportsTemperature(model.id)
+			? (this.options.modelTemperature ?? defaultTemperature)
+			: undefined
+
+		try {
+			const { text } = await generateText({
+				model: languageModel,
+				prompt,
+				maxOutputTokens,
+				temperature,
+			})
+			return text
 		} catch (error) {
 			if (error instanceof Error) {
 				throw new Error(`Chutes completion error: ${error.message}`)
 			}
 			throw error
-		}
-	}
-
-	override getModel() {
-		const model = super.getModel()
-		const isDeepSeekR1 = model.id.includes("DeepSeek-R1")
-
-		return {
-			...model,
-			info: {
-				...model.info,
-				temperature: isDeepSeekR1 ? DEEP_SEEK_DEFAULT_TEMPERATURE : 0.5,
-			},
 		}
 	}
 }


### PR DESCRIPTION
Migrates the Chutes provider from legacy RouterProvider (direct openai SDK) to AI SDK using @ai-sdk/openai-compatible. Preserves DeepSeek-R1 reasoning handling, dynamic model fetching, and temperature control.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `ChutesHandler` to use AI SDK, preserving existing functionalities and updating tests accordingly.
> 
>   - **Refactor**:
>     - Migrate `ChutesHandler` from `RouterProvider` to `AI SDK` using `@ai-sdk/openai-compatible`.
>     - Preserve DeepSeek-R1 reasoning, dynamic model fetching, and temperature control.
>   - **Testing**:
>     - Update `chutes.spec.ts` to mock `ai` and `@ai-sdk/openai-compatible`.
>     - Add tests for `getModel`, `fetchModel`, `createMessage`, and `completePrompt` in `chutes.spec.ts`.
>     - Ensure tests cover DeepSeek-R1 reasoning, tool calls, and usage information.
>   - **Functions**:
>     - Implement `fetchModel`, `getModel`, `createMessage`, and `completePrompt` in `chutes.ts`.
>     - Use `streamText` and `generateText` from `ai` for text generation and streaming.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6c4d1a869dba6c72e78e01b8f8f8df194590b903. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->