### PR TITLE
chore(cli): prepare release v0.1.2

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-02-25
+
+### Changed
+
+- **Streaming Deltas**: Tool use ask messages (command, tool, mcp) are now streamed as structured deltas instead of full snapshots in json-event-emitter for improved efficiency.
+- **Task ID Propagation**: Task ID is now generated upfront and propagated through runTask/createTask so currentTaskId is available in extension state immediately.
+- **Custom Tools**: Enabled customTools experiment in extension host.
+
+### Fixed
+
+- **Cancel Recovery**: Wait for resumable state after cancel before processing follow-up messages to prevent race conditions in stdin-stream.
+- **Custom Tool Schema**: Provide valid empty JSON Schema for custom tools without parameters to fix strict-mode API validation.
+- **Path Handling**: Skip paths outside cwd in RooProtectedController to avoid RangeError.
+- **Retry Handling**: Silently handle abort during exponential backoff retry countdown.
+- Fixed spelling/grammar and casing inconsistencies.
+
+### Added
+
+- **Telemetry Control**: Added `ROO_CODE_DISABLE_TELEMETRY=1` environment variable to disable cloud telemetry.
+
 ## [0.1.1] - 2026-02-24
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.2

This PR prepares the CLI release v0.1.2.

### Changes
- Version bump in package.json
- Changelog update

### Summary of Changes in This Release

**Changed**
- Streaming Deltas: Tool use ask messages now streamed as structured deltas
- Task ID Propagation: Task ID generated upfront for immediate availability
- Custom Tools: Enabled customTools experiment in extension host

**Fixed**
- Cancel Recovery: Wait for resumable state after cancel
- Custom Tool Schema: Valid empty JSON Schema for strict-mode validation
- Path Handling: Skip paths outside cwd in RooProtectedController
- Retry Handling: Silently handle abort during retry countdown
- Spelling/grammar fixes

**Added**
- Telemetry Control: ROO_CODE_DISABLE_TELEMETRY=1 env var

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=9454102be4869b3ce1fe2d7071f3d5a65485c18a&pr=11737&branch=cli-release-v0.1.2)
<!-- roo-code-cloud-preview-end -->