### PR TITLE
fix: surface skill loading errors to users instead of silently dropping them

### DIFF
--- a/packages/types/src/skills.ts
+++ b/packages/types/src/skills.ts
@@ -21,6 +21,22 @@ export interface SkillMetadata {
 }
 
 /**
+ * Warning emitted when a skill fails to load during discovery.
+ * Collected by SkillsManager and surfaced to the UI so users know
+ * which skills were skipped and why.
+ */
+export interface SkillLoadWarning {
+	/** Directory name of the skill that failed to load */
+	skillName: string
+	/** Absolute path to the skill directory */
+	path: string
+	/** Whether this was a global or project skill */
+	source: "global" | "project"
+	/** Human-readable reason the skill was skipped */
+	reason: string
+}
+
+/**
  * Skill name validation constants per agentskills.io specification:
  * https://agentskills.io/specification
  *

--- a/packages/types/src/vscode-extension-host.ts
+++ b/packages/types/src/vscode-extension-host.ts
@@ -20,7 +20,7 @@ import type { GitCommit } from "./git.js"
 import type { McpServer } from "./mcp.js"
 import type { ModelRecord, RouterModels } from "./model.js"
 import type { OpenAiCodexRateLimitInfo } from "./providers/openai-codex-rate-limits.js"
-import type { SkillMetadata } from "./skills.js"
+import type { SkillMetadata, SkillLoadWarning } from "./skills.js"
 import type { WorktreeIncludeStatus } from "./worktree.js"
 
 /**
@@ -180,6 +180,7 @@ export interface ExtensionMessage {
 	organizationId?: string | null // For organizationSwitchResult
 	tools?: SerializedCustomToolDefinition[] // For customToolsResult
 	skills?: SkillMetadata[] // For skills response
+	skillLoadWarnings?: SkillLoadWarning[] // For skill load warnings
 	modes?: { slug: string; name: string }[] // For modes response
 	aggregatedCosts?: {
 		// For taskWithAggregatedCosts response

--- a/src/core/webview/__tests__/skillsMessageHandler.spec.ts
+++ b/src/core/webview/__tests__/skillsMessageHandler.spec.ts
@@ -47,6 +47,7 @@ describe("skillsMessageHandler", () => {
 	const mockLog = vi.fn()
 	const mockPostMessageToWebview = vi.fn()
 	const mockGetSkillsMetadata = vi.fn()
+	const mockGetLoadWarnings = vi.fn().mockReturnValue([])
 	const mockCreateSkill = vi.fn()
 	const mockDeleteSkill = vi.fn()
 	const mockMoveSkill = vi.fn()
@@ -57,6 +58,7 @@ describe("skillsMessageHandler", () => {
 		const skillsManager = hasSkillsManager
 			? {
 					getSkillsMetadata: mockGetSkillsMetadata,
+					getLoadWarnings: mockGetLoadWarnings,
 					createSkill: mockCreateSkill,
 					deleteSkill: mockDeleteSkill,
 					moveSkill: mockMoveSkill,
@@ -100,7 +102,7 @@ describe("skillsMessageHandler", () => {
 			const result = await handleRequestSkills(provider)
 
 			expect(result).toEqual(mockSkills)
-			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: mockSkills })
+			expect(mockPostMessageToWebview).toHaveBeenCalledWith({ type: "skills", skills: mockSkills, skillLoadWarnings: [] })
 		})
 
 		it("returns empty skills when skills manager is not available", async () => {

--- a/src/core/webview/skillsMessageHandler.ts
+++ b/src/core/webview/skillsMessageHandler.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode"
 
-import type { SkillMetadata, WebviewMessage } from "@roo-code/types"
+import type { SkillMetadata, SkillLoadWarning, WebviewMessage } from "@roo-code/types"
 
 import type { ClineProvider } from "./ClineProvider"
 import { openFile } from "../../integrations/misc/open-file"
@@ -16,7 +16,8 @@ export async function handleRequestSkills(provider: ClineProvider): Promise<Skil
 		const skillsManager = provider.getSkillsManager()
 		if (skillsManager) {
 			const skills = skillsManager.getSkillsMetadata()
-			await provider.postMessageToWebview({ type: "skills", skills })
+			const skillLoadWarnings = skillsManager.getLoadWarnings()
+			await provider.postMessageToWebview({ type: "skills", skills, skillLoadWarnings })
 			return skills
 		} else {
 			await provider.postMessageToWebview({ type: "skills", skills: [] })

--- a/src/services/skills/SkillsManager.ts
+++ b/src/services/skills/SkillsManager.ts
@@ -12,14 +12,16 @@ import {
 	validateSkillName as validateSkillNameShared,
 	SkillNameValidationError,
 	SKILL_NAME_MAX_LENGTH,
+	SkillLoadWarning,
 } from "@roo-code/types"
 import { t } from "../../i18n"
 
 // Re-export for convenience
-export type { SkillMetadata, SkillContent }
+export type { SkillMetadata, SkillContent, SkillLoadWarning }
 
 export class SkillsManager {
 	private skills: Map<string, SkillMetadata> = new Map()
+	private loadWarnings: SkillLoadWarning[] = []
 	private providerRef: WeakRef<ClineProvider>
 	private disposables: vscode.Disposable[] = []
 	private isDisposed = false
@@ -42,6 +44,7 @@ export class SkillsManager {
 	 */
 	async discoverSkills(): Promise<void> {
 		this.skills.clear()
+		this.loadWarnings = []
 		const skillsDirs = await this.getSkillsDirectories()
 
 		for (const { dir, source, mode } of skillsDirs) {
@@ -98,6 +101,8 @@ export class SkillsManager {
 		const skillMdPath = path.join(skillDir, "SKILL.md")
 		if (!(await fileExists(skillMdPath))) return
 
+		const effectiveSkillName = skillName || path.basename(skillDir)
+
 		try {
 			const fileContent = await fs.readFile(skillMdPath, "utf-8")
 
@@ -106,19 +111,24 @@ export class SkillsManager {
 
 			// Validate required fields (only name and description for now)
 			if (!frontmatter.name || typeof frontmatter.name !== "string") {
-				console.error(`Skill at ${skillDir} is missing required 'name' field`)
+				const reason = `Missing required 'name' field in frontmatter`
+				console.error(`Skill at ${skillDir}: ${reason}`)
+				this.loadWarnings.push({ skillName: effectiveSkillName, path: skillDir, source, reason })
 				return
 			}
 			if (!frontmatter.description || typeof frontmatter.description !== "string") {
-				console.error(`Skill at ${skillDir} is missing required 'description' field`)
+				const reason = `Missing required 'description' field in frontmatter`
+				console.error(`Skill at ${skillDir}: ${reason}`)
+				this.loadWarnings.push({ skillName: effectiveSkillName, path: skillDir, source, reason })
 				return
 			}
 
 			// Validate that frontmatter name matches the skill name (directory name or symlink name)
 			// Per the Agent Skills spec: "name field must match the parent directory name"
-			const effectiveSkillName = skillName || path.basename(skillDir)
 			if (frontmatter.name !== effectiveSkillName) {
-				console.error(`Skill name "${frontmatter.name}" doesn't match directory "${effectiveSkillName}"`)
+				const reason = `Frontmatter name "${frontmatter.name}" doesn't match directory name "${effectiveSkillName}"`
+				console.error(`Skill at ${skillDir}: ${reason}`)
+				this.loadWarnings.push({ skillName: effectiveSkillName, path: skillDir, source, reason })
 				return
 			}
 
@@ -126,7 +136,9 @@ export class SkillsManager {
 			const nameValidation = validateSkillNameShared(effectiveSkillName)
 			if (!nameValidation.valid) {
 				const errorMessage = this.getSkillNameErrorMessage(effectiveSkillName, nameValidation.error!)
-				console.error(`Skill name "${effectiveSkillName}" is invalid: ${errorMessage}`)
+				const reason = `Invalid skill name: ${errorMessage}`
+				console.error(`Skill "${effectiveSkillName}": ${reason}`)
+				this.loadWarnings.push({ skillName: effectiveSkillName, path: skillDir, source, reason })
 				return
 			}
 
@@ -135,9 +147,9 @@ export class SkillsManager {
 			// - non-empty (after trimming)
 			const description = frontmatter.description.trim()
 			if (description.length < 1 || description.length > 1024) {
-				console.error(
-					`Skill "${effectiveSkillName}" has an invalid description length: must be 1-1024 characters (got ${description.length})`,
-				)
+				const reason = `Invalid description length: must be 1-1024 characters (got ${description.length})`
+				console.error(`Skill "${effectiveSkillName}": ${reason}`)
+				this.loadWarnings.push({ skillName: effectiveSkillName, path: skillDir, source, reason })
 				return
 			}
 
@@ -171,7 +183,9 @@ export class SkillsManager {
 				modeSlugs, // New: array of mode slugs, undefined = any mode
 			})
 		} catch (error) {
-			console.error(`Failed to load skill at ${skillDir}:`, error)
+			const reason = `Failed to load skill: ${error instanceof Error ? error.message : String(error)}`
+			console.error(`Skill at ${skillDir}: ${reason}`)
+			this.loadWarnings.push({ skillName: effectiveSkillName, path: skillDir, source, reason })
 		}
 	}
 
@@ -256,6 +270,14 @@ export class SkillsManager {
 	 */
 	getAllSkills(): SkillMetadata[] {
 		return Array.from(this.skills.values())
+	}
+
+	/**
+	 * Get warnings collected during the last skill discovery.
+	 * Returns skills that failed to load with their specific error reasons.
+	 */
+	getLoadWarnings(): SkillLoadWarning[] {
+		return [...this.loadWarnings]
 	}
 
 	async getSkillContent(name: string, currentMode?: string): Promise<SkillContent | null> {
@@ -715,5 +737,6 @@ Add your skill instructions here.
 		this.disposables.forEach((d) => d.dispose())
 		this.disposables = []
 		this.skills.clear()
+		this.loadWarnings = []
 	}
 }

--- a/src/services/skills/__tests__/SkillsManager.spec.ts
+++ b/src/services/skills/__tests__/SkillsManager.spec.ts
@@ -1756,4 +1756,265 @@ Instructions`)
 			expect(mockRmdir).not.toHaveBeenCalled()
 		})
 	})
+
+	describe("getLoadWarnings", () => {
+		it("should collect warnings for skills with missing name field", async () => {
+			const invalidSkillDir = p(globalSkillsDir, "no-name-skill")
+			const invalidSkillMd = p(invalidSkillDir, "SKILL.md")
+
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) => {
+				if (dir === globalSkillsDir) return ["no-name-skill"]
+				return []
+			})
+			mockStat.mockImplementation(async (pathArg: string) => {
+				if (pathArg === invalidSkillDir) return { isDirectory: () => true }
+				throw new Error("Not found")
+			})
+			mockFileExists.mockImplementation(async (file: string) => file === invalidSkillMd)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === invalidSkillMd) {
+					return `---
+description: A skill without a name
+---
+
+# No Name Skill`
+				}
+				throw new Error("File not found")
+			})
+
+			await skillsManager.discoverSkills()
+
+			const warnings = skillsManager.getLoadWarnings()
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0].skillName).toBe("no-name-skill")
+			expect(warnings[0].source).toBe("global")
+			expect(warnings[0].reason).toContain("name")
+		})
+
+		it("should collect warnings for skills with mismatched name", async () => {
+			const mismatchedDir = p(globalSkillsDir, "my-skill")
+			const mismatchedMd = p(mismatchedDir, "SKILL.md")
+
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) => {
+				if (dir === globalSkillsDir) return ["my-skill"]
+				return []
+			})
+			mockStat.mockImplementation(async (pathArg: string) => {
+				if (pathArg === mismatchedDir) return { isDirectory: () => true }
+				throw new Error("Not found")
+			})
+			mockFileExists.mockImplementation(async (file: string) => file === mismatchedMd)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === mismatchedMd) {
+					return `---
+name: different-name
+description: Name doesn't match directory
+---
+
+# Mismatched`
+				}
+				throw new Error("File not found")
+			})
+
+			await skillsManager.discoverSkills()
+
+			const warnings = skillsManager.getLoadWarnings()
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0].skillName).toBe("my-skill")
+			expect(warnings[0].reason).toContain("doesn't match")
+		})
+
+		it("should collect warnings for skills with invalid name format", async () => {
+			const invalidDir = p(globalSkillsDir, "PDF-processing")
+			const invalidMd = p(invalidDir, "SKILL.md")
+
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) => {
+				if (dir === globalSkillsDir) return ["PDF-processing"]
+				return []
+			})
+			mockStat.mockImplementation(async (pathArg: string) => {
+				if (pathArg === invalidDir) return { isDirectory: () => true }
+				throw new Error("Not found")
+			})
+			mockFileExists.mockImplementation(async (file: string) => file === invalidMd)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === invalidMd) {
+					return `---
+name: PDF-processing
+description: Invalid name format
+---
+
+# Invalid Name`
+				}
+				throw new Error("File not found")
+			})
+
+			await skillsManager.discoverSkills()
+
+			const warnings = skillsManager.getLoadWarnings()
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0].skillName).toBe("PDF-processing")
+			expect(warnings[0].reason).toContain("Invalid skill name")
+		})
+
+		it("should collect warnings for skills with invalid description length", async () => {
+			const invalidDir = p(globalSkillsDir, "bad-desc")
+			const invalidMd = p(invalidDir, "SKILL.md")
+			const longDescription = "A".repeat(1025)
+
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) => {
+				if (dir === globalSkillsDir) return ["bad-desc"]
+				return []
+			})
+			mockStat.mockImplementation(async (pathArg: string) => {
+				if (pathArg === invalidDir) return { isDirectory: () => true }
+				throw new Error("Not found")
+			})
+			mockFileExists.mockImplementation(async (file: string) => file === invalidMd)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === invalidMd) {
+					return `---
+name: bad-desc
+description: ${longDescription}
+---
+
+# Bad Description`
+				}
+				throw new Error("File not found")
+			})
+
+			await skillsManager.discoverSkills()
+
+			const warnings = skillsManager.getLoadWarnings()
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0].skillName).toBe("bad-desc")
+			expect(warnings[0].reason).toContain("description length")
+		})
+
+		it("should return empty warnings when all skills load successfully", async () => {
+			const validDir = p(globalSkillsDir, "valid-skill")
+			const validMd = p(validDir, "SKILL.md")
+
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) => {
+				if (dir === globalSkillsDir) return ["valid-skill"]
+				return []
+			})
+			mockStat.mockImplementation(async (pathArg: string) => {
+				if (pathArg === validDir) return { isDirectory: () => true }
+				throw new Error("Not found")
+			})
+			mockFileExists.mockImplementation(async (file: string) => file === validMd)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === validMd) {
+					return `---
+name: valid-skill
+description: A valid skill
+---
+
+# Valid Skill`
+				}
+				throw new Error("File not found")
+			})
+
+			await skillsManager.discoverSkills()
+
+			const warnings = skillsManager.getLoadWarnings()
+			expect(warnings).toHaveLength(0)
+		})
+
+		it("should clear warnings on rediscovery", async () => {
+			const invalidDir = p(globalSkillsDir, "bad-skill")
+			const invalidMd = p(invalidDir, "SKILL.md")
+
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) => {
+				if (dir === globalSkillsDir) return ["bad-skill"]
+				return []
+			})
+			mockStat.mockImplementation(async (pathArg: string) => {
+				if (pathArg === invalidDir) return { isDirectory: () => true }
+				throw new Error("Not found")
+			})
+			mockFileExists.mockImplementation(async (file: string) => file === invalidMd)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === invalidMd) {
+					return `---
+description: Missing name field
+---
+
+# Bad Skill`
+				}
+				throw new Error("File not found")
+			})
+
+			await skillsManager.discoverSkills()
+			expect(skillsManager.getLoadWarnings()).toHaveLength(1)
+
+			// Rediscover with no skills directory
+			mockDirectoryExists.mockImplementation(async () => false)
+			await skillsManager.discoverSkills()
+			expect(skillsManager.getLoadWarnings()).toHaveLength(0)
+		})
+
+		it("should collect warnings for both valid and invalid skills simultaneously", async () => {
+			const validDir = p(globalSkillsDir, "good-skill")
+			const validMd = p(validDir, "SKILL.md")
+			const invalidDir = p(globalSkillsDir, "bad-skill")
+			const invalidMd = p(invalidDir, "SKILL.md")
+
+			mockDirectoryExists.mockImplementation(async (dir: string) => dir === globalSkillsDir)
+			mockRealpath.mockImplementation(async (pathArg: string) => pathArg)
+			mockReaddir.mockImplementation(async (dir: string) => {
+				if (dir === globalSkillsDir) return ["good-skill", "bad-skill"]
+				return []
+			})
+			mockStat.mockImplementation(async (pathArg: string) => {
+				if (pathArg === validDir || pathArg === invalidDir) return { isDirectory: () => true }
+				throw new Error("Not found")
+			})
+			mockFileExists.mockImplementation(async (file: string) => file === validMd || file === invalidMd)
+			mockReadFile.mockImplementation(async (file: string) => {
+				if (file === validMd) {
+					return `---
+name: good-skill
+description: A valid skill
+---
+
+# Good Skill`
+				}
+				if (file === invalidMd) {
+					return `---
+description: Missing name field
+---
+
+# Bad Skill`
+				}
+				throw new Error("File not found")
+			})
+
+			await skillsManager.discoverSkills()
+
+			// Valid skill should be loaded
+			const skills = skillsManager.getAllSkills()
+			expect(skills).toHaveLength(1)
+			expect(skills[0].name).toBe("good-skill")
+
+			// Invalid skill should produce a warning
+			const warnings = skillsManager.getLoadWarnings()
+			expect(warnings).toHaveLength(1)
+			expect(warnings[0].skillName).toBe("bad-skill")
+			expect(warnings[0].reason).toContain("name")
+		})
+	})
 })

