### PR TITLE
fix: remove deprecated baseUrl from tsconfig files

### DIFF
--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -5,9 +5,8 @@
 		"outDir": "dist",
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
-		"baseUrl": ".",
 		"paths": {
-			"@/*": ["src/*"]
+			"@/*": ["./src/*"]
 		}
 	},
 	"include": ["src", "*.config.ts"],

--- a/webview-ui/tsconfig.json
+++ b/webview-ui/tsconfig.json
@@ -18,7 +18,6 @@
 		"isolatedModules": true,
 		"noEmit": true,
 		"jsx": "react-jsx",
-		"baseUrl": ".",
 		"paths": {
 			"@/*": ["./src/*"],
 			"@src/*": ["./src/*"],


### PR DESCRIPTION
Removes the deprecated `baseUrl` property from tsconfig files. The `baseUrl` option has been deprecated in TypeScript and can cause configuration warnings.

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=06d1b8cd76a0b5171434bfe8252fa01c0e1da5b7&pr=12154&branch=fix%2Ftsconfig-baseurl-deprecation)
<!-- roo-code-cloud-preview-end -->