### PR TITLE
Fix translation key for exit status tooltip

### DIFF
--- a/webview-ui/src/components/chat/CommandExecution.tsx
+++ b/webview-ui/src/components/chat/CommandExecution.tsx
@@ -154,7 +154,7 @@ export const CommandExecution = ({ executionId, text, icon, title }: CommandExec
 					{status?.status === "exited" && (
 						<div className="flex flex-row items-center gap-2 font-mono text-xs">
 							<StandardTooltip
-								content={t("chat.commandExecution.exitStatus", { exitStatus: status.exitCode })}>
+								content={t("chat:commandExecution.exitStatus", { exitStatus: status.exitCode })}>
 								<div
 									className={cn(
 										"rounded-full size-2",


### PR DESCRIPTION
<img width="318" height="126" alt="image" src="https://github.com/user-attachments/assets/3b543471-9afa-416d-bcc3-746a46cdd192" />

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=7259600b5c19707aa4fd5a0bb7d1d9728e7b7ac2&pr=11644&branch=main)
<!-- roo-code-cloud-preview-end -->