### PR TITLE
refactor: extract shared cache breakpoint utility from 4 providers

### DIFF
--- a/src/api/providers/anthropic-vertex.ts
+++ b/src/api/providers/anthropic-vertex.ts
@@ -26,6 +26,7 @@ import {
 	handleAiSdkError,
 } from "../transform/ai-sdk"
 import { calculateApiCostAnthropic } from "../../shared/cost"
+import { applyCacheBreakpoints } from "../transform/cache-breakpoints"
 
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
@@ -124,36 +125,10 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 			anthropicProviderOptions.disableParallelToolUse = true
 		}
 
-		/**
-		 * Vertex API has specific limitations for prompt caching:
-		 * 1. Maximum of 4 blocks can have cache_control
-		 * 2. Only text blocks can be cached (images and other content types cannot)
-		 * 3. Cache control can only be applied to user messages, not assistant messages
-		 *
-		 * Our caching strategy:
-		 * - Cache the system prompt (1 block)
-		 * - Cache the last text block of the second-to-last user message (1 block)
-		 * - Cache the last text block of the last user message (1 block)
-		 * This ensures we stay under the 4-block limit while maintaining effective caching
-		 * for the most relevant context.
-		 */
+		// Apply cache control to user messages (Vertex allows up to 4 cache_control blocks;
+		// 1 for system prompt + 2 for the last 2 user message batches).
 		const cacheProviderOption = { anthropic: { cacheControl: { type: "ephemeral" as const } } }
-
-		const userMsgIndices = messages.reduce(
-			(acc, msg, index) => ("role" in msg && msg.role === "user" ? [...acc, index] : acc),
-			[] as number[],
-		)
-
-		const targetIndices = new Set<number>()
-		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
-		const secondLastUserMsgIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-
-		if (lastUserMsgIndex >= 0) targetIndices.add(lastUserMsgIndex)
-		if (secondLastUserMsgIndex >= 0) targetIndices.add(secondLastUserMsgIndex)
-
-		if (targetIndices.size > 0) {
-			this.applyCacheControlToAiSdkMessages(messages as ModelMessage[], targetIndices, cacheProviderOption)
-		}
+		applyCacheBreakpoints(messages, { cacheProviderOption })
 
 		// Build streamText request
 		// Cast providerOptions to any to bypass strict JSONObject typing — the AI SDK accepts the correct runtime values
@@ -257,29 +232,6 @@ export class AnthropicVertexHandler extends BaseProvider implements SingleComple
 			cacheWriteTokens: cacheWriteTokens > 0 ? cacheWriteTokens : undefined,
 			cacheReadTokens: cacheReadTokens > 0 ? cacheReadTokens : undefined,
 			totalCost,
-		}
-	}
-
-	/**
-	 * Apply cacheControl providerOptions to the correct AI SDK messages by walking
-	 * the original Anthropic messages and converted AI SDK messages in parallel.
-	 *
-	 * convertToAiSdkMessages() can split a single Anthropic user message (containing
-	 * tool_results + text) into 2 AI SDK messages (tool role + user role). This method
-	 * accounts for that split so cache control lands on the right message.
-	 */
-	private applyCacheControlToAiSdkMessages(
-		aiSdkMessages: { role: string; providerOptions?: Record<string, Record<string, unknown>> }[],
-		targetIndices: Set<number>,
-		cacheProviderOption: Record<string, Record<string, unknown>>,
-	): void {
-		for (const idx of targetIndices) {
-			if (idx >= 0 && idx < aiSdkMessages.length) {
-				aiSdkMessages[idx].providerOptions = {
-					...aiSdkMessages[idx].providerOptions,
-					...cacheProviderOption,
-				}
-			}
 		}
 	}
 

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -25,6 +25,7 @@ import {
 	handleAiSdkError,
 } from "../transform/ai-sdk"
 import { calculateApiCostAnthropic } from "../../shared/cost"
+import { applyCacheBreakpoints } from "../transform/cache-breakpoints"
 
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
@@ -114,22 +115,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 		// Apply cache control to user messages
 		// Strategy: cache the last 2 user messages (write-to-cache + read-from-cache)
 		const cacheProviderOption = { anthropic: { cacheControl: { type: "ephemeral" as const } } }
