### PR TITLE
fix: prevent false unsaved changes prompt with OpenAI Compatible headers (#8230)

### DIFF
--- a/webview-ui/src/components/settings/ApiOptions.tsx
+++ b/webview-ui/src/components/settings/ApiOptions.tsx
@@ -155,7 +155,7 @@ const ApiOptions = ({
 
 			// Only update if the processed object is different from the current config.
 			if (JSON.stringify(currentConfigHeaders) !== JSON.stringify(newHeadersObject)) {
-				setApiConfigurationField("openAiHeaders", newHeadersObject)
+				setApiConfigurationField("openAiHeaders", newHeadersObject, false)
 			}
 		},
 		300,

--- a/webview-ui/src/components/settings/SettingsView.tsx
+++ b/webview-ui/src/components/settings/SettingsView.tsx
@@ -262,9 +262,19 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 
 				const previousValue = prevState.apiConfiguration?.[field]
 
+				// Helper to check if two values are semantically equal
+				const areValuesEqual = (a: any, b: any): boolean => {
+					if (a === b) return true
+					if (a == null && b == null) return true
+					if (typeof a !== typeof b) return false
+					if (typeof a === "object" && typeof b === "object") {
+						return JSON.stringify(a) === JSON.stringify(b)
+					}
+					return false
+				}
+
 				// Only skip change detection for automatic initialization (not user actions)
 				// This prevents the dirty state when the component initializes and auto-syncs values
-				// Treat undefined, null, and empty string as uninitialized states
 				const isInitialSync =
 					!isUserAction &&
 					(previousValue === undefined || previousValue === "" || previousValue === null) &&
@@ -272,7 +282,10 @@ const SettingsView = forwardRef<SettingsViewRef, SettingsViewProps>(({ onDone, t
 					value !== "" &&
 					value !== null
 
-				if (!isInitialSync) {
+				// Also skip if it's an automatic sync with semantically equal values
+				const isAutomaticNoOpSync = !isUserAction && areValuesEqual(previousValue, value)
+
+				if (!isInitialSync && !isAutomaticNoOpSync) {
 					setChangeDetected(true)
 				}
 				return { ...prevState, apiConfiguration: { ...prevState.apiConfiguration, [field]: value } }

--- a/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
+++ b/webview-ui/src/components/settings/providers/OpenAICompatible.tsx
@@ -24,7 +24,11 @@ import { ThinkingBudget } from "../ThinkingBudget"
 
 type OpenAICompatibleProps = {
 	apiConfiguration: ProviderSettings
-	setApiConfigurationField: (field: keyof ProviderSettings, value: ProviderSettings[keyof ProviderSettings]) => void
+	setApiConfigurationField: <K extends keyof ProviderSettings>(
+		field: K,
+		value: ProviderSettings[K],
+		isUserAction?: boolean,
+	) => void
 	organizationAllowList: OrganizationAllowList
 	modelValidationError?: string
 	simplifySettings?: boolean
@@ -88,7 +92,7 @@ export const OpenAICompatible = ({
 	useEffect(() => {
 		const timer = setTimeout(() => {
 			const headerObject = convertHeadersToObject(customHeaders)
-			setApiConfigurationField("openAiHeaders", headerObject)
+			setApiConfigurationField("openAiHeaders", headerObject, false)
 		}, 300)
 
 		return () => clearTimeout(timer)


### PR DESCRIPTION
### Related GitHub Issue

Closes: #8230

### Description

Picks up the fix from #11300 by @robertjmcintyre (without the unrelated Windows test changes).

#### Root Cause
Automatic header synchronization in the OpenAI Compatible provider settings causes a false dirty state. Two separate components (`ApiOptions` and `OpenAICompatible`) manage `openAiHeaders` state and automatically sync it back to the configuration. When components mount/remount:

1. `customHeaders` state initializes with a new array/object reference (even if content is identical)
2. Debounced/timeout effects fire after 300ms to sync headers
3. These effects call `setApiConfigurationField("openAiHeaders", ...)` **without** marking them as non-user actions
4. The change detection logic treats these automatic syncs as user changes

#### Solution
Three changes fix this issue:
1. **ApiOptions.tsx** — Mark debounced header sync as non-user action (`isUserAction: false`)
2. **OpenAICompatible.tsx** — Mark timeout header sync as non-user action (and update type definition)
3. **SettingsView.tsx** — Enhanced change detection logic to skip automatic syncs with semantically equal values (`areValuesEqual` helper)

### Credit

Original fix by @robertjmcintyre in #11300.

### Test Procedure

All existing tests pass (300 webview-ui settings tests, 5314 roo-cline tests).

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue.
- [x] **Scope**: Changes are focused on the linked issue only.
- [x] **Self-Review**: Performed a thorough self-review.
- [x] **Testing**: All existing tests pass.
- [x] **Contribution Guidelines**: Read and agreed to the Contributor Guidelines.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix false unsaved changes prompt by marking automatic header syncs as non-user actions and enhancing change detection logic in OpenAI Compatible settings.
> 
>   - **Behavior**:
>     - Fix false unsaved changes prompt by marking automatic header syncs as non-user actions in `ApiOptions.tsx` and `OpenAICompatible.tsx`.
>     - Enhance change detection in `SettingsView.tsx` to skip automatic syncs with semantically equal values using `areValuesEqual` helper.
>   - **Functions**:
>     - Update `setApiConfigurationField` in `ApiOptions.tsx` and `OpenAICompatible.tsx` to include `isUserAction: false` for automatic syncs.
>     - Add `areValuesEqual` helper in `SettingsView.tsx` to compare values semantically.
>   - **Misc**:
>     - Closes issue #8230 by adopting fix from #11300.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 6433d6577353939b9552b1f75b557b4bcdd6b5ed. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->