### PR TITLE
fix: add null check for inputValue in ChatTextArea

### DIFF
--- a/webview-ui/src/components/chat/ChatTextArea.tsx
+++ b/webview-ui/src/components/chat/ChatTextArea.tsx
@@ -245,7 +245,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 		}, [selectedType, searchQuery])
 
 		const handleEnhancePrompt = useCallback(() => {
-			const trimmedInput = inputValue.trim()
+			const trimmedInput = (inputValue || "").trim()
 
 			if (trimmedInput) {
 				setIsEnhancingPrompt(true)
@@ -259,7 +259,7 @@ export const ChatTextArea = forwardRef<HTMLTextAreaElement, ChatTextAreaProps>(
 
 		// Memoized check for whether the input has content (text or images)
 		const hasInputContent = useMemo(() => {
-			return inputValue.trim().length > 0 || selectedImages.length > 0
+			return (inputValue || "").trim().length > 0 || selectedImages.length > 0
 		}, [inputValue, selectedImages])
 
 		// Compute the key combination text for the send button tooltip based on enterBehavior


### PR DESCRIPTION
Fixes #11753

## Summary
Added defensive null checks for `inputValue` in `ChatTextArea.tsx` to prevent "Cannot read properties of undefined (reading 'trim')" error. The fix ensures the component handles undefined `inputValue` gracefully by using fallback values.

## Changes
- Modified `hasInputContent` useMemo to use `(inputValue || "").trim()` instead of `inputValue.trim()`
- Modified `handleEnhancePrompt` to use `(inputValue || "").trim()` instead of `inputValue.trim()`

## Testing
- Existing tests continue to pass with no modifications needed
- The change is backward compatible since empty strings and non-empty strings work correctly

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=3372288a9862f35a14fe24f0295eab5ace865d82&pr=11905&branch=fix%2Fissue-11753-inputvalue-trim-crash)
<!-- roo-code-cloud-preview-end -->