### PR TITLE
feat(cli): add openai provider support for OpenAI-compatible endpoints

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -215,9 +215,12 @@ The CLI will look for API keys in environment variables if not provided via `--a
 | roo               | `ROO_API_KEY`               |
 | anthropic         | `ANTHROPIC_API_KEY`         |
 | openai-native     | `OPENAI_API_KEY`            |
+| openai            | `OPENAI_API_KEY`            |
 | openrouter        | `OPENROUTER_API_KEY`        |
 | gemini            | `GOOGLE_API_KEY`            |
 | vercel-ai-gateway | `VERCEL_AI_GATEWAY_API_KEY` |
+
+The `openai` provider also reads `OPENAI_BASE_URL` to set a custom API endpoint (e.g., `http://localhost:8080/v1` for locally deployed models).
 
 **Authentication Environment Variables:**
 

--- a/apps/cli/src/lib/utils/provider.ts
+++ b/apps/cli/src/lib/utils/provider.ts
@@ -5,6 +5,7 @@ import type { SupportedProvider } from "@/types/index.js"
 const envVarMap: Record<SupportedProvider, string> = {
 	anthropic: "ANTHROPIC_API_KEY",
 	"openai-native": "OPENAI_API_KEY",
+	openai: "OPENAI_API_KEY",
 	gemini: "GOOGLE_API_KEY",
 	openrouter: "OPENROUTER_API_KEY",
 	"vercel-ai-gateway": "VERCEL_AI_GATEWAY_API_KEY",
@@ -35,6 +36,11 @@ export function getProviderSettings(
 		case "openai-native":
 			if (apiKey) config.openAiNativeApiKey = apiKey
 			if (model) config.apiModelId = model
+			break
+		case "openai":
+			if (apiKey) config.openAiApiKey = apiKey
+			if (model) config.openAiModelId = model
+			if (process.env.OPENAI_BASE_URL) config.openAiBaseUrl = process.env.OPENAI_BASE_URL
 			break
 		case "gemini":
 			if (apiKey) config.geminiApiKey = apiKey

--- a/apps/cli/src/types/types.ts
+++ b/apps/cli/src/types/types.ts
@@ -4,6 +4,7 @@ import type { OutputFormat } from "./json-events.js"
 export const supportedProviders = [
 	"anthropic",
 	"openai-native",
+	"openai",
 	"gemini",
 	"openrouter",
 	"vercel-ai-gateway",


### PR DESCRIPTION
## Summary

Adds the `openai` provider to the CLI's supported providers list, enabling use of OpenAI-compatible API endpoints. This allows the CLI to connect to locally deployed LLMs (vLLM, llama.cpp, Ollama, LM Studio, etc.) and any OpenAI-compatible inference server.

- Add `"openai"` to `supportedProviders` in `types.ts`
- Add `openai: "OPENAI_API_KEY"` to `envVarMap` in `provider.ts`
- Add `"openai"` case in `getProviderSettings()` with `OPENAI_BASE_URL` env var support
- Update README environment variable table

The `openai` provider already exists in `@roo-code/types` as a `customProvider` with full schema support (`openAiBaseUrl`, `openAiApiKey`, `openAiModelId`), and the core extension already handles it via `OpenAiHandler`. The CLI simply needed to expose it in its provider whitelist.

## Usage

```bash
export OPENAI_API_KEY=sk-local
export OPENAI_BASE_URL=http://localhost:8080/v1
roo --provider openai --model my-model "Hello"
```

Or via settings file (`~/.roo/cli-settings.json`):
```json
{
  "provider": "openai",
  "model": "my-model"
}
```

## Difference from `openai-native`

| | `openai` | `openai-native` |
|---|---|---|
| **API** | Chat Completions (`/v1/chat/completions`) | Responses API |
| **Custom base URL** | Yes, via `OPENAI_BASE_URL` | Limited |
| **Local LLMs** | Yes (vLLM, llama.cpp, Ollama, etc.) | No |
| **Settings fields** | `openAiBaseUrl`, `openAiApiKey`, `openAiModelId` | `openAiNativeApiKey` |

## Test plan

- [x] Verified locally with vLLM-MLX serving Qwen 3.5 122B on `http://127.0.0.1:8080/v1`
- [x] Confirmed `--provider openai --model <model> -k <key>` resolves correctly
- [x] Confirmed `OPENAI_API_KEY` and `OPENAI_BASE_URL` env vars are read
- [x] Type-checked: `"openai"` satisfies `ProviderName` (already in `customProviders`)

Closes #11917

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=1e9c05a54aa78c4e8527c8fea31847b60c5dcd3d&pr=11941&branch=feat%2Fcli-openai-provider)
<!-- roo-code-cloud-preview-end -->