### PR TITLE
chore(cli): prepare release v0.1.9

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.9] - 2026-03-02
+
+### Fixed
+
+- **Stdin Stream Cancel Race**: Fixed a race condition during startup cancellation in stdin-stream mode that could cause unexpected behavior when canceling tasks immediately after starting them.
+
+### Tests
+
+- **Integration Test Suite**: Added comprehensive integration test suite for stdin-stream protocol covering cancel, followup, multi-message queue, and shutdown scenarios.
+
 ## [0.1.8] - 2026-03-02
 
 ### Changed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.9

This PR prepares the CLI release v0.1.9.

### Changes
- Version bump in package.json (0.1.8 → 0.1.9)
- Changelog update with:
  - **Fixed**: Stdin stream cancel race condition during startup cancellation
  - **Tests**: Added comprehensive integration test suite for stdin-stream protocol

### Checklist
- [ ] Version number is correct
- [ ] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=677dc8c7053f378450ea76b82115517e47f83eb9&pr=11818&branch=cli-release-v0.1.9)
<!-- roo-code-cloud-preview-end -->