### PR TITLE
fix: prevent redundant skill reloading in conversation

### DIFF
--- a/src/core/prompts/sections/skills.ts
+++ b/src/core/prompts/sections/skills.ts
@@ -74,6 +74,7 @@ Step 2: Branching Decision
 CONSTRAINTS:
 - Do NOT load every skill up front.
 - Load skills ONLY after a skill is selected.
+- Do NOT reload a skill whose instructions already appear in this conversation.
 - Do NOT skip this check.
 - FAILURE to perform this check is an error.
 </mandatory_skill_check>


### PR DESCRIPTION
## Problem

Models sometimes re-invoke the `skill` tool for a skill whose instructions are already present in the conversation history. This wastes tokens and adds unnecessary tool call round-trips.

## Root Cause

The `<mandatory_skill_check>` instructions in the system prompt tell the model to check for applicable skills "before producing ANY user-facing response" but never say to skip if the skill is already loaded. The model sometimes complies literally and re-loads the same skill.

## Fix

Added a single deduplication constraint to the CONSTRAINTS block in `getSkillsSection()`:

```
- Do NOT reload a skill whose instructions already appear in this conversation.
```

One-line change. All existing tests pass.

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=2105d0df2cf2574022f105d80d9e49ecaf524af4&pr=11838&branch=fix%2Fskill-dedup-constraint)
<!-- roo-code-cloud-preview-end -->