--- a/webview-ui/src/components/settings/SkillsSettings.tsx
+++ b/webview-ui/src/components/settings/SkillsSettings.tsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react"
-import { Plus, Globe, Folder, Edit, Trash2, Settings } from "lucide-react"
+import { Plus, Globe, Folder, Edit, Trash2, Settings, AlertTriangle, ChevronDown, ChevronRight } from "lucide-react"
 import { Trans } from "react-i18next"
 
-import type { SkillMetadata } from "@roo-code/types"
+import type { SkillMetadata, SkillLoadWarning } from "@roo-code/types"
 
 import { getAllModes } from "@roo/modes"
 
@@ -35,12 +35,14 @@ import { CreateSkillDialog } from "./CreateSkillDialog"
 
 export const SkillsSettings: React.FC = () => {
 	const { t } = useAppTranslation()
-	const { cwd, skills: rawSkills, customModes } = useExtensionState()
+	const { cwd, skills: rawSkills, skillLoadWarnings: rawWarnings, customModes } = useExtensionState()
 	const skills = useMemo(() => rawSkills ?? [], [rawSkills])
+	const skillLoadWarnings = useMemo(() => rawWarnings ?? [], [rawWarnings])
 
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
 	const [skillToDelete, setSkillToDelete] = useState<SkillMetadata | null>(null)
 	const [createDialogOpen, setCreateDialogOpen] = useState(false)
+	const [warningsExpanded, setWarningsExpanded] = useState(false)
 
 	// Mode selection modal state
 	const [modeDialogOpen, setModeDialogOpen] = useState(false)
@@ -244,6 +246,36 @@ export const SkillsSettings: React.FC = () => {
 			{/* Scrollable List Area */}
 			<div className="flex-1 overflow-y-auto px-4 py-2 min-h-0">
 				<div className="flex flex-col gap-1">
+					{/* Load Warnings Section */}
+					{skillLoadWarnings.length > 0 && (
+						<div className="mx-2 mb-2 rounded-lg border border-vscode-inputValidation-warningBorder bg-vscode-inputValidation-warningBackground">
+							<button
+								className="flex items-center gap-2 w-full px-3 py-2 text-left text-sm font-medium text-vscode-inputValidation-warningForeground hover:opacity-80"
+								onClick={() => setWarningsExpanded(!warningsExpanded)}>
+								{warningsExpanded ? (
+									<ChevronDown className="size-4 shrink-0" />
+								) : (
+									<ChevronRight className="size-4 shrink-0" />
+								)}
+								<AlertTriangle className="size-4 shrink-0" />
+								<span>
+									{t("settings:skills.loadWarnings.title", { count: skillLoadWarnings.length })}
+								</span>
+							</button>
+							{warningsExpanded && (
+								<div className="px-3 pb-3 flex flex-col gap-1.5">
+									{skillLoadWarnings.map((warning, index) => (
+										<div key={index} className="text-xs text-vscode-descriptionForeground pl-6">
+											<span className="font-medium">{warning.skillName}</span>
+											<span className="opacity-70"> ({warning.source})</span>
+											<span>: {warning.reason}</span>
+										</div>
+									))}
+								</div>
+							)}
+						</div>
+					)}
+
 					{/* Project Skills Section - Only show if in a workspace */}
 					{hasWorkspace && (
 						<>

--- a/webview-ui/src/components/settings/SkillsSettings.tsx
+++ b/webview-ui/src/components/settings/SkillsSettings.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from "react"
 import { Plus, Globe, Folder, Edit, Trash2, Settings, AlertTriangle, ChevronDown, ChevronRight } from "lucide-react"
 import { Trans } from "react-i18next"
 
-import type { SkillMetadata, SkillLoadWarning } from "@roo-code/types"
+import type { SkillMetadata } from "@roo-code/types"
 
 import { getAllModes } from "@roo/modes"
 

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -14,6 +14,7 @@ import {
 	type ExtensionState,
 	type MarketplaceInstalledMetadata,
 	type SkillMetadata,
+	type SkillLoadWarning,
 	type Command,
 	type McpServer,
 	RouterModels,
@@ -144,6 +145,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	showWorktreesInHomeScreen: boolean
 	setShowWorktreesInHomeScreen: (value: boolean) => void
 	skills?: SkillMetadata[]
+	skillLoadWarnings?: SkillLoadWarning[]
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)
@@ -282,6 +284,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		global: {},
 	})
 	const [skills, setSkills] = useState<SkillMetadata[]>([])
+	const [skillLoadWarnings, setSkillLoadWarnings] = useState<SkillLoadWarning[]>([])
 	const [includeTaskHistoryInEnhance, setIncludeTaskHistoryInEnhance] = useState(true)
 	const [prevCloudIsAuthenticated, setPrevCloudIsAuthenticated] = useState(false)
 	const [includeCurrentTime, setIncludeCurrentTime] = useState(true)
@@ -395,6 +398,9 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 				case "skills": {
 					if (message.skills) {
 						setSkills(message.skills)
+					}
+					if (message.skillLoadWarnings) {
+						setSkillLoadWarnings(message.skillLoadWarnings)
 					}
 					break
 				}
@@ -606,6 +612,7 @@ export const ExtensionStateContextProvider: React.FC<{ children: React.ReactNode
 		includeCurrentCost,
 		setIncludeCurrentCost,
 		skills,
+		skillLoadWarnings,
 		showWorktreesInHomeScreen: state.showWorktreesInHomeScreen ?? true,
 		setShowWorktreesInHomeScreen: (value) =>
 			setState((prevState) => ({ ...prevState, showWorktreesInHomeScreen: value })),

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "La descripció és obligatòria",
 			"descriptionTooLong": "La descripció ha de tenir com a màxim 1024 caràcters"
 		},
-		"footer": "Crea les teves pròpies skills amb el mode Skill Writer, disponible al <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Crea les teves pròpies skills amb el mode Skill Writer, disponible al <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "Beschreibung ist erforderlich",
 			"descriptionTooLong": "Beschreibung muss 1024 Zeichen oder weniger sein"
 		},
-		"footer": "Erstelle deine eigenen Skills mit dem Skill Writer Modus, verfügbar im <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Erstelle deine eigenen Skills mit dem Skill Writer Modus, verfügbar im <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -150,7 +150,10 @@
 			"descriptionRequired": "Description is required",
 			"descriptionTooLong": "Description must be 1024 characters or less"
 		},
