### PR TITLE
feat(bedrock): add Cohere Embed v4 model and improve credential handling (Fixes #11823)

### DIFF
--- a/src/services/code-index/embedders/bedrock.ts
+++ b/src/services/code-index/embedders/bedrock.ts
@@ -1,5 +1,5 @@
 import { BedrockRuntimeClient, InvokeModelCommand, InvokeModelCommandInput } from "@aws-sdk/client-bedrock-runtime"
-import { fromEnv, fromIni } from "@aws-sdk/credential-providers"
+import { fromIni, fromNodeProviderChain } from "@aws-sdk/credential-providers"
 import { IEmbedder, EmbeddingResponse, EmbedderInfo } from "../interfaces"
 import {
 	MAX_BATCH_TOKENS,
@@ -38,7 +38,7 @@ export class BedrockEmbedder implements IEmbedder {
 
 		// Initialize the Bedrock client with credentials
 		// If profile is specified, use it; otherwise use default credential chain
-		const credentials = this.profile ? fromIni({ profile: this.profile }) : fromEnv()
+		const credentials = this.profile ? fromIni({ profile: this.profile }) : fromNodeProviderChain()
 
 		this.bedrockClient = new BedrockRuntimeClient({
 			userAgentAppId: `RooCode#${Package.version}`,
@@ -209,10 +209,18 @@ export class BedrockEmbedder implements IEmbedder {
 			requestBody = {
 				inputText: text,
 			}
-		} else if (model.startsWith("cohere.embed")) {
+		} else if (model.startsWith("cohere.embed-v4")) {
+			// Cohere Embed v4 requires embedding_types parameter
 			requestBody = {
 				texts: [text],
-				input_type: "search_document", // or "search_query" depending on use case
+				input_type: "search_document",
+				embedding_types: ["float"],
+			}
+		} else if (model.startsWith("cohere.embed")) {
+			// Cohere Embed v3 format
+			requestBody = {
+				texts: [text],
+				input_type: "search_document",
 			}
 		} else {
 			// Default to Titan format
@@ -248,10 +256,15 @@ export class BedrockEmbedder implements IEmbedder {
 				embedding: responseBody.embedding,
 				inputTextTokenCount: responseBody.inputTextTokenCount,
 			}
+		} else if (model.startsWith("cohere.embed-v4")) {
+			// Cohere Embed v4 returns { embeddings: { float: [[...]] } }
+			return {
+				embedding: responseBody.embeddings?.float?.[0] || responseBody.embeddings?.[0],
+			}
 		} else if (model.startsWith("cohere.embed")) {
+			// Cohere Embed v3 returns { embeddings: [[...]] }
 			return {
 				embedding: responseBody.embeddings[0],
-				// Cohere doesn't provide token count in response
 			}
 		} else {
 			// Default to Titan format

--- a/src/shared/embeddingModels.ts
+++ b/src/shared/embeddingModels.ts
@@ -66,7 +66,9 @@ export const EMBEDDING_MODEL_PROFILES: EmbeddingModelProfiles = {
 		"amazon.titan-embed-image-v1": { dimension: 1024, scoreThreshold: 0.4 },
 		// Amazon Nova Embed models
 		"amazon.nova-2-multimodal-embeddings-v1:0": { dimension: 1024, scoreThreshold: 0.4 },
-		// Cohere models available through Bedrock
+		// Cohere Embed v4 (supports only text for now; multimodal image support planned)
+		"cohere.embed-v4:0": { dimension: 1536, scoreThreshold: 0.4 },
+		// Cohere Embed v3 models available through Bedrock
 		"cohere.embed-english-v3": { dimension: 1024, scoreThreshold: 0.4 },
 		"cohere.embed-multilingual-v3": { dimension: 1024, scoreThreshold: 0.4 },
 	},


### PR DESCRIPTION
## Summary

Fixes #11823

Adds Cohere Embed v4 (`cohere.embed-v4:0`) support for Bedrock code indexing and fixes credential refresh for long-running indexing sessions on large codebases.

## Changes

### 1. Cohere Embed v4 Support (Text-Only)
- Added `cohere.embed-v4:0` to Bedrock embedding model profiles with dimension 1536
- Added v4-specific request format with `embedding_types: ["float"]` parameter
- Added v4-specific response parsing for `{embeddings: {float: [[...]]}}` structure
- v4 check placed before v3 in the if/else chain to prevent misrouting
- Text-only for now; multimodal image support planned as follow-up

### 2. Credential Refresh Fix
- Replaced `fromEnv()` with `fromNodeProviderChain()` as the default credential fallback when no AWS profile is specified
- `fromNodeProviderChain()` supports all credential sources (env vars, SSO, INI, IMDS, ECS) with built-in memoization and auto-refresh
- Fixes credential expiry during long-running indexing sessions (>1 hour) on large codebases

### 3. Tests
- 5 new unit tests covering credential provider selection, Cohere v4 request/response handling, and v3 regression
- All 143 related tests pass (30 bedrock + 113 service-factory/config-manager)

## Files Changed (3 files)
- `src/services/code-index/embedders/bedrock.ts` — Credential fix + Cohere v4 request/response
- `src/shared/embeddingModels.ts` — New model profile entry
- `src/services/code-index/embedders/__tests__/bedrock.spec.ts` — 5 new tests

## Roadmap Alignment

This aligns with: **"Expand robust support for a wide variety of AI providers and models."**

## Testing

- ✅ 30/30 bedrock embedder tests pass
- ✅ 113/113 service-factory + config-manager tests pass
- ✅ TypeScript compiles cleanly
- ✅ 14/14 packages lint clean
- ✅ Cohere v4 API format validated with real Bedrock API call (LT-1)
- ✅ Parsing logic validated with simulated responses (LT-4)

Related: https://github.com/aws-samples/bedrock-access-gateway/issues/212

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=0937ec63c599ebe2524c1ae69d3fa181af22d317&pr=11824&branch=feat%2Fbedrock-cohere-v4-and-credentials)
<!-- roo-code-cloud-preview-end -->