### PR TITLE
feat: migrate MiniMax provider to AI SDK

### DIFF
--- a/src/api/providers/__tests__/minimax.spec.ts
+++ b/src/api/providers/__tests__/minimax.spec.ts
@@ -51,20 +51,13 @@ vi.mock("../../transform/ai-sdk", async (importOriginal) => {
 	}
 })
 
-type HandlerOptions = Partial<ApiHandlerOptions> & {
-	apiConfiguration?: {
-		apiKey?: string
-		baseUrl?: string
-		apiModelId?: string
-	}
+type HandlerOptions = Omit<Partial<ApiHandlerOptions>, "minimaxBaseUrl"> & {
+	minimaxBaseUrl?: string
 }
 
 function createHandler(options: HandlerOptions = {}) {
 	return new MiniMaxHandler({
-		apiConfiguration: {
-			apiKey: "test-api-key",
-			...options.apiConfiguration,
-		},
+		minimaxApiKey: "test-api-key",
 		...options,
 	} as ApiHandlerOptions)
 }
@@ -134,10 +127,7 @@ describe("MiniMaxHandler", () => {
 
 		it("converts /v1 base URL to /anthropic/v1", () => {
 			createHandler({
-				apiConfiguration: {
-					apiKey: "test-api-key",
-					baseUrl: "https://api.minimax.io/v1",
-				},
+				minimaxBaseUrl: "https://api.minimax.io/v1",
 			})
 
 			expect(mockCreateAnthropic).toHaveBeenCalledWith(
@@ -149,10 +139,7 @@ describe("MiniMaxHandler", () => {
 
 		it("appends /v1 for base URL already ending with /anthropic", () => {
 			createHandler({
-				apiConfiguration: {
-					apiKey: "test-api-key",
-					baseUrl: "https://api.minimax.io/anthropic",
-				},
+				minimaxBaseUrl: "https://api.minimax.io/anthropic",
 			})
 
 			expect(mockCreateAnthropic).toHaveBeenCalledWith(
@@ -164,10 +151,7 @@ describe("MiniMaxHandler", () => {
 
 		it("appends /anthropic/v1 when base URL has no suffix", () => {
 			createHandler({
-				apiConfiguration: {
-					apiKey: "test-api-key",
-					baseUrl: "https://api.minimax.io/custom",
-				},
+				minimaxBaseUrl: "https://api.minimax.io/custom",
 			})
 
 			expect(mockCreateAnthropic).toHaveBeenCalledWith(
@@ -179,10 +163,7 @@ describe("MiniMaxHandler", () => {
 
 		it("supports the China endpoint", () => {
 			createHandler({
-				apiConfiguration: {
-					apiKey: "test-api-key",
-					baseUrl: "https://api.minimaxi.com/anthropic",
-				},
+				minimaxBaseUrl: "https://api.minimaxi.com/anthropic",
 			})
 
 			expect(mockCreateAnthropic).toHaveBeenCalledWith(
@@ -194,10 +175,7 @@ describe("MiniMaxHandler", () => {
 
 		it("treats empty baseUrl as falsy and falls back to default", () => {
 			createHandler({
-				apiConfiguration: {
-					apiKey: "test-api-key",
-					baseUrl: "",
-				},
+				minimaxBaseUrl: "",
 			})
 
 			expect(mockCreateAnthropic).toHaveBeenCalledWith(
@@ -209,9 +187,7 @@ describe("MiniMaxHandler", () => {
 
 		it("passes API key through to createAnthropic", () => {
 			createHandler({
-				apiConfiguration: {
-					apiKey: "minimax-key-123",
-				},
+				minimaxApiKey: "minimax-key-123",
 			})
 
 			expect(mockCreateAnthropic).toHaveBeenCalledWith(
@@ -232,10 +208,7 @@ describe("MiniMaxHandler", () => {
 
 		it("returns specified model when valid model ID is provided", () => {
 			const handler = createHandler({
-				apiConfiguration: {
-					apiKey: "test-api-key",
-					apiModelId: "MiniMax-M2-Stable",
-				},
+				apiModelId: "MiniMax-M2-Stable",
 			})
 			const model = handler.getModel()
 			expect(model.id).toBe("MiniMax-M2-Stable")
@@ -243,10 +216,7 @@ describe("MiniMaxHandler", () => {
 
 		it("falls back to default model when unknown model ID is provided", () => {
 			const handler = createHandler({
-				apiConfiguration: {
-					apiKey: "test-api-key",
-					apiModelId: "unknown-model",
-				},
+				apiModelId: "unknown-model",
 			})
 			const model = handler.getModel()
 			expect(model.id).toBe(minimaxDefaultModelId)


### PR DESCRIPTION
## Summary

Migrates the MiniMax provider from raw `@anthropic-ai/sdk` usage to the AI SDK (`@ai-sdk/anthropic` with custom baseURL), following the Archetype 3 migration pattern established by the Anthropic handler.

## Changes

- **Rewrite `minimax.ts`**: Replace raw Anthropic SDK client with `createAnthropic()` + `streamText()` / `generateText()` and shared transform layer (`convertToAiSdkMessages`, `processAiSdkStreamPart`, `handleAiSdkError`)
- **BaseURL path fix**: Resolve all URLs to end with `/anthropic/v1` since `@ai-sdk/anthropic` appends `/messages` directly (not `/v1/messages` like the raw Anthropic SDK)
- **Thinking signature capture**: Add `lastThoughtSignature`, `getThoughtSignature()`, and `getRedactedThinkingBlocks()` matching the `anthropic.ts` pattern — critical for MiniMax interleaved thinking round-trip
- **Prompt caching**: Via `providerOptions.anthropic.cacheControl` (AI SDK native) instead of manual `cache_control` blocks
- **`isAiSdkProvider()`**: Returns `true` for proper reasoning block preservation in conversation history
- **Preserve `mergeEnvironmentDetailsForMiniMax`**: Applied before `convertToAiSdkMessages()` to maintain tool result merging behavior
- **Rewrite `minimax.spec.ts`**: Full test rewrite with AI SDK mocks — 21/21 tests pass
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Migrates MiniMax provider to AI SDK, refactoring URL handling, message streaming, and error management, with updated tests.
> 
>   - **Migration to AI SDK**:
>     - Replaces raw Anthropic SDK with AI SDK in `minimax.ts` using `createAnthropic()`, `streamText()`, and `generateText()`.
>     - Adjusts baseURL handling to append `/anthropic/v1`.
>   - **New Methods**:
>     - Adds `getThoughtSignature()` and `getRedactedThinkingBlocks()` for capturing and retrieving thought signatures and redacted thinking blocks.
>     - Implements `isAiSdkProvider()` to return `true`.
>   - **Error Handling**:
>     - Utilizes `handleAiSdkError()` for error management.
>   - **Prompt Caching**:
>     - Uses AI SDK's native caching via `providerOptions.anthropic.cacheControl`.
>   - **Tests**:
>     - Updates `minimax.spec.ts` to mock AI SDK functions and verify new behavior.
>     - Ensures all 21 tests pass with the new implementation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for f470c7140f1010494ef5b508dfc2e54b239460c1. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->