### PR TITLE
fix: cancel backend auto-approval timeout when auto-approve is toggled off mid-countdown

### DIFF
--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -1442,6 +1442,12 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 		vscode.postMessage({ type: "askResponse", askResponse: "objectResponse", text: JSON.stringify(response) })
 	}, [])
 
+	// Cancel backend auto-approval timeout when FollowUpSuggest's countdown effect cleans up.
+	// This is called when auto-approve is toggled off, a suggestion is clicked, or the component unmounts.
+	const handleFollowUpUnmount = useCallback(() => {
+		vscode.postMessage({ type: "cancelAutoApproval" })
+	}, [])
+
 	const itemContent = useCallback(
 		(index: number, messageOrGroup: ClineMessage) => {
 			const hasCheckpoint = modifiedMessages.some((message) => message.say === "checkpoint_saved")
@@ -1459,6 +1465,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 					isStreaming={isStreaming}
 					onSuggestionClick={handleSuggestionClickInRow} // This was already stabilized
 					onBatchFileResponse={handleBatchFileResponse}
+					onFollowUpUnmount={handleFollowUpUnmount}
 					isFollowUpAnswered={messageOrGroup.isAnswered === true || messageOrGroup.ts === currentFollowUpTs}
 					isFollowUpAutoApprovalPaused={isFollowUpAutoApprovalPaused}
 					editable={
@@ -1489,6 +1496,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 			isStreaming,
 			handleSuggestionClickInRow,
 			handleBatchFileResponse,
+			handleFollowUpUnmount,
 			currentFollowUpTs,
 			isFollowUpAutoApprovalPaused,
 			enableButtons,


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

<!-- Every PR MUST be linked to an approved issue. -->

Closes: N/A <!-- This is a bug fix discovered during investigation - no existing issue -->

### Roo Code Task Context (Optional)

_No Roo Code task context for this PR_

### Description

When a user disables auto-approve while a followup question countdown timer is actively running, only the visual timer in the UI was removed — the backend `setTimeout` in `Task.ts` continued running and eventually auto-submitted the answer anyway.

**Root cause:** `ChatView.tsx` was not passing the `onFollowUpUnmount` callback to `ChatRow`, so when `FollowUpSuggest`'s `useEffect` cleanup function fired (due to `autoApprovalEnabled` changing to `false`), the `onCancelAutoApproval?.()` call was a no-op since the callback was `undefined`. The backend was never notified to cancel its pending timeout.

**Fix:**
1. Added a `handleFollowUpUnmount` callback in `ChatView.tsx` that sends a `cancelAutoApproval` message to the backend
2. Passed it as the `onFollowUpUnmount` prop to `ChatRow`

Now the full cancellation chain works:
`FollowUpSuggest` useEffect cleanup → `onCancelAutoApproval()` → `handleFollowUpUnmount()` → `vscode.postMessage({ type: "cancelAutoApproval" })` → `webviewMessageHandler.ts` → `task.cancelAutoApprovalTimeout()` → clears the backend `setTimeout`

### Test Procedure

1. **Automated tests:**
   - Added 2 new tests in `FollowUpSuggest.spec.tsx`:
     - `should call onCancelAutoApproval when autoApprovalEnabled changes to false during countdown`
     - `should call onCancelAutoApproval when alwaysAllowFollowupQuestions changes to false during countdown`
   - All 20 FollowUpSuggest tests pass
   - All 24 ChatView tests pass
   - All 5 ChatRow tests pass
   - Full `pnpm test` suite: 5428 tests passed, 46 skipped

2. **Manual testing steps:**
   - Enable auto-approve with follow-up questions auto-approve enabled
   - Send a message that triggers a follow-up question with suggestions
   - While the countdown timer is visible on the first suggestion, toggle auto-approve off
   - Verify: The countdown timer disappears AND the answer is NOT auto-submitted after the original timeout duration

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR addresses a bug in the auto-approve countdown cancellation flow.
- [x] **Scope**: Changes are focused on fixing the missing callback propagation (2 files changed).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New tests added to cover the toggle-off-mid-countdown scenario.
- [x] **Documentation Impact**: No documentation updates required.
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

_No UI changes in this PR — the fix ensures existing UI behavior (timer disappearing) is properly synchronized with the backend._

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

**Files changed:**
- `webview-ui/src/components/chat/ChatView.tsx` — Added `handleFollowUpUnmount` callback and passed it as `onFollowUpUnmount` prop to `ChatRow`
- `webview-ui/src/components/chat/__tests__/FollowUpSuggest.spec.tsx` — Added 2 regression tests for the toggle-off-mid-countdown scenario

### Get in Touch

Sa
