### PR TITLE
Fix docs GitHub Pages base URL

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -20,10 +20,10 @@ const config: Config = {
 	favicon: "img/favicon.ico",
 
 	// Set the production url of your site here
-	url: "https://roocode.github.io",
+	url: "https://roocodeinc.github.io",
 	// Set the /<baseUrl>/ pathname under which your site is served
 	// For GitHub pages deployment, it is often '/<projectName>/'
-	baseUrl: "/",
+	baseUrl: "/Roo-Code/",
 
 	// GitHub pages deployment config (if needed)
 	organizationName: "RooCodeInc",


### PR DESCRIPTION
## Summary
- Configure the docs Docusaurus site for the current GitHub Pages project URL
- Set asset and canonical paths under /Roo-Code/ so the deployed site loads CSS and JS correctly

## Verification
- pnpm --filter @roo-code/docs build
- pre-commit lint hook passed
- push check-types hook passed

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=1f80bf9de3df36db7129357de9f8cd6cb31ac51f&pr=12370&branch=codex%2Ffix-docs-pages-base-url)
<!-- roo-code-cloud-preview-end -->