### PR TITLE
fix: prevent double notification sound playback

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -233,15 +233,24 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 	const secondLastMessage = useMemo(() => messages.at(-2), [messages])
 
 	const volume = typeof soundVolume === "number" ? soundVolume : 0.5
-	const [playNotification] = useSound(`${audioBaseUri}/notification.wav`, { volume, soundEnabled })
-	const [playCelebration] = useSound(`${audioBaseUri}/celebration.wav`, { volume, soundEnabled })
-	const [playProgressLoop] = useSound(`${audioBaseUri}/progress_loop.wav`, { volume, soundEnabled })
+	const [playNotification] = useSound(`${audioBaseUri}/notification.wav`, { volume, soundEnabled, interrupt: true })
+	const [playCelebration] = useSound(`${audioBaseUri}/celebration.wav`, { volume, soundEnabled, interrupt: true })
+	const [playProgressLoop] = useSound(`${audioBaseUri}/progress_loop.wav`, { volume, soundEnabled, interrupt: true })
+
+	const lastPlayedRef = useRef<Record<string, number>>({})
 
 	const playSound = useCallback(
 		(audioType: AudioType) => {
 			if (!soundEnabled) {
 				return
 			}
+
+			const now = Date.now()
+			const lastPlayed = lastPlayedRef.current[audioType] ?? 0
+			if (now - lastPlayed < 100) {
+				return
+			} // debounce: skip if played within 100ms
+			lastPlayedRef.current[audioType] = now
 
 			switch (audioType) {
 				case "notification":


### PR DESCRIPTION
## Problem
Notification sounds sometimes play twice, with the second starting milliseconds after the first. This is caused by React `<StrictMode>` in `webview-ui/src/index.tsx` which intentionally double-fires effects in development builds. The sound-triggering `useDeepCompareEffect` in `ChatView.tsx` has no cleanup function, so StrictMode's mount → cleanup → mount cycle plays the sound twice. Since `use-sound` (Howler.js) defaults to `interrupt: false`, both audio instances play concurrently.

## Root Cause Analysis
- Systematically investigated and verified against source code across 6 analysis laps
- Eliminated 5 alternative hypotheses (dual messages, multiple panels, partial transitions, Howler reinit, multiple setState)
- Confirmed React StrictMode as the sole mechanism

## Fix
Two layers of protection:

1. **`interrupt: true` on all `useSound` hooks** — Tells Howler.js to stop any playing instance before starting a new one, preventing overlapping audio regardless of cause
2. **Ref-based debounce on `playSound()`** — Tracks last-played timestamp per audio type, skips calls within 100ms window. Directly neutralizes StrictMode's double-fire

## Testing
- Added 2 new tests in `ChatView.notification-sound.spec.tsx`:
  - "should not play the same sound type twice within 100ms"
  - "should allow playing the same sound type again after 100ms"
- All existing tests pass (30/30)

## Files Changed
- `webview-ui/src/components/chat/ChatView.tsx`
- `webview-ui/src/components/chat/__tests__/ChatView.notification-sound.spec.tsx`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix double notification sound playback by setting `interrupt: true` for `useSound` hooks and adding a debounce mechanism in `ChatView.tsx`.
> 
>   - **Behavior**:
>     - Set `interrupt: true` for `useSound` hooks in `ChatView.tsx` to prevent overlapping audio.
>     - Implement ref-based debounce in `playSound()` to skip sound playback within 100ms window.
>   - **Testing**:
>     - Added tests in `ChatView.notification-sound.spec.tsx` to verify sound is not played twice within 100ms and is played after 100ms.
>     - Tests ensure no sound is played when there are queued messages or when the message is partial.
>   - **Files Changed**:
>     - `ChatView.tsx`
>     - `ChatView.notification-sound.spec.tsx`
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7b2b6ca325f4347c83e6f99f3cd6ffaeb39ebdde. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->