### PR TITLE
feat: add xAI grok-4.20 models and update default (Fixes #11955)

### DIFF
--- a/packages/types/src/providers/xai.ts
+++ b/packages/types/src/providers/xai.ts
@@ -3,9 +3,36 @@ import type { ModelInfo } from "../model.js"
 // https://docs.x.ai/docs/api-reference
 export type XAIModelId = keyof typeof xaiModels
 
-export const xaiDefaultModelId: XAIModelId = "grok-code-fast-1"
+export const xaiDefaultModelId: XAIModelId = "grok-4.20-beta-0309-reasoning"
 
 export const xaiModels = {
+	"grok-4.20-beta-0309-reasoning": {
+		maxTokens: 65_536,
+		contextWindow: 2_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2.0,
+		outputPrice: 6.0,
+		cacheWritesPrice: 0.5,
+		cacheReadsPrice: 0.5,
+		description:
+			"xAI's Grok 4.20 reasoning model with 2M context. Reasoning is internal (not exposed via Chat Completions API).",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
+	},
+	"grok-4.20-beta-0309-non-reasoning": {
+		maxTokens: 65_536,
+		contextWindow: 2_000_000,
+		supportsImages: true,
+		supportsPromptCache: true,
+		inputPrice: 2.0,
+		outputPrice: 6.0,
+		cacheWritesPrice: 0.5,
+		cacheReadsPrice: 0.5,
+		description: "xAI's Grok 4.20 non-reasoning model - faster inference with 2M context.",
+		includedTools: ["search_replace"],
+		excludedTools: ["apply_diff"],
+	},
 	"grok-code-fast-1": {
 		maxTokens: 16_384,
 		contextWindow: 256_000,


### PR DESCRIPTION
### Related GitHub Issue
Closes: #11955

### Roo Code Task Context (Optional)
N/A

### Description

Add grok-4.20-beta-0309-reasoning and grok-4.20-beta-0309-non-reasoning to the xAI provider model list. These are xAI's latest flagship models with 2M context windows at $2/$6 per million tokens pricing.

Update the default model from grok-code-fast-1 to
grok-4.20-beta-0309-reasoning.

### Test Procedure

Built the extension and tested both models locally.

### Pre-Submission Checklist


- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue (see "Related GitHub Issue" above).
- [x] **Scope**: My changes are focused on the linked issue (one major feature/fix per PR).
- [x] **Self-Review**: I have performed a thorough self-review of my code.
- [x] **Testing**: New and/or updated tests have been added to cover my changes (if applicable).
- [x] **Documentation Impact**: I have considered if my changes require documentation updates (see "Documentation Updates" section below).
- [x] **Contribution Guidelines**: I have read and agree to the [Contributor Guidelines](/CONTRIBUTING.md).

### Screenshots / Videos

N/A

### Documentation Updates

Does this PR necessitate updates to user-facing documentation?
- [x] No documentation updates are required.
- [ ] Yes, documentation updates are required. (Please describe what needs to be updated or link to a PR in the docs repository).

### Additional Notes

Add the new 4.20 models of grok.

### Get in Touch

Discord username: `ecarlesso`

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=d154f433ac991b4f55bfcfd3cb776dac61a3c670&pr=11956&branch=feat%2Fadd-xai-grok-4.20-models)
<!-- roo-code-cloud-preview-end -->