### PR TITLE
feat: migrate anthropic provider to AI SDK

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -746,6 +746,9 @@ importers:
 
   src:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.37
+        version: 3.0.37(zod@3.25.76)
       '@ai-sdk/cerebras':
         specifier: ^1.0.0
         version: 1.0.35(zod@3.25.76)
@@ -1419,6 +1422,12 @@ packages:
 
   '@ai-sdk/anthropic@2.0.58':
     resolution: {integrity: sha512-CkNW5L1Arv8gPtPlEmKd+yf/SG9ucJf0XQdpMG8OiYEtEMc2smuCA+tyCp8zI7IBVg/FE7nUfFHntQFaOjRwJQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: 3.25.76
+
+  '@ai-sdk/anthropic@3.0.37':
+    resolution: {integrity: sha512-tEgcJPw+a6obbF+SHrEiZsx3DNxOHqeY8bK4IpiNsZ8YPZD141R34g3lEAaQnmNN5mGsEJ8SXoEDabuzi8wFJQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: 3.25.76
@@ -11134,6 +11143,12 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.1
       '@ai-sdk/provider-utils': 3.0.20(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/anthropic@3.0.37(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.7
+      '@ai-sdk/provider-utils': 4.0.13(zod@3.25.76)
       zod: 3.25.76
 
   '@ai-sdk/cerebras@1.0.35(zod@3.25.76)':

--- a/src/api/transform/__tests__/ai-sdk.spec.ts
+++ b/src/api/transform/__tests__/ai-sdk.spec.ts
@@ -349,7 +349,7 @@ describe("AI SDK conversion utilities", () => {
 			expect(result[0]).toEqual({
 				role: "assistant",
 				content: [
-					{ type: "reasoning", text: "Deep thought" },
+					{ type: "reasoning", text: "Deep thought", signature: "sig" },
 					{ type: "text", text: "OK" },
 				],
 			})

--- a/src/api/transform/caching/__tests__/ai-sdk-anthropic.spec.ts
+++ b/src/api/transform/caching/__tests__/ai-sdk-anthropic.spec.ts
@@ -1,0 +1,152 @@
+// npx vitest run src/api/transform/caching/__tests__/ai-sdk-anthropic.spec.ts
+
+import type { ModelMessage } from "ai"
+
+import { addAiSdkAnthropicCacheBreakpoints } from "../ai-sdk-anthropic"
+
+const CACHE_CONTROL = { anthropic: { cacheControl: { type: "ephemeral" } } }
+
+describe("addAiSdkAnthropicCacheBreakpoints", () => {
+	it("should return messages unchanged when there are no user messages", () => {
+		const messages: ModelMessage[] = [{ role: "assistant", content: [{ type: "text", text: "Hello" }] }]
+
+		const result = addAiSdkAnthropicCacheBreakpoints(messages)
+		expect(result).toEqual(messages)
+	})
+
+	it("should add cache breakpoint to a single user message with string content", () => {
+		const messages: ModelMessage[] = [
+			{ role: "user", content: "Hello" },
+			{ role: "assistant", content: [{ type: "text", text: "Hi" }] },
+		]
+
+		const result = addAiSdkAnthropicCacheBreakpoints(messages)
+
+		expect(result[0]).toEqual({
+			role: "user",
+			content: [{ type: "text", text: "Hello", providerOptions: CACHE_CONTROL }],
+		})
+	})
+
+	it("should add cache breakpoints to the last two user messages", () => {
+		const messages: ModelMessage[] = [
+			{ role: "user", content: "First" },
+			{ role: "assistant", content: [{ type: "text", text: "Response 1" }] },
+			{ role: "user", content: "Second" },
+			{ role: "assistant", content: [{ type: "text", text: "Response 2" }] },
+			{ role: "user", content: "Third" },
+		]
+
+		const result = addAiSdkAnthropicCacheBreakpoints(messages)
+
+		// First user message should NOT have cache control
+		expect(result[0]).toEqual({ role: "user", content: "First" })
+
+		// Second user message should have cache control
+		expect(result[2]).toEqual({
+			role: "user",
+			content: [{ type: "text", text: "Second", providerOptions: CACHE_CONTROL }],
+		})
+
+		// Third user message should have cache control
+		expect(result[4]).toEqual({
+			role: "user",
+			content: [{ type: "text", text: "Third", providerOptions: CACHE_CONTROL }],
+		})
+	})
+
+	it("should add cache breakpoint to the last text part of array content", () => {
+		const messages: ModelMessage[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "text", text: "First part" },
+					{ type: "image", image: "data:image/png;base64,..." },
+					{ type: "text", text: "Last text part" },
+				],
+			},
+		]
+
+		const result = addAiSdkAnthropicCacheBreakpoints(messages)
+
+		expect((result[0] as any).content).toEqual([
+			{ type: "text", text: "First part" },
+			{ type: "image", image: "data:image/png;base64,..." },
+			{ type: "text", text: "Last text part", providerOptions: CACHE_CONTROL },
+		])
+	})
+
+	it("should add placeholder text part when no text parts exist in array content", () => {
+		const messages: ModelMessage[] = [
+			{
+				role: "user",
+				content: [{ type: "image", image: "data:image/png;base64,..." }],
+			},
+		]
+
+		const result = addAiSdkAnthropicCacheBreakpoints(messages)
+
+		expect((result[0] as any).content).toEqual([
+			{ type: "image", image: "data:image/png;base64,..." },
+			{ type: "text", text: "...", providerOptions: CACHE_CONTROL },
+		])
+	})
+
+	it("should not mutate the original messages", () => {
+		const messages: ModelMessage[] = [
+			{ role: "user", content: "Hello" },
+			{ role: "assistant", content: [{ type: "text", text: "Hi" }] },
+		]
+
+		const original = JSON.parse(JSON.stringify(messages))
+		addAiSdkAnthropicCacheBreakpoints(messages)
+
+		expect(messages).toEqual(original)
+	})
+
+	it("should handle both user messages when only two exist", () => {
+		const messages: ModelMessage[] = [
+			{ role: "user", content: "First" },
+			{ role: "assistant", content: [{ type: "text", text: "Response" }] },
+			{ role: "user", content: "Second" },
+		]
+
+		const result = addAiSdkAnthropicCacheBreakpoints(messages)
+
+		expect(result[0]).toEqual({
+			role: "user",
+			content: [{ type: "text", text: "First", providerOptions: CACHE_CONTROL }],
+		})
+		expect(result[2]).toEqual({
+			role: "user",
+			content: [{ type: "text", text: "Second", providerOptions: CACHE_CONTROL }],
+		})
+	})
+
+	it("should not modify assistant or tool messages", () => {
+		const assistantMsg: ModelMessage = { role: "assistant", content: [{ type: "text", text: "Response" }] }
+		const toolMsg: ModelMessage = {
+			role: "tool",
+			content: [
+				{
+					type: "tool-result",
+					toolCallId: "call1",
+					toolName: "test",
+					output: { type: "text", value: "result" },
+				},
+			],
+		} as ModelMessage
+
+		const messages: ModelMessage[] = [
+			{ role: "user", content: "Hello" },
+			assistantMsg,
+			toolMsg,
+			{ role: "user", content: "Continue" },
+		]
+
+		const result = addAiSdkAnthropicCacheBreakpoints(messages)
+
+		expect(result[1]).toEqual(assistantMsg)
+		expect(result[2]).toEqual(toolMsg)
+	})
+})

--- a/src/api/transform/caching/ai-sdk-anthropic.ts
+++ b/src/api/transform/caching/ai-sdk-anthropic.ts
@@ -1,0 +1,90 @@
+import type { ModelMessage } from "ai"
+
+const ANTHROPIC_CACHE_CONTROL = {
+	anthropic: { cacheControl: { type: "ephemeral" } },
+}
+
+/**
+ * Add Anthropic cache breakpoints to AI SDK ModelMessage array.
+ * Adds `providerOptions.anthropic.cacheControl` to the last text content part
+ * of the last 2 user messages, enabling prompt caching for Anthropic models
+ * via the AI SDK.
+ *
+ * Note: System prompt caching is handled separately at the streamText call level
+ * by passing the system prompt as an array with providerOptions.
+ *
+ * @param messages - Array of AI SDK ModelMessage objects
+ * @returns New array with cache breakpoints added (does not mutate input)
+ */
+export function addAiSdkAnthropicCacheBreakpoints(messages: ModelMessage[]): ModelMessage[] {
+	const userMsgIndices = messages.reduce(
+		(acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc),
+		[] as number[],
+	)
+
+	const targetIndices = new Set(userMsgIndices.slice(-2))
+
+	if (targetIndices.size === 0) {
+		return messages
+	}
+
+	return messages.map((message, index) => {
+		if (!targetIndices.has(index)) {
+			return message
+		}
+
+		if (typeof message.content === "string") {
+			return {
+				...message,
+				content: [
+					{
+						type: "text" as const,
+						text: message.content,
+						providerOptions: ANTHROPIC_CACHE_CONTROL,
+					},
+				],
+			} as ModelMessage
+		}
+
+		if (Array.isArray(message.content)) {
+			// Find the index of the last text part
+			let lastTextIndex = -1
+			for (let i = message.content.length - 1; i >= 0; i--) {
+				if ((message.content[i] as { type: string }).type === "text") {
+					lastTextIndex = i
+					break
+				}
+			}
+
+			if (lastTextIndex === -1) {
+				// No text part found — add a placeholder
+				return {
+					...message,
+					content: [
+						...message.content,
+						{
+							type: "text" as const,
+							text: "...",
+							providerOptions: ANTHROPIC_CACHE_CONTROL,
+						},
+					],
+				} as ModelMessage
+			}
+
+			return {
+				...message,
+				content: message.content.map((part, i) => {
+					if (i === lastTextIndex) {
+						return {
+							...(part as Record<string, unknown>),
+							providerOptions: ANTHROPIC_CACHE_CONTROL,
+						}
+					}
+					return part
+				}),
+			} as ModelMessage
+		}
+
+		return message
+	})
+}

--- a/src/package.json
+++ b/src/package.json
@@ -450,6 +450,7 @@
 		"clean": "rimraf README.md CHANGELOG.md LICENSE dist logs mock .turbo"
 	},
 	"dependencies": {
+		"@ai-sdk/anthropic": "^3.0.37",
 		"@ai-sdk/cerebras": "^1.0.0",
 		"@ai-sdk/deepseek": "^2.0.14",
 		"@ai-sdk/fireworks": "^2.0.26",


### PR DESCRIPTION
## Summary

Migrates the Anthropic provider (`src/api/providers/anthropic.ts`) from using the raw `@anthropic-ai/sdk` to `@ai-sdk/anthropic` with the Vercel AI SDK, following the same pattern already used by Gemini and Vertex providers.

## Key Changes

### New Files
- `src/api/transform/caching/ai-sdk-anthropic.ts` — Cache breakpoint utility that adds `providerOptions.anthropic.cacheControl` to AI SDK messages
- `src/api/transform/caching/__tests__/ai-sdk-anthropic.spec.ts` — Tests for the cache utility

### Modified Files
- `src/package.json` — Added `@ai-sdk/anthropic` dependency
- `src/api/providers/anthropic.ts` — Full rewrite from raw SDK to AI SDK pattern:
  - Uses `createAnthropic()` + `streamText()`/`generateText()` from the AI SDK
  - Cache breakpoints via post-processing utility (consistent with existing `caching/` directory pattern)
  - System prompt caching with `providerOptions.anthropic.cacheControl`
  - Thinking config mapped from `budget_tokens` → `budgetTokens` (snake_case → camelCase)
  - All beta headers passed manually via `headers` option
  - **Fixes thought signature capture** — previously not implemented (noted at old line 308)
  - **Adds redacted thinking support** via `getRedactedThinkingBlocks()`
  - Cache write tokens from `providerMetadata.anthropic.cacheCreationInputTokens`
- `src/api/transform/ai-sdk.ts` — Enhanced `processAiSdkStreamPart` to handle `reasoning-end` with signatures; `convertToAiSdkMessages` preserves thinking block signatures and redacted_thinking
- `src/api/providers/__tests__/anthropic.spec.ts` — Full rewrite: 33 tests
- `src/api/transform/__tests__/ai-sdk.spec.ts` — Updated for thinking/signature handling

## Testing
- 33 tests passing in `anthropic.spec.ts`
- 60 tests passing in `ai-sdk.spec.ts`
- 8 tests passing in `ai-sdk-anthropic.spec.ts`
- All existing provider tests unaffected

## Migration Pattern
Follows the established AI SDK migration pattern from Gemini/Vertex:
1. Convert Anthropic messages → AI SDK `ModelMessage[]` via `convertToAiSdkMessages()`
2. Post-process with cache breakpoints via `addAiSdkAnthropicCacheBreakpoints()`
3. Stream via `streamText()` → `result.fullStream` → `processAiSdkStreamPart()`
4. Capture reasoning/signatures from `result.reasoning` after stream completes
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Migrates Anthropic provider to AI SDK, adding cache and reasoning support, with extensive testing.
> 
>   - **Behavior**:
>     - Migrates `anthropic.ts` to use `@ai-sdk/anthropic` and `ai` for message processing.
>     - Implements cache breakpoints for Anthropic models in `ai-sdk-anthropic.ts`.
>     - Handles reasoning and tool call stream parts in `ai-sdk.ts`.
>   - **Testing**:
>     - Adds `ai-sdk-anthropic.spec.ts` for cache utility tests.
>     - Updates `anthropic.spec.ts` with 33 tests for new SDK behavior.
>     - Updates `ai-sdk.spec.ts` for reasoning and signature handling.
>   - **Dependencies**:
>     - Adds `@ai-sdk/anthropic` to `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 83561622cc52e1814fe72358bc2319f915cb2d81. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->