### PR TITLE
feat(cli): add session resume/history and upgrade command

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -41,6 +41,12 @@ Re-run the install script to update to the latest version:
 curl -fsSL https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/apps/cli/install.sh | sh
 ```
 
+Or run:
+
+```bash
+roo upgrade
+```
+
 ### Uninstalling
 
 ```bash

--- a/apps/cli/src/commands/cli/__tests__/list.test.ts
+++ b/apps/cli/src/commands/cli/__tests__/list.test.ts
@@ -1,4 +1,17 @@
-import { parseFormat } from "../list.js"
+import * as os from "os"
+import * as path from "path"
+
+import { readTaskSessionsFromStoragePath } from "@roo-code/core/cli"
+
+import { listSessions, parseFormat } from "../list.js"
+
+vi.mock("@roo-code/core/cli", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@roo-code/core/cli")>()
+	return {
+		...actual,
+		readTaskSessionsFromStoragePath: vi.fn(),
+	}
+})
 
 describe("parseFormat", () => {
 	it("defaults to json when undefined", () => {
@@ -25,5 +38,49 @@ describe("parseFormat", () => {
 
 	it("throws on empty string", () => {
 		expect(() => parseFormat("")).toThrow("Invalid format")
+	})
+})
+
+describe("listSessions", () => {
+	const storagePath = path.join(os.homedir(), ".vscode-mock", "global-storage")
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+	})
+
+	const captureStdout = async (fn: () => Promise<void>): Promise<string> => {
+		const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true)
+
+		try {
+			await fn()
+			return stdoutSpy.mock.calls.map(([chunk]) => String(chunk)).join("")
+		} finally {
+			stdoutSpy.mockRestore()
+		}
+	}
+
+	it("uses the CLI runtime storage path and prints JSON output", async () => {
+		vi.mocked(readTaskSessionsFromStoragePath).mockResolvedValue([
+			{ id: "s1", task: "Task 1", ts: 1_700_000_000_000, mode: "code" },
+		])
+
+		const output = await captureStdout(() => listSessions({ format: "json" }))
+
+		expect(readTaskSessionsFromStoragePath).toHaveBeenCalledWith(storagePath)
+		expect(JSON.parse(output)).toEqual({
+			sessions: [{ id: "s1", task: "Task 1", ts: 1_700_000_000_000, mode: "code" }],
+		})
+	})
+
+	it("prints tab-delimited text output with ISO timestamps and formatted titles", async () => {
+		vi.mocked(readTaskSessionsFromStoragePath).mockResolvedValue([
+			{ id: "s1", task: "Task 1", ts: Date.UTC(2024, 0, 1, 0, 0, 0) },
+			{ id: "s2", task: "   ", ts: Date.UTC(2024, 0, 1, 1, 0, 0) },
+		])
+
+		const output = await captureStdout(() => listSessions({ format: "text" }))
+		const lines = output.trim().split("\n")
+
+		expect(lines).toEqual(["s1\t2024-01-01T00:00:00.000Z\tTask 1", "s2\t2024-01-01T01:00:00.000Z\t(untitled)"])
 	})
 })

--- a/apps/cli/src/commands/cli/__tests__/upgrade.test.ts
+++ b/apps/cli/src/commands/cli/__tests__/upgrade.test.ts
@@ -1,0 +1,88 @@
+import { compareVersions, getLatestCliVersion, upgrade } from "../upgrade.js"
+
+function createFetchResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+	const { ok = true, status = 200 } = init
+	return {
+		ok,
+		status,
+		json: async () => body,
+	} as Response
+}
+
+describe("compareVersions", () => {
+	it("returns 1 when first version is newer", () => {
+		expect(compareVersions("0.2.0", "0.1.9")).toBe(1)
+	})
+
+	it("returns -1 when first version is older", () => {
+		expect(compareVersions("0.1.4", "0.1.5")).toBe(-1)
+	})
+
+	it("returns 0 when versions are equivalent", () => {
+		expect(compareVersions("v1.2.0", "1.2")).toBe(0)
+	})
+
+	it("supports cli tag prefixes and prerelease metadata", () => {
+		expect(compareVersions("cli-v1.2.3", "1.2.2")).toBe(1)
+		expect(compareVersions("1.2.3-beta.1", "1.2.3")).toBe(0)
+	})
+})
+
+describe("getLatestCliVersion", () => {
+	it("returns the first cli-v release tag from GitHub releases", async () => {
+		const fetchImpl = (async () =>
+			createFetchResponse([
+				{ tag_name: "v9.9.9" },
+				{ tag_name: "cli-v0.3.1" },
+				{ tag_name: "cli-v0.3.0" },
+			])) as typeof fetch
+
+		await expect(getLatestCliVersion(fetchImpl)).resolves.toBe("0.3.1")
+	})
+
+	it("throws when release check fails", async () => {
+		const fetchImpl = (async () => createFetchResponse({}, { ok: false, status: 503 })) as typeof fetch
+
+		await expect(getLatestCliVersion(fetchImpl)).rejects.toThrow("Failed to check latest version")
+	})
+})
+
+describe("upgrade", () => {
+	let logSpy: ReturnType<typeof vi.spyOn>
+
+	beforeEach(() => {
+		logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined)
+	})
+
+	afterEach(() => {
+		logSpy.mockRestore()
+	})
+
+	it("does not run installer when already up to date", async () => {
+		const runInstaller = vi.fn(async () => undefined)
+		const fetchImpl = (async () => createFetchResponse([{ tag_name: "cli-v0.1.4" }])) as typeof fetch
+
+		await upgrade({
+			currentVersion: "0.1.4",
+			fetchImpl,
+			runInstaller,
+		})
+
+		expect(runInstaller).not.toHaveBeenCalled()
+		expect(logSpy).toHaveBeenCalledWith("Roo CLI is already up to date.")
+	})
+
+	it("runs installer when a newer version is available", async () => {
+		const runInstaller = vi.fn(async () => undefined)
+		const fetchImpl = (async () => createFetchResponse([{ tag_name: "cli-v0.2.0" }])) as typeof fetch
+
+		await upgrade({
+			currentVersion: "0.1.4",
+			fetchImpl,
+			runInstaller,
+		})
+
+		expect(runInstaller).toHaveBeenCalledTimes(1)
+		expect(logSpy).toHaveBeenCalledWith("✓ Upgrade completed.")
+	})
+})

