### PR TITLE
fix(providers): do not force openai-strict tools for zai/ollama

### DIFF
--- a/src/api/providers/native-ollama.ts
+++ b/src/api/providers/native-ollama.ts
@@ -95,8 +95,7 @@ export class NativeOllamaHandler extends BaseProvider implements SingleCompletio
 
 		const aiSdkMessages = convertToAiSdkMessages(messages)
 
-		const openAiTools = this.convertToolsForOpenAI(metadata?.tools)
-		const aiSdkTools = convertToolsForAiSdk(openAiTools) as ToolSet | undefined
+		const aiSdkTools = convertToolsForAiSdk(metadata?.tools) as ToolSet | undefined
 
 		const providerOptions = this.buildProviderOptions(useR1Format)
 

--- a/src/api/providers/zai.ts
+++ b/src/api/providers/zai.ts
@@ -99,8 +99,7 @@ export class ZAiHandler extends BaseProvider implements SingleCompletionHandler 
 
 		const aiSdkMessages = convertToAiSdkMessages(messages)
 
-		const openAiTools = this.convertToolsForOpenAI(metadata?.tools)
-		const aiSdkTools = convertToolsForAiSdk(openAiTools) as ToolSet | undefined
+		const aiSdkTools = convertToolsForAiSdk(metadata?.tools) as ToolSet | undefined
 
 		const requestOptions: Parameters<typeof streamText>[0] = {
 			model: languageModel,


### PR DESCRIPTION
Closes #11404

## Summary

- Remove `convertToolsForOpenAI()` wrapper from Z-AI and Ollama handlers, passing tools directly to `convertToolsForAiSdk()` instead
- The wrapper adds `strict: true`, forces all properties to `required`, and sets `additionalProperties: false` -- constraints that GLM and Qwen models do not support, causing malformed or missing tool call arguments
- This aligns Z-AI and Ollama handlers with the OpenRouter handler, which already passes tools directly and works correctly with these model families

## Test plan

- Existing: parser tests (16/16) unaffected
- Manual: Z-AI GLM-4.7 and Ollama Qwen2.5-Coder tool execution should no longer fail with "missing nativeArgs"
- Verify: OpenRouter path unchanged (no regression)