### PR TITLE
fix: reasoning_effort parameter silently dropped for OpenAI-compatible providers (Baseten, Fireworks, SambaNova, ZAi, Moonshot)

### DIFF
--- a/src/api/providers/base-openai-compatible-provider.ts
+++ b/src/api/providers/base-openai-compatible-provider.ts
@@ -7,6 +7,7 @@ import { type ApiHandlerOptions, getModelMaxOutputTokens } from "../../shared/ap
 import { TagMatcher } from "../../utils/tag-matcher"
 import { ApiStream, ApiStreamUsageChunk } from "../transform/stream"
 import { convertToOpenAiMessages } from "../transform/openai-format"
+import { getModelParams } from "../transform/model-params"
 
 import type { SingleCompletionHandler, ApiHandlerCreateMessageMetadata } from "../index"
 import { DEFAULT_HEADERS } from "./constants"
@@ -73,7 +74,7 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 		metadata?: ApiHandlerCreateMessageMetadata,
 		requestOptions?: OpenAI.RequestOptions,
 	) {
-		const { id: model, info } = this.getModel()
+		const { id: model, info, reasoning } = this.getModel()
 
 		// Centralized cap: clamp to 20% of the context window (unless provider-specific exceptions apply)
 		const max_tokens =
@@ -98,8 +99,14 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 			parallel_tool_calls: metadata?.parallelToolCalls ?? true,
 		}
 
-		// Add thinking parameter if reasoning is enabled and model supports it
-		if (this.options.enableReasoningEffort && info.supportsReasoningBinary) {
+		// Add reasoning_effort from centralized model params (handled by getModelParams)
+		if (reasoning) {
+			Object.assign(params, reasoning)
+		}
+
+		// Fallback: Add binary thinking parameter when reasoning_effort not used but
+		// reasoning is still enabled and model supports simple on/off thinking
+		if (!reasoning && this.options.enableReasoningEffort && info.supportsReasoningBinary) {
 			;(params as any).thinking = { type: "enabled" }
 		}
 
@@ -220,15 +227,20 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 	}
 
 	async completePrompt(prompt: string): Promise<string> {
-		const { id: modelId, info: modelInfo } = this.getModel()
+		const { id: modelId, info: modelInfo, reasoning } = this.getModel()
 
 		const params: OpenAI.Chat.Completions.ChatCompletionCreateParams = {
 			model: modelId,
 			messages: [{ role: "user", content: prompt }],
 		}
 
-		// Add thinking parameter if reasoning is enabled and model supports it
-		if (this.options.enableReasoningEffort && modelInfo.supportsReasoningBinary) {
+		// Add reasoning_effort from centralized model params
+		if (reasoning) {
+			Object.assign(params, reasoning)
+		}
+
+		// Fallback: Add binary thinking parameter when reasoning_effort not used
+		if (!reasoning && this.options.enableReasoningEffort && modelInfo.supportsReasoningBinary) {
 			;(params as any).thinking = { type: "enabled" }
 		}
 
@@ -250,11 +262,23 @@ export abstract class BaseOpenAiCompatibleProvider<ModelName extends string>
 	}
 
 	override getModel() {
-		const id =
+		const providerId =
 			this.options.apiModelId && this.options.apiModelId in this.providerModels
 				? (this.options.apiModelId as ModelName)
 				: this.defaultProviderModelId
 
-		return { id, info: this.providerModels[id] }
+		// Allow user to override model info via openAiCustomModelInfo (like OpenAiHandler),
+		// enabling support for custom/unknown models with reasoning effort capability
+		const info: ModelInfo = this.options.openAiCustomModelInfo ?? this.providerModels[providerId]
+
+		const params = getModelParams({
+			format: "openai",
+			modelId: providerId,
+			model: info,
+			settings: this.options,
+			defaultTemperature: this.defaultTemperature,
+		})
+
+		return { id: providerId as string, info, ...params }
 	}
 }

--- a/src/api/providers/openai-compatible.ts
+++ b/src/api/providers/openai-compatible.ts
@@ -165,6 +165,12 @@ export abstract class OpenAICompatibleHandler extends BaseProvider implements Si
 		const openAiTools = this.convertToolsForOpenAI(metadata?.tools)
 		const aiSdkTools = convertToolsForAiSdk(openAiTools) as ToolSet | undefined
 
+		// Build provider options for reasoning_effort (supported by @ai-sdk/openai-compatible)
+		const modelReasoning = (model as any).reasoning as { reasoning_effort?: string } | undefined
+		const openaiCompatibleOptions = modelReasoning?.reasoning_effort
+			? { reasoningEffort: modelReasoning.reasoning_effort }
+			: undefined
+
 		// Build the request options
 		const requestOptions: Parameters<typeof streamText>[0] = {
 			model: languageModel,
@@ -174,6 +180,9 @@ export abstract class OpenAICompatibleHandler extends BaseProvider implements Si
 			maxOutputTokens: this.getMaxOutputTokens(),
 			tools: aiSdkTools,
 			toolChoice: this.mapToolChoice(metadata?.tool_choice),
+			...(openaiCompatibleOptions
+				? { providerOptions: { openaiCompatible: openaiCompatibleOptions } as any }
+				: {}),
 		}
 
 		// Use streamText for streaming responses
