### PR TITLE
feat: pipe MCP annotations.title through to UI

### DIFF
--- a/packages/types/src/mcp.ts
+++ b/packages/types/src/mcp.ts
@@ -73,6 +73,13 @@ export type McpTool = {
 	inputSchema?: object
 	alwaysAllow?: boolean
 	enabledForPrompt?: boolean
+	annotations?: {
+		title?: string
+		readOnlyHint?: boolean
+		destructiveHint?: boolean
+		idempotentHint?: boolean
+		openWorldHint?: boolean
+	}
 }
 
 export type McpResource = {

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -845,6 +845,7 @@ export interface ClineAskUseMcpServer {
 	serverName: string
 	type: "use_mcp_tool" | "access_mcp_resource"
 	toolName?: string
+	toolTitle?: string
 	arguments?: string
 	uri?: string
 	response?: string

--- a/src/core/tools/UseMcpToolTool.ts
+++ b/src/core/tools/UseMcpToolTool.ts
@@ -56,6 +56,7 @@ export class UseMcpToolTool extends BaseTool<"use_mcp_tool"> {
 				type: "use_mcp_tool",
 				serverName,
 				toolName: resolvedToolName,
+				toolTitle: toolValidation.resolvedToolTitle,
 				arguments: params.arguments ? JSON.stringify(params.arguments) : undefined,
 			} satisfies ClineAskUseMcpServer)
 
@@ -142,7 +143,7 @@ export class UseMcpToolTool extends BaseTool<"use_mcp_tool"> {
 		serverName: string,
 		toolName: string,
 		pushToolResult: (content: string) => void,
-	): Promise<{ isValid: boolean; availableTools?: string[]; resolvedToolName?: string }> {
+	): Promise<{ isValid: boolean; availableTools?: string[]; resolvedToolName?: string; resolvedToolTitle?: string }> {
 		try {
 			// Get the MCP hub to access server information
 			const provider = task.providerRef.deref()
@@ -238,7 +239,12 @@ export class UseMcpToolTool extends BaseTool<"use_mcp_tool"> {
 			}
 
 			// Tool exists and is enabled - return the original tool name for use with the MCP server
-			return { isValid: true, availableTools: server.tools.map((t) => t.name), resolvedToolName: tool.name }
+			return {
+				isValid: true,
+				availableTools: server.tools.map((t) => t.name),
+				resolvedToolName: tool.name,
+				resolvedToolTitle: tool.annotations?.title,
+			}
 		} catch (error) {
 			// If there's an error during validation, log it but don't block the tool execution
 			// The actual tool call might still fail with a proper error


### PR DESCRIPTION
## Summary
- Add `annotations` field to `McpTool` type to capture MCP tool metadata (title, readOnlyHint, destructiveHint, etc.)
- Add `toolTitle` to `ClineAskUseMcpServer` interface
- Pass `annotations.title` as `toolTitle` in `UseMcpToolTool.execute()` so downstream consumers (Roomote web UI) can display human-readable labels like "Navigate to a URL" instead of generic "Used MCP tool"

## Test plan
- [x] All 5305 existing Roo-Code tests pass
- [x] Type-checking passes across all packages
- [x] Built canary CLI tarball and verified end-to-end with Roomote: Playwright `browser_navigate` renders as "Navigate to a URL" and `browser_take_screenshot` renders as "Take a screenshot"
- [x] MCP tools without `annotations.title` fall back to generic "Used MCP tool" display

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=551d02f51056f00883557c7f3ae287764c51cdbf&pr=11789&branch=feat%2Fpipe-mcp-annotations-title)
<!-- roo-code-cloud-preview-end -->