-		"footer": "Create your own skills with the Skill Writer mode, available in the <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Create your own skills with the Skill Writer mode, available in the <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	},
 	"ui": {
 		"collapseThinking": {

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "La descripción es obligatoria",
 			"descriptionTooLong": "La descripción debe tener como máximo 1024 caracteres"
 		},
-		"footer": "Crea tus propias skills con el modo Skill Writer, disponible en el <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Crea tus propias skills con el modo Skill Writer, disponible en el <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "La description est obligatoire",
 			"descriptionTooLong": "La description doit contenir au maximum 1024 caractères"
 		},
-		"footer": "Créez vos propres skills avec le mode Skill Writer, disponible dans le <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Créez vos propres skills avec le mode Skill Writer, disponible dans le <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "विवरण आवश्यक है",
 			"descriptionTooLong": "विवरण 1024 वर्णों से अधिक नहीं होना चाहिए"
 		},
-		"footer": "Skill Writer मोड के साथ अपने स्वयं के Skills बनाएं, <MarketplaceLink>Modes Marketplace</MarketplaceLink> में उपलब्ध।"
+		"footer": "Skill Writer मोड के साथ अपने स्वयं के Skills बनाएं, <MarketplaceLink>Modes Marketplace</MarketplaceLink> में उपलब्ध।",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "Deskripsi diperlukan",
 			"descriptionTooLong": "Deskripsi harus 1024 karakter atau kurang"
 		},
