### PR TITLE
Update Roo Router retired provider refund copy

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -114,7 +114,7 @@ export function buildApiHandler(configuration: ProviderSettings): ApiHandler {
 	if (apiProvider && isRetiredProvider(apiProvider)) {
 		const retiredProviderMessage =
 			apiProvider === "roo"
-				? "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+				? "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 				: "This provider is no longer supported."
 
 		throw new Error(`${retiredProviderMessage}\n\nPlease select a different provider in your API profile settings.`)

--- a/webview-ui/src/i18n/locales/ca/chat.json
+++ b/webview-ui/src/i18n/locales/ca/chat.json
@@ -486,6 +486,6 @@
 		"title": "Proveïdor ja no compatible",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Obrir configuració",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Com a part de la nostra decisió de retirar l'extensió Roo Code, també vam tancar Roo Code Router, que només existia per donar suport a l'extensió. Si tenies saldo sense utilitzar, hauries d'haver rebut un correu electrònic de billing@roocode.com sobre un reemborsament."
 	}
 }

--- a/webview-ui/src/i18n/locales/ca/chat.json
+++ b/webview-ui/src/i18n/locales/ca/chat.json
@@ -486,6 +486,6 @@
 		"title": "Proveïdor ja no compatible",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Obrir configuració",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Tokens màxims de sortida",
 			"maxTokensDescription": "Nombre màxim de tokens de sortida per a les respostes de Claude Code. El valor per defecte és 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Com a part de la nostra decisió de retirar l'extensió Roo Code, també vam tancar Roo Code Router, que només existia per donar suport a l'extensió. Si tenies saldo sense utilitzar, hauries d'haver rebut un correu electrònic de billing@roocode.com sobre un reemborsament."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/ca/settings.json
+++ b/webview-ui/src/i18n/locales/ca/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Tokens màxims de sortida",
 			"maxTokensDescription": "Nombre màxim de tokens de sortida per a les respostes de Claude Code. El valor per defecte és 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/de/chat.json
+++ b/webview-ui/src/i18n/locales/de/chat.json
@@ -486,6 +486,6 @@
 		"title": "Anbieter wird nicht mehr unterstützt",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Einstellungen öffnen",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Im Zuge unserer Entscheidung, die Roo Code-Erweiterung einzustellen, haben wir auch den Roo Code Router eingestellt, der nur zur Unterstützung der Erweiterung existierte. Wenn du ungenutztes Guthaben hattest, solltest du eine E-Mail von billing@roocode.com zu einer Rückerstattung erhalten haben."
 	}
 }

--- a/webview-ui/src/i18n/locales/de/chat.json
+++ b/webview-ui/src/i18n/locales/de/chat.json
@@ -486,6 +486,6 @@
 		"title": "Anbieter wird nicht mehr unterstützt",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Einstellungen öffnen",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Maximale Ausgabe-Tokens",
 			"maxTokensDescription": "Maximale Anzahl an Ausgabe-Tokens für Claude Code-Antworten. Standard ist 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Im Zuge unserer Entscheidung, die Roo Code-Erweiterung einzustellen, haben wir auch den Roo Code Router eingestellt, der nur zur Unterstützung der Erweiterung existierte. Wenn du ungenutztes Guthaben hattest, solltest du eine E-Mail von billing@roocode.com zu einer Rückerstattung erhalten haben."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/de/settings.json
+++ b/webview-ui/src/i18n/locales/de/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Maximale Ausgabe-Tokens",
 			"maxTokensDescription": "Maximale Anzahl an Ausgabe-Tokens für Claude Code-Antworten. Standard ist 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/en/chat.json
+++ b/webview-ui/src/i18n/locales/en/chat.json
@@ -479,6 +479,6 @@
 		"title": "Provider no longer supported",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Open Settings",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/en/settings.json
