### PR TITLE
fix(cli): ignore model-provided timeout in CLI runtime

### DIFF
--- a/src/core/tools/ExecuteCommandTool.ts
+++ b/src/core/tools/ExecuteCommandTool.ts
@@ -29,6 +29,15 @@ interface ExecuteCommandParams {
 	timeout?: number | null
 }
 
+export function resolveAgentTimeoutMs(timeoutSeconds: number | null | undefined): number {
+	const requestedAgentTimeout = typeof timeoutSeconds === "number" && timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0
+
+	// In CLI runtime, stdin harnesses expect command lifetime to be governed
+	// solely by commandExecutionTimeout (user setting), not model-provided
+	// background timeouts.
+	return process.env.ROO_CLI_RUNTIME === "1" ? 0 : requestedAgentTimeout
+}
+
 export class ExecuteCommandTool extends BaseTool<"execute_command"> {
 	readonly name = "execute_command" as const
 
@@ -87,7 +96,7 @@ export class ExecuteCommandTool extends BaseTool<"execute_command"> {
 			const commandExecutionTimeout = isCommandAllowlisted ? 0 : commandExecutionTimeoutSeconds * 1000
 
 			// Convert agent-specified timeout from seconds to milliseconds
-			const agentTimeout = typeof timeoutSeconds === "number" && timeoutSeconds > 0 ? timeoutSeconds * 1000 : 0
+			const agentTimeout = resolveAgentTimeoutMs(timeoutSeconds)
 
 			const options: ExecuteCommandOptions = {
 				executionId,

--- a/src/core/tools/__tests__/executeCommandTool.spec.ts
+++ b/src/core/tools/__tests__/executeCommandTool.spec.ts
@@ -48,6 +48,7 @@ describe("executeCommandTool", () => {
 	let mockHandleError: any
 	let mockPushToolResult: any
 	let mockToolUse: ToolUse<"execute_command">
+	const originalCliRuntime = process.env.ROO_CLI_RUNTIME
 
 	beforeEach(() => {
 		// Reset mocks
@@ -104,6 +105,10 @@ describe("executeCommandTool", () => {
 			},
 			partial: false,
 		}
+	})
+
+	afterEach(() => {
+		process.env.ROO_CLI_RUNTIME = originalCliRuntime
 	})
 
 	/**
@@ -284,6 +289,16 @@ describe("executeCommandTool", () => {
 			expect(mockOptions.executionId).toBeDefined()
 			expect(mockOptions.command).toBeDefined()
 			expect(mockOptions.commandExecutionTimeout).toBeDefined()
+		})
+
+		it("should ignore model timeout in CLI runtime", () => {
+			process.env.ROO_CLI_RUNTIME = "1"
+			expect(executeCommandModule.resolveAgentTimeoutMs(30)).toBe(0)
+		})
+
+		it("should honor model timeout outside CLI runtime", () => {
+			delete process.env.ROO_CLI_RUNTIME
+			expect(executeCommandModule.resolveAgentTimeoutMs(30)).toBe(30_000)
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Extract `resolveAgentTimeoutMs()` from inline timeout logic in `ExecuteCommandTool`
- Return `0` (no agent timeout) when `ROO_CLI_RUNTIME=1`, so command lifetime is governed solely by the user's `commandExecutionTimeout` setting
- Add unit tests covering both CLI runtime and non-CLI runtime paths

## Test plan
- [x] Unit tests added for `resolveAgentTimeoutMs` (CLI runtime returns 0, non-CLI returns converted ms)
- [ ] Verify CLI stdin harness commands are no longer killed by model-provided background timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=72c288536cb0ce1ce8225517bce77530515d424a&pr=11835&branch=cte%2Fcli-ignore-agent-timeout)
<!-- roo-code-cloud-preview-end -->