### PR TITLE
feat: add Adaptive Thinking support for Claude Opus 4.6 and Sonnet 4.6

### DIFF
--- a/packages/types/src/model.ts
+++ b/packages/types/src/model.ts
@@ -82,6 +82,10 @@ export const modelInfoSchema = z.object({
 	// Capability flag to indicate whether the model supports an output verbosity parameter
 	supportsVerbosity: z.boolean().optional(),
 	supportsReasoningBudget: z.boolean().optional(),
+	// Capability flag to indicate whether the model supports adaptive thinking (Claude Sonnet 4.6 / Opus 4.6+)
+	supportsAdaptiveThinking: z.boolean().optional(),
+	// Capability flag to indicate whether the model supports "max" effort in adaptive thinking (Opus 4.6 only)
+	supportsAdaptiveThinkingMaxEffort: z.boolean().optional(),
 	// Capability flag to indicate whether the model supports simple on/off binary reasoning
 	supportsReasoningBinary: z.boolean().optional(),
 	// Capability flag to indicate whether the model supports temperature parameter

--- a/packages/types/src/provider-settings.ts
+++ b/packages/types/src/provider-settings.ts
@@ -184,6 +184,9 @@ const baseProviderSettingsSchema = z.object({
 	reasoningEffort: reasoningEffortSettingSchema.optional(),
 	modelMaxTokens: z.number().optional(),
 	modelMaxThinkingTokens: z.number().optional(),
+	// Adaptive thinking (Claude Sonnet 4.6 / Opus 4.6 only)
+	useAdaptiveThinking: z.boolean().optional(),
+	adaptiveThinkingEffort: z.enum(["low", "medium", "high", "max"]).optional(),
 
 	// Model verbosity.
 	verbosity: verbosityLevelsSchema.optional(),

--- a/packages/types/src/providers/anthropic.ts
+++ b/packages/types/src/providers/anthropic.ts
@@ -17,6 +17,7 @@ export const anthropicModels = {
 		cacheWritesPrice: 3.75, // $3.75 per million tokens
 		cacheReadsPrice: 0.3, // $0.30 per million tokens
 		supportsReasoningBudget: true,
+		supportsAdaptiveThinking: true,
 		// Tiered pricing for extended context (requires beta flag 'context-1m-2025-08-07')
 		tiers: [
 			{
@@ -80,6 +81,8 @@ export const anthropicModels = {
 		cacheWritesPrice: 6.25, // $6.25 per million tokens
 		cacheReadsPrice: 0.5, // $0.50 per million tokens
 		supportsReasoningBudget: true,
+		supportsAdaptiveThinking: true,
+		supportsAdaptiveThinkingMaxEffort: true, // "max" effort is only available for Opus 4.6
 		// Tiered pricing for extended context (requires beta flag)
 		tiers: [
 			{

--- a/src/api/providers/anthropic.ts
+++ b/src/api/providers/anthropic.ts
@@ -59,6 +59,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 			maxTokens,
 			temperature,
 			reasoning: thinking,
+			outputConfig,
 		} = this.getModel()
 
 		// Filter out non-Anthropic blocks (reasoning, thoughtSignature, etc.) before sending to the API
@@ -119,6 +120,7 @@ export class AnthropicHandler extends BaseProvider implements SingleCompletionHa
 							max_tokens: maxTokens ?? ANTHROPIC_DEFAULT_MAX_TOKENS,
 							temperature,
 							thinking,
+							...(outputConfig ? { output_config: outputConfig } : {}),
 							// Setting cache breakpoint for system prompt so new tasks can reuse it.
 							system: [{ text: systemPrompt, type: "text", cache_control: cacheControl }],
 							messages: sanitizedMessages.map((message, index) => {

--- a/src/api/transform/model-params.ts
+++ b/src/api/transform/model-params.ts
@@ -17,10 +17,12 @@ import {
 
 import {
 	type AnthropicReasoningParams,
+	type AnthropicOutputConfig,
 	type OpenAiReasoningParams,
 	type GeminiReasoningParams,
 	type OpenRouterReasoningParams,
 	getAnthropicReasoning,
+	getAnthropicOutputConfig,
 	getOpenAiReasoning,
 	getGeminiReasoning,
 	getOpenRouterReasoning,
@@ -48,6 +50,7 @@ type BaseModelParams = {
 type AnthropicModelParams = {
 	format: "anthropic"
 	reasoning: AnthropicReasoningParams | undefined
+	outputConfig: AnthropicOutputConfig | undefined
 } & BaseModelParams
 
 type OpenAiModelParams = {
@@ -151,6 +154,7 @@ export function getModelParams({
 			format,
 			...params,
 			reasoning: getAnthropicReasoning({ model, reasoningBudget, reasoningEffort, settings }),
+			outputConfig: getAnthropicOutputConfig({ model, settings }),
 		}
 	} else if (format === "openai") {
 		// Special case for o1 and o3-mini, which don't support temperature.

--- a/webview-ui/src/components/settings/ThinkingBudget.tsx
+++ b/webview-ui/src/components/settings/ThinkingBudget.tsx
@@ -179,6 +179,24 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 		)
 	}
 
+	const isAdaptiveThinkingSupported = !!modelInfo && (modelInfo as any).supportsAdaptiveThinking
+	const isMaxEffortSupported = !!modelInfo && (modelInfo as any).supportsAdaptiveThinkingMaxEffort
+	const useAdaptiveThinking = apiConfiguration.useAdaptiveThinking ?? false
+	const adaptiveThinkingEffort = (apiConfiguration.adaptiveThinkingEffort ?? "high") as
+		| "low"
+		| "medium"
+		| "high"
+		| "max"
+
+	const adaptiveEffortOptions: Array<{ value: "low" | "medium" | "high" | "max"; labelKey: string }> = [
+		{ value: "low", labelKey: "settings:thinkingBudget.adaptiveEffort.low" },
+		{ value: "medium", labelKey: "settings:thinkingBudget.adaptiveEffort.medium" },
+		{ value: "high", labelKey: "settings:thinkingBudget.adaptiveEffort.high" },
+		...(isMaxEffortSupported
+			? [{ value: "max" as const, labelKey: "settings:thinkingBudget.adaptiveEffort.max" }]
+			: []),
+	]
+
 	return isReasoningBudgetSupported && !!modelInfo.maxTokens ? (
 		<>
 			{!isReasoningBudgetRequired && (
@@ -194,6 +212,43 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 			)}
 			{(isReasoningBudgetRequired || enableReasoningEffort) && (
 				<>
+					{isAdaptiveThinkingSupported && (
+						<div className="flex flex-col gap-1">
+							<Checkbox
+								checked={useAdaptiveThinking}
+								onChange={(checked: boolean) => {
+									setApiConfigurationField("useAdaptiveThinking", checked === true)
+									if (!checked) {
+										setApiConfigurationField("adaptiveThinkingEffort", undefined as any)
+									}
+								}}>
+								{t("settings:thinkingBudget.useAdaptiveThinking")}
+							</Checkbox>
+							{useAdaptiveThinking && (
+								<div className="ml-5 flex flex-col gap-1">
+									<div className="text-sm text-vscode-descriptionForeground">
+										{t("settings:thinkingBudget.adaptiveThinkingDescription")}
+									</div>
+									<Select
+										value={adaptiveThinkingEffort}
+										onValueChange={(value: "low" | "medium" | "high" | "max") =>
+											setApiConfigurationField("adaptiveThinkingEffort", value)
+										}>
+										<SelectTrigger className="w-full">
+											<SelectValue />
+										</SelectTrigger>
+										<SelectContent>
+											{adaptiveEffortOptions.map(({ value, labelKey }) => (
+												<SelectItem key={value} value={value}>
+													{t(labelKey)}
+												</SelectItem>
+											))}
+										</SelectContent>
+									</Select>
+								</div>
+							)}
+						</div>
+					)}
 					<div className="flex flex-col gap-1">
 						<div className="font-medium">{t("settings:thinkingBudget.maxTokens")}</div>
 						<div className="flex items-center gap-1">
@@ -211,19 +266,23 @@ export const ThinkingBudget = ({ apiConfiguration, setApiConfigurationField, mod
 							<div className="w-12 text-sm text-center">{customMaxOutputTokens}</div>
 						</div>
 					</div>
-					<div className="flex flex-col gap-1">
-						<div className="font-medium">{t("settings:thinkingBudget.maxThinkingTokens")}</div>
-						<div className="flex items-center gap-1" data-testid="reasoning-budget">
-							<Slider
-								min={minThinkingTokens}
-								max={modelMaxThinkingTokens}
-								step={minThinkingTokens === 128 ? 128 : 1024}
-								value={[customMaxThinkingTokens]}
-								onValueChange={([value]) => setApiConfigurationField("modelMaxThinkingTokens", value)}
-							/>
-							<div className="w-12 text-sm text-center">{customMaxThinkingTokens}</div>
+					{!useAdaptiveThinking && (
+						<div className="flex flex-col gap-1">
+							<div className="font-medium">{t("settings:thinkingBudget.maxThinkingTokens")}</div>
+							<div className="flex items-center gap-1" data-testid="reasoning-budget">
+								<Slider
+									min={minThinkingTokens}
+									max={modelMaxThinkingTokens}
+									step={minThinkingTokens === 128 ? 128 : 1024}
+									value={[customMaxThinkingTokens]}
+									onValueChange={([value]) =>
+										setApiConfigurationField("modelMaxThinkingTokens", value)
+									}
+								/>
+								<div className="w-12 text-sm text-center">{customMaxThinkingTokens}</div>
+							</div>
 						</div>
-					</div>
+					)}
 				</>
 			)}
 		</>

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Tokens màxims",
-		"maxThinkingTokens": "Tokens de pensament màxims"
+		"maxThinkingTokens": "Tokens de pensament màxims",
+		"useAdaptiveThinking": "Usa el pensament adaptatiu",
+		"adaptiveThinkingDescription": "Deixa que Claude determini dinàmicament quan i quant pensar en funció de la complexitat de la sol·licitud.",
+		"adaptiveEffort": {
+			"low": "Baix",
+			"medium": "Mitjà",
+			"high": "Alt (per defecte)",
+			"max": "Màxim (només Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Heu de proporcionar una clau API vàlida.",

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Max Tokens",
-		"maxThinkingTokens": "Max Thinking Tokens"
+		"maxThinkingTokens": "Max Thinking Tokens",
+		"useAdaptiveThinking": "Adaptives Denken verwenden",
+		"adaptiveThinkingDescription": "Lasse Claude dynamisch bestimmen, wann und wie viel es basierend auf der Anfragekomplexität denkt.",
+		"adaptiveEffort": {
+			"low": "Niedrig",
+			"medium": "Mittel",
+			"high": "Hoch (Standard)",
+			"max": "Maximal (nur Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Du musst einen gültigen API-Schlüssel angeben.",

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -940,7 +940,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Max Tokens",
-		"maxThinkingTokens": "Max Thinking Tokens"
+		"maxThinkingTokens": "Max Thinking Tokens",
+		"useAdaptiveThinking": "Use Adaptive Thinking",
+		"adaptiveThinkingDescription": "Let Claude dynamically determine when and how much to think based on request complexity.",
+		"adaptiveEffort": {
+			"low": "Low",
+			"medium": "Medium",
+			"high": "High (Default)",
+			"max": "Max (Opus 4.6 only)"
+		}
 	},
 	"validation": {
 		"apiKey": "You must provide a valid API key.",

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Tokens máximos",
-		"maxThinkingTokens": "Tokens máximos de pensamiento"
+		"maxThinkingTokens": "Tokens máximos de pensamiento",
+		"useAdaptiveThinking": "Usar pensamiento adaptativo",
+		"adaptiveThinkingDescription": "Deja que Claude determine dinámicamente cuándo y cuánto pensar según la complejidad de la solicitud.",
+		"adaptiveEffort": {
+			"low": "Bajo",
+			"medium": "Medio",
+			"high": "Alto (predeterminado)",
+			"max": "Máximo (solo Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Debe proporcionar una clave API válida.",

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Tokens maximum",
-		"maxThinkingTokens": "Tokens de réflexion maximum"
+		"maxThinkingTokens": "Tokens de réflexion maximum",
+		"useAdaptiveThinking": "Utiliser la réflexion adaptative",
+		"adaptiveThinkingDescription": "Laissez Claude déterminer dynamiquement quand et combien réfléchir en fonction de la complexité de la demande.",
+		"adaptiveEffort": {
+			"low": "Faible",
+			"medium": "Moyen",
+			"high": "Élevé (par défaut)",
+			"max": "Maximum (Opus 4.6 uniquement)"
+		}
 	},
 	"validation": {
 		"apiKey": "Vous devez fournir une clé API valide.",

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "अधिकतम tokens",
-		"maxThinkingTokens": "अधिकतम thinking tokens"
+		"maxThinkingTokens": "अधिकतम thinking tokens",
+		"useAdaptiveThinking": "अनुकूली सोच का उपयोग करें",
+		"adaptiveThinkingDescription": "Claude को अनुरोध की जटिलता के आधार पर गतिशील रूप से यह निर्धारित करने दें कि कब और कितना सोचना है।",
+		"adaptiveEffort": {
+			"low": "कम",
+			"medium": "मध्यम",
+			"high": "उच्च (डिफ़ॉल्ट)",
+			"max": "अधिकतम (केवल Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "आपको एक मान्य API कुंजी प्रदान करनी होगी।",

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Token Maksimum",
-		"maxThinkingTokens": "Token Thinking Maksimum"
+		"maxThinkingTokens": "Token Thinking Maksimum",
+		"useAdaptiveThinking": "Gunakan Pemikiran Adaptif",
+		"adaptiveThinkingDescription": "Biarkan Claude menentukan secara dinamis kapan dan seberapa banyak berpikir berdasarkan kompleksitas permintaan.",
+		"adaptiveEffort": {
+			"low": "Rendah",
+			"medium": "Sedang",
+			"high": "Tinggi (Default)",
+			"max": "Maksimum (Hanya Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Kamu harus menyediakan API key yang valid.",

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Token massimi",
-		"maxThinkingTokens": "Token massimi di pensiero"
+		"maxThinkingTokens": "Token massimi di pensiero",
+		"useAdaptiveThinking": "Usa il pensiero adattivo",
+		"adaptiveThinkingDescription": "Lascia che Claude determini dinamicamente quando e quanto pensare in base alla complessità della richiesta.",
+		"adaptiveEffort": {
+			"low": "Basso",
+			"medium": "Medio",
+			"high": "Alto (predefinito)",
+			"max": "Massimo (solo Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "È necessario fornire una chiave API valida.",

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "最大 tokens",
-		"maxThinkingTokens": "最大思考 tokens"
+		"maxThinkingTokens": "最大思考 tokens",
+		"useAdaptiveThinking": "アダプティブ思考を使用",
+		"adaptiveThinkingDescription": "リクエストの複雑さに基づいて、Claudeがいつどれだけ考えるかを動的に決定できるようにします。",
+		"adaptiveEffort": {
+			"low": "低",
+			"medium": "中",
+			"high": "高（デフォルト）",
+			"max": "最大（Opus 4.6のみ）"
+		}
 	},
 	"validation": {
 		"apiKey": "有効なAPIキーを入力してください。",

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "최대 tokens",
-		"maxThinkingTokens": "최대 사고 tokens"
+		"maxThinkingTokens": "최대 사고 tokens",
+		"useAdaptiveThinking": "적응형 사고 사용",
+		"adaptiveThinkingDescription": "Claude가 요청 복잡성에 따라 언제, 얼마나 생각할지를 동적으로 결정하도록 합니다.",
+		"adaptiveEffort": {
+			"low": "낮음",
+			"medium": "중간",
+			"high": "높음 (기본값)",
+			"max": "최대 (Opus 4.6만 해당)"
+		}
 	},
 	"validation": {
 		"apiKey": "유효한 API 키를 입력해야 합니다.",

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Max tokens",
-		"maxThinkingTokens": "Max denk-tokens"
+		"maxThinkingTokens": "Max denk-tokens",
+		"useAdaptiveThinking": "Adaptief denken gebruiken",
+		"adaptiveThinkingDescription": "Laat Claude dynamisch bepalen wanneer en hoeveel te denken op basis van de complexiteit van het verzoek.",
+		"adaptiveEffort": {
+			"low": "Laag",
+			"medium": "Gemiddeld",
+			"high": "Hoog (standaard)",
+			"max": "Maximaal (alleen Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Je moet een geldige API-sleutel opgeven.",

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Maksymalna liczba tokenów",
-		"maxThinkingTokens": "Maksymalna liczba tokenów myślenia"
+		"maxThinkingTokens": "Maksymalna liczba tokenów myślenia",
+		"useAdaptiveThinking": "Używaj adaptywnego myślenia",
+		"adaptiveThinkingDescription": "Pozwól Claude dynamicznie określać, kiedy i ile myśleć w oparciu o złożoność żądania.",
+		"adaptiveEffort": {
+			"low": "Niski",
+			"medium": "Średni",
+			"high": "Wysoki (domyślny)",
+			"max": "Maksymalny (tylko Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Musisz podać prawidłowy klucz API.",

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Tokens máximos",
-		"maxThinkingTokens": "Tokens máximos de pensamento"
+		"maxThinkingTokens": "Tokens máximos de pensamento",
+		"useAdaptiveThinking": "Usar pensamento adaptativo",
+		"adaptiveThinkingDescription": "Deixe o Claude determinar dinamicamente quando e quanto pensar com base na complexidade da solicitação.",
+		"adaptiveEffort": {
+			"low": "Baixo",
+			"medium": "Médio",
+			"high": "Alto (padrão)",
+			"max": "Máximo (apenas Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Você deve fornecer uma chave de API válida.",

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Максимум токенов",
-		"maxThinkingTokens": "Максимум токенов на размышления"
+		"maxThinkingTokens": "Максимум токенов на размышления",
+		"useAdaptiveThinking": "Использовать адаптивное мышление",
+		"adaptiveThinkingDescription": "Позвольте Claude динамически определять, когда и сколько думать в зависимости от сложности запроса.",
+		"adaptiveEffort": {
+			"low": "Низкий",
+			"medium": "Средний",
+			"high": "Высокий (по умолчанию)",
+			"max": "Максимальный (только Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Вы должны указать действительный API-ключ.",

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Maksimum token",
-		"maxThinkingTokens": "Maksimum düşünme tokeni"
+		"maxThinkingTokens": "Maksimum düşünme tokeni",
+		"useAdaptiveThinking": "Uyarlamalı Düşünmeyi Kullan",
+		"adaptiveThinkingDescription": "Claude'un istek karmaşıklığına göre ne zaman ve ne kadar düşüneceğini dinamik olarak belirlemesine izin verin.",
+		"adaptiveEffort": {
+			"low": "Düşük",
+			"medium": "Orta",
+			"high": "Yüksek (Varsayılan)",
+			"max": "Maksimum (Yalnızca Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Geçerli bir API anahtarı sağlamalısınız.",

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "Tokens tối đa",
-		"maxThinkingTokens": "Tokens suy nghĩ tối đa"
+		"maxThinkingTokens": "Tokens suy nghĩ tối đa",
+		"useAdaptiveThinking": "Sử dụng tư duy thích ứng",
+		"adaptiveThinkingDescription": "Để Claude tự động xác định khi nào và bao nhiêu để suy nghĩ dựa trên độ phức tạp của yêu cầu.",
+		"adaptiveEffort": {
+			"low": "Thấp",
+			"medium": "Trung bình",
+			"high": "Cao (mặc định)",
+			"max": "Tối đa (chỉ Opus 4.6)"
+		}
 	},
 	"validation": {
 		"apiKey": "Bạn phải cung cấp khóa API hợp lệ.",

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -877,7 +877,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "最大Token数",
-		"maxThinkingTokens": "最大思考Token数"
+		"maxThinkingTokens": "最大思考Token数",
+		"useAdaptiveThinking": "使用自适应思考",
+		"adaptiveThinkingDescription": "让Claude根据请求复杂性动态决定何时以及思考多少。",
+		"adaptiveEffort": {
+			"low": "低",
+			"medium": "中",
+			"high": "高（默认）",
+			"max": "最大（仅Opus 4.6）"
+		}
 	},
 	"validation": {
 		"apiKey": "您必须提供有效的 API 密钥。",

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -887,7 +887,15 @@
 	},
 	"thinkingBudget": {
 		"maxTokens": "最大 Token 數",
-		"maxThinkingTokens": "最大思考 Token 數"
+		"maxThinkingTokens": "最大思考 Token 數",
+		"useAdaptiveThinking": "使用自適應思考",
+		"adaptiveThinkingDescription": "讓 Claude 根據請求複雜性動態決定何時以及思考多少。",
+		"adaptiveEffort": {
+			"low": "低",
+			"medium": "中",
+			"high": "高（預設）",
+			"max": "最大（僅 Opus 4.6）"
+		}
 	},
 	"validation": {
 		"apiKey": "請提供有效的 API 金鑰。",


### PR DESCRIPTION
## Summary

Adds support for Anthropic's **Adaptive Thinking** mode on Claude Opus 4.6 and Sonnet 4.6 models. When enabled, Claude dynamically determines when and how much to think using `thinking: {type: "adaptive"}` instead of fixed `budget_tokens`.

## Changes

### Types (`packages/types/`)
- Added `supportsAdaptiveThinking` and `supportsAdaptiveThinkingMaxEffort` flags to model definitions
- Added `useAdaptiveThinking` (boolean) and `adaptiveThinkingEffort` ("low"|"medium"|"high"|"max") to provider settings schema

### API Transform (`src/api/transform/reasoning.ts`)
- `getAnthropicReasoning()`: Returns `{type: "adaptive"}` when adaptive thinking enabled and model supports it
- `getAnthropicOutputConfig()`: Returns `{effort}` as separate top-level API parameter
- "max" effort only supported on Opus 4.6; falls back to "high" on Sonnet 4.6

### UI (`webview-ui/src/components/settings/ThinkingBudget.tsx`)
- Added adaptive thinking checkbox and effort level selector
- **Bug fix**: Max Output Tokens slider is always visible (independent of adaptive thinking toggle)

### i18n
- Added translations for all 17 supported locales

### Tests
- Added comprehensive test coverage for reasoning transforms

## Test Plan
- [x] All 75+ existing tests pass
- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] ESLint passes (all packages)
- [x] New tests cover adaptive thinking reasoning and output config transforms

Fixes #11732

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=a1bedb343479dc5f512c6283b3ca1160e0ff940b&pr=11733&branch=feature%2Fadaptive-thinking)
<!-- roo-code-cloud-preview-end -->