### PR TITLE
feat: inject queued messages into next API call for mid-task guidance

### DIFF
--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -2639,6 +2639,31 @@ export class Task extends EventEmitter<TaskEvents> implements TaskLike {
 			// Add environment details as its own text block, separate from tool
 			// results.
 			let finalUserContent = [...contentWithoutEnvDetails, { type: "text" as const, text: environmentDetails }]
+
+			// Inject any queued user messages into this API call.
+			// This allows users to provide mid-task guidance that the agent
+			// picks up immediately on the next API request, rather than
+			// waiting for the current turn to fully complete.
+			if (!this.messageQueueService.isEmpty()) {
+				const queuedTexts: string[] = []
+
+				while (!this.messageQueueService.isEmpty()) {
+					const msg = this.messageQueueService.dequeueMessage()
+
+					if (msg?.text) {
+						queuedTexts.push(msg.text)
+					}
+				}
+
+				if (queuedTexts.length > 0) {
+					const injection =
+						"\n[USER_MID_TASK_MESSAGE]\nThe user has sent the following message(s) while you were working. " +
+						"Please acknowledge and incorporate this feedback into your current task:\n" +
+						queuedTexts.join("\n") +
+						"\n[/USER_MID_TASK_MESSAGE]"
+					finalUserContent.push({ type: "text" as const, text: injection })
+				}
+			}
 			// Only add user message to conversation history if:
 			// 1. This is the first attempt (retryAttempt === 0), AND
 			// 2. The original userContent was not empty (empty signals delegation resume where

--- a/src/core/task/__tests__/mid-task-message-injection.spec.ts
+++ b/src/core/task/__tests__/mid-task-message-injection.spec.ts
@@ -1,0 +1,113 @@
+import { MessageQueueService } from "../../message-queue/MessageQueueService"
+
+/**
+ * Tests for the mid-task message injection feature.
+ *
+ * When a user queues messages while the agent is working,
+ * they should be drained and injected into the next API call's
+ * user content as [USER_MID_TASK_MESSAGE] blocks.
+ *
+ * This test validates the drain-and-inject logic in isolation,
+ * using the same MessageQueueService that Task.ts uses.
+ */
+describe("Mid-task message injection", () => {
+	let queue: MessageQueueService
+
+	beforeEach(() => {
+		queue = new MessageQueueService()
+	})
+
+	afterEach(() => {
+		queue.dispose()
+	})
+
+	/**
+	 * Simulates the drain-and-inject logic from Task.ts L2647-2666.
+	 * Returns the injection text block if any messages were queued,
+	 * or undefined if the queue was empty.
+	 */
+	function drainAndBuildInjection(mqs: MessageQueueService): string | undefined {
+		if (mqs.isEmpty()) {
+			return undefined
+		}
+
+		const queuedTexts: string[] = []
+
+		while (!mqs.isEmpty()) {
+			const msg = mqs.dequeueMessage()
+
+			if (msg?.text) {
+				queuedTexts.push(msg.text)
+			}
+		}
+
+		if (queuedTexts.length === 0) {
+			return undefined
+		}
+
+		return (
+			"\n[USER_MID_TASK_MESSAGE]\nThe user has sent the following message(s) while you were working. " +
+			"Please acknowledge and incorporate this feedback into your current task:\n" +
+			queuedTexts.join("\n") +
+			"\n[/USER_MID_TASK_MESSAGE]"
+		)
+	}
+
+	it("returns undefined when queue is empty", () => {
+		const result = drainAndBuildInjection(queue)
+		expect(result).toBeUndefined()
+	})
+
+	it("injects a single queued message with correct tags", () => {
+		queue.addMessage("use TypeScript instead of JavaScript")
+		const result = drainAndBuildInjection(queue)
+
+		expect(result).toBeDefined()
+		expect(result).toContain("[USER_MID_TASK_MESSAGE]")
+		expect(result).toContain("use TypeScript instead of JavaScript")
+		expect(result).toContain("[/USER_MID_TASK_MESSAGE]")
+	})
+
+	it("injects multiple queued messages in order", () => {
+		queue.addMessage("first advice")
+		queue.addMessage("second advice")
+		queue.addMessage("third advice")
+		const result = drainAndBuildInjection(queue)
+
+		expect(result).toBeDefined()
+		expect(result).toContain("first advice")
+		expect(result).toContain("second advice")
+		expect(result).toContain("third advice")
+
+		// Verify order: first should appear before second
+		const firstIndex = result!.indexOf("first advice")
+		const secondIndex = result!.indexOf("second advice")
+		const thirdIndex = result!.indexOf("third advice")
+		expect(firstIndex).toBeLessThan(secondIndex)
+		expect(secondIndex).toBeLessThan(thirdIndex)
+	})
+
+	it("drains the queue completely after injection", () => {
+		queue.addMessage("some advice")
+		queue.addMessage("more advice")
+
+		drainAndBuildInjection(queue)
+
+		expect(queue.isEmpty()).toBe(true)
+		// Second drain should return undefined
+		expect(drainAndBuildInjection(queue)).toBeUndefined()
+	})
+
+	it("does not interfere with messages queued after drain", () => {
+		queue.addMessage("before drain")
+		drainAndBuildInjection(queue)
+
+		// Simulate new message arriving after drain (during API call)
+		queue.addMessage("after drain")
+		expect(queue.isEmpty()).toBe(false)
+
+		const result = drainAndBuildInjection(queue)
+		expect(result).toContain("after drain")
+		expect(result).not.toContain("before drain")
+	})
+})


### PR DESCRIPTION
<!--
Thank you for contributing to Roo Code!

Before submitting your PR, please ensure:
- It's linked to an approved GitHub Issue.
- You've reviewed our [Contributing Guidelines](../CONTRIBUTING.md).
-->

### Related GitHub Issue

Closes: #11802

### Roo Code Task Context (Optional)

_N/A_

### Description

**TL;DR**: Queued messages now get injected into the _very next_ API call instead of waiting for the task to fully complete.

After discussing the approach with @hannesrudolph in DMs, we agreed that the simplest and most natural UX is to **enhance the existing message queue** rather than adding a separate steering mechanism. When users type a message while the agent is working, they expect it to be noticed at the next step — not after the entire task finishes.

**Implementation** (25 lines in [Task.ts](file:///e:/repositories/Roo-Code/src/core/task/Task.ts)):
- At the `finalUserContent` assembly point in [recursivelyMakeClineRequests](file:///e:/repositories/Roo-Code/src/core/task/Task.ts#2503-3761), drain the message queue
- Append any pending messages as a `[USER_MID_TASK_MESSAGE]` block
- The agent reads them immediately at the next API request and incorporates the feedback

**What's NOT changed:**
- No new UI elements, buttons, or message types
- No new dependencies
- Existing [ask](file:///e:/repositories/Roo-Code/src/core/task/Task.ts#1261-1497) blocking-point queue handling is **preserved** — messages queued _during_ an API call are still handled by the existing logic at the ask blocking point

**Design trade-off**: This is "reactive" injection (between API calls), not "preemptive" (mid-stream abort). Preemptive injection is noted as future work. The reactive approach is zero-risk to existing behavior and covers the most common use case.

### Test Procedure

**Automated:**
- `npx vitest run core/task/__tests__/mid-task-message-injection.spec.ts` — 5 tests covering: empty queue, single message injection, multiple message ordering, queue drain completeness, and post-drain independence
- Existing [ask-queued-message-drain.spec.ts](file:///e:/repositories/Roo-Code/src/core/task/__tests__/ask-queued-message-drain.spec.ts) continues to pass

**Manual (F5 Extension Development Host):**
1. Start a long task: _"Write a Python script to find primes from 1-100 with detailed comments"_
2. While the agent is streaming, queue a message: _"Actually, use JavaScript instead"_
3. Observe: the agent picks up the message at the next API call and switches to JavaScript

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

_No UI changes._

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

The original issue proposed using an external `@steer-agent/core` library. After feedback from @hannesrudolph ("Why not make that the default?"), the approach was simplified to a minimal change to the existing queue behavior — no external dependencies, no new UI, just 25 lines that make the queue smarter.

**Future work**: Preemptive injection — abort the current stream when a queued message arrives and restart with the message injected, enabling truly real-time mid-stream course correction.

### Get in Touch

Discord: shdomi_8599

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=69db1b2f269ca6fbfdd59713561c7c464f89e8c7&pr=11813&branch=feat%2Fmid-task-message-injection)
<!-- roo-code-cloud-preview-end -->