+++ b/webview-ui/src/i18n/locales/en/settings.json
@@ -608,7 +608,7 @@
 			"maxTokensLabel": "Max Output Tokens",
 			"maxTokensDescription": "Maximum number of output tokens for Claude Code responses. Default is 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/es/chat.json
+++ b/webview-ui/src/i18n/locales/es/chat.json
@@ -486,6 +486,6 @@
 		"title": "Proveedor ya no compatible",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Abrir configuración",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Como parte de nuestra decisión de retirar la extensión Roo Code, también finalizamos Roo Code Router, que solo existía para dar soporte a la extensión. Si tenías saldo sin usar, deberías haber recibido un correo de billing@roocode.com sobre un reembolso."
 	}
 }

--- a/webview-ui/src/i18n/locales/es/chat.json
+++ b/webview-ui/src/i18n/locales/es/chat.json
@@ -486,6 +486,6 @@
 		"title": "Proveedor ya no compatible",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Abrir configuración",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Tokens máximos de salida",
 			"maxTokensDescription": "Número máximo de tokens de salida para las respuestas de Claude Code. El valor predeterminado es 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/es/settings.json
+++ b/webview-ui/src/i18n/locales/es/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Tokens máximos de salida",
 			"maxTokensDescription": "Número máximo de tokens de salida para las respuestas de Claude Code. El valor predeterminado es 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Como parte de nuestra decisión de retirar la extensión Roo Code, también finalizamos Roo Code Router, que solo existía para dar soporte a la extensión. Si tenías saldo sin usar, deberías haber recibido un correo de billing@roocode.com sobre un reembolso."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/fr/chat.json
+++ b/webview-ui/src/i18n/locales/fr/chat.json
@@ -486,6 +486,6 @@
 		"title": "Fournisseur plus pris en charge",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Ouvrir les paramètres",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/fr/chat.json
+++ b/webview-ui/src/i18n/locales/fr/chat.json
@@ -486,6 +486,6 @@
 		"title": "Fournisseur plus pris en charge",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Ouvrir les paramètres",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Dans le cadre de notre décision de mettre fin à l'extension Roo Code, nous avons également arrêté Roo Code Router, qui n'existait que pour prendre en charge l'extension. Si vous aviez un solde inutilisé, vous devriez avoir reçu un e-mail de billing@roocode.com au sujet d'un remboursement."
 	}
 }

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Jetons de sortie max",
 			"maxTokensDescription": "Nombre maximum de jetons de sortie pour les réponses de Claude Code. La valeur par défaut est 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Dans le cadre de notre décision de mettre fin à l'extension Roo Code, nous avons également arrêté Roo Code Router, qui n'existait que pour prendre en charge l'extension. Si vous aviez un solde inutilisé, vous devriez avoir reçu un e-mail de billing@roocode.com au sujet d'un remboursement."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/fr/settings.json
+++ b/webview-ui/src/i18n/locales/fr/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Jetons de sortie max",
 			"maxTokensDescription": "Nombre maximum de jetons de sortie pour les réponses de Claude Code. La valeur par défaut est 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/hi/chat.json
+++ b/webview-ui/src/i18n/locales/hi/chat.json
@@ -486,6 +486,6 @@
 		"title": "प्रदाता अब समर्थित नहीं है",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "सेटिंग्स खोलें",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Roo Code एक्सटेंशन को बंद करने के हमारे निर्णय के हिस्से के रूप में, हमने Roo Code Router को भी बंद कर दिया, जो केवल एक्सटेंशन का समर्थन करने के लिए मौजूद था। यदि आपके पास कोई अप्रयुक्त शेष राशि थी, तो आपको रिफंड के बारे में billing@roocode.com से ईमेल प्राप्त हुआ होगा।"
 	}
 }