-
-		const userMsgIndices = messages.reduce(
-			(acc, msg, index) => ("role" in msg && msg.role === "user" ? [...acc, index] : acc),
-			[] as number[],
-		)
-
-		const targetIndices = new Set<number>()
-		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
-		const secondLastUserMsgIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-
-		if (lastUserMsgIndex >= 0) targetIndices.add(lastUserMsgIndex)
-		if (secondLastUserMsgIndex >= 0) targetIndices.add(secondLastUserMsgIndex)
-
-		if (targetIndices.size > 0) {
-			this.applyCacheControlToAiSdkMessages(messages as ModelMessage[], targetIndices, cacheProviderOption)
-		}
+		applyCacheBreakpoints(messages, { cacheProviderOption })
 
 		// Build streamText request
 		// Cast providerOptions to any to bypass strict JSONObject typing — the AI SDK accepts the correct runtime values
@@ -233,29 +219,6 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 			cacheWriteTokens: cacheWriteTokens > 0 ? cacheWriteTokens : undefined,
 			cacheReadTokens: cacheReadTokens > 0 ? cacheReadTokens : undefined,
 			totalCost,
-		}
-	}
-
-	/**
-	 * Apply cacheControl providerOptions to the correct AI SDK messages by walking
-	 * the original Anthropic messages and converted AI SDK messages in parallel.
-	 *
-	 * convertToAiSdkMessages() can split a single Anthropic user message (containing
-	 * tool_results + text) into 2 AI SDK messages (tool role + user role). This method
-	 * accounts for that split so cache control lands on the right message.
-	 */
-	private applyCacheControlToAiSdkMessages(
-		aiSdkMessages: { role: string; providerOptions?: Record<string, Record<string, unknown>> }[],
-		targetIndices: Set<number>,
-		cacheProviderOption: Record<string, Record<string, unknown>>,
-	): void {
-		for (const idx of targetIndices) {
-			if (idx >= 0 && idx < aiSdkMessages.length) {
-				aiSdkMessages[idx].providerOptions = {
-					...aiSdkMessages[idx].providerOptions,
-					...cacheProviderOption,
-				}
-			}
 		}
 	}
 

--- a/src/api/providers/minimax.ts
+++ b/src/api/providers/minimax.ts
@@ -16,6 +16,7 @@ import {
 	handleAiSdkError,
 } from "../transform/ai-sdk"
 import { calculateApiCostAnthropic } from "../../shared/cost"
+import { applyCacheBreakpoints } from "../transform/cache-breakpoints"
 
 import { DEFAULT_HEADERS } from "./constants"
 import { BaseProvider } from "./base-provider"
@@ -95,21 +96,7 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 		}
 
 		const cacheProviderOption = { anthropic: { cacheControl: { type: "ephemeral" as const } } }
-		const userMsgIndices = mergedMessages.reduce(
-			(acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc),
-			[] as number[],
-		)
-
-		const targetIndices = new Set<number>()
-		const lastUserMsgIndex = userMsgIndices[userMsgIndices.length - 1] ?? -1
-		const secondLastUserMsgIndex = userMsgIndices[userMsgIndices.length - 2] ?? -1
-
-		if (lastUserMsgIndex >= 0) targetIndices.add(lastUserMsgIndex)
-		if (secondLastUserMsgIndex >= 0) targetIndices.add(secondLastUserMsgIndex)
-
-		if (targetIndices.size > 0) {
-			this.applyCacheControlToAiSdkMessages(aiSdkMessages, targetIndices, cacheProviderOption)
-		}
+		applyCacheBreakpoints(aiSdkMessages as RooMessage[], { cacheProviderOption })
 
 		const requestOptions = {
 			model: this.client(modelConfig.id),
@@ -209,21 +196,6 @@ export class MiniMaxHandler extends BaseProvider implements SingleCompletionHand
 			cacheWriteTokens: cacheWriteTokens > 0 ? cacheWriteTokens : undefined,
 			cacheReadTokens: cacheReadTokens > 0 ? cacheReadTokens : undefined,
 			totalCost,
-		}
-	}
-
-	private applyCacheControlToAiSdkMessages(
-		aiSdkMessages: { role: string; providerOptions?: Record<string, Record<string, unknown>> }[],
-		targetIndices: Set<number>,
-		cacheProviderOption: Record<string, Record<string, unknown>>,
-	): void {
-		for (const idx of targetIndices) {
-			if (idx >= 0 && idx < aiSdkMessages.length) {
-				aiSdkMessages[idx].providerOptions = {
-					...aiSdkMessages[idx].providerOptions,
-					...cacheProviderOption,
-				}
-			}
 		}
 	}
 

