### PR TITLE
chore(cli): prepare release v0.1.14

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.14] - 2026-03-03
+
+### Fixed
+
+- **Command Output Streaming**: Ensure full command output is streamed before the done event is emitted, preventing truncated output in stdin-stream mode.
+
 ## [0.1.13] - 2026-03-02
 
 ### Added

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.1.13",
+	"version": "0.1.14",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.14

This PR prepares the CLI release v0.1.14.

### Changes
- Version bump in package.json
- Changelog update

### Release Notes
- **Fixed**: Ensure full command output is streamed before the done event is emitted, preventing truncated output in stdin-stream mode.

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=007946eadccde295ca8c54e63119b00383d70a3c&pr=11843&branch=cli-release-v0.1.14)
<!-- roo-code-cloud-preview-end -->