### PR TITLE
Remove stale roocode.github.io docs references

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,6 +1,6 @@
 # Roo Code Docs
 
-This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator, and lives at https://roocode.github.io
+This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator, and lives at https://roocodeinc.github.io/Roo-Code/
 
 ### Installation
 

--- a/apps/docs/static/CNAME
+++ b/apps/docs/static/CNAME
@@ -1,1 +1,0 @@
-roocode.github.io

--- a/apps/docs/static/robots.txt
+++ b/apps/docs/static/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://roocode.github.io/sitemap.xml
+Sitemap: https://roocodeinc.github.io/Roo-Code/sitemap.xml


### PR DESCRIPTION
## Summary
- Update the docs README to point at the current GitHub Pages project URL
- Update robots.txt sitemap URL for /Roo-Code/
- Remove the stale CNAME file for roocode.github.io, which is not needed for the current project Pages deployment

## Verification
- rg "roocode\.github\.io|roo-code\.github\.io" returns no matches
- git diff --check
- pnpm --filter @roo-code/docs build
- pre-commit lint hook passed
- push check-types hook passed

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=71962b3eded120996e154cff79474c32eecf72d2&pr=12372&branch=codex%2Ffix-remaining-github-pages-refs)
<!-- roo-code-cloud-preview-end -->