### PR TITLE
chore(cli): prepare release v0.0.51

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.51] - 2026-02-06
+
+### Changed
+
+- **Default Model Update**: Changed the default model from Opus 4.5 to Opus 4.6 for improved performance and capabilities
+
 ## [0.0.50] - 2026-02-05
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.0.50",
+	"version": "0.0.51",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.0.51

This PR prepares the CLI release v0.0.51.

### Changes
- Version bump in package.json
- Changelog update

### Summary
- **Changed**: Default model updated from Opus 4.5 to Opus 4.6 for improved performance and capabilities

### Checklist
- [ ] Version number is correct
- [ ] Changelog entry is complete and accurate
- [ ] All CI checks pass
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prepare CLI release v0.0.51 with default model update to Opus 4.6.
> 
>   - **Version Update**:
>     - Bump version to `0.0.51` in `package.json`.
>   - **Changelog**:
>     - Update `CHANGELOG.md` to document the change of default model from Opus 4.5 to Opus 4.6 for improved performance and capabilities.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 2e509f0da9c866c0c07b0853ee88f081359173cb. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->