### PR TITLE
fix(editor): make tab close best-effort in DiffViewProvider.open

### DIFF
--- a/src/integrations/editor/DiffViewProvider.ts
+++ b/src/integrations/editor/DiffViewProvider.ts
@@ -98,7 +98,11 @@ export class DiffViewProvider {
 
 		for (const tab of tabs) {
 			if (!tab.isDirty) {
-				await vscode.window.tabGroups.close(tab)
+				try {
+					await vscode.window.tabGroups.close(tab)
+				} catch (err) {
+					console.error(`Failed to close tab ${tab.label}`, err)
+				}
 			}
 			this.documentWasOpen = true
 		}


### PR DESCRIPTION
Closes #11362

## Summary

- `DiffViewProvider.open()` closes existing editor tabs for the file being edited before opening the diff view. The `tabGroups.close(tab)` call is unguarded — if the tab reference becomes invalid between lookup and close, it throws `"Tab close: Invalid tab not found!"` and aborts the entire edit operation.
- This is best-effort cleanup; failure should not block the edit flow.
- Wraps the `tabGroups.close(tab)` call in a try-catch, matching the existing defensive pattern in `closeAllDiffViews()` in the same file.
- The `documentWasOpen` flag assignment remains unconditional and outside the close success path (it tracks whether the file had an open tab, not whether the close succeeded).
- VS Code has an upstream regression producing the same error string (microsoft/vscode#228270); this change treats close failures defensively regardless of trigger.

## Test plan

- Existing: 15/15 DiffViewProvider tests passing
- Manual: open a file in the editor, trigger a Roo edit on that file, verify the diff view opens and editing proceeds normally
- Manual (WSL/remote): same flow in a remote environment where the race window is wider
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Wrap `tabGroups.close(tab)` in `DiffViewProvider.open()` with try-catch to prevent aborting edit operation on tab close failure.
> 
>   - **Behavior**:
>     - Wraps `tabGroups.close(tab)` in `DiffViewProvider.open()` with try-catch to prevent aborting edit operation on tab close failure.
>     - `documentWasOpen` flag remains outside try-catch to track if file had an open tab.
>   - **Context**:
>     - Matches defensive pattern in `closeAllDiffViews()`.
>     - Addresses similar error in VS Code (microsoft/vscode#228270).
>   - **Testing**:
>     - 15/15 existing tests passing.
>     - Manual tests for local and remote environments confirm normal operation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 7053813c67ac455da8a7667bd2459a807909ce2f. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->