### PR TITLE
chore(cli): prepare release v0.1.0

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.0] - 2026-02-19
+
+### Added
+
+- **NDJSON Stdin Protocol**: Overhauled the stdin prompt stream from raw text lines to a structured NDJSON command protocol (`start`/`message`/`cancel`/`ping`/`shutdown`) with requestId correlation, ack/done/error lifecycle events, and queue telemetry. See [`stdin-stream.ts`](src/ui/stdin-stream.ts) for implementation.
+- **List Subcommands**: New `list` subcommands (`commands`, `modes`, `models`) for programmatic discovery of available CLI capabilities.
+- **Shared Utilities**: Added `isRecord` guard utility for improved type safety.
+
+### Changed
+
+- **Modularized Architecture**: Extracted stdin stream logic from `run.ts` into dedicated [`stdin-stream.ts`](src/ui/stdin-stream.ts) module for better code organization and maintainability.
+
+### Fixed
+
+- Fixed a bug in `Task.ts` affecting CLI operation.
+
 ## [0.0.55] - 2026-02-17
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.0.55",
+	"version": "0.1.0",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.0

This PR prepares the CLI release v0.1.0.

### Changes
- Version bump in package.json (0.0.55 → 0.1.0)
- Changelog update

### Summary of Changes Since v0.0.55
- **NDJSON Stdin Protocol**: Overhauled stdin prompt stream from raw text lines to a structured NDJSON command protocol with requestId correlation, ack/done/error lifecycle events, and queue telemetry
- **List Subcommands**: New `list` subcommands (`commands`, `modes`, `models`) for programmatic discovery
- **Modularized Architecture**: Extracted stdin stream logic from `run.ts` into dedicated `stdin-stream.ts` module
- **Bug Fix**: Fixed a bug in `Task.ts` affecting CLI operation

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Start a new Roo Code Cloud session on this branch](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=48ba2229e21effbea8287245a71c795d64265bfc&pr=11599&branch=cli-release-v0.1.0)
<!-- roo-code-cloud-preview-end -->