### PR TITLE
feat(cli): include exitCode in command tool_result events

### DIFF
--- a/apps/cli/src/agent/__tests__/json-event-emitter-streaming.test.ts
+++ b/apps/cli/src/agent/__tests__/json-event-emitter-streaming.test.ts
@@ -302,7 +302,7 @@ describe("JsonEventEmitter streaming deltas", () => {
 
 		emitter.emitCommandOutputChunk("line1\n")
 		emitter.emitCommandOutputChunk("line1\nline2\n")
-		emitter.emitCommandOutputDone()
+		emitter.emitCommandOutputDone(17)
 
 		// This completion say is expected from the extension, but should be suppressed
 		// because we already streamed and completed via commandExecutionStatus.
@@ -339,7 +339,7 @@ describe("JsonEventEmitter streaming deltas", () => {
 			type: "tool_result",
 			id: commandId,
 			subtype: "command",
-			tool_result: { name: "execute_command" },
+			tool_result: { name: "execute_command", exitCode: 17 },
 			done: true,
 		})
 	})

--- a/apps/cli/src/agent/json-event-emitter.ts
+++ b/apps/cli/src/agent/json-event-emitter.ts
@@ -310,7 +310,12 @@ export class JsonEventEmitter {
 		return normalized.startsWith(previous) ? normalized.slice(previous.length) : normalized
 	}
 
-	private emitCommandOutputEvent(commandId: number, fullOutput: string | undefined, isDone: boolean): void {
+	private emitCommandOutputEvent(
+		commandId: number,
+		fullOutput: string | undefined,
+		isDone: boolean,
+		exitCode?: number,
+	): void {
 		if (this.mode === "stream-json") {
 			const outputDelta = this.computeCommandOutputDelta(commandId, fullOutput)
 			const event: JsonEvent = {
@@ -322,6 +327,13 @@ export class JsonEventEmitter {
 
 			if (outputDelta !== null && outputDelta.length > 0) {
 				event.tool_result = { name: "execute_command", output: outputDelta }
+			}
+
+			if (isDone && exitCode !== undefined) {
+				event.tool_result = {
+					...(event.tool_result ?? { name: "execute_command" }),
+					exitCode,
+				}
 			}
 
 			if (isDone) {
@@ -347,7 +359,11 @@ export class JsonEventEmitter {
 			type: "tool_result",
 			id: commandId,
 			subtype: "command",
-			tool_result: { name: "execute_command", output: fullOutput },
+			tool_result: {
+				name: "execute_command",
+				output: fullOutput,
+				...(isDone && exitCode !== undefined ? { exitCode } : {}),
+			},
 			...(isDone ? { done: true } : {}),
 		})
 
@@ -371,7 +387,7 @@ export class JsonEventEmitter {
 		this.emitCommandOutputEvent(commandId, outputSnapshot, false)
 	}
 
-	public emitCommandOutputDone(): void {
+	public emitCommandOutputDone(exitCode?: number): void {
 		const commandId = this.activeCommandToolUseId
 		if (commandId === undefined) {
 			return
@@ -379,7 +395,7 @@ export class JsonEventEmitter {
 
 		this.statusDrivenCommandOutputIds.add(commandId)
 		this.suppressNextCommandOutputSay = true
-		this.emitCommandOutputEvent(commandId, undefined, true)
+		this.emitCommandOutputEvent(commandId, undefined, true, exitCode)
 	}
 
 	/**

--- a/apps/cli/src/commands/cli/stdin-stream.ts
+++ b/apps/cli/src/commands/cli/stdin-stream.ts
@@ -419,7 +419,11 @@ export async function runStdinStreamMode({ host, jsonEmitter, setStreamRequestId
 				parsedStatus.status === "timeout" ||
 				parsedStatus.status === "fallback"
 			) {
-				jsonEmitter.emitCommandOutputDone()
+				const exitCode =
+					parsedStatus.status === "exited" && typeof parsedStatus.exitCode === "number"
+						? parsedStatus.exitCode
+						: undefined
+				jsonEmitter.emitCommandOutputDone(exitCode)
 				return
 			}
 

--- a/packages/types/src/cli.ts
+++ b/packages/types/src/cli.ts
@@ -115,6 +115,7 @@ export const rooCliToolResultSchema = z.object({
 	name: z.string(),
 	output: z.string().optional(),
 	error: z.string().optional(),
+	exitCode: z.number().optional(),
 })
 
 export type RooCliToolResult = z.infer<typeof rooCliToolResultSchema>


### PR DESCRIPTION
## Summary
- Propagate the command exit code through the JSON event emitter's `tool_result` events so CLI consumers can distinguish between successful and failed command executions
- Add `exitCode` field to `rooCliToolResultSchema` in the types package
- Extract exit code from `commandExecutionStatus` in `stdin-stream.ts` and pass it through to `emitCommandOutputDone`

## Test plan
- [x] Updated existing streaming test to verify `exitCode` is included in `tool_result` events
- [ ] Verify CLI consumers receive the `exitCode` field in command completion events
- [ ] Run full test suite to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=03f4279669d355c0cf0a1ae9dd00111b38ab67ad&pr=11820&branch=cte%2Fcli-exit-code-in-tool-result)
<!-- roo-code-cloud-preview-end -->