--- a/webview-ui/src/i18n/locales/hi/chat.json
+++ b/webview-ui/src/i18n/locales/hi/chat.json
@@ -486,6 +486,6 @@
 		"title": "प्रदाता अब समर्थित नहीं है",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "सेटिंग्स खोलें",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "अधिकतम आउटपुट टोकन",
 			"maxTokensDescription": "Claude Code प्रतिक्रियाओं के लिए आउटपुट टोकन की अधिकतम संख्या। डिफ़ॉल्ट 8000 है।"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Roo Code एक्सटेंशन को बंद करने के हमारे निर्णय के हिस्से के रूप में, हमने Roo Code Router को भी बंद कर दिया, जो केवल एक्सटेंशन का समर्थन करने के लिए मौजूद था। यदि आपके पास कोई अप्रयुक्त शेष राशि थी, तो आपको रिफंड के बारे में billing@roocode.com से ईमेल प्राप्त हुआ होगा।"
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/hi/settings.json
+++ b/webview-ui/src/i18n/locales/hi/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "अधिकतम आउटपुट टोकन",
 			"maxTokensDescription": "Claude Code प्रतिक्रियाओं के लिए आउटपुट टोकन की अधिकतम संख्या। डिफ़ॉल्ट 8000 है।"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/id/chat.json
+++ b/webview-ui/src/i18n/locales/id/chat.json
@@ -492,6 +492,6 @@
 		"title": "Penyedia tidak lagi didukung",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Buka Pengaturan",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/id/chat.json
+++ b/webview-ui/src/i18n/locales/id/chat.json
@@ -492,6 +492,6 @@
 		"title": "Penyedia tidak lagi didukung",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Buka Pengaturan",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Sebagai bagian dari keputusan kami untuk menghentikan ekstensi Roo Code, kami juga mengakhiri Roo Code Router, yang hanya ada untuk mendukung ekstensi tersebut. Jika Anda memiliki saldo yang belum digunakan, Anda seharusnya sudah menerima email dari billing@roocode.com tentang pengembalian dana."
 	}
 }

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Token Output Maks",
 			"maxTokensDescription": "Jumlah maksimum token output untuk respons Claude Code. Default adalah 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/id/settings.json
+++ b/webview-ui/src/i18n/locales/id/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Token Output Maks",
 			"maxTokensDescription": "Jumlah maksimum token output untuk respons Claude Code. Default adalah 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Sebagai bagian dari keputusan kami untuk menghentikan ekstensi Roo Code, kami juga mengakhiri Roo Code Router, yang hanya ada untuk mendukung ekstensi tersebut. Jika Anda memiliki saldo yang belum digunakan, Anda seharusnya sudah menerima email dari billing@roocode.com tentang pengembalian dana."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/it/chat.json
+++ b/webview-ui/src/i18n/locales/it/chat.json
@@ -486,6 +486,6 @@
 		"title": "Provider non più supportato",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Apri impostazioni",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/it/chat.json
+++ b/webview-ui/src/i18n/locales/it/chat.json
@@ -486,6 +486,6 @@
 		"title": "Provider non più supportato",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Apri impostazioni",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Nell'ambito della nostra decisione di dismettere l'estensione Roo Code, abbiamo terminato anche Roo Code Router, che esisteva solo per supportare l'estensione. Se avevi un saldo inutilizzato, dovresti aver ricevuto un'email da billing@roocode.com riguardo a un rimborso."
 	}
 }

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Token di output massimi",
 			"maxTokensDescription": "Numero massimo di token di output per le risposte di Claude Code. Il valore predefinito è 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/it/settings.json
+++ b/webview-ui/src/i18n/locales/it/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Token di output massimi",
 			"maxTokensDescription": "Numero massimo di token di output per le risposte di Claude Code. Il valore predefinito è 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Nell'ambito della nostra decisione di dismettere l'estensione Roo Code, abbiamo terminato anche Roo Code Router, che esisteva solo per supportare l'estensione. Se avevi un saldo inutilizzato, dovresti aver ricevuto un'email da billing@roocode.com riguardo a un rimborso."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/ja/chat.json
