### PR TITLE
feat: add ROO_ACTIVE env variable to terminal env settings

### DIFF
--- a/src/integrations/terminal/Terminal.ts
+++ b/src/integrations/terminal/Terminal.ts
@@ -152,6 +152,7 @@ export class Terminal extends BaseTerminal {
 
 	public static getEnv(): Record<string, string> {
 		const env: Record<string, string> = {
+			ROO_ACTIVE: "true",
 			PAGER: process.platform === "win32" ? "" : "cat",
 
 			// VTE must be disabled because it prevents the prompt command from executing

--- a/src/integrations/terminal/__tests__/TerminalRegistry.spec.ts
+++ b/src/integrations/terminal/__tests__/TerminalRegistry.spec.ts
@@ -46,6 +46,7 @@ describe("TerminalRegistry", () => {
 				iconPath: expect.any(Object),
 				env: {
 					PAGER,
+					ROO_ACTIVE: "true",
 					VTE_VERSION: "0",
 					PROMPT_EOL_MARK: "",
 				},
@@ -66,6 +67,7 @@ describe("TerminalRegistry", () => {
 					iconPath: expect.any(Object),
 					env: {
 						PAGER,
+						ROO_ACTIVE: "true",
 						PROMPT_COMMAND: "sleep 0.05",
 						VTE_VERSION: "0",
 						PROMPT_EOL_MARK: "",
@@ -88,6 +90,7 @@ describe("TerminalRegistry", () => {
 					iconPath: expect.any(Object),
 					env: {
 						PAGER,
+						ROO_ACTIVE: "true",
 						VTE_VERSION: "0",
 						PROMPT_EOL_MARK: "",
 						ITERM_SHELL_INTEGRATION_INSTALLED: "Yes",
@@ -109,6 +112,7 @@ describe("TerminalRegistry", () => {
 					iconPath: expect.any(Object),
 					env: {
 						PAGER,
+						ROO_ACTIVE: "true",
 						VTE_VERSION: "0",
 						PROMPT_EOL_MARK: "",
 						POWERLEVEL9K_TERM_SHELL_INTEGRATION: "true",


### PR DESCRIPTION
### Related GitHub Issue

Closes: #11864

### Roo Code Task Context (Optional)

N/A

### Description

Adds `ROO_ACTIVE: "true"` to the terminal environment variables in `Terminal.getEnv()`. This allows scripts and tools running inside Roo Code terminals to detect they are in a Roo Code session by checking the `ROO_ACTIVE` env variable, enabling safety guardrails against destructive operations initiated by Roo.

### Test Procedure

1. Open a Roo Code terminal
2. Run `echo $ROO_ACTIVE` — should output `true`
3. Verify other env variables (PAGER, VTE_VERSION) are unaffected

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [ ] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

<img width="1684" height="1027" alt="image" src="https://github.com/user-attachments/assets/597f984b-5b5a-4a3e-8b1a-a074a5018892" />


### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

Minimal one-line change to the env object in `getEnv()`.

### Get in Touch

<!-- Please provide your Discord username -->

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=fd23385b8fdc7dc529a091beb8c00f82fef28ff5&pr=11862&branch=feat%2Fadd-roo-active-env-var)
<!-- roo-code-cloud-preview-end -->