### PR TITLE
fix: serialize taskHistory writes and fix delegation status overwrite race

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -149,6 +149,7 @@ export class ClineProvider
 	private currentWorkspacePath: string | undefined
 
 	private recentTasksCache?: string[]
+	private taskHistoryWriteLock: Promise<void> = Promise.resolve()
 	private pendingOperations: Map<string, PendingEditOperation> = new Map()
 	private static readonly PENDING_OPERATION_TIMEOUT_MS = 30000 // 30 seconds
 
@@ -1803,10 +1804,12 @@ export class ClineProvider
 			}
 
 			// Delete all tasks from state in one batch
-			const taskHistory = this.getGlobalState("taskHistory") ?? []
-			const updatedTaskHistory = taskHistory.filter((task) => !allIdsToDelete.includes(task.id))
-			await this.updateGlobalState("taskHistory", updatedTaskHistory)
-			this.recentTasksCache = undefined
+			await this.withTaskHistoryLock(async () => {
+				const taskHistory = this.getGlobalState("taskHistory") ?? []
+				const updatedTaskHistory = taskHistory.filter((task) => !allIdsToDelete.includes(task.id))
+				await this.updateGlobalState("taskHistory", updatedTaskHistory)
+				this.recentTasksCache = undefined
+			})
 
 			// Delete associated shadow repositories or branches and task directories
 			const globalStorageDir = this.contextProxy.globalStorageUri.fsPath
@@ -1847,10 +1850,12 @@ export class ClineProvider
 	}
 
 	async deleteTaskFromState(id: string) {
-		const taskHistory = this.getGlobalState("taskHistory") ?? []
-		const updatedTaskHistory = taskHistory.filter((task) => task.id !== id)
-		await this.updateGlobalState("taskHistory", updatedTaskHistory)
-		this.recentTasksCache = undefined
+		await this.withTaskHistoryLock(async () => {
+			const taskHistory = this.getGlobalState("taskHistory") ?? []
+			const updatedTaskHistory = taskHistory.filter((task) => task.id !== id)
+			await this.updateGlobalState("taskHistory", updatedTaskHistory)
+			this.recentTasksCache = undefined
+		})
 		await this.postStateToWebview()
 	}
 
