### PR TITLE
chore(cli): prepare release v0.1.16

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the `@roo-code/cli` package will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.16] - 2026-03-04
+
+### Added
+
+- **Custom Shell Selection**: New `--terminal-shell` flag to specify which shell to use for inline command execution. The shell path is validated at the CLI layer and passed through the standard settings mechanism.
+
+### Tests
+
+- Added integration coverage for stdin stream routing and race invariants.
+
 ## [0.1.15] - 2026-03-03
 
 ### Fixed

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@roo-code/cli",
-	"version": "0.1.15",
+	"version": "0.1.16",
 	"description": "Roo Code CLI - Run the Roo Code agent from the command line",
 	"private": true,
 	"type": "module",


### PR DESCRIPTION
## CLI Release v0.1.16

This PR prepares the CLI release v0.1.16.

### Changes
- Version bump in package.json
- Changelog update

### Summary
- **Added**: Custom shell selection via `--terminal-shell` flag
- **Tests**: Integration coverage for stdin stream routing/race invariants

### Checklist
- [x] Version number is correct
- [x] Changelog entry is complete and accurate
- [ ] All CI checks pass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=53ba9dfda8898866881aeff2f5d440c785538df8&pr=11852&branch=cli-release-v0.1.16)
<!-- roo-code-cloud-preview-end -->