### PR TITLE
fix(native-tools): accept empty attempt_completion.result

### DIFF
--- a/src/core/assistant-message/NativeToolCallParser.ts
+++ b/src/core/assistant-message/NativeToolCallParser.ts
@@ -449,7 +449,7 @@ export class NativeToolCallParser {
 				break
 
 			case "attempt_completion":
-				if (partialArgs.result) {
+				if (partialArgs.result !== undefined) {
 					nativeArgs = { result: partialArgs.result }
 				}
 				break
@@ -790,7 +790,7 @@ export class NativeToolCallParser {
 					break
 
 				case "attempt_completion":
-					if (args.result) {
+					if (args.result !== undefined) {
 						nativeArgs = { result: args.result } as NativeArgsFor<TName>
 					}
 					break

--- a/src/core/assistant-message/__tests__/NativeToolCallParser.spec.ts
+++ b/src/core/assistant-message/__tests__/NativeToolCallParser.spec.ts
@@ -293,6 +293,73 @@ describe("NativeToolCallParser", () => {
 		})
 	})
 
+	describe("parseToolCall - attempt_completion", () => {
+		it("should produce nativeArgs when result is an empty string", () => {
+			const toolCall = {
+				id: "toolu_empty_result",
+				name: "attempt_completion" as const,
+				arguments: JSON.stringify({ result: "" }),
+			}
+
+			const result = NativeToolCallParser.parseToolCall(toolCall)
+
+			expect(result).not.toBeNull()
+			expect(result?.type).toBe("tool_use")
+			if (result?.type === "tool_use") {
+				expect(result.nativeArgs).toBeDefined()
+				const nativeArgs = result.nativeArgs as { result: string }
+				expect(nativeArgs.result).toBe("")
+			}
+		})
+
+		it("should produce nativeArgs when result is a non-empty string", () => {
+			const toolCall = {
+				id: "toolu_normal_result",
+				name: "attempt_completion" as const,
+				arguments: JSON.stringify({ result: "Task completed successfully." }),
+			}
+
+			const result = NativeToolCallParser.parseToolCall(toolCall)
+
+			expect(result).not.toBeNull()
+			expect(result?.type).toBe("tool_use")
+			if (result?.type === "tool_use") {
+				expect(result.nativeArgs).toBeDefined()
+				const nativeArgs = result.nativeArgs as { result: string }
+				expect(nativeArgs.result).toBe("Task completed successfully.")
+			}
+		})
+
+		it("should return null when result is missing entirely", () => {
+			const toolCall = {
+				id: "toolu_no_result",
+				name: "attempt_completion" as const,
+				arguments: JSON.stringify({}),
+			}
+
+			const result = NativeToolCallParser.parseToolCall(toolCall)
+
+			expect(result).toBeNull()
+		})
+	})
+
+	describe("processStreamingChunk - attempt_completion", () => {
+		it("should produce nativeArgs during streaming when result is an empty string", () => {
+			const id = "toolu_stream_empty_completion"
+			NativeToolCallParser.startStreamingToolCall(id, "attempt_completion")
+
+			const result = NativeToolCallParser.processStreamingChunk(
+				id,
+				JSON.stringify({ result: "" }),
+			)
+
+			expect(result).not.toBeNull()
+			expect(result?.nativeArgs).toBeDefined()
+			const nativeArgs = result?.nativeArgs as { result: string }
+			expect(nativeArgs.result).toBe("")
+		})
+	})
+
 	describe("processStreamingChunk", () => {
 		describe("read_file tool", () => {
 			it("should emit a partial ToolUse with nativeArgs.path during streaming", () => {


### PR DESCRIPTION
Refs #11404

## Summary

- Change `attempt_completion` nativeArgs gating from truthiness (`if (args.result)`) to existence check (`if (args.result !== undefined)`) in both the streaming partial parse path and the finalize parse path in `NativeToolCallParser.ts`
- An empty string `""` is falsy in JavaScript, so `result: ""` was incorrectly treated as missing, producing the "missing nativeArgs" error
- Add 4 regression tests: empty-string result, non-empty result, missing result, and streaming empty-string result

## Test plan

- Existing: 12 parser tests continue to pass
- New: 4 tests for `attempt_completion` edge cases (empty string, non-empty, missing, streaming empty)
- Total: 16/16 passing

```
cd src && npx vitest run core/assistant-message/__tests__/NativeToolCallParser.spec.ts
```