### PR TITLE
Baseten new models

### DIFF
--- a/packages/types/src/providers/baseten.ts
+++ b/packages/types/src/providers/baseten.ts
@@ -116,4 +116,4 @@ export const basetenModels = {
 
 export type BasetenModelId = keyof typeof basetenModels
 
-export const basetenDefaultModelId = "zai-org/GLM-4.6" satisfies BasetenModelId
+export const basetenDefaultModelId = "MiniMaxAI/MiniMax-M2.5" satisfies BasetenModelId


### PR DESCRIPTION
  Summary                                                                           
  - Updated Baseten model list to match the current Model APIs documentation
  - Added new models: GLM-4.7, GLM-5, Kimi-K2.5, MiniMax-M2.5
  - Removed deprecated models: DeepSeek-R1, DeepSeek-R1-0528, Qwen3-235B,
  Qwen3-Coder-480B
  - Fixed Kimi K2 maxTokens values to match docs (164k)
  - Reordered models to match docs page ordering
  - Updated default model to MiniMax-M2.5

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=bf6816e944ca41ce310ec2bf9678712f43ae655b&pr=11767&branch=baseten-new-models)
<!-- roo-code-cloud-preview-end -->