-		"footer": "Buat skills Anda sendiri dengan mode Skill Writer, tersedia di <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Buat skills Anda sendiri dengan mode Skill Writer, tersedia di <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "La descrizione è obbligatoria",
 			"descriptionTooLong": "La descrizione deve essere di massimo 1024 caratteri"
 		},
-		"footer": "Crea le tue skill con la modalità Skill Writer, disponibile in <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Crea le tue skill con la modalità Skill Writer, disponibile in <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "説明は必須です",
 			"descriptionTooLong": "説明は1024文字以内である必要があります"
 		},
-		"footer": "スキルライターモードで独自のスキルを作成します。<MarketplaceLink>モードマーケットプレイス</MarketplaceLink>で入手可能です。"
+		"footer": "スキルライターモードで独自のスキルを作成します。<MarketplaceLink>モードマーケットプレイス</MarketplaceLink>で入手可能です。",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "설명은 필수입니다",
 			"descriptionTooLong": "설명은 1024자 이하여야 합니다"
 		},
-		"footer": "스킬 작성자 모드로 자신만의 스킬을 만들 수 있습니다. <MarketplaceLink>모드 마켓플레이스</MarketplaceLink>에서 사용 가능합니다."
+		"footer": "스킬 작성자 모드로 자신만의 스킬을 만들 수 있습니다. <MarketplaceLink>모드 마켓플레이스</MarketplaceLink>에서 사용 가능합니다.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "Beschrijving is verplicht",
 			"descriptionTooLong": "Beschrijving moet maximaal 1024 tekens zijn"
 		},
