### PR TITLE
fix(data): preserve HTML entities in file writes, diffs, and commands

### DIFF
--- a/src/core/tools/ApplyDiffTool.ts
+++ b/src/core/tools/ApplyDiffTool.ts
@@ -9,7 +9,6 @@ import { Task } from "../task/Task"
 import { formatResponse } from "../prompts/responses"
 import { fileExistsAtPath } from "../../utils/fs"
 import { RecordSource } from "../context-tracking/FileContextTrackerTypes"
-import { unescapeHtmlEntities } from "../../utils/text-normalization"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import type { ToolUse } from "../../shared/tools"
@@ -26,11 +25,7 @@ export class ApplyDiffTool extends BaseTool<"apply_diff"> {
 
 	async execute(params: ApplyDiffParams, task: Task, callbacks: ToolCallbacks): Promise<void> {
 		const { askApproval, handleError, pushToolResult } = callbacks
-		let { path: relPath, diff: diffContent } = params
-
-		if (diffContent && !task.api.getModel().id.includes("claude")) {
-			diffContent = unescapeHtmlEntities(diffContent)
-		}
+		const { path: relPath, diff: diffContent } = params
 
 		try {
 			if (!relPath) {

--- a/src/core/tools/ExecuteCommandTool.ts
+++ b/src/core/tools/ExecuteCommandTool.ts
@@ -11,7 +11,6 @@ import { Task } from "../task/Task"
 
 import { ToolUse, ToolResponse } from "../../shared/tools"
 import { formatResponse } from "../prompts/responses"
-import { unescapeHtmlEntities } from "../../utils/text-normalization"
 import { ExitCodeDetails, RooTerminalCallbacks, RooTerminalProcess } from "../../integrations/terminal/types"
 import { TerminalRegistry } from "../../integrations/terminal/TerminalRegistry"
 import { Terminal } from "../../integrations/terminal/Terminal"
@@ -43,9 +42,7 @@ export class ExecuteCommandTool extends BaseTool<"execute_command"> {
 				return
 			}
 
-			const canonicalCommand = unescapeHtmlEntities(command)
-
-			const ignoredFileAttemptedToAccess = task.rooIgnoreController?.validateCommand(canonicalCommand)
+			const ignoredFileAttemptedToAccess = task.rooIgnoreController?.validateCommand(command)
 
 			if (ignoredFileAttemptedToAccess) {
 				await task.say("rooignore_error", ignoredFileAttemptedToAccess)
@@ -55,7 +52,7 @@ export class ExecuteCommandTool extends BaseTool<"execute_command"> {
 
 			task.consecutiveMistakeCount = 0
 
-			const didApprove = await askApproval("command", canonicalCommand)
+			const didApprove = await askApproval("command", command)
 
 			if (!didApprove) {
 				return
@@ -79,7 +76,7 @@ export class ExecuteCommandTool extends BaseTool<"execute_command"> {
 
 			// Check if command matches any prefix in the allowlist
 			const isCommandAllowlisted = commandTimeoutAllowlist.some((prefix) =>
-				canonicalCommand.startsWith(prefix.trim()),
+				command.startsWith(prefix.trim()),
 			)
 
 			// Convert seconds to milliseconds for internal use, but skip timeout if command is allowlisted
@@ -87,7 +84,7 @@ export class ExecuteCommandTool extends BaseTool<"execute_command"> {
 
 			const options: ExecuteCommandOptions = {
 				executionId,
-				command: canonicalCommand,
+				command,
 				customCwd,
 				terminalShellIntegrationDisabled,
 				commandExecutionTimeout,

--- a/src/core/tools/WriteToFileTool.ts
+++ b/src/core/tools/WriteToFileTool.ts
@@ -11,7 +11,6 @@ import { fileExistsAtPath, createDirectoriesForFile } from "../../utils/fs"
 import { stripLineNumbers, everyLineHasLineNumbers } from "../../integrations/misc/extract-text"
 import { getReadablePath } from "../../utils/path"
 import { isPathOutsideWorkspace } from "../../utils/pathUtils"
-import { unescapeHtmlEntities } from "../../utils/text-normalization"
 import { EXPERIMENT_IDS, experiments } from "../../shared/experiments"
 import { convertNewFileToUnifiedDiff, computeDiffStats, sanitizeUnifiedDiff } from "../diff/stats"
 import type { ToolUse } from "../../shared/tools"
@@ -79,10 +78,6 @@ export class WriteToFileTool extends BaseTool<"write_to_file"> {
 
 		if (newContent.endsWith("```")) {
 			newContent = newContent.split("\n").slice(0, -1).join("\n")
-		}
-
-		if (!task.api.getModel().id.includes("claude")) {
-			newContent = unescapeHtmlEntities(newContent)
 		}
 
 		const fullPath = relPath ? path.resolve(task.cwd, relPath) : ""

--- a/src/core/tools/__tests__/executeCommandTimeout.integration.spec.ts
+++ b/src/core/tools/__tests__/executeCommandTimeout.integration.spec.ts
@@ -23,9 +23,6 @@ vitest.mock("../../prompts/responses", () => ({
 		rooIgnoreError: vitest.fn((msg) => `RooIgnore Error: ${msg}`),
 	},
 }))
-vitest.mock("../../../utils/text-normalization", () => ({
-	unescapeHtmlEntities: vitest.fn((text) => text),
-}))
 vitest.mock("../../../shared/package", () => ({
 	Package: {
 		name: "roo-cline",

--- a/src/core/tools/__tests__/writeToFileTool.spec.ts
+++ b/src/core/tools/__tests__/writeToFileTool.spec.ts
@@ -5,7 +5,6 @@ import type { MockedFunction } from "vitest"
 import { fileExistsAtPath, createDirectoriesForFile } from "../../../utils/fs"
 import { isPathOutsideWorkspace } from "../../../utils/pathUtils"
 import { getReadablePath } from "../../../utils/path"
-import { unescapeHtmlEntities } from "../../../utils/text-normalization"
 import { everyLineHasLineNumbers, stripLineNumbers } from "../../../integrations/misc/extract-text"
 import { ToolUse, ToolResponse } from "../../../shared/tools"
 import { writeToFileTool } from "../WriteToFileTool"
@@ -45,10 +44,6 @@ vi.mock("../../../utils/pathUtils", () => ({
 
 vi.mock("../../../utils/path", () => ({
 	getReadablePath: vi.fn().mockReturnValue("test/path.txt"),
-}))
-
-vi.mock("../../../utils/text-normalization", () => ({
-	unescapeHtmlEntities: vi.fn().mockImplementation((content) => content),
 }))
 
 vi.mock("../../../integrations/misc/extract-text", () => ({
@@ -97,7 +92,6 @@ describe("writeToFileTool", () => {
 	const mockedCreateDirectoriesForFile = createDirectoriesForFile as MockedFunction<typeof createDirectoriesForFile>
 	const mockedIsPathOutsideWorkspace = isPathOutsideWorkspace as MockedFunction<typeof isPathOutsideWorkspace>
 	const mockedGetReadablePath = getReadablePath as MockedFunction<typeof getReadablePath>
-	const mockedUnescapeHtmlEntities = unescapeHtmlEntities as MockedFunction<typeof unescapeHtmlEntities>
 	const mockedEveryLineHasLineNumbers = everyLineHasLineNumbers as MockedFunction<typeof everyLineHasLineNumbers>
 	const mockedStripLineNumbers = stripLineNumbers as MockedFunction<typeof stripLineNumbers>
 	const mockedPathResolve = path.resolve as MockedFunction<typeof path.resolve>
@@ -116,7 +110,6 @@ describe("writeToFileTool", () => {
 		mockedFileExistsAtPath.mockResolvedValue(false)
 		mockedIsPathOutsideWorkspace.mockReturnValue(false)
 		mockedGetReadablePath.mockReturnValue("test/path.txt")
-		mockedUnescapeHtmlEntities.mockImplementation((content) => content)
 		mockedEveryLineHasLineNumbers.mockReturnValue(false)
 		mockedStripLineNumbers.mockImplementation((content) => content)
 
@@ -327,20 +320,13 @@ describe("writeToFileTool", () => {
 			expect(mockCline.diffViewProvider.update).toHaveBeenCalledWith("", true)
 		})
 
-		it("unescapes HTML entities for non-Claude models", async () => {
+		it("preserves HTML entities in content regardless of model", async () => {
 			mockCline.api.getModel.mockReturnValue({ id: "gpt-4" })
+			const contentWithEntities = "&lt;div&gt;John&apos;s &amp; Jane&apos;s &quot;test&quot;&lt;/div&gt;"
 
-			await executeWriteFileTool({ content: "&lt;test&gt;" })
+			await executeWriteFileTool({ content: contentWithEntities })
 
-			expect(mockedUnescapeHtmlEntities).toHaveBeenCalledWith("&lt;test&gt;")
-		})
-
-		it("skips HTML unescaping for Claude models", async () => {
-			mockCline.api.getModel.mockReturnValue({ id: "claude-3" })
-
-			await executeWriteFileTool({ content: "&lt;test&gt;" })
-
-			expect(mockedUnescapeHtmlEntities).not.toHaveBeenCalled()
+			expect(mockCline.diffViewProvider.update).toHaveBeenCalledWith(contentWithEntities, true)
 		})
 
 		it("strips line numbers from numbered content", async () => {


### PR DESCRIPTION
Closes #10804

## Summary

- Remove `unescapeHtmlEntities()` calls from `WriteToFileTool`, `ApplyDiffTool`, and `ExecuteCommandTool` that converted HTML entities (`&lt;`, `&gt;`, `&amp;`, `&apos;`, `&quot;`) to literal characters during file writes, diff application, and command execution
- This conversion corrupted HTML/JSX/TSX content (e.g., `&apos;` becoming `'` breaks JSX attributes, `&lt;` becoming `<` breaks HTML entity display)
- Commands containing shell-significant characters were also affected — `&gt;` was silently converted to `>` before execution
- Removed the now-redundant `canonicalCommand` alias per review feedback

## Background

HTML entity decoding was originally added in PR #2120 (Mar 2025) as a workaround for XML-encoded tool-call payloads. When models used the XML tool protocol, special characters in tool parameters were XML-encoded (`&` became `&amp;`, `<` became `&lt;`, etc.), so the tool layer decoded them before execution. Over time the same decoding was applied to file writes and diff application, where it caused data corruption by mutating HTML/JSX/TSX content. The XML tool protocol has since been removed entirely — the codebase now uses native JSON tool calls exclusively, which do not XML-encode parameters. The `unescapeHtmlEntities()` calls are no longer needed.

## Test plan

- Existing: 37 tests pass across 3 test files (executeCommandTool, executeCommandTimeout, writeToFileTool)
- Modified: HTML entity tests now assert preservation instead of conversion (executeCommandTool.spec.ts, writeToFileTool.spec.ts)
- Modified: Removed stale `text-normalization` mock from integration tests (executeCommandTimeout.integration.spec.ts)