### PR TITLE
fix(docs): correct command merge comment to match union behavior   

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1978,8 +1978,7 @@ export class ClineProvider
 				? workspaceCommands.filter((cmd) => typeof cmd === "string" && cmd.trim().length > 0)
 				: []
 
-			// Combine and deduplicate commands
-			// Global state takes precedence over workspace configuration
+			// Combine and deduplicate commands from global state and workspace configuration
 			const mergedCommands = [...new Set([...validGlobalCommands, ...validWorkspaceCommands])]
 
 			return mergedCommands


### PR DESCRIPTION
### Related GitHub Issue

Closes: #11309

### Description

The comment above the command merge logic in `mergeCommandLists()` states that global state "takes precedence over workspace configuration." The implementation performs a Set union with no override logic — neither source takes precedence. Updated the comment to accurately describe the combine and deduplicate behavior.

No functional changes.

### Test Procedure

N/A (comment-only change)

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue.
- [x] **Scope**: My changes are focused on the linked issue.
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: N/A (comment-only change).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A — no UI changes

### Documentation Updates

- [x] No documentation updates are required.

### Get in Touch

0xMink
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Corrects comment in `mergeCommandLists()` in `ClineProvider.ts` to accurately describe command merging behavior as a set union without precedence.
> 
>   - **Comment Update**:
>     - Corrects comment in `mergeCommandLists()` in `ClineProvider.ts` to reflect actual behavior of combining and deduplicating commands from global state and workspace configuration.
>     - Previous comment incorrectly stated precedence of global state over workspace configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 51cedcd99d7ebeb613e5e676953817a45d4ac9e0. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->