### PR TITLE
fix(security): require explicit approval for shell redirection/background in command auto-approve

### DIFF
--- a/src/core/auto-approval/__tests__/commands.spec.ts
+++ b/src/core/auto-approval/__tests__/commands.spec.ts
@@ -205,6 +205,23 @@ describe("containsShellFileRedirection", () => {
 	it("detects file redirection even with fd redirect present", () => {
 		expect(containsShellFileRedirection("cmd 2>&1 > out.txt")).toBe(true)
 	})
+
+	// Quote-aware: operators inside quotes are literal, not redirection
+	it("does not flag > inside double quotes (arrow function)", () => {
+		expect(containsShellFileRedirection(`node -e "const f=(a)=>a"`)).toBe(false)
+	})
+
+	it("does not flag > inside single quotes", () => {
+		expect(containsShellFileRedirection("echo 'hello > world'")).toBe(false)
+	})
+
+	it("detects > outside quotes even when quoted content has >", () => {
+		expect(containsShellFileRedirection(`node -e "x" > out.txt`)).toBe(true)
+	})
+
+	it("does not flag < inside double quotes", () => {
+		expect(containsShellFileRedirection(`node -e "if (a < b) {}"`)).toBe(false)
+	})
 })
 
 describe("containsBackgroundOperator", () => {
@@ -241,6 +258,11 @@ describe("containsBackgroundOperator", () => {
 
 	it("does not flag plain command", () => {
 		expect(containsBackgroundOperator("git status")).toBe(false)
+	})
+
+	// Quote-aware: & inside quotes is literal
+	it("does not flag & inside double quotes", () => {
+		expect(containsBackgroundOperator(`node -e "a & b"`)).toBe(false)
 	})
 })
 


### PR DESCRIPTION
Refs #11095

## Summary

- Command auto-approval could approve an allowlisted prefix while shell operators (redirection/background) alter execution semantics under `shell: true`. For example, auto-approving `git show` would also auto-approve `git show > out.txt`, allowing writes to an arbitrary file.
- Commands containing file redirection (`<`, `>`, `>>`, `<<`, etc.) now require explicit approval (`ask_user`).
  - Safe fd-to-fd duplication is excluded (for example `2>&1`, `>&2`, `<&3`, `0<&4`).
- Commands containing a standalone background operator (`&`) now require explicit approval.
- fd-to-fd stripping now uses a **token-boundary** lookahead `(?=$|\s|[;&|()<>])` to avoid false negatives such as `>&2file` and `<&3in`, where the redirection target is a word and therefore represents file redirection, not fd-to-fd duplication.

## Test plan

- `containsShellFileRedirection()` — 21 cases: detects output/input/append/here-doc/stderr/mixed redirections (9), excludes safe fd-to-fd like `2>&1`, `>&2`, `<&3`, `0<&4` (5), token-boundary edge cases — `>&2file`, `<&3in`, `2>&1&&`, `2>&1>out.txt`, `0<&4|` (5), general sanity checks (2)
- `containsBackgroundOperator()` — 8 cases: detects standalone `&`, excludes `&&`, `&>`, `>&`, `<&`
- `getCommandDecision()` — 15 integration cases: redirection forces `ask_user`, fd-to-fd preserves `auto_approve`, background forces `ask_user`, token-boundary edge cases, denylist regression
- Existing regression coverage for `containsDangerousSubstitution`, `findLongestPrefixMatch`, `getSingleCommandDecision` — 11 cases
- Total: 55 tests, all passing