### PR TITLE
feat(cli): improve CLI agent and command handling

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -190,6 +190,7 @@ Tokens are valid for 90 days. The CLI will prompt you to re-authenticate when yo
 | `-k, --api-key <key>`                   | API key for the LLM provider                                                            | From env var                             |
 | `--provider <provider>`                 | API provider (roo, anthropic, openai, openrouter, etc.)                                 | `openrouter` (or `roo` if authenticated) |
 | `-m, --model <model>`                   | Model to use                                                                            | `anthropic/claude-opus-4.6`              |
+| `-b, --base-url <url>`                  | Base URL for the LLM provider (e.g., for OpenAI-compatible APIs)                        | None                                     |
 | `--mode <mode>`                         | Mode to start in (code, architect, ask, debug, etc.)                                    | `code`                                   |
 | `--terminal-shell <path>`               | Absolute shell path for inline terminal command execution                               | Auto-detected shell                      |
 | `-r, --reasoning-effort <effort>`       | Reasoning effort level (unspecified, disabled, none, minimal, low, medium, high, xhigh) | `medium`                                 |

--- a/apps/cli/src/agent/extension-host.ts
+++ b/apps/cli/src/agent/extension-host.ts
@@ -71,6 +71,7 @@ export interface ExtensionHostOptions {
 	provider: SupportedProvider
 	apiKey?: string
 	model: string
+	baseUrl?: string
 	workspacePath: string
 	extensionPath: string
 	nonInteractive?: boolean
@@ -227,7 +228,12 @@ export class ExtensionHost extends EventEmitter implements ExtensionHostInterfac
 			experiments: {
 				customTools: true,
 			},
-			...getProviderSettings(this.options.provider, this.options.apiKey, this.options.model),
+			...getProviderSettings(
+				this.options.provider,
+				this.options.apiKey,
+				this.options.model,
+				this.options.baseUrl,
+			),
 		}
 
 		this.initialSettings = this.options.nonInteractive

