### PR TITLE
ci: trigger code-qa workflow on pull_request_review approval

### DIFF
--- a/.github/workflows/code-qa.yml
+++ b/.github/workflows/code-qa.yml
@@ -7,9 +7,15 @@ on:
     pull_request:
         types: [opened, reopened, ready_for_review, synchronize]
         branches: [main]
+    pull_request_review:
+        types: [submitted]
+        branches: [main]
 
 jobs:
     check-translations:
+        if: |
+            github.event_name != 'pull_request_review' ||
+            github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -20,6 +26,9 @@ jobs:
               run: node scripts/find-missing-translations.js
 
     knip:
+        if: |
+            github.event_name != 'pull_request_review' ||
+            github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -30,6 +39,9 @@ jobs:
               run: pnpm knip
 
     compile:
+        if: |
+            github.event_name != 'pull_request_review' ||
+            github.event.review.state == 'approved'
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -43,6 +55,9 @@ jobs:
 
     unit-test:
         name: platform-unit-test (${{ matrix.name }})
+        if: |
+            github.event_name != 'pull_request_review' ||
+            github.event.review.state == 'approved'
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:


### PR DESCRIPTION
## Problem

Changeset version bump PRs (opened by the `github-actions[bot]` using `GITHUB_TOKEN`) do not fire `pull_request` events that trigger other workflows. This is a GitHub platform restriction — workflows cannot trigger other workflows via `GITHUB_TOKEN`. As a result, the required CI checks (`compile`, `knip`, `check-translations`, `platform-unit-test`) never run on these PRs and remain perpetually "waiting for status to be reported".

## Fix

Adds a `pull_request_review` trigger to `code-qa.yml` so CI fires when a code owner approves the PR. Each job includes an `if` guard so the workflow only runs on review events when the review state is `approved`, avoiding spurious runs on comments or change requests.

<!-- roo-code-cloud-preview-start -->
[Start a new Roo Code Cloud session on this branch](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=69f9fe386f984dc2bafd2e260dbd6ec572c980ec&pr=11636&branch=fix%2Fci-trigger-on-review-approval)
<!-- roo-code-cloud-preview-end -->