### PR TITLE
perf(refactor): consolidate getState calls in resolveWebviewView

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -747,35 +747,29 @@ export class ClineProvider
 
 		// Initialize out-of-scope variables that need to receive persistent
 		// global state values.
-		this.getState().then(
-			({
-				terminalShellIntegrationTimeout = Terminal.defaultShellIntegrationTimeout,
-				terminalShellIntegrationDisabled = false,
-				terminalCommandDelay = 0,
-				terminalZshClearEolMark = true,
-				terminalZshOhMy = false,
-				terminalZshP10k = false,
-				terminalPowershellCounter = false,
-				terminalZdotdir = false,
-			}) => {
-				Terminal.setShellIntegrationTimeout(terminalShellIntegrationTimeout)
-				Terminal.setShellIntegrationDisabled(terminalShellIntegrationDisabled)
-				Terminal.setCommandDelay(terminalCommandDelay)
-				Terminal.setTerminalZshClearEolMark(terminalZshClearEolMark)
-				Terminal.setTerminalZshOhMy(terminalZshOhMy)
-				Terminal.setTerminalZshP10k(terminalZshP10k)
-				Terminal.setPowershellCounter(terminalPowershellCounter)
-				Terminal.setTerminalZdotdir(terminalZdotdir)
-			},
-		)
+		const {
+			terminalShellIntegrationTimeout = Terminal.defaultShellIntegrationTimeout,
+			terminalShellIntegrationDisabled = false,
+			terminalCommandDelay = 0,
+			terminalZshClearEolMark = true,
+			terminalZshOhMy = false,
+			terminalZshP10k = false,
+			terminalPowershellCounter = false,
+			terminalZdotdir = false,
+			ttsEnabled,
+			ttsSpeed,
+		} = await this.getState()
 
-		this.getState().then(({ ttsEnabled }) => {
-			setTtsEnabled(ttsEnabled ?? false)
-		})
-
-		this.getState().then(({ ttsSpeed }) => {
-			setTtsSpeed(ttsSpeed ?? 1)
-		})
+		Terminal.setShellIntegrationTimeout(terminalShellIntegrationTimeout)
+		Terminal.setShellIntegrationDisabled(terminalShellIntegrationDisabled)
+		Terminal.setCommandDelay(terminalCommandDelay)
+		Terminal.setTerminalZshClearEolMark(terminalZshClearEolMark)
+		Terminal.setTerminalZshOhMy(terminalZshOhMy)
+		Terminal.setTerminalZshP10k(terminalZshP10k)
+		Terminal.setPowershellCounter(terminalPowershellCounter)
+		Terminal.setTerminalZdotdir(terminalZdotdir)
+		setTtsEnabled(ttsEnabled ?? false)
+		setTtsSpeed(ttsSpeed ?? 1)
 
 		// Set up webview options with proper resource roots
 		const resourceRoots = [this.contextProxy.extensionUri]


### PR DESCRIPTION
## Summary

- Consolidate three separate `this.getState().then(...)` calls into a single `await this.getState()` with destructuring in `resolveWebviewView()`
- Eliminates two redundant executions of `getState()` which includes CloudService calls, ContextProxy reads, and other work
- No behavioral change — same defaults, same setter calls, same values

## Test plan

- [x] Existing `ClineProvider.spec.ts` tests pass (90/90, 6 skipped unchanged)
- [ ] Verify terminal settings (shell integration timeout, command delay, zsh options) are applied correctly on webview load
- [ ] Verify TTS enabled/speed settings are applied correctly on webview load
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `resolveWebviewView` in `ClineProvider.ts` to consolidate multiple `getState` calls into a single call, improving performance without changing behavior.
> 
>   - **Refactor**:
>     - Consolidate three `this.getState().then(...)` calls into a single `await this.getState()` in `resolveWebviewView()` in `ClineProvider.ts`.
>     - Use destructuring to extract state values, reducing redundant `getState()` executions.
>   - **Behavior**:
>     - No change in behavior; same defaults, setter calls, and values are maintained.
>   - **Testing**:
>     - Existing tests in `ClineProvider.spec.ts` pass (90/90, 6 skipped unchanged).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for e69da98ec1e84b198d9ee377ad2f49c37ee30c20. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->