+++ b/webview-ui/src/i18n/locales/ja/chat.json
@@ -486,6 +486,6 @@
 		"title": "プロバイダーのサポート終了",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "設定を開く",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Roo Code 拡張機能の提供終了に伴い、その拡張機能をサポートするためだけに存在していた Roo Code Router も終了しました。未使用残高があった場合は、返金について billing@roocode.com からメールを受け取っているはずです。"
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/chat.json
+++ b/webview-ui/src/i18n/locales/ja/chat.json
@@ -486,6 +486,6 @@
 		"title": "プロバイダーのサポート終了",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "設定を開く",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "最大出力トークン",
 			"maxTokensDescription": "Claude Codeレスポンスの最大出力トークン数。デフォルトは8000です。"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/ja/settings.json
+++ b/webview-ui/src/i18n/locales/ja/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "最大出力トークン",
 			"maxTokensDescription": "Claude Codeレスポンスの最大出力トークン数。デフォルトは8000です。"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Roo Code 拡張機能の提供終了に伴い、その拡張機能をサポートするためだけに存在していた Roo Code Router も終了しました。未使用残高があった場合は、返金について billing@roocode.com からメールを受け取っているはずです。"
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/ko/chat.json
+++ b/webview-ui/src/i18n/locales/ko/chat.json
@@ -486,6 +486,6 @@
 		"title": "공급자 지원 종료",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "설정 열기",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Roo Code 확장 프로그램을 종료하기로 한 결정에 따라, 확장 프로그램 지원만을 위해 존재하던 Roo Code Router도 종료했습니다. 사용하지 않은 잔액이 있었다면 환불과 관련하여 billing@roocode.com에서 보낸 이메일을 받으셨을 것입니다."
 	}
 }

--- a/webview-ui/src/i18n/locales/ko/chat.json
+++ b/webview-ui/src/i18n/locales/ko/chat.json
@@ -486,6 +486,6 @@
 		"title": "공급자 지원 종료",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "설정 열기",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "최대 출력 토큰",
 			"maxTokensDescription": "Claude Code 응답의 최대 출력 토큰 수. 기본값은 8000입니다."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Roo Code 확장 프로그램을 종료하기로 한 결정에 따라, 확장 프로그램 지원만을 위해 존재하던 Roo Code Router도 종료했습니다. 사용하지 않은 잔액이 있었다면 환불과 관련하여 billing@roocode.com에서 보낸 이메일을 받으셨을 것입니다."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/ko/settings.json
+++ b/webview-ui/src/i18n/locales/ko/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "최대 출력 토큰",
 			"maxTokensDescription": "Claude Code 응답의 최대 출력 토큰 수. 기본값은 8000입니다."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/nl/chat.json
+++ b/webview-ui/src/i18n/locales/nl/chat.json
@@ -486,6 +486,6 @@
 		"title": "Provider wordt niet meer ondersteund",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Instellingen openen",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Als onderdeel van onze beslissing om de Roo Code-extensie stop te zetten, hebben we ook Roo Code Router beëindigd, dat alleen bestond om de extensie te ondersteunen. Als je ongebruikt saldo had, zou je een e-mail van billing@roocode.com over een terugbetaling moeten hebben ontvangen."
 	}
 }

--- a/webview-ui/src/i18n/locales/nl/chat.json
+++ b/webview-ui/src/i18n/locales/nl/chat.json
@@ -486,6 +486,6 @@
 		"title": "Provider wordt niet meer ondersteund",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Instellingen openen",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Max Output Tokens",
 			"maxTokensDescription": "Maximaal aantal output-tokens voor Claude Code-reacties. Standaard is 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/nl/settings.json
