### PR TITLE
fix: stop replaying Anthropic thinking as visible xAI assistant text (#12128)

### DIFF
--- a/src/api/transform/__tests__/responses-api-input.spec.ts
+++ b/src/api/transform/__tests__/responses-api-input.spec.ts
@@ -280,6 +280,28 @@ describe("convertToResponsesApiInput", () => {
 				}),
 			)
 		})
+
+		it("should not replay Anthropic thinking blocks as assistant-visible text", () => {
+			const messages: Anthropic.Messages.MessageParam[] = [
+				{
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "SECRET_CHAIN_OF_THOUGHT", signature: "sig-1" } as any,
+						{ type: "text", text: "visible answer" },
+					],
+				},
+			]
+
+			const result = convertToResponsesApiInput(messages)
+
+			expect(result).toEqual([
+				{
+					type: "message",
+					role: "assistant",
+					content: [{ type: "output_text", text: "visible answer" }],
+				},
+			])
+		})
 	})
 
 	describe("multi-turn conversations", () => {

--- a/src/api/transform/responses-api-input.ts
+++ b/src/api/transform/responses-api-input.ts
@@ -53,14 +53,11 @@ export function convertToResponsesApiInput(messages: Anthropic.Messages.MessageP
 						})
 						break
 					case "thinking":
-						// Include reasoning if it has content
-						if ((part as any).thinking && (part as any).thinking.trim().length > 0) {
-							input.push({
-								type: "message",
-								role: "assistant",
-								content: [{ type: "output_text", text: `[Thinking] ${(part as any).thinking}` }],
-							})
-						}
+						// Anthropic thinking blocks represent hidden reasoning. The
+						// Responses API input format does not have a compatible hidden
+						// reasoning representation for these persisted blocks, so replaying
+						// them as normal assistant-visible text changes conversation
+						// semantics. Skip them instead of flattening them into output_text.
 						break
 				}
 			}


### PR DESCRIPTION
### Related GitHub Issue

Closes: #12128

### Description

This PR keeps the fix intentionally narrow and only addresses the replay behavior reported in `#12128`.

The current xAI Responses path reuses `convertToResponsesApiInput()` when replaying persisted conversation history. That helper was flattening Anthropic `thinking` blocks into ordinary assistant-visible `output_text` entries like `[Thinking] ...`, which changes the semantics of the saved history.

This PR changes the replay transform to **skip persisted Anthropic `thinking` blocks** instead of converting them into visible assistant text.

**Why this scope is narrow:**
- no provider selection changes
- no task persistence changes
- no attempt to invent a new hidden-reasoning format for Responses replay
- only the replay transform behavior is corrected, plus a regression test

**Files touched:**
- `src/api/transform/responses-api-input.ts`
- `src/api/transform/__tests__/responses-api-input.spec.ts`

### Test Procedure

- `pnpm --dir src exec vitest run api/transform/__tests__/responses-api-input.spec.ts api/providers/__tests__/xai.spec.ts`

Result locally:
- `2` test files passed
- `30` tests passed

### Pre-Submission Checklist

- [x] **Issue Linked**: This PR is linked to an approved GitHub Issue.
- [x] **Scope**: Changes are focused on the linked issue.
- [x] **Self-Review**: I performed a self-review.
- [x] **Testing**: Added/updated tests for the changed behavior.
- [x] **Documentation Impact**: No user-facing documentation updates are required.
- [x] **Contribution Guidelines**: I reviewed the contribution guidelines.

### Documentation Updates

- [x] No documentation updates are required.

### Additional Notes

I chose the narrowest behaviorally-safe fix I could see from the issue discussion: do not replay persisted Anthropic hidden reasoning as visible assistant text. If maintainers want a different provider-specific hidden-reasoning replay strategy later, this should still be a cleaner baseline than flattening `thinking` into `output_text`.
