### PR TITLE
Fix Bedrock Claude Sonnet 4.6 model ID, cc #11509

### DIFF
--- a/packages/types/src/providers/bedrock.ts
+++ b/packages/types/src/providers/bedrock.ts
@@ -27,7 +27,7 @@ export const bedrockModels = {
 		maxCachePoints: 4,
 		cachableFields: ["system", "messages", "tools"],
 	},
-	"anthropic.claude-sonnet-4-6-20260114-v1:0": {
+	"anthropic.claude-sonnet-4-6": {
 		maxTokens: 8192,
 		contextWindow: 200_000, // Default 200K, extendable to 1M with beta flag 'context-1m-2025-08-07'
 		supportsImages: true,
@@ -523,7 +523,7 @@ export const BEDROCK_REGIONS = [
 export const BEDROCK_1M_CONTEXT_MODEL_IDS = [
 	"anthropic.claude-sonnet-4-20250514-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
-	"anthropic.claude-sonnet-4-6-20260114-v1:0",
+	"anthropic.claude-sonnet-4-6",
 	"anthropic.claude-opus-4-6-v1",
 ] as const
 
@@ -538,7 +538,7 @@ export const BEDROCK_1M_CONTEXT_MODEL_IDS = [
 export const BEDROCK_GLOBAL_INFERENCE_MODEL_IDS = [
 	"anthropic.claude-sonnet-4-20250514-v1:0",
 	"anthropic.claude-sonnet-4-5-20250929-v1:0",
-	"anthropic.claude-sonnet-4-6-20260114-v1:0",
+	"anthropic.claude-sonnet-4-6",
 	"anthropic.claude-haiku-4-5-20251001-v1:0",
 	"anthropic.claude-opus-4-5-20251101-v1:0",
 	"anthropic.claude-opus-4-6-v1",

--- a/src/api/providers/__tests__/bedrock.spec.ts
+++ b/src/api/providers/__tests__/bedrock.spec.ts
@@ -703,7 +703,7 @@ describe("AwsBedrockHandler", () => {
 
 		it("should apply 1M tier pricing when awsBedrock1MContext is true for Claude Sonnet 4.6", () => {
 			const handler = new AwsBedrockHandler({
-				apiModelId: "anthropic.claude-sonnet-4-6-20260114-v1:0",
+				apiModelId: "anthropic.claude-sonnet-4-6",
 				awsAccessKey: "test",
 				awsSecretKey: "test",
 				awsRegion: "us-east-1",


### PR DESCRIPTION
This PR fixes the Bedrock model ID for Claude Sonnet 4.6.

- Replaced the incorrect Bedrock model ID:
  - from `anthropic.claude-sonnet-4-6-20260114-v1:0`
  - to `anthropic.claude-sonnet-4-6`
- Updated Bedrock 1M/global inference model ID lists to use the corrected ID.
- Updated Bedrock tests to use the corrected Sonnet 4.6 ID.

Scope is intentionally minimal and focused on the incorrect Bedrock identifier.

### Test Procedure

1. Run Bedrock provider tests:
   - `pnpm --filter roo-cline exec vitest run api/providers/__tests__/bedrock.spec.ts`
2. Confirm the Sonnet 4.6 ID references are corrected in:
   - `packages/types/src/providers/bedrock.ts`
   - `src/api/providers/__tests__/bedrock.spec.ts`

### Pre-Submission Checklist

- [ ] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Documentation Updates

- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

### Additional Notes

- This follows reports on PR #11509 that the previous Sonnet 4.6 Bedrock ID did not work.
- No additional behavior changes were introduced beyond correcting the model ID references.

<!-- roo-code-cloud-preview-start -->
[Start a new Roo Code Cloud session on this branch](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=7548c547c278697f14b890d362af9e01ff477e17&pr=11569&branch=fix%2Fbedrock-sonnet-4-6-model-id)
<!-- roo-code-cloud-preview-end -->