+++ b/webview-ui/src/i18n/locales/nl/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Max Output Tokens",
 			"maxTokensDescription": "Maximaal aantal output-tokens voor Claude Code-reacties. Standaard is 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Als onderdeel van onze beslissing om de Roo Code-extensie stop te zetten, hebben we ook Roo Code Router beëindigd, dat alleen bestond om de extensie te ondersteunen. Als je ongebruikt saldo had, zou je een e-mail van billing@roocode.com over een terugbetaling moeten hebben ontvangen."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/pl/chat.json
+++ b/webview-ui/src/i18n/locales/pl/chat.json
@@ -486,6 +486,6 @@
 		"title": "Dostawca nie jest już obsługiwany",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Otwórz ustawienia",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/pl/chat.json
+++ b/webview-ui/src/i18n/locales/pl/chat.json
@@ -486,6 +486,6 @@
 		"title": "Dostawca nie jest już obsługiwany",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Otwórz ustawienia",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "W ramach naszej decyzji o wygaszeniu rozszerzenia Roo Code zakończyliśmy również działanie Roo Code Router, który istniał wyłącznie po to, by obsługiwać to rozszerzenie. Jeśli miałeś niewykorzystane saldo, powinieneś otrzymać wiadomość e-mail z billing@roocode.com dotyczącą zwrotu."
 	}
 }

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Maksymalna liczba tokenów wyjściowych",
 			"maxTokensDescription": "Maksymalna liczba tokenów wyjściowych dla odpowiedzi Claude Code. Domyślnie 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/pl/settings.json
+++ b/webview-ui/src/i18n/locales/pl/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Maksymalna liczba tokenów wyjściowych",
 			"maxTokensDescription": "Maksymalna liczba tokenów wyjściowych dla odpowiedzi Claude Code. Domyślnie 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "W ramach naszej decyzji o wygaszeniu rozszerzenia Roo Code zakończyliśmy również działanie Roo Code Router, który istniał wyłącznie po to, by obsługiwać to rozszerzenie. Jeśli miałeś niewykorzystane saldo, powinieneś otrzymać wiadomość e-mail z billing@roocode.com dotyczącą zwrotu."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/pt-BR/chat.json
+++ b/webview-ui/src/i18n/locales/pt-BR/chat.json
@@ -486,6 +486,6 @@
 		"title": "Provedor não é mais suportado",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Abrir configurações",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Como parte da nossa decisão de descontinuar a extensão Roo Code, também encerramos o Roo Code Router, que existia apenas para dar suporte à extensão. Se você tinha saldo não utilizado, já deve ter recebido um e-mail de billing@roocode.com sobre um reembolso."
 	}
 }

--- a/webview-ui/src/i18n/locales/pt-BR/chat.json
+++ b/webview-ui/src/i18n/locales/pt-BR/chat.json
@@ -486,6 +486,6 @@
 		"title": "Provedor não é mais suportado",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Abrir configurações",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Tokens de saída máximos",
 			"maxTokensDescription": "Número máximo de tokens de saída para respostas do Claude Code. O padrão é 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/pt-BR/settings.json
+++ b/webview-ui/src/i18n/locales/pt-BR/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Tokens de saída máximos",
 			"maxTokensDescription": "Número máximo de tokens de saída para respostas do Claude Code. O padrão é 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Como parte da nossa decisão de descontinuar a extensão Roo Code, também encerramos o Roo Code Router, que existia apenas para dar suporte à extensão. Se você tinha saldo não utilizado, já deve ter recebido um e-mail de billing@roocode.com sobre um reembolso."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/ru/chat.json
+++ b/webview-ui/src/i18n/locales/ru/chat.json
@@ -487,6 +487,6 @@
 		"title": "Провайдер больше не поддерживается",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Открыть настройки",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "В рамках нашего решения прекратить поддержку расширения Roo Code мы также закрыли Roo Code Router, который существовал только для поддержки расширения. Если у вас был неиспользованный баланс, вы должны были получить письмо от billing@roocode.com о возврате средств."
 	}
 }

