### PR TITLE
chore(cli): prepare release v0.1.7

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2026-03-01
+
+### Fixed
+
+- **Stdin Stream Control Flow**: Gracefully handle control-flow errors in stdin-stream mode to prevent unexpected crashes during cancellation and shutdown sequences.
+
+### Changed
+
+- **Type Definitions**: Refactored and simplified JSON event type definitions for better type safety.
+
 ## [0.1.6] - 2026-02-27
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.7

This PR prepares the CLI release v0.1.7.

### Changes
- Version bump in package.json
- Changelog update

### Summary of Changes Since v0.1.6
- **Fixed**: Gracefully handle control-flow errors in stdin-stream mode to prevent unexpected crashes during cancellation and shutdown sequences (#11811)
- **Changed**: Refactored and simplified JSON event type definitions for better type safety (#11781)

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=db14cb0a738d8388fe40b3a5f751e1851374c896&pr=11812&branch=cli-release-v0.1.7)
<!-- roo-code-cloud-preview-end -->