--- a/apps/cli/src/commands/cli/run.ts
+++ b/apps/cli/src/commands/cli/run.ts
@@ -219,6 +219,7 @@ export async function run(promptArg: string | undefined, flagOptions: FlagOption
 		user: null,
 		provider: effectiveProvider,
 		model: effectiveModel,
+		baseUrl: flagOptions.baseUrl,
 		workspacePath: effectiveWorkspacePath,
 		extensionPath: path.resolve(flagOptions.extension || getDefaultExtensionPath(__dirname)),
 		nonInteractive: !effectiveRequireApproval,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -47,6 +47,7 @@ program
 	.option("-k, --api-key <key>", "API key for the LLM provider")
 	.option("--provider <provider>", "API provider (roo, anthropic, openai, openrouter, etc.)")
 	.option("-m, --model <model>", "Model to use", DEFAULT_FLAGS.model)
+	.option("-b, --base-url <url>", "Base URL for the LLM provider (e.g., for OpenAI-compatible APIs)")
 	.option("--mode <mode>", "Mode to start in (code, architect, ask, debug, etc.)", DEFAULT_FLAGS.mode)
 	.option("--terminal-shell <path>", "Absolute path to shell executable for inline terminal commands")
 	.option(

--- a/apps/cli/src/lib/utils/provider.ts
+++ b/apps/cli/src/lib/utils/provider.ts
@@ -5,6 +5,7 @@ import type { SupportedProvider } from "@/types/index.js"
 const envVarMap: Record<SupportedProvider, string> = {
 	anthropic: "ANTHROPIC_API_KEY",
 	"openai-native": "OPENAI_API_KEY",
+	openai: "OPENAI_API_KEY",
 	gemini: "GOOGLE_API_KEY",
 	openrouter: "OPENROUTER_API_KEY",
 	"vercel-ai-gateway": "VERCEL_AI_GATEWAY_API_KEY",
@@ -24,6 +25,7 @@ export function getProviderSettings(
 	provider: SupportedProvider,
 	apiKey: string | undefined,
 	model: string | undefined,
+	baseUrl: string | undefined,
 ): RooCodeSettings {
 	const config: RooCodeSettings = { apiProvider: provider }
 
@@ -32,17 +34,25 @@ export function getProviderSettings(
 			if (apiKey) config.apiKey = apiKey
 			if (model) config.apiModelId = model
 			break
+		case "openai":
+			if (apiKey) config.openAiApiKey = apiKey
+			if (model) config.openAiModelId = model
+			if (baseUrl) config.openAiBaseUrl = baseUrl
+			break
 		case "openai-native":
 			if (apiKey) config.openAiNativeApiKey = apiKey
 			if (model) config.apiModelId = model
+			if (baseUrl) config.openAiNativeBaseUrl = baseUrl
 			break
 		case "gemini":
 			if (apiKey) config.geminiApiKey = apiKey
 			if (model) config.apiModelId = model
+			if (baseUrl) config.googleGeminiBaseUrl = baseUrl
 			break
 		case "openrouter":
 			if (apiKey) config.openRouterApiKey = apiKey
 			if (model) config.openRouterModelId = model
+			if (baseUrl) config.openRouterBaseUrl = baseUrl
 			break
 		case "vercel-ai-gateway":
 			if (apiKey) config.vercelAiGatewayApiKey = apiKey
@@ -55,6 +65,7 @@ export function getProviderSettings(
 		default:
 			if (apiKey) config.apiKey = apiKey
 			if (model) config.apiModelId = model
+			if (baseUrl) config.openAiBaseUrl = baseUrl
 	}
 
 	return config

--- a/apps/cli/src/types/types.ts
+++ b/apps/cli/src/types/types.ts
@@ -4,6 +4,7 @@ import type { OutputFormat } from "./json-events.js"
 export const supportedProviders = [
 	"anthropic",
 	"openai-native",
+	"openai",
 	"gemini",
 	"openrouter",
 	"vercel-ai-gateway",
@@ -34,6 +35,7 @@ export type FlagOptions = {
 	apiKey?: string
 	provider?: SupportedProvider
 	model?: string
+	baseUrl?: string
 	mode?: string
 	terminalShell?: string
 	reasoningEffort?: ReasoningEffortFlagOptions


### PR DESCRIPTION
This PR adds `--base-url` (`-b`) CLI flag support for the Roo-Code CLI, enabling users to connect to OpenAI-compatible APIs and custom API endpoints. It also adds `openai` as a supported provider.

**Key changes:**
- Added `-b, --base-url <url>` CLI option to specify a custom base URL for LLM providers
- Added `openai` to the list of supported providers (`anthropic`, `openai-native`, `openai`, `gemini`, `openrouter`, `vercel-ai-gateway`)
- Updated `getProviderSettings()` in `provider.ts` to handle `baseUrl` for all applicable providers:
  - `openai`: `openAiBaseUrl`, `openAiApiKey`, `openAiModelId`
  - `openai-native`: `openAiNativeBaseUrl`
  - `gemini`: `googleGeminiBaseUrl`
  - `openrouter`: `openRouterBaseUrl`
- Updated `apps/cli/README.md` with the new flag documentation

**Design choices:**
- The `baseUrl` parameter is passed through the `ExtensionHostOptions` interface to maintain consistency with existing provider settings
- Default providers map to their respective base URL configurations, while custom URLs can be overridden via the CLI flag

### Test Procedure

1. **Lint check**: Run `pnpm lint` from the project root - all checks pass
2. **CLI flag test**:
   ```bash
   # Test with OpenAI-compatible API
   cd apps/cli && pnpm start -b https://api.openai.com/v1 -k $OPENAI_API_KEY --provider openai -m gpt-4o
   
   # Test with local LLM server (e.g., Ollama)
   cd apps/cli && pnpm start -b http://localhost:11434/v1 --provider openai -m llama3