### PR TITLE
fix: add follow_up param validation in AskFollowupQuestionTool

### DIFF
--- a/src/core/tools/AskFollowupQuestionTool.ts
+++ b/src/core/tools/AskFollowupQuestionTool.ts
@@ -21,12 +21,21 @@ export class AskFollowupQuestionTool extends BaseTool<"ask_followup_question"> {
 		const { question, follow_up } = params
 		const { handleError, pushToolResult } = callbacks
 
+		const recordMissingParamError = async (paramName: string): Promise<void> => {
+			task.consecutiveMistakeCount++
+			task.recordToolError("ask_followup_question")
+			task.didToolFailInCurrentTurn = true
+			pushToolResult(await task.sayAndCreateMissingParamError("ask_followup_question", paramName))
+		}
+
 		try {
 			if (!question) {
-				task.consecutiveMistakeCount++
-				task.recordToolError("ask_followup_question")
-				task.didToolFailInCurrentTurn = true
-				pushToolResult(await task.sayAndCreateMissingParamError("ask_followup_question", "question"))
+				await recordMissingParamError("question")
+				return
+			}
+
+			if (!follow_up || !Array.isArray(follow_up)) {
+				await recordMissingParamError("follow_up")
 				return
 			}
 


### PR DESCRIPTION
### Related GitHub Issue

Closes: #11066

### Description

Added strict validation for the `follow_up` parameter to check for presence and type (Array). Added test cases covering missing, null, and invalid type scenarios. Refactored parameter error handling into a helper method to reduce duplication.

### Test Procedure

Created unit tests to test missing parameter and invalid parameter.

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.