### PR TITLE
fix: persist auto-approve detail settings immediately

### DIFF
--- a/webview-ui/src/components/settings/AutoApproveSettings.tsx
+++ b/webview-ui/src/components/settings/AutoApproveSettings.tsx
@@ -81,6 +81,31 @@ export const AutoApproveSettings = ({
 
 	const { effectiveAutoApprovalEnabled } = useAutoApprovalState(toggles, autoApprovalEnabled)
 
+	const syncAutoApproveSettings = (overrides: Partial<AutoApproveSettingsProps> = {}) => {
+		vscode.postMessage({
+			type: "updateSettings",
+			updatedSettings: {
+				alwaysAllowReadOnly: overrides.alwaysAllowReadOnly ?? alwaysAllowReadOnly ?? false,
+				alwaysAllowReadOnlyOutsideWorkspace:
+					overrides.alwaysAllowReadOnlyOutsideWorkspace ?? alwaysAllowReadOnlyOutsideWorkspace ?? false,
+				alwaysAllowWrite: overrides.alwaysAllowWrite ?? alwaysAllowWrite ?? false,
+				alwaysAllowWriteOutsideWorkspace:
+					overrides.alwaysAllowWriteOutsideWorkspace ?? alwaysAllowWriteOutsideWorkspace ?? false,
+				alwaysAllowWriteProtected: overrides.alwaysAllowWriteProtected ?? alwaysAllowWriteProtected ?? false,
+				alwaysAllowMcp: overrides.alwaysAllowMcp ?? alwaysAllowMcp ?? false,
+				alwaysAllowModeSwitch: overrides.alwaysAllowModeSwitch ?? alwaysAllowModeSwitch ?? false,
+				alwaysAllowSubtasks: overrides.alwaysAllowSubtasks ?? alwaysAllowSubtasks ?? false,
+				alwaysAllowExecute: overrides.alwaysAllowExecute ?? alwaysAllowExecute ?? false,
+				alwaysAllowFollowupQuestions:
+					overrides.alwaysAllowFollowupQuestions ?? alwaysAllowFollowupQuestions ?? false,
+				followupAutoApproveTimeoutMs:
+					overrides.followupAutoApproveTimeoutMs ?? followupAutoApproveTimeoutMs ?? 60000,
+				allowedMaxRequests: overrides.allowedMaxRequests ?? allowedMaxRequests ?? null,
+				allowedMaxCost: overrides.allowedMaxCost ?? allowedMaxCost ?? null,
+			},
+		})
+	}
+
 	const handleAddCommand = () => {
 		const currentCommands = allowedCommands ?? []
 
@@ -120,6 +145,7 @@ export const AutoApproveSettings = ({
 								const newValue = !(autoApprovalEnabled ?? false)
 								setAutoApprovalEnabled(newValue)
 								vscode.postMessage({ type: "autoApprovalEnabled", bool: newValue })
+								syncAutoApproveSettings()
 							}}>
 							<span className="font-medium">{t("settings:autoApprove.enabled")}</span>
 						</VSCodeCheckbox>
@@ -157,14 +183,23 @@ export const AutoApproveSettings = ({
 						alwaysAllowSubtasks={alwaysAllowSubtasks}
 						alwaysAllowExecute={alwaysAllowExecute}
 						alwaysAllowFollowupQuestions={alwaysAllowFollowupQuestions}
-						onToggle={(key, value) => setCachedStateField(key, value)}
+						onToggle={(key, value) => {
+							setCachedStateField(key, value)
+							syncAutoApproveSettings({ [key]: value })
+						}}
 					/>
 
 					<MaxLimitInputs
 						allowedMaxRequests={allowedMaxRequests}
 						allowedMaxCost={allowedMaxCost}
-						onMaxRequestsChange={(value) => setCachedStateField("allowedMaxRequests", value)}
-						onMaxCostChange={(value) => setCachedStateField("allowedMaxCost", value)}
+						onMaxRequestsChange={(value) => {
+							setCachedStateField("allowedMaxRequests", value)
+							syncAutoApproveSettings({ allowedMaxRequests: value })
+						}}
+						onMaxCostChange={(value) => {
+							setCachedStateField("allowedMaxCost", value)
+							syncAutoApproveSettings({ allowedMaxCost: value })
+						}}
 					/>
 				</div>
 
@@ -183,7 +218,12 @@ export const AutoApproveSettings = ({
 							<VSCodeCheckbox
 								checked={alwaysAllowReadOnlyOutsideWorkspace}
 								onChange={(e: any) =>
-									setCachedStateField("alwaysAllowReadOnlyOutsideWorkspace", e.target.checked)
+									{
+										setCachedStateField("alwaysAllowReadOnlyOutsideWorkspace", e.target.checked)
+										syncAutoApproveSettings({
+											alwaysAllowReadOnlyOutsideWorkspace: e.target.checked,
+										})
+									}
 								}
 								data-testid="always-allow-readonly-outside-workspace-checkbox">
 								<span className="font-medium">
@@ -210,7 +250,12 @@ export const AutoApproveSettings = ({
 							<VSCodeCheckbox
 								checked={alwaysAllowWriteOutsideWorkspace}
 								onChange={(e: any) =>
-									setCachedStateField("alwaysAllowWriteOutsideWorkspace", e.target.checked)
+									{
+										setCachedStateField("alwaysAllowWriteOutsideWorkspace", e.target.checked)
+										syncAutoApproveSettings({
+											alwaysAllowWriteOutsideWorkspace: e.target.checked,
+										})
+									}
 								}
 								data-testid="always-allow-write-outside-workspace-checkbox">
 								<span className="font-medium">
@@ -228,7 +273,12 @@ export const AutoApproveSettings = ({
 							<VSCodeCheckbox
 								checked={alwaysAllowWriteProtected}
 								onChange={(e: any) =>
-									setCachedStateField("alwaysAllowWriteProtected", e.target.checked)
+									{
+										setCachedStateField("alwaysAllowWriteProtected", e.target.checked)
+										syncAutoApproveSettings({
+											alwaysAllowWriteProtected: e.target.checked,
+										})
+									}
 								}
 								data-testid="always-allow-write-protected-checkbox">
 								<span className="font-medium">{t("settings:autoApprove.write.protected.label")}</span>
@@ -256,9 +306,10 @@ export const AutoApproveSettings = ({
 									max={300000}
 									step={1000}
 									value={[followupAutoApproveTimeoutMs]}
-									onValueChange={([value]) =>
+									onValueChange={([value]) => {
 										setCachedStateField("followupAutoApproveTimeoutMs", value)
-									}
+										syncAutoApproveSettings({ followupAutoApproveTimeoutMs: value })
+									}}
 									data-testid="followup-timeout-slider"
 								/>
 								<span className="w-20">{followupAutoApproveTimeoutMs / 1000}s</span>


### PR DESCRIPTION
## Summary

Fixes #12038 by persisting auto-approve detail settings immediately instead of leaving them only in the settings view cache.

## Root Cause

`autoApprovalEnabled` already syncs to the extension host immediately, but the related permission details in `AutoApproveSettings` were only stored in `SettingsView`'s local `cachedState` until the user explicitly saved settings.

That mismatch meant a second VS Code window could inherit the global auto-approve master toggle while still missing the actual per-action allowlist state, so Roo kept prompting for approvals.

## Fix

1. Add a small `syncAutoApproveSettings()` helper in `AutoApproveSettings.tsx`
2. Reuse it whenever auto-approve toggles, limits, or follow-up timeout settings change
3. Keep the change tightly scoped to the auto-approve settings surface so the rest of the settings workflow is unchanged

## Testing

- `git diff --check`
- Did not run project tests locally in this environment

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=4d62f8925d85f23f4f41e445e961c26cc7a85b56&pr=12049&branch=fix%2Fautoapprove-sync-suyua9)
<!-- roo-code-cloud-preview-end -->