### PR TITLE
feat: migrate LiteLLM provider to AI SDK (@ai-sdk/openai-compatible)

### DIFF
--- a/src/api/providers/__tests__/lite-llm.spec.ts
+++ b/src/api/providers/__tests__/lite-llm.spec.ts
@@ -422,6 +422,20 @@ describe("LiteLLMHandler", () => {
 			const callArgs = mockGenerateText.mock.calls[0][0]
 			expect(callArgs.maxOutputTokens).toBeDefined()
 		})
+
+		it("should fetch models before completing prompt", async () => {
+			mockGenerateText.mockResolvedValue({
+				text: "Response",
+			})
+
+			await handler.completePrompt("Test prompt")
+
+			expect(getModels).toHaveBeenCalledWith({
+				provider: "litellm",
+				apiKey: "test-key",
+				baseUrl: "http://localhost:4000",
+			})
+		})
 	})
 
 	describe("isAiSdkProvider", () => {

--- a/src/api/providers/lite-llm.ts
+++ b/src/api/providers/lite-llm.ts
@@ -87,6 +87,11 @@ export class LiteLLMHandler extends OpenAICompatibleHandler implements SingleCom
 		yield* super.createMessage(systemPrompt, messages, metadata)
 	}
 
+	override async completePrompt(prompt: string): Promise<string> {
+		await this.fetchModel()
+		return super.completePrompt(prompt)
+	}
+
 	protected override processUsageMetrics(usage: {
 		inputTokens?: number
 		outputTokens?: number


### PR DESCRIPTION
## Summary

Migrates the LiteLLM provider from the raw OpenAI SDK (`RouterProvider`) to the Vercel AI SDK using the existing `OpenAICompatibleHandler` base class (`@ai-sdk/openai-compatible`).

## Changes

### `src/api/providers/lite-llm.ts`
- **Extends `OpenAICompatibleHandler`** instead of `RouterProvider` — uses `createOpenAICompatible()` from `@ai-sdk/openai-compatible` via the parent class
- **Streams via AI SDK's `streamText()` / `generateText()`** instead of raw `OpenAI.chat.completions.create()`
- **Retains dynamic model fetching** from LiteLLM server via `getModels()` / `getModelsFromCache()` — `fetchModel()` is called before each `createMessage()`
- **Uses centralized `getModelMaxOutputTokens()`** to cap output tokens at 20% of context window, preventing overflow errors with large context models (e.g., Sonnet 4.5 via LiteLLM reporting 1M context)
- **Removed LiteLLM-specific workarounds**: Gemini thought signature injection, prompt cache control headers, GPT-5 max_completion_tokens branching — these are either unnecessary with AI SDK or handled by the proxy

### `src/api/providers/__tests__/lite-llm.spec.ts`
- Rewrote tests to mock AI SDK (`streamText`, `generateText`, `createOpenAICompatible`) instead of raw OpenAI SDK
- 25 tests covering: constructor, `getModel()`, `createMessage()` (text streaming, usage metrics, tool calls, reasoning, errors), `completePrompt()`, and `isAiSdkProvider()`

## Net change
```
2 files changed, 451 insertions(+), 1072 deletions(-)
```
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates LiteLLM provider to Vercel AI SDK, updating `LiteLLMHandler` to use AI SDK methods and rewriting tests for compatibility.
> 
>   - **Behavior**:
>     - `LiteLLMHandler` now extends `OpenAICompatibleHandler` in `lite-llm.ts`, using `createOpenAICompatible()` from `@ai-sdk/openai-compatible`.
>     - Uses AI SDK's `streamText()` and `generateText()` instead of `OpenAI.chat.completions.create()`.
>     - Retains dynamic model fetching via `getModels()` and `getModelsFromCache()`.
>     - Uses `getModelMaxOutputTokens()` to cap output tokens, preventing overflow errors.
>     - Removed LiteLLM-specific workarounds like Gemini thought signature injection.
>   - **Tests**:
>     - Rewrote tests in `lite-llm.spec.ts` to mock AI SDK (`streamText`, `generateText`) instead of OpenAI SDK.
>     - 25 tests cover constructor, `getModel()`, `createMessage()`, `completePrompt()`, and `isAiSdkProvider()`.
>   - **Misc**:
>     - Removed unused imports and functions related to the old OpenAI SDK.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3c4cada3e0a6513c024b6d2f3b76c7852a509c1d. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->