### PR TITLE
fix: point .roomodes schema $id at the raw schema document (#12129)

### DIFF
--- a/packages/types/src/__tests__/roomodes-schema.spec.ts
+++ b/packages/types/src/__tests__/roomodes-schema.spec.ts
@@ -28,6 +28,10 @@ describe("roomodes JSON schema", () => {
 		expect(validate).toBeDefined()
 	})
 
+	it("should advertise a JSON-serving canonical $id", () => {
+		expect(schema["$id"]).toBe("https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/schemas/roomodes.json")
+	})
+
 	it("should accept a minimal valid .roomodes config", () => {
 		const config = {
 			customModes: [

--- a/packages/types/src/roomodes-schema.ts
+++ b/packages/types/src/roomodes-schema.ts
@@ -50,7 +50,7 @@ export function generateRoomodesJsonSchema(): Record<string, unknown> {
 		target: "jsonSchema7",
 	}) as Record<string, unknown>
 
-	jsonSchema["$id"] = "https://github.com/RooCodeInc/Roo-Code/blob/main/schemas/roomodes.json"
+	jsonSchema["$id"] = "https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/schemas/roomodes.json"
 	jsonSchema["title"] = "Roo Code Custom Modes"
 	jsonSchema["description"] = "Schema for .roomodes configuration files used by Roo Code to define custom modes."
 

--- a/schemas/roomodes.json
+++ b/schemas/roomodes.json
@@ -90,7 +90,7 @@
 	"required": ["customModes"],
 	"additionalProperties": false,
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"$id": "https://github.com/RooCodeInc/Roo-Code/blob/main/schemas/roomodes.json",
+	"$id": "https://raw.githubusercontent.com/RooCodeInc/Roo-Code/main/schemas/roomodes.json",
 	"title": "Roo Code Custom Modes",
 	"description": "Schema for .roomodes configuration files used by Roo Code to define custom modes."
 }


### PR DESCRIPTION
### Related GitHub Issue

Closes: #12129

### Description

This PR keeps the fix intentionally narrow and only addresses the canonical schema identity value exposed by the generated `.roomodes` schema.

The current generator sets `$id` to the GitHub blob URL:

- `https://github.com/RooCodeInc/Roo-Code/blob/main/schemas/roomodes.json`

That URL serves HTML, not the schema document itself. This PR changes the source-of-truth generator and the checked-in schema to use the raw JSON URL instead, and adds a regression assertion for the advertised `$id`.

**Why this scope is narrow:**
- no schema shape changes
- no runtime behavior changes
- no docs flow changes
- only the canonical schema URL metadata is corrected

**Files touched:**
- `packages/types/src/roomodes-schema.ts`
- `schemas/roomodes.json`
- `packages/types/src/__tests__/roomodes-schema.spec.ts`

### Test Procedure

- `pnpm --dir packages/types exec vitest run src/__tests__/roomodes-schema.spec.ts src/__tests__/roomodes-schema-sync.spec.ts`

Result locally:
- `2` test files passed
- `27` tests passed

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue.
- [x] **Scope**: Changes are focused on the linked issue.
- [x] **Self-Review**: I performed a self-review.
- [x] **Testing**: Added/updated tests for the changed behavior.
- [x] **Documentation Impact**: No user-facing documentation updates are required.
- [x] **Contribution Guidelines**: I reviewed the contribution guidelines.

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

This is intended as a low-risk follow-up to `#11790` / `#11791`, which fixed schema/content alignment but did not update the canonical `$id` to a JSON-serving URL.