-		"footer": "Maak je eigen skills met de Skill Writer modus, beschikbaar in de <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Maak je eigen skills met de Skill Writer modus, beschikbaar in de <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "Opis jest wymagany",
 			"descriptionTooLong": "Opis musi mieć maksymalnie 1024 znaki"
 		},
-		"footer": "Twórz własne umiejętności za pomocą trybu Skill Writer, dostępnego w <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Twórz własne umiejętności za pomocą trybu Skill Writer, dostępnego w <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "A descrição é obrigatória",
 			"descriptionTooLong": "A descrição deve ter no máximo 1024 caracteres"
 		},
-		"footer": "Crie suas próprias skills com o modo Skill Writer, disponível em <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Crie suas próprias skills com o modo Skill Writer, disponível em <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "Описание обязательно",
 			"descriptionTooLong": "Описание должно быть не более 1024 символов"
 		},
-		"footer": "Создавайте собственные навыки с режимом Skill Writer, доступным в <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Создавайте собственные навыки с режимом Skill Writer, доступным в <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "Açıklama gereklidir",
 			"descriptionTooLong": "Açıklama en fazla 1024 karakter olmalıdır"
 		},
-		"footer": "Skill Writer modu ile kendi becerilerinizi oluşturun. <MarketplaceLink>Modes Marketplace</MarketplaceLink>'de mevcut."
+		"footer": "Skill Writer modu ile kendi becerilerinizi oluşturun. <MarketplaceLink>Modes Marketplace</MarketplaceLink>'de mevcut.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "Mô tả là bắt buộc",
 			"descriptionTooLong": "Mô tả phải có tối đa 1024 ký tự"
 		},
