### PR TITLE
perf(refactor): consolidate getState calls in resolveWebviewView

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -747,29 +747,31 @@ export class ClineProvider
 
 		// Initialize out-of-scope variables that need to receive persistent
 		// global state values.
-		const {
-			terminalShellIntegrationTimeout = Terminal.defaultShellIntegrationTimeout,
-			terminalShellIntegrationDisabled = false,
-			terminalCommandDelay = 0,
-			terminalZshClearEolMark = true,
-			terminalZshOhMy = false,
-			terminalZshP10k = false,
-			terminalPowershellCounter = false,
-			terminalZdotdir = false,
-			ttsEnabled,
-			ttsSpeed,
-		} = await this.getState()
-
-		Terminal.setShellIntegrationTimeout(terminalShellIntegrationTimeout)
-		Terminal.setShellIntegrationDisabled(terminalShellIntegrationDisabled)
-		Terminal.setCommandDelay(terminalCommandDelay)
-		Terminal.setTerminalZshClearEolMark(terminalZshClearEolMark)
-		Terminal.setTerminalZshOhMy(terminalZshOhMy)
-		Terminal.setTerminalZshP10k(terminalZshP10k)
-		Terminal.setPowershellCounter(terminalPowershellCounter)
-		Terminal.setTerminalZdotdir(terminalZdotdir)
-		setTtsEnabled(ttsEnabled ?? false)
-		setTtsSpeed(ttsSpeed ?? 1)
+		this.getState().then(
+			({
+				terminalShellIntegrationTimeout = Terminal.defaultShellIntegrationTimeout,
+				terminalShellIntegrationDisabled = false,
+				terminalCommandDelay = 0,
+				terminalZshClearEolMark = true,
+				terminalZshOhMy = false,
+				terminalZshP10k = false,
+				terminalPowershellCounter = false,
+				terminalZdotdir = false,
+				ttsEnabled,
+				ttsSpeed,
+			}) => {
+				Terminal.setShellIntegrationTimeout(terminalShellIntegrationTimeout)
+				Terminal.setShellIntegrationDisabled(terminalShellIntegrationDisabled)
+				Terminal.setCommandDelay(terminalCommandDelay)
+				Terminal.setTerminalZshClearEolMark(terminalZshClearEolMark)
+				Terminal.setTerminalZshOhMy(terminalZshOhMy)
+				Terminal.setTerminalZshP10k(terminalZshP10k)
+				Terminal.setPowershellCounter(terminalPowershellCounter)
+				Terminal.setTerminalZdotdir(terminalZdotdir)
+				setTtsEnabled(ttsEnabled ?? false)
+				setTtsSpeed(ttsSpeed ?? 1)
+			},
+		)
 
 		// Set up webview options with proper resource roots
 		const resourceRoots = [this.contextProxy.extensionUri]


### PR DESCRIPTION
## Summary

- Consolidate three separate `this.getState().then(...)` calls into a single `await this.getState()` with destructuring in `resolveWebviewView()`
- Eliminates two redundant executions of `getState()` which includes CloudService calls, ContextProxy reads, and other work
- Uses a single snapshot, avoiding potential inconsistency if settings change mid-resolution
- No behavioral change — same defaults, same setter calls, same values

Closes: #11319

## Test plan

- [x] Existing `ClineProvider.spec.ts` tests pass (90/90, 6 skipped unchanged)
- [ ] Verify terminal settings (shell integration timeout, command delay, zsh options) are applied correctly on webview load
- [ ] Verify TTS enabled/speed settings are applied correctly on webview load

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `resolveWebviewView` in `ClineProvider.ts` to consolidate multiple `getState` calls into a single call, improving performance and consistency without changing behavior.
> 
>   - **Refactor**:
>     - Consolidate three `this.getState().then(...)` calls into a single `await this.getState()` in `resolveWebviewView()` in `ClineProvider.ts`.
>     - Use destructuring to extract state values in one go, reducing redundant `getState()` executions.
>     - Maintain same defaults, setter calls, and values, ensuring no behavioral change.
>   - **Performance**:
>     - Eliminates redundant CloudService calls and ContextProxy reads by using a single state snapshot.
>     - Avoids potential inconsistencies if settings change during multiple `getState()` calls.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 5519dcd18ac0c9da4be028fd167813c3eec0c752. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->