### PR TITLE
fix(gemini): split model messages with mixed signed/unsigned thoughtSignature parts

### DIFF
--- a/src/api/transform/gemini-format.ts
+++ b/src/api/transform/gemini-format.ts
@@ -180,6 +180,17 @@ export function convertAnthropicContentToGemini(
 	return parts
 }
 
+/**
+ * Convert an Anthropic message to Gemini Content objects.
+ *
+ * For model (assistant) messages, Gemini requires that parts WITH thoughtSignature
+ * and parts WITHOUT are NOT mixed in the same Content. When a message contains
+ * both (e.g. text without signature + functionCall with signature), we split them
+ * into separate Content objects: unsigned first, signed second.
+ *
+ * Reference: https://ai.google.dev/gemini-api/docs/thought-signatures
+ * "Don't merge one part with a signature with another part without a signature"
+ */
 export function convertAnthropicMessageToGemini(
 	message: Anthropic.Messages.MessageParam,
 	options?: { includeThoughtSignatures?: boolean; toolIdToName?: Map<string, string> },
@@ -190,10 +201,23 @@ export function convertAnthropicMessageToGemini(
 		return []
 	}
 
-	return [
-		{
-			role: message.role === "assistant" ? "model" : "user",
-			parts,
-		},
-	]
+	const role = message.role === "assistant" ? "model" : "user"
+
+	// Only split model messages — user messages don't have thoughtSignature concerns
+	if (role === "model" && parts.length > 1) {
+		const signed = parts.filter((p) => "thoughtSignature" in p && (p as PartWithThoughtSignature).thoughtSignature)
+		const unsigned = parts.filter(
+			(p) => !("thoughtSignature" in p && (p as PartWithThoughtSignature).thoughtSignature),
+		)
+
+		if (signed.length > 0 && unsigned.length > 0) {
+			// Split: unsigned parts first (text), then signed parts (functionCall/thinking)
+			return [
+				{ role, parts: unsigned },
+				{ role, parts: signed },
+			]
+		}
+	}
+
+	return [{ role, parts }]
 }


### PR DESCRIPTION
## Problem

When Gemini thinking mode is enabled, assistant messages can contain both:
- Text parts **without** `thoughtSignature`
- `functionCall` parts **with** `thoughtSignature`

Gemini API rejects this mix with a 400 error.

From [Gemini thought signature docs](https://ai.google.dev/gemini-api/docs/thought-signatures):
> "Don't merge one part with a signature with another part without a signature"

## Fix

`convertAnthropicMessageToGemini()` now detects mixed signed/unsigned parts in model messages and splits them into two `Content` objects: unsigned first, signed second.

No caller changes needed — the function already returns `Content[]` and callers already use `.flat()`.

## Changes

- `src/api/transform/gemini-format.ts` — split logic in `convertAnthropicMessageToGemini()`

## Context

Same root cause as [LiteLLM #17949](https://github.com/BerriAI/litellm/issues/17949) (open 3+ months, affects all LiteLLM-based proxies). Fix documented in [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge).

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=dec135545e1b7cb0f508d9ecbc4081ddb602ea67&pr=11950&branch=fix%2Fgemini-split-mixed-thought-signature-parts)
<!-- roo-code-cloud-preview-end -->