### PR TITLE
chore(cli): prepare release v0.1.15

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.15] - 2026-03-03
+
+### Fixed
+
+- **Follow-up Routing for Completion Asks**: Fixed routing of follow-up messages when the agent asks for clarification (ask_followup_question) in stdin-stream mode. Messages sent after a completion ask are now correctly delivered to the agent instead of being queued.
+
 ## [0.1.14] - 2026-03-03
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.1.14",
+	"version": "0.1.15",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.15

This PR prepares the CLI release v0.1.15.

### Changes
- Version bump in package.json
- Changelog update

### Summary
- **Follow-up Routing for Completion Asks**: Fixed routing of follow-up messages when the agent asks for clarification (ask_followup_question) in stdin-stream mode.

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=028a37b8df13398522493c1b6f9558b11df53664&pr=11845&branch=cli-release-v0.1.15)
<!-- roo-code-cloud-preview-end -->