### PR TITLE
chore(cli): prepare release v0.1.5

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-02-26
+
+### Added
+
+- **Session History**: New `list sessions` subcommand to view recent CLI sessions with task IDs, timestamps, and initial prompts.
+- **Session Resume**: New `--resume <taskId>` flag to continue a previous session from where it left off.
+- **Upgrade Command**: New `upgrade` command to check for and install the latest CLI version.
+
 ## [0.1.4] - 2026-02-26
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.5

This PR prepares the CLI release v0.1.5.

### Changes
- Version bump in package.json
- Changelog update

### New Features
- **Session History**: New `list sessions` subcommand to view recent CLI sessions
- **Session Resume**: New `--resume <taskId>` flag to continue a previous session
- **Upgrade Command**: New `upgrade` command to check for and install the latest CLI version

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=4088997fb3c01b42f8f3e784db875d1375609477&pr=11772&branch=cli-release-v0.1.5)
<!-- roo-code-cloud-preview-end -->