### PR TITLE
Handle stdin-stream control-flow errors gracefully

### DIFF
--- a/apps/cli/src/commands/cli/__tests__/cancellation.test.ts
+++ b/apps/cli/src/commands/cli/__tests__/cancellation.test.ts
@@ -1,0 +1,104 @@
+import {
+	isCancellationLikeError,
+	isExpectedControlFlowError,
+	isNoActiveTaskLikeError,
+	isStreamTeardownLikeError,
+} from "../cancellation.js"
+
+describe("isCancellationLikeError", () => {
+	it("returns true for aborted error messages", () => {
+		expect(isCancellationLikeError(new Error("[RooCode#say] task 123 aborted"))).toBe(true)
+		expect(isCancellationLikeError("AbortError: operation aborted")).toBe(true)
+	})
+
+	it("returns true for abort/cancel error names and codes", () => {
+		expect(isCancellationLikeError({ name: "AbortError", message: "stop now" })).toBe(true)
+		expect(isCancellationLikeError({ code: "ABORT_ERR", message: "aborted" })).toBe(true)
+		expect(isCancellationLikeError({ code: "ERR_CANCELED", message: "request failed" })).toBe(true)
+	})
+
+	it("returns true for canceled/cancelled error messages", () => {
+		expect(isCancellationLikeError(new Error("Request canceled"))).toBe(true)
+		expect(isCancellationLikeError(new Error("request cancelled by user"))).toBe(true)
+	})
+
+	it("returns false for non-cancellation errors", () => {
+		expect(isCancellationLikeError(new Error("network timeout"))).toBe(false)
+		expect(isCancellationLikeError("validation failed")).toBe(false)
+	})
+})
+
+describe("isNoActiveTaskLikeError", () => {
+	it("matches task-settled cancel race messages", () => {
+		expect(isNoActiveTaskLikeError(new Error("no active task to cancel"))).toBe(true)
+		expect(isNoActiveTaskLikeError(new Error("task not found"))).toBe(true)
+		expect(isNoActiveTaskLikeError("already completed")).toBe(true)
+	})
+
+	it("does not match unrelated messages", () => {
+		expect(isNoActiveTaskLikeError("network timeout")).toBe(false)
+	})
+})
+
+describe("isStreamTeardownLikeError", () => {
+	it("matches common stream teardown errors", () => {
+		expect(isStreamTeardownLikeError({ code: "EPIPE", message: "broken pipe" })).toBe(true)
+		expect(isStreamTeardownLikeError({ code: "ERR_STREAM_DESTROYED", message: "stream destroyed" })).toBe(true)
+		expect(isStreamTeardownLikeError(new Error("write after end"))).toBe(true)
+	})
+
+	it("does not match unrelated stream errors", () => {
+		expect(isStreamTeardownLikeError(new Error("permission denied"))).toBe(false)
+	})
+})
+
+describe("isExpectedControlFlowError", () => {
+	it("returns false when not in stdin stream mode", () => {
+		expect(
+			isExpectedControlFlowError(new Error("AbortError: aborted"), {
+				stdinStreamMode: false,
+				operation: "runtime",
+			}),
+		).toBe(false)
+	})
+
+	it("accepts cancellation-like runtime errors in stdin stream mode", () => {
+		expect(
+			isExpectedControlFlowError(new Error("AbortError: aborted"), {
+				stdinStreamMode: true,
+				operation: "runtime",
+			}),
+		).toBe(true)
+	})
+
+	it("accepts no-active-task races for cancel operations", () => {
+		expect(
+			isExpectedControlFlowError(new Error("task not found"), {
+				stdinStreamMode: true,
+				operation: "cancel",
+			}),
+		).toBe(true)
+	})
+
+	it("accepts stream teardown errors during shutdown", () => {
+		expect(
+			isExpectedControlFlowError(
+				{ code: "EPIPE", message: "broken pipe" },
+				{
+					stdinStreamMode: true,
+					shuttingDown: true,
+					operation: "runtime",
+				},
+			),
+		).toBe(true)
+	})
+
+	it("rejects unrelated errors", () => {
+		expect(
+			isExpectedControlFlowError(new Error("authentication failed"), {
+				stdinStreamMode: true,
+				operation: "runtime",
+			}),
+		).toBe(false)
+	})
+})

