### PR TITLE
fix(apply_diff): detect malformed `-------` separator and surface helpful error (#12210)

### DIFF
--- a/.changeset/fix-apply-diff-malformed-separator.md
+++ b/.changeset/fix-apply-diff-malformed-separator.md
@@ -1,0 +1,5 @@
+---
+"roo-cline": patch
+---
+
+apply_diff: detect a malformed `-------` separator in the SEARCH section (e.g. `-------import { ... }` with no trailing newline) and surface a clear "Malformed separator" error instead of the generic "63% similar" mismatch. Smaller models that occasionally emit this shape can now self-correct on the next attempt instead of looping. Closes #12210.

--- a/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
+++ b/src/core/diff/strategies/__tests__/multi-search-replace.spec.ts
@@ -1204,4 +1204,80 @@ function sum(a, b) {
 			expect(result.error).toContain(":start_line:5    <-- Invalid location")
 		})
 	})
+
+	// Regression for https://github.com/RooCodeInc/Roo-Code/issues/12210.
+	describe("malformed `-------` separator detection", () => {
+		let strategy: MultiSearchReplaceDiffStrategy
+
+		beforeEach(() => {
+			strategy = new MultiSearchReplaceDiffStrategy(1.0, 5)
+		})
+
+		it("returns a 'malformed separator' error when LLM omits the newline after -------", async () => {
+			const originalContent =
+				"import { useTranslate } from '../../i18n/I18nContext';\n" +
+				"\n" +
+				"type MouseMode = 'draw' | 'erase';\n"
+			const diffContent =
+				"<<<<<<< SEARCH\n" +
+				":start_line:1\n" +
+				"-------import { useTranslate } from '../../i18n/I18nContext';\n" +
+				"\n" +
+				"type MouseMode\n" +
+				"=======\n" +
+				"import { useTranslate } from '../../i18n/I18nContext';\n" +
+				"import { MaskEditorProvider, useMaskEditor } from './MaskEditorContext';\n" +
+				"\n" +
+				"type MouseMode\n" +
+				">>>>>>> REPLACE"
+
+			const result = await strategy.applyDiff(originalContent, diffContent)
+			expect(result.success).toBe(false)
+			if (!result.success) {
+				const parts = result.failParts ?? []
+				const errors = parts
+					.filter((part) => part.success === false)
+					.map((part) => ("error" in part ? (part.error ?? "") : ""))
+					.concat("error" in result ? (result.error ?? "") : "")
+					.join(" ")
+				expect(errors).toContain("Malformed separator")
+				expect(errors).toContain("must be on its own line")
+				expect(errors).not.toContain("63%")
+				expect(errors).not.toContain("similar")
+			}
+		})
+
+		it("does not flag a well-formed -------\\n separator", async () => {
+			const originalContent = "function hello() {\n    console.log('hello')\n}\n"
+			const diffContent =
+				"<<<<<<< SEARCH\n" +
+				":start_line:1\n" +
+				"-------\n" +
+				"function hello() {\n" +
+				"=======\n" +
+				"function helloWorld() {\n" +
+				">>>>>>> REPLACE"
+
+			const result = await strategy.applyDiff(originalContent, diffContent)
+			expect(result.success).toBe(true)
+			if (result.success) {
+				expect(result.content).toBe("function helloWorld() {\n    console.log('hello')\n}\n")
+			}
+		})
+
+		it("does not flag a search line that legitimately contains many dashes", async () => {
+			const originalContent = "/* ---------- header ---------- */\nconst x = 1;\n"
+			const diffContent =
+				"<<<<<<< SEARCH\n" +
+				":start_line:1\n" +
+				"-------\n" +
+				"/* ---------- header ---------- */\n" +
+				"=======\n" +
+				"/* === header === */\n" +
+				">>>>>>> REPLACE"
+
+			const result = await strategy.applyDiff(originalContent, diffContent)
+			expect(result.success).toBe(true)
+		})
+	})
 })

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -8,6 +8,45 @@ import { normalizeString } from "../../../utils/text-normalization"
 
 const BUFFER_LINES = 40 // Number of extra context lines to show before and after matches
 
