### PR TITLE
feat: add FirePass kimi-k2p5-turbo router model

### DIFF
--- a/packages/types/src/providers/fireworks.ts
+++ b/packages/types/src/providers/fireworks.ts
@@ -77,10 +77,9 @@ export const fireworksModels = {
 		maxTokens: 16384,
 		contextWindow: 262144,
 		supportsImages: true,
-		supportsPromptCache: true,
+		supportsPromptCache: false,
 		inputPrice: 0,
 		outputPrice: 0,
-		cacheReadsPrice: 0,
 		description:
 			"Kimi K2.5 Turbo router - same configuration as kimi-k2p5 but with improved performance through Fireworks routing (FirePass - https://docs.fireworks.ai/firepass).",
 	},


### PR DESCRIPTION
Add `accounts/fireworks/routers/kimi-k2p5-turbo` to the Fireworks provider.

This router model uses FirePass seat-based pricing (zero cost per token) and provides improved performance through Fireworks routing.

Configuration copied from `kimi-k2p5` with:
- maxTokens: 16384
- contextWindow: 262144
- supportsImages: true
- supportsPromptCache: true
- inputPrice: 0
- outputPrice: 0
- cacheReadsPrice: 0

Documentation: https://docs.fireworks.ai/firepass

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=eb51e1117cfdc56c02ffb78dbb30c823ffd193e0&pr=12053&branch=add-firepass-kimi-k2p5-turbo)
<!-- roo-code-cloud-preview-end -->