--- a/apps/cli/src/commands/cli/index.ts
+++ b/apps/cli/src/commands/cli/index.ts
@@ -1,2 +1,3 @@
 export * from "./run.js"
 export * from "./list.js"
+export * from "./upgrade.js"

--- a/apps/cli/src/commands/cli/list.ts
+++ b/apps/cli/src/commands/cli/list.ts
@@ -1,9 +1,11 @@
 import fs from "fs"
+import os from "os"
 import path from "path"
 import { fileURLToPath } from "url"
 
 import pWaitFor from "p-wait-for"
 
+import { readTaskSessionsFromStoragePath, type TaskSessionEntry } from "@roo-code/core/cli"
 import type { Command, ModelRecord, WebviewMessage } from "@roo-code/types"
 import { getProviderDefaultModelId } from "@roo-code/types"
 
@@ -14,6 +16,7 @@ import { getApiKeyFromEnv } from "@/lib/utils/provider.js"
 import { isRecord } from "@/lib/utils/guards.js"
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
 const REQUEST_TIMEOUT_MS = 10_000
 
 type ListFormat = "json" | "text"
@@ -28,6 +31,9 @@ type BaseListOptions = {
 
 type CommandLike = Pick<Command, "name" | "source" | "filePath" | "description" | "argumentHint">
 type ModeLike = { slug: string; name: string }
+type SessionLike = TaskSessionEntry
+type ListHostOptions = { ephemeral: boolean }
+const DEFAULT_CLI_TASK_STORAGE_PATH = path.join(os.homedir(), ".vscode-mock", "global-storage")
 
 export function parseFormat(rawFormat: string | undefined): ListFormat {
 	const format = (rawFormat ?? "json").toLowerCase()
@@ -81,7 +87,24 @@ function outputModelsText(models: ModelRecord): void {
 	}
 }
 
-async function createListHost(options: BaseListOptions): Promise<ExtensionHost> {
+function formatSessionTitle(task: string): string {
+	const compact = task.replace(/\s+/g, " ").trim()
+
+	if (!compact) {
+		return "(untitled)"
+	}
+
+	return compact.length <= 120 ? compact : `${compact.slice(0, 117)}...`
+}
+
+function outputSessionsText(sessions: SessionLike[]): void {
+	for (const session of sessions) {
+		const startedAt = Number.isFinite(session.ts) ? new Date(session.ts).toISOString() : "unknown-time"
+		process.stdout.write(`${session.id}\t${startedAt}\t${formatSessionTitle(session.task)}\n`)
+	}
+}
+
+async function createListHost(options: BaseListOptions, hostOptions: ListHostOptions): Promise<ExtensionHost> {
 	const workspacePath = resolveWorkspacePath(options.workspace)
 	const extensionPath = resolveExtensionPath(options.extension)
 	const apiKey = options.apiKey || (await loadToken()) || getApiKeyFromEnv("roo")
@@ -96,7 +119,7 @@ async function createListHost(options: BaseListOptions): Promise<ExtensionHost> 
 		workspacePath,
 		extensionPath,
 		nonInteractive: true,
-		ephemeral: true,
+		ephemeral: hostOptions.ephemeral,
 		debug: options.debug ?? false,
 		exitOnComplete: true,
 		exitOnError: false,
@@ -104,6 +127,7 @@ async function createListHost(options: BaseListOptions): Promise<ExtensionHost> 
 	}
 
 	const host = new ExtensionHost(extensionHostOptions)
+
 	await host.activate()
 
 	// Best effort wait; mode/commands requests can still succeed without this.
@@ -217,9 +241,10 @@ function requestRooModels(host: ExtensionHost): Promise<ModelRecord> {
 
 async function withHostAndSignalHandlers<T>(
 	options: BaseListOptions,
+	hostOptions: ListHostOptions,
 	fn: (host: ExtensionHost) => Promise<T>,
 ): Promise<T> {
-	const host = await createListHost(options)
+	const host = await createListHost(options, hostOptions)
 
 	const shutdown = async (exitCode: number) => {
 		await host.dispose()
@@ -244,7 +269,7 @@ async function withHostAndSignalHandlers<T>(
 export async function listCommands(options: BaseListOptions): Promise<void> {
 	const format = parseFormat(options.format)
 
-	await withHostAndSignalHandlers(options, async (host) => {
+	await withHostAndSignalHandlers(options, { ephemeral: true }, async (host) => {
 		const commands = await requestCommands(host)
 
 		if (format === "json") {
@@ -259,7 +284,7 @@ export async function listCommands(options: BaseListOptions): Promise<void> {
 export async function listModes(options: BaseListOptions): Promise<void> {
 	const format = parseFormat(options.format)
 
-	await withHostAndSignalHandlers(options, async (host) => {
+	await withHostAndSignalHandlers(options, { ephemeral: true }, async (host) => {
 		const modes = await requestModes(host)
 
 		if (format === "json") {
@@ -274,7 +299,7 @@ export async function listModes(options: BaseListOptions): Promise<void> {
 export async function listModels(options: BaseListOptions): Promise<void> {
 	const format = parseFormat(options.format)
 
-	await withHostAndSignalHandlers(options, async (host) => {
+	await withHostAndSignalHandlers(options, { ephemeral: true }, async (host) => {
 		const models = await requestRooModels(host)
 
 		if (format === "json") {
@@ -284,4 +309,16 @@ export async function listModels(options: BaseListOptions): Promise<void> {
 
 		outputModelsText(models)
 	})
+}
+
+export async function listSessions(options: BaseListOptions): Promise<void> {
+	const format = parseFormat(options.format)
+	const sessions = await readTaskSessionsFromStoragePath(DEFAULT_CLI_TASK_STORAGE_PATH)
+
+	if (format === "json") {
+		outputJson({ sessions })
+		return
+	}
+
+	outputSessionsText(sessions)
 }

--- a/apps/cli/src/commands/cli/upgrade.ts
+++ b/apps/cli/src/commands/cli/upgrade.ts
@@ -1,0 +1,137 @@
+import { spawn } from "child_process"
+
+import { VERSION } from "@/lib/utils/version.js"
+import { isRecord } from "@/lib/utils/guards.js"
+
+const RELEASES_URL = "https://api.github.com/repos/RooCodeInc/Roo-Code/releases?per_page=100"
+export const INSTALL_SCRIPT_COMMAND =
+	"curl -fsSL https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/apps/cli/install.sh | sh"
+
+export interface UpgradeOptions {
+	currentVersion?: string
+	fetchImpl?: typeof fetch
+	runInstaller?: () => Promise<void>
+}
+
+function parseVersion(version: string): number[] {
+	const cleaned = version
+		.trim()
+		.replace(/^cli-v/, "")
+		.replace(/^v/, "")
+	const core = cleaned.split("+", 1)[0]?.split("-", 1)[0]
+
+	if (!core) {
+		throw new Error(`Invalid version: ${version}`)
+	}
+
+	const parts = core.split(".")
+	if (parts.length === 0) {
+		throw new Error(`Invalid version: ${version}`)
+	}
+
+	return parts.map((part) => {
+		if (!/^\d+$/.test(part)) {
+			throw new Error(`Invalid version: ${version}`)
+		}
+
+		return Number.parseInt(part, 10)
+	})
+}
+
+/**
+ * Returns:
+ * - 1 when `a > b`
+ * - 0 when `a === b`
+ * - -1 when `a < b`
+ */
+export function compareVersions(a: string, b: string): number {
+	const aParts = parseVersion(a)
+	const bParts = parseVersion(b)
+	const maxLength = Math.max(aParts.length, bParts.length)
+
+	for (let i = 0; i < maxLength; i++) {
+		const aPart = aParts[i] ?? 0
+		const bPart = bParts[i] ?? 0
+
+		if (aPart > bPart) {
+			return 1
+		}
+
+		if (aPart < bPart) {
+			return -1
+		}
+	}
+
+	return 0
+}
+
+export async function getLatestCliVersion(fetchImpl: typeof fetch = fetch): Promise<string> {
+	const response = await fetchImpl(RELEASES_URL, {
+		headers: {
+			Accept: "application/vnd.github+json",
+			"User-Agent": "roo-cli",
+		},
+	})
+
+	if (!response.ok) {
+		throw new Error(`Failed to check latest version (HTTP ${response.status})`)
+	}
+
+	const releases = await response.json()
+	if (!Array.isArray(releases)) {
+		throw new Error("Invalid release response from GitHub.")
+	}
+
+	for (const release of releases) {
+		if (!isRecord(release)) {
+			continue
+		}
+
+		const tagName = release.tag_name
+		if (typeof tagName === "string" && tagName.startsWith("cli-v")) {
+			return tagName.slice("cli-v".length)
+		}
+	}
+
+	throw new Error("Could not determine the latest CLI release version.")
+}
+
+export function runUpgradeInstaller(spawnImpl: typeof spawn = spawn): Promise<void> {
+	return new Promise((resolve, reject) => {
+		const child = spawnImpl("sh", ["-c", INSTALL_SCRIPT_COMMAND], { stdio: "inherit" })
+
+		child.once("error", (error) => {
+			reject(error)
+		})
+
+		child.once("close", (code, signal) => {
+			if (code === 0) {
+				resolve()
+				return
+			}
+
+			const reason = signal ? `signal ${signal}` : `exit code ${code ?? "unknown"}`
+			reject(new Error(`Upgrade installer failed (${reason}).`))
+		})
+	})
+}
+
+export async function upgrade(options: UpgradeOptions = {}): Promise<void> {
+	const currentVersion = options.currentVersion ?? VERSION
+	const fetchImpl = options.fetchImpl ?? fetch
+	const runInstaller = options.runInstaller ?? (() => runUpgradeInstaller())
+
+	console.log(`Current version: ${currentVersion}`)
+
+	const latestVersion = await getLatestCliVersion(fetchImpl)
+	console.log(`Latest version: ${latestVersion}`)
+
+	if (compareVersions(latestVersion, currentVersion) <= 0) {
+		console.log("Roo CLI is already up to date.")
+		return
+	}
+
+	console.log(`Upgrading Roo CLI from ${currentVersion} to ${latestVersion}...`)
+	await runInstaller()
+	console.log("✓ Upgrade completed.")
+}

--- a/apps/cli/src/types/types.ts
+++ b/apps/cli/src/types/types.ts
@@ -20,6 +20,8 @@ export type ReasoningEffortFlagOptions = ReasoningEffortExtended | "unspecified"
 
 export type FlagOptions = {
 	promptFile?: string
+	sessionId?: string
+	continue: boolean
 	workspace?: string
 	print: boolean
 	stdinPromptStream: boolean

--- a/apps/cli/src/ui/App.tsx
+++ b/apps/cli/src/ui/App.tsx
@@ -60,6 +60,8 @@ const PICKER_HEIGHT = 10
 
 export interface TUIAppProps extends ExtensionHostOptions {
 	initialPrompt?: string
+	initialSessionId?: string
+	continueSession?: boolean
 	version: string
 	// Create extension host factory for dependency injection.
 	createExtensionHost: (options: ExtensionHostOptions) => ExtensionHostInterface
@@ -71,6 +73,8 @@ export interface TUIAppProps extends ExtensionHostOptions {
 function AppInner({ createExtensionHost, ...extensionHostOptions }: TUIAppProps) {
 	const {
 		initialPrompt,
+		initialSessionId,
+		continueSession,
 		workspacePath,
 		extensionPath,
 		user,
@@ -170,6 +174,8 @@ function AppInner({ createExtensionHost, ...extensionHostOptions }: TUIAppProps)
 
 	const { sendToExtension, runTask, cleanup } = useExtensionHost({
 		initialPrompt,
+		initialSessionId,
+		continueSession,
 		mode,
 		reasoningEffort,
 		user,

--- a/packages/core/src/cli.ts
+++ b/packages/core/src/cli.ts
@@ -4,3 +4,4 @@
 
 export * from "./debug-log/index.js"
 export * from "./message-utils/index.js"
+export * from "./task-history/index.js"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./custom-tools/index.js"
 export * from "./debug-log/index.js"
 export * from "./message-utils/index.js"
+export * from "./task-history/index.js"
 export * from "./worktree/index.js"

--- a/packages/core/src/task-history/__tests__/task-history.spec.ts
+++ b/packages/core/src/task-history/__tests__/task-history.spec.ts
@@ -1,0 +1,114 @@
+import * as fs from "fs/promises"
+import * as os from "os"
+import * as path from "path"
+
+import { readTaskSessionsFromStoragePath } from "../index.js"
+
+describe("readTaskSessionsFromStoragePath", () => {
+	let tempDir: string
+
+	beforeEach(async () => {
+		tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "task-history-core-"))
+	})
+
+	afterEach(async () => {
+		await fs.rm(tempDir, { recursive: true, force: true })
+	})
+
+	it("reads sessions from _index.json and sorts by timestamp descending", async () => {
+		const tasksDir = path.join(tempDir, "tasks")
+		await fs.mkdir(path.join(tasksDir, "a"), { recursive: true })
+		await fs.mkdir(path.join(tasksDir, "b"), { recursive: true })
+
+		await fs.writeFile(
+			path.join(tasksDir, "_index.json"),
+			JSON.stringify({
+				entries: [
+					{ id: "a", task: "Task A", ts: 100, status: "completed" },
+					{ id: "b", task: "Task B", ts: 300, mode: "code" },
+					{ id: "invalid", ts: 200 },
+				],
+			}),
+		)
+
+		const sessions = await readTaskSessionsFromStoragePath(tempDir)
+
+		expect(sessions).toEqual([
+			{ id: "b", task: "Task B", ts: 300, mode: "code", workspace: undefined, status: undefined },
+			{ id: "a", task: "Task A", ts: 100, mode: undefined, workspace: undefined, status: "completed" },
+		])
+	})
+
+	it("merges missing sessions from tasks/<id>/history_item.json", async () => {
+		const tasksDir = path.join(tempDir, "tasks")
+		await fs.mkdir(path.join(tasksDir, "a"), { recursive: true })
+		await fs.mkdir(path.join(tasksDir, "c"), { recursive: true })
+
+		await fs.writeFile(
+			path.join(tasksDir, "_index.json"),
+			JSON.stringify({
+				entries: [{ id: "a", task: "Task A", ts: 100 }],
+			}),
+		)
+		await fs.writeFile(
+			path.join(tasksDir, "c", "history_item.json"),
+			JSON.stringify({ id: "c", task: "Task C", ts: 500, workspace: "/tmp/project" }),
+		)
+
+		const sessions = await readTaskSessionsFromStoragePath(tempDir)
+
+		expect(sessions).toEqual([
+			{ id: "c", task: "Task C", ts: 500, workspace: "/tmp/project", mode: undefined, status: undefined },
+			{ id: "a", task: "Task A", ts: 100, workspace: undefined, mode: undefined, status: undefined },
+		])
+	})
+
+	it("removes stale index entries that have no on-disk task directory", async () => {
+		const tasksDir = path.join(tempDir, "tasks")
+		await fs.mkdir(path.join(tasksDir, "live"), { recursive: true })
+
+		await fs.writeFile(
+			path.join(tasksDir, "_index.json"),
+			JSON.stringify({
+				entries: [
+					{ id: "stale", task: "Stale Task", ts: 999 },
+					{ id: "live", task: "Live Task", ts: 100 },
+				],
+			}),
+		)
+
+		const sessions = await readTaskSessionsFromStoragePath(tempDir)
+
+		expect(sessions).toEqual([
+			{ id: "live", task: "Live Task", ts: 100, workspace: undefined, mode: undefined, status: undefined },
+		])
+	})
+
+	it("ignores malformed JSON and invalid history entries", async () => {
+		const tasksDir = path.join(tempDir, "tasks")
+		await fs.mkdir(path.join(tasksDir, "good"), { recursive: true })
+		await fs.mkdir(path.join(tasksDir, "bad-json"), { recursive: true })
+		await fs.mkdir(path.join(tasksDir, "bad-shape"), { recursive: true })
+
+		await fs.writeFile(path.join(tasksDir, "_index.json"), "{not-valid-json")
+		await fs.writeFile(
+			path.join(tasksDir, "good", "history_item.json"),
+			JSON.stringify({ id: "good", task: "Good Task", ts: 10, status: "active" }),
+		)
+		await fs.writeFile(path.join(tasksDir, "bad-json", "history_item.json"), "{oops")
+		await fs.writeFile(
+			path.join(tasksDir, "bad-shape", "history_item.json"),
+			JSON.stringify({ id: "bad-shape", task: 123, ts: "not-a-number" }),
+		)
+
+		const sessions = await readTaskSessionsFromStoragePath(tempDir)
+
+		expect(sessions).toEqual([
+			{ id: "good", task: "Good Task", ts: 10, workspace: undefined, mode: undefined, status: "active" },
+		])
+	})
+
+	it("returns an empty list when tasks directory does not exist", async () => {
+		await expect(readTaskSessionsFromStoragePath(tempDir)).resolves.toEqual([])
+	})
+})

--- a/packages/core/src/task-history/index.ts
+++ b/packages/core/src/task-history/index.ts
@@ -1,0 +1,105 @@
+import * as fs from "fs/promises"
+import * as path from "path"
+
+import type { HistoryItem } from "@roo-code/types"
+
+const HISTORY_ITEM_FILENAME = "history_item.json"
+const HISTORY_INDEX_FILENAME = "_index.json"
+
+export interface TaskSessionEntry {
+	id: string
+	task: string
+	ts: number
+	workspace?: string
+	mode?: string
+	status?: HistoryItem["status"]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null
+}
+
+function extractSessionEntry(value: unknown): TaskSessionEntry | undefined {
+	if (!isRecord(value)) {
+		return undefined
+	}
+
+	const id = value.id
+	const task = value.task
+	const ts = value.ts
+	const workspace = value.workspace
+	const mode = value.mode
+	const status = value.status
+
+	if (typeof id !== "string" || typeof task !== "string" || typeof ts !== "number") {
+		return undefined
+	}
+
+	return {
+		id,
+		task,
+		ts,
+		workspace: typeof workspace === "string" ? workspace : undefined,
+		mode: typeof mode === "string" ? mode : undefined,
+		status: status === "active" || status === "completed" || status === "delegated" ? status : undefined,
+	}
+}
+
+async function readJsonFile(filePath: string): Promise<unknown | undefined> {
+	try {
+		const raw = await fs.readFile(filePath, "utf8")
+		return JSON.parse(raw)
+	} catch {
+		return undefined
+	}
+}
+
+export async function readTaskSessionsFromStoragePath(storageBasePath: string): Promise<TaskSessionEntry[]> {
+	const tasksDir = path.join(storageBasePath, "tasks")
+	const sessionsById = new Map<string, TaskSessionEntry>()
+
+	const historyIndex = await readJsonFile(path.join(tasksDir, HISTORY_INDEX_FILENAME))
+	const indexEntries = isRecord(historyIndex) && Array.isArray(historyIndex.entries) ? historyIndex.entries : []
+
+	for (const entry of indexEntries) {
+		const session = extractSessionEntry(entry)
+		if (session) {
+			sessionsById.set(session.id, session)
+		}
+	}
+
+	let taskDirs: string[] = []
+
+	try {
+		const entries = await fs.readdir(tasksDir, { withFileTypes: true })
+		taskDirs = entries
+			.filter((entry) => entry.isDirectory() && !entry.name.startsWith("_") && !entry.name.startsWith("."))
+			.map((entry) => entry.name)
+	} catch {
+		// No tasks directory; return index-derived entries only.
+	}
+
+	for (const taskId of taskDirs) {
+		if (sessionsById.has(taskId)) {
+			continue
+		}
+
+		const historyItem = await readJsonFile(path.join(tasksDir, taskId, HISTORY_ITEM_FILENAME))
+		const session = extractSessionEntry(historyItem)
+
+		if (session) {
+			sessionsById.set(session.id, session)
+		}
+	}
+
+	if (taskDirs.length > 0) {
+		const onDiskIds = new Set(taskDirs)
+		for (const sessionId of sessionsById.keys()) {
+			if (!onDiskIds.has(sessionId)) {
+				sessionsById.delete(sessionId)
+			}
+		}
+	}
+
+	return Array.from(sessionsById.values()).sort((a, b) => b.ts - a.ts)
+}


### PR DESCRIPTION
## Summary
- add --session-id and --continue (-c) resume flows in CLI runtime/host wiring
- add roo list sessions with reusable task-history filesystem reader in @roo-code/core
- add roo upgrade to check latest CLI release and run the install script when an update is available
- add/update tests for extension host resume behavior, session listing, core task-history parsing, and upgrade logic

## Validation
- pnpm --filter @roo-code/core test -- src/task-history/__tests__/task-history.spec.ts
- pnpm --filter @roo-code/cli test -- src/commands/cli/__tests__/list.test.ts
- pnpm --filter @roo-code/cli test -- src/commands/cli/__tests__/upgrade.test.ts
- pnpm --filter @roo-code/core check-types
- pnpm --filter @roo-code/core lint
- pnpm --filter @roo-code/cli check-types
- pnpm --filter @roo-code/cli lint

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=efe18968edbdfe7e671eb0d78f13eea86f38826c&pr=11768&branch=cte%2Fcli-session-history-upgrade)
<!-- roo-code-cloud-preview-end -->