+/**
+ * Detect a malformed `-------` separator in the SEARCH section content.
+ *
+ * If the LLM forgets the newline after the separator, the run-on line
+ * (e.g. `-------import { ... }`) ends up as the first line of the
+ * captured search content. The outer regex doesn't reject this — it
+ * just falls through, and the file-content match fails with a
+ * confusing "63% similar" error. By detecting the malformed prefix
+ * here we can return an actionable error instead.
+ *
+ * Returns the offending line when malformed, or `null` otherwise.
+ *
+ * Regression test for https://github.com/RooCodeInc/Roo-Code/issues/12210.
+ */
+function detectMalformedSeparator(searchContent: string): string | null {
+	if (!searchContent) {
+		return null
+	}
+	const firstLine = searchContent.split(/\r?\n/, 1)[0] ?? ""
+	const trimmed = firstLine.trim()
+	// Must start with at least seven dashes (the separator) AND have
+	// non-dash, non-whitespace content immediately after them on the
+	// same line. A bare `-------` (separator on its own line that
+	// happened to land in the search content for unrelated reasons) is
+	// not flagged.
+	const match = trimmed.match(/^-{7,}(.+)$/)
+	if (!match) {
+		return null
+	}
+	const tail = match[1].trim()
+	// Allow lines that start with a literal `-` continuation (e.g.
+	// markdown bullets that begin with extra dashes) — they wouldn't
+	// look like the separator-then-code shape that confuses callers.
+	if (tail === "" || /^-+$/.test(tail)) {
+		return null
+	}
+	return firstLine
+}
+
 function getSimilarity(original: string, search: string): number {
 	// Empty searches are no longer supported
 	if (search === "") {
@@ -320,6 +359,31 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 			// First unescape any escaped markers in the content
 			searchContent = this.unescapeMarkers(searchContent)
 			replaceContent = this.unescapeMarkers(replaceContent)
+
+			// Detect the specific malformation flagged in #12210: an
+			// unescaped `-------` separator that lacks the trailing
+			// newline (e.g. `-------import { ... }`). The outer regex
+			// makes the separator group optional, so the search content
+			// silently absorbs the run-on line and matching fails with
+			// a confusing "63% similar" error. Surface the actual root
+			// cause so the model can self-correct.
+			const malformedSeparator = detectMalformedSeparator(searchContent)
+			if (malformedSeparator) {
+				diffResults.push({
+					success: false,
+					error:
+						`Malformed separator in SEARCH section\n\n` +
+						`Debug Info:\n` +
+						`- The "-------" separator that follows :start_line:/:end_line: must be on its own line, followed by a newline before the search content begins.\n` +
+						`- Got: ${JSON.stringify(malformedSeparator)}\n` +
+						`- Expected:\n` +
+						`    :start_line:7\n` +
+						`    -------\n` +
+						`    <search content here>\n` +
+						`- Tip: insert a newline immediately after "-------". Do not put the first line of search content on the same line as the separator.`,
+				})
+				continue
+			}
 
 			// Strip line numbers from search and replace content if every line starts with a line number
 			const hasAllLineNumbers =

--- a/src/core/diff/strategies/multi-search-replace.ts
+++ b/src/core/diff/strategies/multi-search-replace.ts
@@ -13,7 +13,7 @@ const BUFFER_LINES = 40 // Number of extra context lines to show before and afte
  *
  * If the LLM forgets the newline after the separator, the run-on line
  * (e.g. `-------import { ... }`) ends up as the first line of the
- * captured search content. The outer regex doesn't reject this — it
+ * captured search content. The outer regex doesn't reject this, it
  * just falls through, and the file-content match fails with a
  * confusing "63% similar" error. By detecting the malformed prefix
  * here we can return an actionable error instead.
@@ -39,7 +39,7 @@ function detectMalformedSeparator(searchContent: string): string | null {
 	}
 	const tail = match[1].trim()
 	// Allow lines that start with a literal `-` continuation (e.g.
-	// markdown bullets that begin with extra dashes) — they wouldn't
+	// markdown bullets that begin with extra dashes), they wouldn't
 	// look like the separator-then-code shape that confuses callers.
 	if (tail === "" || /^-+$/.test(tail)) {
 		return null
@@ -302,7 +302,7 @@ export class MultiSearchReplaceDiffStrategy implements DiffStrategy {
 			  Ensures the first marker starts at the beginning of the file or right after a newline.
 
 			2. (?<!\\)<<<<<<< SEARCH\s*\n  
-			  Matches the line "<<<<<<< SEARCH" (ignoring any trailing spaces) – the negative lookbehind makes sure it isn't escaped.
+			  Matches the line "<<<<<<< SEARCH" (ignoring any trailing spaces), the negative lookbehind makes sure it isn't escaped.
 
 			3. ((?:\:start_line:\s*(\d+)\s*\n))?  
 			  Optionally matches a ":start_line:" line. The outer capturing group is group 1 and the inner (\d+) is group 2.


### PR DESCRIPTION
Closes #12210.

## Summary
Smaller models (Qwen 3.6 in the issue) sometimes emit an apply_diff payload where the `-------` separator is missing its trailing newline:
```
<<<<<<< SEARCH
:start_line:7
-------import { useTranslate } from '...';
...
```
The outer regex makes the separator group optional, so the run-on line is silently absorbed into the search content. Roo then reports:
```
No sufficiently similar match found at line: 7 (63% similar, needs 100%)
```
which sends the model into a loop, trying the same malformation again. The reporter notes the model can recover *if* told what's wrong, so a clearer error fixes the cause of the loop.

## Change
Add `detectMalformedSeparator(searchContent)` that runs against each replacement's search content right after marker unescaping. Flags first lines that start with seven-or-more dashes followed by non-dash, non-whitespace content on the same line. Returns the offending line so the error message can quote it; otherwise returns `null` and the existing flow continues unchanged.

When malformed, emit:
```
Malformed separator in SEARCH section

Debug Info:
- The "-------" separator that follows :start_line:/:end_line: must be on its own line, followed by a newline before the search content begins.
- Got: "-------import { useTranslate } from '...';"
- Expected:
    :start_line:7
    -------
    <search content here>
- Tip: insert a newline immediately after "-------". Do not put the first line of search content on the same line as the separator.
```

False-positive guards: a search line that legitimately contains a long row of dashes inside the file content (markdown HR, comment header like `/* ---------- header ---------- */`) is NOT flagged because the helper requires a non-dash, non-whitespace tail.

## Test plan
Three regression tests under `malformed \`-------\` separator detection`:
- [x] Exact repro from the issue → \"Malformed separator\" + \"must be on its own line\" surfaced; the unhelpful \"63% similar\" message no longer appears.
- [x] Well-formed `-------\n` separator still applies cleanly.
- [x] SEARCH content with a long row of dashes inside the file is NOT misclassified.

Results:
- [x] `pnpm vitest run core/diff/strategies/__tests__/` → **66 passed; 0 failed** (3 new + 63 existing).
- [x] `pnpm run check-types` → all 14 tasks pass.

## Notes
- No production-path behavior change for well-formed diffs.
- Per-replacement (inside the `for (const replacement of replacements)` loop), so other replacements in the same diff still apply normally if only one is malformed.
- Changeset added under `.changeset/fix-apply-diff-malformed-separator.md` (patch).

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=1efc0cb4c30c1de4eeaea97157573f688dc245fb&pr=12213&branch=fix%2Fapply-diff-malformed-separator-12210)
<!-- roo-code-cloud-preview-end -->