--- a/webview-ui/src/i18n/locales/ru/chat.json
+++ b/webview-ui/src/i18n/locales/ru/chat.json
@@ -487,6 +487,6 @@
 		"title": "Провайдер больше не поддерживается",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Открыть настройки",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Макс. выходных токенов",
 			"maxTokensDescription": "Максимальное количество выходных токенов для ответов Claude Code. По умолчанию 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/ru/settings.json
+++ b/webview-ui/src/i18n/locales/ru/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Макс. выходных токенов",
 			"maxTokensDescription": "Максимальное количество выходных токенов для ответов Claude Code. По умолчанию 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "В рамках нашего решения прекратить поддержку расширения Roo Code мы также закрыли Roo Code Router, который существовал только для поддержки расширения. Если у вас был неиспользованный баланс, вы должны были получить письмо от billing@roocode.com о возврате средств."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/tr/chat.json
+++ b/webview-ui/src/i18n/locales/tr/chat.json
@@ -487,6 +487,6 @@
 		"title": "Sağlayıcı artık desteklenmiyor",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Ayarları aç",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Roo Code uzantısını sonlandırma kararımızın bir parçası olarak, yalnızca uzantıyı desteklemek için var olan Roo Code Router'ı da sonlandırdık. Kullanılmamış bakiyeniz varsa, geri ödeme hakkında billing@roocode.com adresinden bir e-posta almış olmalısınız."
 	}
 }

--- a/webview-ui/src/i18n/locales/tr/chat.json
+++ b/webview-ui/src/i18n/locales/tr/chat.json
@@ -487,6 +487,6 @@
 		"title": "Sağlayıcı artık desteklenmiyor",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Ayarları aç",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Maksimum Çıktı Token sayısı",
 			"maxTokensDescription": "Claude Code yanıtları için maksimum çıktı token sayısı. Varsayılan 8000'dir."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/tr/settings.json
+++ b/webview-ui/src/i18n/locales/tr/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Maksimum Çıktı Token sayısı",
 			"maxTokensDescription": "Claude Code yanıtları için maksimum çıktı token sayısı. Varsayılan 8000'dir."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Roo Code uzantısını sonlandırma kararımızın bir parçası olarak, yalnızca uzantıyı desteklemek için var olan Roo Code Router'ı da sonlandırdık. Kullanılmamış bakiyeniz varsa, geri ödeme hakkında billing@roocode.com adresinden bir e-posta almış olmalısınız."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/vi/chat.json
+++ b/webview-ui/src/i18n/locales/vi/chat.json
@@ -487,6 +487,6 @@
 		"title": "Nhà cung cấp không còn được hỗ trợ",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Mở cài đặt",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/vi/chat.json
+++ b/webview-ui/src/i18n/locales/vi/chat.json
@@ -487,6 +487,6 @@
 		"title": "Nhà cung cấp không còn được hỗ trợ",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "Mở cài đặt",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "Trong quyết định ngừng hỗ trợ tiện ích Roo Code, chúng tôi cũng đã kết thúc Roo Code Router, vốn chỉ tồn tại để hỗ trợ tiện ích này. Nếu bạn có số dư chưa sử dụng, bạn hẳn đã nhận được email từ billing@roocode.com về khoản hoàn tiền."
 	}
 }

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Số token đầu ra tối đa",
 			"maxTokensDescription": "Số lượng token đầu ra tối đa cho các phản hồi của Claude Code. Mặc định là 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "Trong quyết định ngừng hỗ trợ tiện ích Roo Code, chúng tôi cũng đã kết thúc Roo Code Router, vốn chỉ tồn tại để hỗ trợ tiện ích này. Nếu bạn có số dư chưa sử dụng, bạn hẳn đã nhận được email từ billing@roocode.com về khoản hoàn tiền."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/vi/settings.json