--- a/apps/cli/src/commands/cli/cancellation.ts
+++ b/apps/cli/src/commands/cli/cancellation.ts
@@ -1,0 +1,131 @@
+const CANCELLATION_ERROR_PATTERNS = ["aborted", "aborterror", "cancelled", "canceled"]
+const CANCELLATION_ERROR_NAMES = new Set(["aborterror"])
+const CANCELLATION_ERROR_CODES = new Set(["ABORT_ERR", "ERR_CANCELED", "ERR_CANCELLED"])
+const NO_ACTIVE_TASK_PATTERNS = [
+	"no active task",
+	"no task to cancel",
+	"task not found",
+	"unable to find task",
+	"already completed",
+	"already cancelled",
+	"already canceled",
+]
+const STREAM_TEARDOWN_CODES = new Set(["EPIPE", "ECONNRESET", "ERR_STREAM_DESTROYED", "ERR_STREAM_PREMATURE_CLOSE"])
+const STREAM_TEARDOWN_PATTERNS = [
+	"write after end",
+	"stream destroyed",
+	"premature close",
+	"socket hang up",
+	"broken pipe",
+]
+
+export interface ExpectedControlFlowErrorContext {
+	stdinStreamMode: boolean
+	cancelRequested?: boolean
+	shuttingDown?: boolean
+	operation?: "runtime" | "client" | "cancel" | "shutdown"
+}
+
+interface ErrorMetadata {
+	message: string
+	normalizedMessage: string
+	name?: string
+	normalizedName?: string
+	code?: string
+}
+
+function getErrorMetadata(error: unknown): ErrorMetadata {
+	if (error instanceof Error) {
+		const maybeCode = (error as Error & { code?: unknown }).code
+		const code = typeof maybeCode === "string" ? maybeCode : undefined
+		return {
+			message: error.message,
+			normalizedMessage: error.message.toLowerCase(),
+			name: error.name,
+			normalizedName: error.name.toLowerCase(),
+			code,
+		}
+	}
+
+	if (typeof error === "object" && error !== null) {
+		const nameRaw = (error as { name?: unknown }).name
+		const messageRaw = (error as { message?: unknown }).message
+		const codeRaw = (error as { code?: unknown }).code
+		const message = typeof messageRaw === "string" ? messageRaw : String(error)
+		return {
+			message,
+			normalizedMessage: message.toLowerCase(),
+			name: typeof nameRaw === "string" ? nameRaw : undefined,
+			normalizedName: typeof nameRaw === "string" ? nameRaw.toLowerCase() : undefined,
+			code: typeof codeRaw === "string" ? codeRaw : undefined,
+		}
+	}
+
+	const message = String(error)
+	return {
+		message,
+		normalizedMessage: message.toLowerCase(),
+	}
+}
+
+/**
+ * Best-effort classifier for cancellation/abort failures.
+ */
+export function isCancellationLikeError(error: unknown): boolean {
+	const details = getErrorMetadata(error)
+
+	if (details.code && CANCELLATION_ERROR_CODES.has(details.code)) {
+		return true
+	}
+
+	if (details.normalizedName && CANCELLATION_ERROR_NAMES.has(details.normalizedName)) {
+		return true
+	}
+
+	return CANCELLATION_ERROR_PATTERNS.some((pattern) => details.normalizedMessage.includes(pattern))
+}
+
+export function isNoActiveTaskLikeError(error: unknown): boolean {
+	const details = getErrorMetadata(error)
+	return NO_ACTIVE_TASK_PATTERNS.some((pattern) => details.normalizedMessage.includes(pattern))
+}
+
+export function isStreamTeardownLikeError(error: unknown): boolean {
+	const details = getErrorMetadata(error)
+	if (details.code && STREAM_TEARDOWN_CODES.has(details.code)) {
+		return true
+	}
+
+	return STREAM_TEARDOWN_PATTERNS.some((pattern) => details.normalizedMessage.includes(pattern))
+}
+
+/**
+ * Classify errors that should be treated as expected control flow rather than
+ * fatal failures while handling stdin stream tasks.
+ */
+export function isExpectedControlFlowError(error: unknown, context: ExpectedControlFlowErrorContext): boolean {
+	if (!context.stdinStreamMode) {
+		return false
+	}
+
+	if (context.shuttingDown && isStreamTeardownLikeError(error)) {
+		return true
+	}
+
+	const isCancelLike = isCancellationLikeError(error)
+	if (isCancelLike && (context.cancelRequested || context.shuttingDown || context.operation === "runtime")) {
+		return true
+	}
+
+	if (
+		isNoActiveTaskLikeError(error) &&
+		(context.cancelRequested ||
+			context.shuttingDown ||
+			context.operation === "cancel" ||
+			context.operation === "shutdown")
+	) {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
## Summary

- add a shared expected-control-flow error classifier for stdin stream mode
- treat abort/cancel variants, no-active-task cancel races, and stream teardown-on-shutdown as non-fatal control flow
- apply classifier in both CLI runtime unhandled error handlers and stdin-stream client/cancel paths
- add focused unit tests for new classifiers and contexts

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=dfec4837ae5acfd68f39e688550f8c94695798cb&pr=11811&branch=codex%2Fstdin-stream-control-flow-errors)
<!-- roo-code-cloud-preview-end -->