-		"footer": "Tạo các skill của riêng bạn với chế độ Skill Writer, có sẵn tại <MarketplaceLink>Modes Marketplace</MarketplaceLink>."
+		"footer": "Tạo các skill của riêng bạn với chế độ Skill Writer, có sẵn tại <MarketplaceLink>Modes Marketplace</MarketplaceLink>.",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "描述为必填项",
 			"descriptionTooLong": "描述不得超过1024个字符"
 		},
-		"footer": "使用技能编写器模式创建您自己的技能，可在 <MarketplaceLink>模式市集</MarketplaceLink> 中获得。"
+		"footer": "使用技能编写器模式创建您自己的技能，可在 <MarketplaceLink>模式市集</MarketplaceLink> 中获得。",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -1010,6 +1010,9 @@
 			"descriptionRequired": "說明為必填",
 			"descriptionTooLong": "說明不得超過1024個字元"
 		},
-		"footer": "使用技能編寫器模式建立您自己的技能，可在 <MarketplaceLink>模式市集</MarketplaceLink> 中取得。"
+		"footer": "使用技能編寫器模式建立您自己的技能，可在 <MarketplaceLink>模式市集</MarketplaceLink> 中取得。",
+		"loadWarnings": {
+			"title": "{{count}} skill(s) failed to load"
+		}
 	}
 }


