### PR TITLE
feat: wire Vercel AI Gateway reasoning via AI SDK v6 native path

### DIFF
--- a/src/api/providers/fetchers/__tests__/vercel-ai-gateway.spec.ts
+++ b/src/api/providers/fetchers/__tests__/vercel-ai-gateway.spec.ts
@@ -237,6 +237,21 @@ describe("Vercel AI Gateway Fetchers", () => {
 			)
 		})
 
+		it("sets supportsReasoningEffort when model tags include reasoning", () => {
+			const reasoningModel = {
+				...baseModel,
+				id: "anthropic/claude-opus-4.6",
+				tags: ["tool-use", "reasoning", "vision"],
+			}
+
+			const result = parseVercelAiGatewayModel({
+				id: reasoningModel.id,
+				model: reasoningModel,
+			})
+
+			expect(result.supportsReasoningEffort).toBe(true)
+		})
+
 		it("handles missing cache pricing", () => {
 			const modelNoCachePricing = {
 				...baseModel,


### PR DESCRIPTION
## Summary

Properly configures reasoning support for the Vercel AI Gateway provider using AI SDK v6 semantics, replacing the previous incomplete wiring.

## Changes

### Model capability detection (`src/api/providers/fetchers/vercel-ai-gateway.ts`)
- Parse `tags` array from the `/v1/models` response schema
- Detect reasoning capability from `"reasoning"` tag (in addition to model ID prefix heuristics)
- Set `supportsReasoningEffort: true` on models with reasoning tags

### Request wiring (`src/api/providers/vercel-ai-gateway.ts`)
- Use AI SDK v6 top-level `reasoning` parameter in `streamText()` and `generateText()`
- For Anthropic models (`anthropic/\*`), additionally pass `providerOptions.anthropic.thinking` with `{ type: "enabled", budgetTokens }` — the documented way to enable Claude extended thinking through Gateway
- Compute thinking budget from `reasoningBudget` (80% of maxTokens cap) with fallback
- Add `reasoningBudget` to `ModelSelection` type

### Tests (`src/api/providers/__tests__/vercel-ai-gateway.spec.ts`)
- New test: verifies both top-level `reasoning` and `providerOptions.anthropic.thinking` are sent when reasoning is enabled on an Anthropic model
- Model cache mock extended with a reasoning-capable Anthropic model entry

### Fetcher tests (`src/api/providers/fetchers/__tests__/vercel-ai-gateway.spec.ts`)
- Tests for tag-based reasoning detection in `parseVercelAiGatewayModel()`

## Why

The Vercel AI Gateway uses the OpenAI-compatible API format, but Anthropic reasoning through Gateway requires explicit `providerOptions.anthropic.thinking` configuration per [AI SDK v6 docs](https://github.com/vercel/ai/blob/ai@6.0.0-beta.128/content/providers/01-ai-sdk-providers/00-ai-gateway.mdx). Without this, the model computes reasoning internally but does not return thinking blocks in the stream.

## Validation
- `cd src && npx vitest run api/providers/__tests__/vercel-ai-gateway.spec.ts api/providers/fetchers/__tests__/vercel-ai-gateway.spec.ts` — 32/32 passing
- Lint passes