### PR TITLE
fix(openai): handle done-only/content-part responses

### DIFF
--- a/.changeset/sly-candles-hide.md
+++ b/.changeset/sly-candles-hide.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+Fix OpenAI Codex and OpenAI Native stream parsing for done-only and `content_part` events, including duplicate-text guards when deltas are already streamed.


### PR DESCRIPTION
## Summary
- harden OpenAI Codex response stream parsing for done-only/content-part event shapes
- emit assistant text fallback when only done/completed payloads contain text
- emit function-call fallback for done-only tool call outputs
- add regression tests for done-only/content-part and tool-call fallback paths

## Why
Some Codex/Spark responses can omit expected delta events, which caused:
`Unexpected API Response: The language model did not provide any assistant messages.`

## Testing
- `pnpm vitest run api/providers/__tests__/openai-codex-native-tool-calls.spec.ts` (in `src`)
- `pnpm vitest run api/providers/__tests__/openai-codex.spec.ts api/providers/__tests__/openai-codex-native-tool-calls.spec.ts` (in `src`)

<!-- roo-code-cloud-preview-start -->
[Start a new Roo Code Cloud session on this branch](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=ae6589e1d22f1cd6ddbe9320150175b290928a44&pr=11621&branch=fix%2Fopenai-codex-stream-fallbacks)
<!-- roo-code-cloud-preview-end -->