@@ -199,12 +208,22 @@ export abstract class OpenAICompatibleHandler extends BaseProvider implements Si
 	 */
 	async completePrompt(prompt: string): Promise<string> {
 		const languageModel = this.getLanguageModel()
+		const model = this.getModel()
+
+		// Build provider options for reasoning_effort
+		const modelReasoning = (model as any).reasoning as { reasoning_effort?: string } | undefined
+		const openaiCompatibleOptions = modelReasoning?.reasoning_effort
+			? { reasoningEffort: modelReasoning.reasoning_effort }
+			: undefined
 
 		const { text } = await generateText({
 			model: languageModel,
 			prompt,
 			maxOutputTokens: this.getMaxOutputTokens(),
 			temperature: this.config.temperature ?? 0,
+			...(openaiCompatibleOptions
+				? { providerOptions: { openaiCompatible: openaiCompatibleOptions } as any }
+				: {}),
 		})
 
 		return text


### PR DESCRIPTION
## Problem

When using any OpenAI-compatible provider (Baseten, Fireworks, SambaNova, ZAi, Moonshot), the `reasoning_effort` parameter (low/medium/high) is **silently ignored** — the request is sent without any reasoning effort control, causing the model to use its default behavior regardless of user settings.

## Root Cause

Two base classes for OpenAI-compatible providers **never called `getModelParams()`** and **never read `options.reasoningEffort`**:

1. **`BaseOpenAiCompatibleProvider`** — only checked `supportsReasoningBinary` (on/off thinking flag) to send `thinking: { type: "enabled" }`. Never checked `supportsReasoningEffort` or `reasoningEffort` setting.

2. **`OpenAICompatibleHandler`** (Vercel AI SDK path, used by Moonshot) — didn't pass `reasoning_effort` via `providerOptions`.

Meanwhile `OpenAiHandler` (plain "OpenAI" provider) already worked correctly because it calls `getModelParams()` → `getOpenAiReasoning()` and spreads `reasoning` into request params.

## Changes

### [`BaseOpenAiCompatibleProvider.getModel()`](src/api/providers/base-openai-compatible-provider.ts)
- Now calls `getModelParams({ format: "openai", ... })` — same pattern as `OpenAiHandler` and `DeepSeekHandler`
- Added `openAiCustomModelInfo` fallback (like `OpenAiHandler`), enabling users to define model capabilities for custom/unknown API endpoints
- `createStream()` and `completePrompt()` now spread `reasoning` from `getModel()` into request params
- Binary thinking (`thinking: { type: "enabled" }`) preserved as fallback when `reasoning_effort` is not applicable

### [`OpenAICompatibleHandler`](src/api/providers/openai-compatible.ts)
- `createMessage()` and `completePrompt()` now pass `reasoning_effort` via AI SDK's `providerOptions.openaiCompatible.reasoningEffort` (the `@ai-sdk/openai-compatible` library already supports this parameter natively)

## Affected Providers

| Provider | Base Class | Status |
|----------|-----------|--------|
| Baseten | `BaseOpenAiCompatibleProvider` | Fixed |
| Fireworks | `BaseOpenAiCompatibleProvider` | Fixed |
| SambaNova | `BaseOpenAiCompatibleProvider` | Fixed |
| Z.ai (GLM) | `BaseOpenAiCompatibleProvider` | Fixed (non-thinking path) |
| Moonshot | `OpenAICompatibleHandler` | Fixed |
| OpenAI | `OpenAiHandler` | Already worked, unchanged |
| DeepSeek | `DeepSeekHandler` | Already worked, unchanged |

## Testing

- ✅ TypeScript compilation passes (`npx tsc --noEmit`)
- ✅ Full build passes (`pnpm build`)
- ✅ VSIX package created successfully (`pnpm vsix`)
- Backward compatible: existing binary thinking mode (`supportsReasoningBinary`) still works as fallback

## Usage Notes

For **custom/unknown models** with reasoning effort capability, users can now set `openAiCustomModelInfo` in provider settings (e.g. `{ supportsReasoningEffort: true, reasoningEffort: "high" }`) when using any of the affected providers.
This pull request enhances support for model-specific reasoning parameters in OpenAI-compatible providers by centralizing the handling of the `reasoning_effort` parameter and improving how reasoning capabilities are passed to downstream APIs. The changes ensure that models supporting advanced reasoning features can expose these capabilities in a consistent way, and that custom/unknown models can also be supported via user overrides.

**Centralized reasoning parameter handling:**

* The `getModel` method in `BaseOpenAiCompatibleProvider` now returns a `reasoning` property, populated using the new `getModelParams` utility. This allows for consistent handling of the `reasoning_effort` parameter across providers and supports user overrides for custom models.
* When constructing API parameters, the code now prefers the centralized `reasoning` property for advanced reasoning support, falling back to the legacy binary `thinking` flag only if necessary. [[1]](diffhunk://#diff-52d548a1af60b2b746cef1221cf0b31c525fbe58634eb50e425c960ed5fcd63cL101-R109) [[2]](diffhunk://#diff-52d548a1af60b2b746cef1221cf0b31c525fbe58634eb50e425c960ed5fcd63cL223-R243) [[3]](diffhunk://#diff-52d548a1af60b2b746cef1221cf0b31c525fbe58634eb50e425c960ed5fcd63cL76-R77)

**Integration with downstream SDKs and handlers:**

* In `OpenAICompatibleHandler`, the `reasoning_effort` parameter is extracted from the model and included in the `providerOptions` for both streaming and non-streaming text generation, enabling advanced reasoning features in compatible SDKs. [[1]](diffhunk://#diff-972c638f3ace9bbe8eb9694aca28c4402f9ee1c841816ff25d2247233e19037cR168-R173) [[2]](diffhunk://#diff-972c638f3ace9bbe8eb9694aca28c4402f9ee1c841816ff25d2247233e19037cR183-R185) [[3]](diffhunk://#diff-972c638f3ace9bbe8eb9694aca28c4402f9ee1c841816ff25d2247233e19037cR211-R226)

**Utility and import updates:**

* The `getModelParams` utility is now imported and used to standardize model parameter extraction, supporting the new reasoning capability.