@@ -2512,40 +2517,55 @@ export class ClineProvider
 	}
 
 	/**
+	 * Serializes all read-modify-write operations on taskHistory to prevent
+	 * concurrent interleaving that can cause entries to vanish.
+	 */
+	private withTaskHistoryLock<T>(fn: () => Promise<T>): Promise<T> {
+		const result = this.taskHistoryWriteLock.then(fn, fn) // run even if previous write errored
+		this.taskHistoryWriteLock = result.then(
+			() => {},
+			() => {},
+		) // swallow for chain continuity
+		return result
+	}
+
+	/**
 	 * Updates a task in the task history and optionally broadcasts the updated history to the webview.
 	 * @param item The history item to update or add
 	 * @param options.broadcast Whether to broadcast the updated history to the webview (default: true)
 	 * @returns The updated task history array
 	 */
 	async updateTaskHistory(item: HistoryItem, options: { broadcast?: boolean } = {}): Promise<HistoryItem[]> {
-		const { broadcast = true } = options
-		const history = (this.getGlobalState("taskHistory") as HistoryItem[] | undefined) || []
-		const existingItemIndex = history.findIndex((h) => h.id === item.id)
-		const wasExisting = existingItemIndex !== -1
+		return this.withTaskHistoryLock(async () => {
+			const { broadcast = true } = options
+			const history = (this.getGlobalState("taskHistory") as HistoryItem[] | undefined) || []
+			const existingItemIndex = history.findIndex((h) => h.id === item.id)
+			const wasExisting = existingItemIndex !== -1
 
-		if (wasExisting) {
-			// Preserve existing metadata (e.g., delegation fields) unless explicitly overwritten.
-			// This prevents loss of status/awaitingChildId/delegatedToId when tasks are reopened,
-			// terminated, or when routine message persistence occurs.
-			history[existingItemIndex] = {
-				...history[existingItemIndex],
-				...item,
+			if (wasExisting) {
+				// Preserve existing metadata (e.g., delegation fields) unless explicitly overwritten.
+				// This prevents loss of status/awaitingChildId/delegatedToId when tasks are reopened,
+				// terminated, or when routine message persistence occurs.
+				history[existingItemIndex] = {
+					...history[existingItemIndex],
+					...item,
+				}
+			} else {
+				history.push(item)
 			}
-		} else {
-			history.push(item)
-		}
 
-		await this.updateGlobalState("taskHistory", history)
-		this.recentTasksCache = undefined
+			await this.updateGlobalState("taskHistory", history)
+			this.recentTasksCache = undefined
 
-		// Broadcast the updated history to the webview if requested.
-		// Prefer per-item updates to avoid repeatedly cloning/sending the full history.
-		if (broadcast && this.isViewLaunched) {
-			const updatedItem = wasExisting ? history[existingItemIndex] : item
-			await this.postMessageToWebview({ type: "taskHistoryItemUpdated", taskHistoryItem: updatedItem })
-		}
+			// Broadcast the updated history to the webview if requested.
+			// Prefer per-item updates to avoid repeatedly cloning/sending the full history.
+			if (broadcast && this.isViewLaunched) {
+				const updatedItem = wasExisting ? history[existingItemIndex] : item
+				await this.postMessageToWebview({ type: "taskHistoryItemUpdated", taskHistoryItem: updatedItem })
+			}
 
-		return history
+			return history
+		})
 	}
 
 	/**
@@ -3416,7 +3436,19 @@ export class ClineProvider
 
 		await saveApiMessages({ messages: parentApiMessages as any, taskId: parentTaskId, globalStoragePath })
 
-		// 3) Update child metadata to "completed" status
+		// 3) Close child instance if still open (single-open-task invariant).
+		//    This MUST happen BEFORE updating the child's status to "completed" because
+		//    removeClineFromStack() → abortTask(true) → saveClineMessages() writes
+		//    the historyItem with initialStatus (typically "active"), which would
+		//    overwrite a "completed" status set earlier.
+		const current = this.getCurrentTask()
+		if (current?.taskId === childTaskId) {
+			await this.removeClineFromStack()
+		}
+
+		// 4) Update child metadata to "completed" status.
+		//    This runs after the abort so it overwrites the stale "active" status
+		//    that saveClineMessages() may have written during step 3.
 		try {
 			const { historyItem: childHistory } = await this.getTaskWithId(childTaskId)
 			await this.updateTaskHistory({
@@ -3431,7 +3463,7 @@ export class ClineProvider
 			)
 		}
 
-		// 4) Update parent metadata and persist BEFORE emitting completion event
+		// 5) Update parent metadata and persist BEFORE emitting completion event
 		const childIds = Array.from(new Set([...(historyItem.childIds ?? []), childTaskId]))
 		const updatedHistory: typeof historyItem = {
 			...historyItem,
@@ -3443,17 +3475,11 @@ export class ClineProvider
 		}
 		await this.updateTaskHistory(updatedHistory)
 
-		// 5) Emit TaskDelegationCompleted (provider-level)
+		// 6) Emit TaskDelegationCompleted (provider-level)
 		try {
 			this.emit(RooCodeEventName.TaskDelegationCompleted, parentTaskId, childTaskId, completionResultSummary)
 		} catch {
 			// non-fatal
-		}
-
-		// 6) Close child instance if still open (single-open-task invariant)
-		const current = this.getCurrentTask()
-		if (current?.taskId === childTaskId) {
-			await this.removeClineFromStack()
 		}
 
 		// 7) Reopen the parent from history as the sole active task (restores saved mode)

--- a/src/core/webview/__tests__/ClineProvider.taskHistory.spec.ts
+++ b/src/core/webview/__tests__/ClineProvider.taskHistory.spec.ts
@@ -420,6 +420,74 @@ describe("ClineProvider Task History Synchronization", () => {
 			expect(taskHistoryItemUpdatedCalls.length).toBe(0)
 		})
 
+		it("preserves delegated metadata on partial update unless explicitly overwritten (UTH-02)", async () => {
+			await provider.resolveWebviewView(mockWebviewView)
+			provider.isViewLaunched = true
+
+			const initial = createHistoryItem({
+				id: "task-delegated-metadata",
+				task: "Delegated task",
+				status: "delegated",
+				delegatedToId: "child-1",
+				awaitingChildId: "child-1",
+				childIds: ["child-1"],
+			})
+
+			await provider.updateTaskHistory(initial, { broadcast: false })
+
+			// Partial update intentionally omits delegated metadata fields.
+			const partialUpdate: HistoryItem = {
+				...createHistoryItem({ id: "task-delegated-metadata", task: "Delegated task (updated)" }),
+				status: "active",
+			}
+
+			const updatedHistory = await provider.updateTaskHistory(partialUpdate, { broadcast: false })
+			const updatedItem = updatedHistory.find((item) => item.id === "task-delegated-metadata")
+
+			expect(updatedItem).toBeDefined()
+			expect(updatedItem?.status).toBe("active")
+			expect(updatedItem?.delegatedToId).toBe("child-1")
+			expect(updatedItem?.awaitingChildId).toBe("child-1")
+			expect(updatedItem?.childIds).toEqual(["child-1"])
+		})
+
+		it("invalidates recentTasksCache on updateTaskHistory (UTH-04)", async () => {
+			const workspace = provider.cwd
+			const tsBase = Date.now()
+
+			await provider.updateTaskHistory(
+				createHistoryItem({
+					id: "cache-seed",
+					task: "Cache seed",
+					workspace,
+					ts: tsBase,
+				}),
+				{ broadcast: false },
+			)
+
+			const initialRecent = provider.getRecentTasks()
+			expect(initialRecent).toContain("cache-seed")
+
+			// Prime cache and verify internal cache is set.
+			expect((provider as unknown as { recentTasksCache?: string[] }).recentTasksCache).toEqual(initialRecent)
+
+			await provider.updateTaskHistory(
+				createHistoryItem({
+					id: "cache-new",
+					task: "Cache new",
+					workspace,
+					ts: tsBase + 1,
+				}),
+				{ broadcast: false },
+			)
+
+			// Direct assertion for invalidation side-effect.
+			expect((provider as unknown as { recentTasksCache?: string[] }).recentTasksCache).toBeUndefined()
+
+			const recomputedRecent = provider.getRecentTasks()
+			expect(recomputedRecent).toContain("cache-new")
+		})
+
 		it("updates existing task in history", async () => {
 			await provider.resolveWebviewView(mockWebviewView)
 			provider.isViewLaunched = true
@@ -595,6 +663,99 @@ describe("ClineProvider Task History Synchronization", () => {
 			expect(state.taskHistory.some((item: HistoryItem) => item.workspace === "/path/to/workspace1")).toBe(true)
 			expect(state.taskHistory.some((item: HistoryItem) => item.workspace === "/path/to/workspace2")).toBe(true)
 			expect(state.taskHistory.some((item: HistoryItem) => item.workspace === "/different/workspace")).toBe(true)
+		})
+	})
+
+	describe("taskHistory write lock (mutex)", () => {
+		it("serializes concurrent updateTaskHistory calls so no entries are lost", async () => {
+			await provider.resolveWebviewView(mockWebviewView)
+
+			// Fire 5 concurrent updateTaskHistory calls
+			const items = Array.from({ length: 5 }, (_, i) =>
+				createHistoryItem({ id: `concurrent-${i}`, task: `Task ${i}` }),
+			)
+
+			await Promise.all(items.map((item) => provider.updateTaskHistory(item, { broadcast: false })))
+
+			// All 5 entries must survive
+			const history = (provider as any).contextProxy.getGlobalState("taskHistory") as HistoryItem[]
+			const ids = history.map((h: HistoryItem) => h.id)
+			for (const item of items) {
+				expect(ids).toContain(item.id)
+			}
+			expect(history.length).toBe(5)
+		})
+
+		it("serializes concurrent update and deleteTaskFromState so they don't corrupt each other", async () => {
+			await provider.resolveWebviewView(mockWebviewView)
+
+			// Seed with two items
+			const keep = createHistoryItem({ id: "keep-me", task: "Keep" })
+			const remove = createHistoryItem({ id: "remove-me", task: "Remove" })
+			await provider.updateTaskHistory(keep, { broadcast: false })
+			await provider.updateTaskHistory(remove, { broadcast: false })
+
+			// Concurrently: add a new item AND delete "remove-me"
+			const newItem = createHistoryItem({ id: "new-item", task: "New" })
+			await Promise.all([
+				provider.updateTaskHistory(newItem, { broadcast: false }),
+				provider.deleteTaskFromState("remove-me"),
+			])
+
+			const history = (provider as any).contextProxy.getGlobalState("taskHistory") as HistoryItem[]
+			const ids = history.map((h: HistoryItem) => h.id)
+			expect(ids).toContain("keep-me")
+			expect(ids).toContain("new-item")
+			expect(ids).not.toContain("remove-me")
+		})
+
+		it("does not block subsequent writes when a previous write errors", async () => {
+			await provider.resolveWebviewView(mockWebviewView)
+
+			// Temporarily make updateGlobalState throw
+			const origUpdateGlobalState = (provider as any).updateGlobalState.bind(provider)
+			let callCount = 0
+			;(provider as any).updateGlobalState = vi.fn().mockImplementation((...args: unknown[]) => {
+				callCount++
+				if (callCount === 1) {
+					return Promise.reject(new Error("simulated write failure"))
+				}
+				return origUpdateGlobalState(...args)
+			})
+
+			// First call should fail
+			const item1 = createHistoryItem({ id: "fail-item", task: "Fail" })
+			await expect(provider.updateTaskHistory(item1, { broadcast: false })).rejects.toThrow(
+				"simulated write failure",
+			)
+
+			// Second call should still succeed (lock not stuck)
+			const item2 = createHistoryItem({ id: "ok-item", task: "OK" })
+			const result = await provider.updateTaskHistory(item2, { broadcast: false })
+			expect(result.some((h) => h.id === "ok-item")).toBe(true)
+		})
+
+		it("serializes concurrent updates to the same item preserving the last write", async () => {
+			await provider.resolveWebviewView(mockWebviewView)
+
+			const base = createHistoryItem({ id: "race-item", task: "Original" })
+			await provider.updateTaskHistory(base, { broadcast: false })
+
+			// Fire two concurrent updates to the same item
+			await Promise.all([
+				provider.updateTaskHistory(createHistoryItem({ id: "race-item", task: "Original", tokensIn: 111 }), {
+					broadcast: false,
+				}),
+				provider.updateTaskHistory(createHistoryItem({ id: "race-item", task: "Original", tokensIn: 222 }), {
+					broadcast: false,
+				}),
+			])
+
+			const history = (provider as any).contextProxy.getGlobalState("taskHistory") as HistoryItem[]
+			const item = history.find((h: HistoryItem) => h.id === "race-item")
+			expect(item).toBeDefined()
+			// The second write (tokensIn: 222) should be the last one since writes are serialized
+			expect(item!.tokensIn).toBe(222)
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Fixes two race conditions in the task history subsystem that could cause entries to silently disappear or retain stale status values during task delegation workflows.

### 1. Task history write lock (mutex)

Adds a promise-chain mutex (`withTaskHistoryLock`) that serializes all read-modify-write operations on `taskHistory`. Without this, concurrent callers (e.g. `updateTaskHistory` + `deleteTaskFromState`) could each read the same snapshot, modify independently, and the second write would silently discard the first's changes.

Applied to:
- `updateTaskHistory()`
- `deleteTaskFromState()`
- Batch delete in `deleteMultipleTasks`

### 2. Delegation child close/status ordering fix

Reorders `reopenParentFromDelegation` to close the child instance (`removeClineFromStack`) **before** marking it `completed`. Previously, the abort path in `removeClineFromStack` → `saveClineMessages()` would overwrite the child's `completed` status back to `active` because it persists the `initialStatus`.

## Changes

- Add `taskHistoryWriteLock` property and `withTaskHistoryLock()` serialization method
- Wrap `updateTaskHistory`, `deleteTaskFromState`, and batch delete in the write lock
- Reorder steps 3–6 in `reopenParentFromDelegation` so child instance is closed before status update
- Add tests: RPD-04, RPD-05, RPD-06 (delegation lifecycle ordering and resilience)
- Add tests: UTH-02, UTH-04 (metadata preservation and cache invalidation)
- Add mutex concurrency test suite (serialization, error recovery, last-write-wins)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes race conditions in task history by serializing operations and reordering task delegation steps in `ClineProvider`.
> 
>   - **Behavior**:
>     - Introduces `withTaskHistoryLock()` in `ClineProvider` to serialize `taskHistory` operations, preventing concurrent modifications from causing data loss.
>     - Reorders `reopenParentFromDelegation` in `ClineProvider` to close child tasks before marking them as completed, preventing status overwrite.
>   - **Functions**:
>     - Wraps `updateTaskHistory`, `deleteTaskFromState`, and batch delete operations in `ClineProvider` with the new mutex.
>   - **Tests**:
>     - Adds tests `RPD-04`, `RPD-05`, `RPD-06` for delegation lifecycle and error handling in `history-resume-delegation.spec.ts`.
>     - Adds tests `UTH-02`, `UTH-04` for metadata preservation and cache invalidation in `ClineProvider.taskHistory.spec.ts`.
>     - Includes a mutex concurrency test suite for serialization and error recovery in `ClineProvider.taskHistory.spec.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for a6b64a29084b0ff92cea0ea2e0f07a54600bc739. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->