+++ b/webview-ui/src/i18n/locales/vi/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "Số token đầu ra tối đa",
 			"maxTokensDescription": "Số lượng token đầu ra tối đa cho các phản hồi của Claude Code. Mặc định là 8000."
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -487,6 +487,6 @@
 		"title": "供应商不再受支持",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "打开设置",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/chat.json
+++ b/webview-ui/src/i18n/locales/zh-CN/chat.json
@@ -487,6 +487,6 @@
 		"title": "供应商不再受支持",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "打开设置",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "作为停用 Roo Code 扩展这一决定的一部分，我们也结束了 Roo Code Router；它原本只是为了支持该扩展而存在。如果你有任何未使用的余额，应该已经收到 billing@roocode.com 发来的退款相关邮件。"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "最大输出 Token",
 			"maxTokensDescription": "Claude Code 响应的最大输出 Token 数量。默认为 8000。"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "作为停用 Roo Code 扩展这一决定的一部分，我们也结束了 Roo Code Router；它原本只是为了支持该扩展而存在。如果你有任何未使用的余额，应该已经收到 billing@roocode.com 发来的退款相关邮件。"
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/zh-CN/settings.json
+++ b/webview-ui/src/i18n/locales/zh-CN/settings.json
@@ -546,7 +546,7 @@
 			"maxTokensLabel": "最大输出 Token",
 			"maxTokensDescription": "Claude Code 响应的最大输出 Token 数量。默认为 8000。"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -482,6 +482,6 @@
 		"title": "供應商不再受支援",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "開啟設定",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/chat.json
+++ b/webview-ui/src/i18n/locales/zh-TW/chat.json
@@ -482,6 +482,6 @@
 		"title": "供應商不再受支援",
 		"message": "This provider is no longer supported. Please select a different provider in your API profile settings.",
 		"openSettings": "開啟設定",
-		"rooMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"rooMessage": "作為停用 Roo Code 擴充功能這項決定的一部分，我們也結束了 Roo Code Router；它原本只是為了支援該擴充功能而存在。如果你有任何未使用的餘額，應該已經收到 billing@roocode.com 寄來的退款相關電子郵件。"
 	}
 }

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -556,7 +556,7 @@
 			"maxTokensLabel": "最大輸出 Token",
 			"maxTokensDescription": "Claude Code 回應的最大輸出 Token 數量。預設為 8000。"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. Sorry about the hassle."
+		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
 	},
 	"checkpoints": {
 		"timeout": {

--- a/webview-ui/src/i18n/locales/zh-TW/settings.json
+++ b/webview-ui/src/i18n/locales/zh-TW/settings.json
@@ -556,7 +556,7 @@
 			"maxTokensLabel": "最大輸出 Token",
 			"maxTokensDescription": "Claude Code 回應的最大輸出 Token 數量。預設為 8000。"
 		},
-		"retiredRooProviderMessage": "As part of our decision to sunset the Roo Code extension, we also ended the Roo Code Router, which only existed to support the extension. If you had any unused balance, you should have received an email from billing@roocode.com about a refund."
+		"retiredRooProviderMessage": "作為停用 Roo Code 擴充功能這項決定的一部分，我們也結束了 Roo Code Router；它原本只是為了支援該擴充功能而存在。如果你有任何未使用的餘額，應該已經收到 billing@roocode.com 寄來的退款相關電子郵件。"
 	},
 	"checkpoints": {
 		"timeout": {


### PR DESCRIPTION
## Summary
- Update the Roo Code Router retired-provider error to mention refund notification emails from billing@roocode.com
- Localize the Roo-specific refund copy across webview chat/settings locale files
- Keep the backend retired-provider error aligned with the English client copy

## Verification
- Parsed all changed JSON locale files successfully
- Focused ApiOptions Vitest could not be run because the local vitest bin is not installed in this worktree

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=b731e5ed54be104c0ec795a3b41748f61836ed09&pr=12355&branch=codex%2Froo-router-refund-error)
<!-- roo-code-cloud-preview-end -->