### PR TITLE
Redirect roocode.com to roomote.dev

### DIFF
--- a/apps/web-roo-code/next.config.ts
+++ b/apps/web-roo-code/next.config.ts
@@ -7,84 +7,9 @@ const nextConfig: NextConfig = {
 	},
 	async redirects() {
 		return [
-			// Redirect www to non-www
 			{
 				source: "/:path*",
-				has: [{ type: "host", value: "www.roocode.com" }],
-				destination: "https://roocode.com/:path*",
-				permanent: true,
-			},
-			// Redirect HTTP to HTTPS
-			{
-				source: "/:path*",
-				has: [{ type: "header", key: "x-forwarded-proto", value: "http" }],
-				destination: "https://roocode.com/:path*",
-				permanent: true,
-			},
-			// Redirect cloud waitlist to Notion page (kept for extension compatibility)
-			{
-				source: "/cloud-waitlist",
-				destination: "https://roo-code.notion.site/238fd1401b0a8087b858e1ad431507cf?pvs=105",
-				permanent: false,
-			},
-			{
-				source: "/extension",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/provider/pricing",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/pricing",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/provider",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/cloud",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/cloud/team",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/enterprise",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/slack",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/linear",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/reviewer",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/pr-fixer",
-				destination: "/",
-				permanent: true,
-			},
-			{
-				source: "/github",
-				destination: "/",
+				destination: "https://roomote.dev",
 				permanent: true,
 			},
 		]


### PR DESCRIPTION
## Summary
- Replace the roocode.com web app redirect rules with a single permanent catch-all redirect to https://roomote.dev
- Remove route-specific legacy redirects so all app traffic exits to the new domain

## Tests
- pnpm --filter @roo-code/web-roo-code check-types
- pnpm --filter @roo-code/web-roo-code build
- pre-commit lint hook
- pre-push check-types hook

Note: local commands reported the existing Node engine warning because this shell is on Node 20.18.1 while the repo requests 20.19.2.

<!-- roo-code-cloud-preview-start -->
[Interactively review PR in Roo Code Cloud](https://app.roocode.com/preview?repo=RooCodeInc%2FRoo-Code&sha=189d2be22b1a70d8be028222fa305909ba64b2e1&pr=12374&branch=codex%2Fredirect-roocode-to-roomote)
<!-- roo-code-cloud-preview-end -->