--- a/src/api/transform/__tests__/cache-breakpoints.spec.ts
+++ b/src/api/transform/__tests__/cache-breakpoints.spec.ts
@@ -1,0 +1,164 @@
+import type { RooMessage } from "../../../core/task-persistence/rooMessage"
+import { applyCacheBreakpoints, type CacheBreakpointConfig } from "../cache-breakpoints"
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeUserMsg(content = "hi"): RooMessage {
+	return { role: "user", content: [{ type: "text", text: content }], ts: Date.now() } as RooMessage
+}
+
+function makeAssistantMsg(content = "hello"): RooMessage {
+	return { role: "assistant", content: [{ type: "text", text: content }], ts: Date.now() } as RooMessage
+}
+
+function makeToolMsg(content = "result"): RooMessage {
+	return {
+		role: "tool",
+		content: [{ type: "tool-result", toolCallId: "1", toolName: "test", output: { type: "text", value: content } }],
+		ts: Date.now(),
+	} as RooMessage
+}
+
+const anthropicCache: CacheBreakpointConfig["cacheProviderOption"] = {
+	anthropic: { cacheControl: { type: "ephemeral" } },
+}
+
+function defaultConfig(overrides?: Partial<CacheBreakpointConfig>): CacheBreakpointConfig {
+	return { cacheProviderOption: anthropicCache, ...overrides }
+}
+
+function getProviderOptions(msg: RooMessage): Record<string, Record<string, unknown>> | undefined {
+	return (msg as RooMessage & { providerOptions?: Record<string, Record<string, unknown>> }).providerOptions
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("applyCacheBreakpoints", () => {
+	it("empty messages → no crash", () => {
+		const messages: RooMessage[] = []
+		expect(() => applyCacheBreakpoints(messages, defaultConfig())).not.toThrow()
+	})
+
+	it("single user message → gets breakpoint", () => {
+		const messages = [makeUserMsg()]
+		applyCacheBreakpoints(messages, defaultConfig())
+
+		expect(getProviderOptions(messages[0])).toEqual(anthropicCache)
+	})
+
+	it("single tool message → gets breakpoint", () => {
+		const messages = [makeToolMsg()]
+		applyCacheBreakpoints(messages, defaultConfig())
+
+		expect(getProviderOptions(messages[0])).toEqual(anthropicCache)
+	})
+
+	it("3 batches with maxMessageBreakpoints=2 → only last 2 batches get breakpoints", () => {
+		// Batch 1: user (idx 0)
+		// Batch 2: tool (idx 2)
+		// Batch 3: user (idx 4)
+		const messages = [
+			makeUserMsg("q1"),
+			makeAssistantMsg("a1"),
+			makeToolMsg("r1"),
+			makeAssistantMsg("a2"),
+			makeUserMsg("q2"),
+		]
+
+		applyCacheBreakpoints(messages, defaultConfig({ maxMessageBreakpoints: 2 }))
+
+		// Batch 1 (idx 0) should NOT get a breakpoint
+		expect(getProviderOptions(messages[0])).toBeUndefined()
+		// Batch 2 last = tool at idx 2
+		expect(getProviderOptions(messages[2])).toEqual(anthropicCache)
+		// Batch 3 last = user at idx 4
+		expect(getProviderOptions(messages[4])).toEqual(anthropicCache)
+		// Assistants never get breakpoints
+		expect(getProviderOptions(messages[1])).toBeUndefined()
+		expect(getProviderOptions(messages[3])).toBeUndefined()
+	})
+
+	it("consecutive tool+user in same batch → only last in batch gets breakpoint", () => {
+		// [tool, user, assistant] → one batch: tool(0), user(1); then assistant(2)
+		// Last in batch = user at idx 1
+		const messages = [makeToolMsg(), makeUserMsg(), makeAssistantMsg()]
+
+		applyCacheBreakpoints(messages, defaultConfig())
+
+		expect(getProviderOptions(messages[0])).toBeUndefined()
+		expect(getProviderOptions(messages[1])).toEqual(anthropicCache)
+		expect(getProviderOptions(messages[2])).toBeUndefined()
+	})
+
+	it("long conversation with anchor enabled → anchor at ~1/3", () => {
+		// Create 6 batches: [user, assistant] × 6, ending with user
+		// Pattern: user, assistant, user, assistant, user, assistant, user, assistant, user, assistant, user
+		// Batches: idx 0, 2, 4, 6, 8, 10 → batchLastIndices = [0, 2, 4, 6, 8, 10]
+		const messages: RooMessage[] = []
+		for (let i = 0; i < 6; i++) {
+			messages.push(makeUserMsg(`q${i}`))
+			if (i < 5) {
+				messages.push(makeAssistantMsg(`a${i}`))
+			}
+		}
+		// 6 batches total (each single user msg is a batch)
+		// anchorBatchIdx = Math.floor(6 / 3) = 2 → batchLastIndices[2] = idx 4
+
+		applyCacheBreakpoints(
+			messages,
+			defaultConfig({ maxMessageBreakpoints: 2, useAnchor: true, anchorThreshold: 5 }),
+		)
+
+		// Last 2 batches: idx 10 (batch 5) and idx 8 (batch 4)
+		expect(getProviderOptions(messages[10])).toEqual(anthropicCache)
+		expect(getProviderOptions(messages[8])).toEqual(anthropicCache)
+		// Anchor at batch 2 → idx 4
+		expect(getProviderOptions(messages[4])).toEqual(anthropicCache)
+		// Other user messages should NOT have breakpoints
+		expect(getProviderOptions(messages[0])).toBeUndefined()
+		expect(getProviderOptions(messages[2])).toBeUndefined()
+		expect(getProviderOptions(messages[6])).toBeUndefined()
+	})
+
+	it("messages with existing providerOptions → preserved", () => {
+		const msg = makeUserMsg()
+		;(msg as RooMessage & { providerOptions?: Record<string, Record<string, unknown>> }).providerOptions = {
+			other: { key: "val" },
+		}
+		const messages = [msg]
+
+		applyCacheBreakpoints(messages, defaultConfig())
+
+		const opts = getProviderOptions(messages[0])
+		expect(opts).toEqual({
+			other: { key: "val" },
+			anthropic: { cacheControl: { type: "ephemeral" } },
+		})
+	})
+
+	it("maxMessageBreakpoints=3 (Bedrock config) → 3 breakpoints", () => {
+		// 4 batches: user, asst, user, asst, user, asst, user
+		const messages: RooMessage[] = []
+		for (let i = 0; i < 4; i++) {
+			messages.push(makeUserMsg(`q${i}`))
+			if (i < 3) {
+				messages.push(makeAssistantMsg(`a${i}`))
+			}
+		}
+		// batchLastIndices = [0, 2, 4, 6] → 4 batches
+		// maxMessageBreakpoints=3 → last 3: idx 6, 4, 2
+
+		applyCacheBreakpoints(messages, defaultConfig({ maxMessageBreakpoints: 3 }))
+
+		// Last 3 batch-end messages get breakpoints
+		expect(getProviderOptions(messages[6])).toEqual(anthropicCache)
+		expect(getProviderOptions(messages[4])).toEqual(anthropicCache)
+		expect(getProviderOptions(messages[2])).toEqual(anthropicCache)
+		// First batch (idx 0) should NOT
+		expect(getProviderOptions(messages[0])).toBeUndefined()
+	})
+})

--- a/src/api/transform/cache-breakpoints.ts
+++ b/src/api/transform/cache-breakpoints.ts
@@ -1,0 +1,65 @@
+import type { RooMessage } from "../../core/task-persistence/rooMessage"
+
+export interface CacheBreakpointConfig {
+	/** The providerOptions value to apply to targeted messages */
+	cacheProviderOption: Record<string, Record<string, unknown>>
+	/** Max number of message cache breakpoints (excluding system). Default: 2 */
+	maxMessageBreakpoints?: number
+	/** Add an anchor breakpoint in the middle for long conversations. Default: false */
+	useAnchor?: boolean
+	/** Min non-assistant batch count before anchor is added. Default: 5 */
+	anchorThreshold?: number
+}
+
+/**
+ * Apply cache breakpoints to RooMessage[].
+ *
+ * Targets the last message in each non-assistant batch (user/tool).
+ * A "batch" is a consecutive run of non-assistant messages.
+ * We only cache the last message per batch to avoid redundant breakpoints.
+ *
+ * Mutates messages in place by adding providerOptions.
+ */
+export function applyCacheBreakpoints(messages: RooMessage[], config: CacheBreakpointConfig): void {
+	const { cacheProviderOption, maxMessageBreakpoints = 2, useAnchor = false, anchorThreshold = 5 } = config
+
+	// Find the index of the last message in each non-assistant batch
+	const batchLastIndices: number[] = []
+	let inBatch = false
+
+	for (let i = 0; i < messages.length; i++) {
+		const msg = messages[i]
+		const isNonAssistant = "role" in msg && msg.role !== "assistant"
+
+		if (isNonAssistant) {
+			inBatch = true
+		} else if (inBatch) {
+			batchLastIndices.push(i - 1)
+			inBatch = false
+		}
+	}
+	if (inBatch) {
+		batchLastIndices.push(messages.length - 1)
+	}
+
+	// Select targets: last N batches + optional anchor
+	const targets = new Set<number>()
+	const numBatches = batchLastIndices.length
+
+	for (let j = 0; j < Math.min(maxMessageBreakpoints, numBatches); j++) {
+		targets.add(batchLastIndices[numBatches - 1 - j])
+	}
+
+	if (useAnchor && numBatches >= anchorThreshold) {
+		const anchorBatchIdx = Math.floor(numBatches / 3)
+		targets.add(batchLastIndices[anchorBatchIdx])
+	}
+
+	// Apply providerOptions to targeted messages
+	for (const idx of targets) {
+		const msg = messages[idx] as RooMessage & {
+			providerOptions?: Record<string, Record<string, unknown>>
+		}
+		msg.providerOptions = { ...msg.providerOptions, ...cacheProviderOption }
+	}
+}


### PR DESCRIPTION
## Summary

Extracts duplicated cache breakpoint logic from 4 providers into a shared utility `applyCacheBreakpoints()`, fixing a tool message caching gap introduced by PR #11386.

### Problem

Cache breakpoint placement was duplicated across 4 providers (Anthropic, Anthropic Vertex, Minimax, Bedrock) with identical targeting logic that only targeted `role === "user"` messages. After PR #11386, tool results became separate `role: "tool"` messages, creating a gap where the last message from our side (often a tool response) wouldn't get a cache breakpoint.

### Solution

New shared utility in [`src/api/transform/cache-breakpoints.ts`](src/api/transform/cache-breakpoints.ts):
- `applyCacheBreakpoints(messages, config)` — targets the **last message in each non-assistant batch** (user + tool), fixing the tool message gap
- `CacheBreakpointConfig` interface — supports per-provider differences:
  - Anthropic/Vertex/Minimax: 2 breakpoints (default)
  - Bedrock: 3 breakpoints + anchor at ~1/3 position

### Changes

| Provider | Before | After |
|---|---|---|
| `anthropic.ts` | 18-line targeting block + `applyCacheControlToAiSdkMessages()` method | Single `applyCacheBreakpoints()` call |
| `anthropic-vertex.ts` | 30-line block + method | Single call |
| `minimax.ts` | 18-line block + method | Single call |
| `bedrock.ts` | 42-line block + `applyCachePointsToAiSdkMessages()` method | Single call with `useAnchor: true` |

**+244 / -184 lines** (net +60, mostly new tests)

### Test Coverage

- **8 new tests** in `cache-breakpoints.spec.ts`: empty array, single user, single tool (gap fix), multi-batch selection, same-batch dedup, anchor placement, existing providerOptions preservation, maxMessageBreakpoints=3
- **0 regressions** across 136 existing provider tests
- **5,500 total tests pass**

### Key improvement

```
// Before (only user messages cached):
messages.reduce((acc, msg, index) => (msg.role === "user" ? [...acc, index] : acc), [])

// After (last message in each non-assistant batch cached):
// user, tool, user → caches the tool msg AND the last user msg (2 separate batches)
```
----
<!-- ELLIPSIS_HIDDEN -->
> [!IMPORTANT]
> Refactored cache breakpoint logic across multiple provider implementations by extracting common functionality into a centralized `applyCacheBreakpoints` utility function.
> 
>   ## Cache Breakpoint Utility Extraction
>   - **New `cache-breakpoints.ts` module**:
>     - Introduced `CacheBreakpointConfig` interface with options for cache provider settings, maximum message breakpoints, anchor breakpoint support, and anchor threshold configuration.
>     - Implemented `applyCacheBreakpoints()` function that identifies the last message in each non-assistant message batch and applies cache provider options to targeted messages.
>     - Supports selecting the last N batches based on `maxMessageBreakpoints` configuration and optionally adds an anchor breakpoint at one-third position when `useAnchor` is enabled.
>   - **Provider implementations simplified**:
>     - Replaced inline cache control logic in `anthropic-vertex.ts`, `anthropic.ts`, `bedrock.ts`, and `minimax.ts` with calls to `applyCacheBreakpoints()`.
>     - Removed private `applyCacheControlToAiSdkMessages()` and `applyCachePointsToAiSdkMessages()` methods from all provider files.
>     - Removed detailed comments and manual cache point calculation logic that is now handled by the utility function.
>   - **Test coverage**:
>     - Added comprehensive test suite in `cache-breakpoints.spec.ts` covering empty messages, single/multiple batches, anchor point behavior, existing provider options preservation, and Bedrock-specific configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RooCodeInc%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 205aa9a518ae38c0fa04f1f7831efc92cd0e665b. You can [customize](https://app.ellipsis.dev/RooCodeInc/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>
<!-- ELLIPSIS_HIDDEN -->