### PR DESCRIPTION
## Problem

When skills fail validation during discovery (missing frontmatter fields, name/directory mismatch, invalid name format, bad description length), the errors were only logged to `console.error()` with no user-facing feedback. Users had no way to know why their skills were not appearing in Settings → Skills.

Fixes #12194

## Changes

- **`packages/types/src/skills.ts`**: Added `SkillLoadWarning` interface to track failed skills with their specific error reasons
- **`packages/types/src/vscode-extension-host.ts`**: Added `skillLoadWarnings` field to `ExtensionMessage` for webview communication
- **`src/services/skills/SkillsManager.ts`**: 
  - Added `loadWarnings` array to collect warnings during discovery
  - Modified `loadSkillMetadata()` to push structured warnings instead of silent `console.error()`
  - Added `getLoadWarnings()` method to expose warnings
  - Clear warnings on `discoverSkills()` and `dispose()`
- **`src/core/webview/skillsMessageHandler.ts`**: Send `skillLoadWarnings` alongside skills metadata in `handleRequestSkills()`
- **`webview-ui/src/context/ExtensionStateContext.tsx`**: Added `skillLoadWarnings` state management and message handling
- **`webview-ui/src/components/settings/SkillsSettings.tsx`**: Added collapsible warning banner UI with AlertTriangle icon, showing each failed skill name, source, and reason
- **`webview-ui/src/i18n/locales/en/settings.json`**: Added `loadWarnings.title` translation
- **`src/services/skills/__tests__/SkillsManager.spec.ts`**: Added 7 new test cases covering all warning scenarios

## Testing

All 53 tests pass (46 existing + 7 new):
- Missing name field → warning collected
- Mismatched name/directory → warning collected  
- Invalid name format → warning collected
- Invalid description length → warning collected
- Valid skills → no warnings
- Rediscovery clears warnings
- Mixed valid/invalid skills → correct warnings + valid skills still loaded

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=351fa14b9d4f30bb2de4f73c4eed34110e176158&pr=12198&branch=fix%2Fskill-loading-warnings)
<!-- roo-code-cloud-preview-end -->