### PR TITLE
fix: make settings search results same width as search input

### DIFF
--- a/webview-ui/src/components/settings/SettingsSearch.tsx
+++ b/webview-ui/src/components/settings/SettingsSearch.tsx
@@ -108,7 +108,7 @@ export function SettingsSearch({ index, onNavigate, sections }: SettingsSearchPr
 				inputRef={inputRef}
 			/>
 			{searchQuery && isOpen && (
-				<div className="absolute top-full min-w-[300px] right-0 mt-2 border border-vscode-dropdown-border bg-vscode-dropdown-background rounded-2xl overflow-hidden shadow-xl z-50">
+				<div className="absolute top-full left-0 w-full mt-2 border border-vscode-dropdown-border bg-vscode-dropdown-background rounded-2xl overflow-hidden shadow-xl z-50">
 					<SettingsSearchResults
 						results={results}
 						query={searchQuery}


### PR DESCRIPTION
### Description

The setting search results was aligned with the right of the search input and set to a width of 300 pixels. This resulted in overflow on narrow panels and made the results unreadable.

Changed the settings search results to be the same width as the search input. This ensures the results dropdown does not overflow outside of the parent panel.

### Test Procedure

Used the search input to see results.

### Documentation Updates

- [x] No documentation updates are required.

<!-- roo-code-cloud-preview-start -->
[Start a new Roo Code Cloud session on this branch](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=4c216eb238730134976f3f424e6bbc2e5332d88f&pr=11617&branch=fix%2Fsettings-search-width)
<!-- roo-code-cloud-preview-end -->